### PR TITLE
RevisionReader: Update after at most 500 ms

### DIFF
--- a/src/app/GitCommands/GitCommands.csproj
+++ b/src/app/GitCommands/GitCommands.csproj
@@ -5,8 +5,7 @@
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- To be limited to Debug after initial usage -->
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>$(DefineConstants);TRACE_REVISIONREADER</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/11621#discussion_r1532965374

## Proposed changes

- fix(RevisionReader): Update after at most 500 ms
- fix(RevisionReader): Define `TRACE_REVISIONREADER` for debug build only

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![before](https://github.com/gitextensions/gitextensions/assets/36601201/ef84344a-cc6e-48b4-8875-c3636c92c497)

### After

![after](https://github.com/gitextensions/gitextensions/assets/36601201/e51117a7-7a1c-4974-9409-499b458ca580)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).