### PR TITLE
fix(ShellEx): Support adding multiple files

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormAddFiles.cs
+++ b/src/app/GitUI/CommandsDialogs/FormAddFiles.cs
@@ -15,13 +15,13 @@ namespace GitUI.CommandsDialogs
 
         private void ShowFilesClick(object sender, EventArgs e)
         {
-            string arguments = string.Format("add --dry-run{0} \"{1}\"", force.Checked ? " -f" : "", Filter.Text);
+            string arguments = string.Format("add --dry-run{0} {1}", force.Checked ? " -f" : "", Filter.Text);
             FormProcess.ShowDialog(this, UICommands, arguments, Module.WorkingDir, input: null, useDialogSettings: false);
         }
 
         private void AddFilesClick(object sender, EventArgs e)
         {
-            string arguments = string.Format("add{0} \"{1}\"", force.Checked ? " -f" : "", Filter.Text);
+            string arguments = string.Format("add{0} {1}", force.Checked ? " -f" : "", Filter.Text);
             if (FormProcess.ShowDialog(this, UICommands, arguments, Module.WorkingDir, input: null, useDialogSettings: false))
             {
                 Close();

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/ShellExtension/ShellExtensionManager.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/ShellExtension/ShellExtensionManager.cs
@@ -42,7 +42,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.ShellExtension
         /// <exception cref="FileNotFoundException">If at least one necessary for registration file wasn't found</exception>
         /// <exception cref="Win32Exception">If user canceled elevation dialog (when ex.NativeErrorCode == 1223)</exception>
         /// <exception cref="Exception">Other potential error</exception>
-        public static void Register() => RunRegSvrForShellExtensionDlls("/s {0}");
+        public static void Register()
+        {
+            AppSettings.SetInstallDir(AppSettings.GetGitExtensionsDirectory());
+            RunRegSvrForShellExtensionDlls("/s {0}");
+        }
 
         /// <summary>
         /// Unregister shell extensions

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1427,7 +1427,8 @@ namespace GitUI
                     return true;
                 case "add":
                 case "addfiles":
-                    return StartAddFilesDialog(null, args.Count == 3 ? args[2] : ".");
+                    // If filenames have been specified, quote them and pass them to the dialog, else pass '.' for current dir.
+                    return StartAddFilesDialog(owner: null, addFiles: args.Count < 3 ? "." : string.Join(' ', args.Skip(2).Select(file => file.Quote())));
                 case "apply":       // [filename]
                 case "applypatch":
                     return StartApplyPatchDialog(null, args.Count == 3 ? args[2] : "");

--- a/src/native/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/src/native/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -709,32 +709,32 @@ STDMETHODIMP CGitExtensionsShellEx::GetCommandString(
 
 void CGitExtensionsShellEx::RunGitEx(const TCHAR* command)
 {
-    CString szFile = m_szFile;
-    CString szCommandName = command;
-    CString args;
+    CString sFile = m_szFile;
+    CString sArgs;
 
-    if (szFile.GetLength() > 1 && szFile[szFile.GetLength() - 1] == '\\')
+    if (sFile.GetLength() > 1 && sFile[sFile.GetLength() - 1] == '\\')
     {
         // Escape the final backslash to avoid escaping the quote.
         // This is a problem for drive roots on Windows, such as "C:\".
-        szFile += '\\';
+        sFile += '\\';
     }
 
-    args += command;
-    args += " \"";
-    args += szFile;
-    args += "\"";
+    sArgs += command;
+    sArgs += " \"";
+    sArgs += sFile;
+    sArgs += "\"";
 
-    CString dir = "";
+    CString sDir = "";
 
-    if (dir.GetLength() == 0)
-        dir = GetRegistryValue(HKEY_CURRENT_USER, L"SOFTWARE\\GitExtensions", L"InstallDir");
-    if (dir.GetLength() == 0)
-        dir = GetRegistryValue(HKEY_USERS, L"SOFTWARE\\GitExtensions", L"InstallDir");
-    if (dir.GetLength() == 0)
-        dir = GetRegistryValue(HKEY_LOCAL_MACHINE, L"SOFTWARE\\GitExtensions", L"InstallDir");
+    if (sDir.GetLength() == 0)
+        sDir = GetRegistryValue(HKEY_CURRENT_USER, L"SOFTWARE\\GitExtensions", L"InstallDir");
+    if (sDir.GetLength() == 0)
+        sDir = GetRegistryValue(HKEY_USERS, L"SOFTWARE\\GitExtensions", L"InstallDir");
+    if (sDir.GetLength() == 0)
+        sDir = GetRegistryValue(HKEY_LOCAL_MACHINE, L"SOFTWARE\\GitExtensions", L"InstallDir");
 
-    ShellExecute(NULL, L"open", L"GitExtensions.exe", args, dir, SW_SHOWNORMAL);
+    CString sExe = sDir + L"\\GitExtensions.exe";
+    ShellExecute(NULL, L"open", sExe, sArgs, nullptr, SW_SHOWNORMAL);
 }
 
 STDMETHODIMP CGitExtensionsShellEx::InvokeCommand(LPCMINVOKECOMMANDINFO pCmdInfo)

--- a/src/native/GitExtensionsShellEx/GitExtensionsShellEx.h
+++ b/src/native/GitExtensionsShellEx/GitExtensionsShellEx.h
@@ -81,7 +81,9 @@ private:
 
     UINT AddMenuItem(HMENU hmenu, LPTSTR text, int resource, UINT firstId, UINT id, UINT position, bool isSubMenu);
 
+    UINT m_uNumFiles;
     TCHAR m_szFile[MAX_PATH];
+    CString m_sFilesQuoted;
     std::map<UINT_PTR, int> myIDMap;
     std::map<UINT, HBITMAP> bitmaps;
     std::map<int, int> commandsId;


### PR DESCRIPTION
Fixes #11711

## Proposed changes

- fix(ShellEx): Support adding multiple files
- fix(ShellEx): Write `InstallDir` to registry on registration of the shell extension
- fix(ShellEx): Open GE with current dir as work dir

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

N/A

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/39e1905d-f5c5-4644-b55f-98d5ca2d443f)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).