### PR TITLE
feat(ScriptOptionsProvider): {SelectedRelativePaths}

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -913,7 +913,7 @@ namespace GitUI.CommandsDialogs
 
         public override IScriptOptionsProvider? GetScriptOptionsProvider()
         {
-            return new ScriptOptionsProvider(_currentFilesList, () => _fullPathResolver, () => SelectedDiff.CurrentFileLine);
+            return new ScriptOptionsProvider(_currentFilesList, () => SelectedDiff.CurrentFileLine);
         }
 
         #endregion

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -193,7 +193,7 @@ namespace GitUI.CommandsDialogs
 
         protected override IScriptOptionsProvider? GetScriptOptionsProvider()
         {
-            return new ScriptOptionsProvider(DiffFiles, () => _fullPathResolver, () => BlameControl.Visible ? BlameControl.CurrentFileLine : DiffText.CurrentFileLine);
+            return new ScriptOptionsProvider(DiffFiles, () => BlameControl.Visible ? BlameControl.CurrentFileLine : DiffText.CurrentFileLine);
         }
 
         public void ReloadHotkeys()

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -298,12 +298,11 @@ See the changes in the commit form.");
                 {
                     if (tvGitTree.SelectedNode?.Tag is not GitItem gitItem || gitItem.ObjectType != GitObjectType.Blob)
                     {
-                        return Array.Empty<string>();
+                        return [];
                     }
 
-                    return new string[] { gitItem.FileName };
+                    return [gitItem.FileName];
                 },
-                () => _fullPathResolver,
                 () => BlameControl.Visible ? BlameControl.CurrentFileLine : FileText.CurrentFileLine);
         }
 

--- a/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
+++ b/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
@@ -5,43 +5,33 @@ namespace GitUI.CommandsDialogs;
 
 internal class ScriptOptionsProvider : IScriptOptionsProvider
 {
-    private const string _selectedFiles = "SelectedFiles";
+    private const string _selectedRelativePaths = "SelectedRelativePaths";
     private const string _lineNumber = "LineNumber";
 
-    private Func<IEnumerable<string>> _getSelectedFiles;
-    private Func<IFullPathResolver> _getFullPathResolver;
+    private Func<IEnumerable<string>> _getSelectedRelativePaths;
     private Func<int?> _getCurrentLineNumber;
 
-    public ScriptOptionsProvider(Func<IEnumerable<string>> getSelectedFiles, Func<IFullPathResolver> getFullPathResolver, Func<int?> getCurrentLineNumber)
+    public ScriptOptionsProvider(Func<IEnumerable<string>> getSelectedRelativePaths, Func<int?> getCurrentLineNumber)
     {
-        _getSelectedFiles = getSelectedFiles;
-        _getFullPathResolver = getFullPathResolver;
+        _getSelectedRelativePaths = getSelectedRelativePaths;
         _getCurrentLineNumber = getCurrentLineNumber;
     }
 
-    public ScriptOptionsProvider(FileStatusList fileStatusList, Func<IFullPathResolver> getFullPathResolver, Func<int?> getCurrentLineNumber)
-        : this(() => fileStatusList.SelectedItems.Select(item => item.Item.Name), getFullPathResolver, getCurrentLineNumber)
+    public ScriptOptionsProvider(FileStatusList fileStatusList, Func<int?> getCurrentLineNumber)
+        : this(() => fileStatusList.SelectedItems.Select(item => item.Item.Name), getCurrentLineNumber)
     {
     }
 
-    IReadOnlyList<string> IScriptOptionsProvider.Options { get; } = new[] { _selectedFiles, _lineNumber };
+    IReadOnlyList<string> IScriptOptionsProvider.Options { get; } = new[] { _selectedRelativePaths, _lineNumber };
 
     string? IScriptOptionsProvider.GetValue(string option)
     {
         switch (option)
         {
-            case _selectedFiles:
-                IEnumerable<string> selectedFiles = _getSelectedFiles();
-                if (!selectedFiles.Any())
-                {
-                    return null;
-                }
-
-                IFullPathResolver fullPathResolver = _getFullPathResolver();
-                return string.Join(" ", selectedFiles.Select(item => fullPathResolver.Resolve(item).QuoteForCommandLine()));
+            case _selectedRelativePaths:
+                return string.Join(" ", _getSelectedRelativePaths().Select(item => item.QuoteForCommandLine()));
             case _lineNumber:
-                int? line = _getCurrentLineNumber();
-                return line?.ToString();
+                return _getCurrentLineNumber()?.ToString() ?? "";
             default:
                 throw new NotImplementedException(option);
         }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -70,8 +70,8 @@ Currently checked out revision:
 {cDefaultRemoteUrl}
 {cDefaultRemotePathFromUrl}
 
-File(s):
-{SelectedFiles}
+Diff selection:
+{SelectedRelativePaths}   (relative paths as they were in the selected commit)
 {LineNumber}");
 
         private static readonly string[] WatchedProxyPropertiesOnFocusChanged =

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -9822,8 +9822,8 @@ Currently checked out revision:
 {cDefaultRemoteUrl}
 {cDefaultRemotePathFromUrl}
 
-File(s):
-{SelectedFiles}
+Diff selection:
+{SelectedRelativePaths}   (relative paths as they were in the selected commit)
 {LineNumber}</source>
         <target />
       </trans-unit>


### PR DESCRIPTION
Relates to https://github.com/gitextensions/gitextensions/pull/11734#issuecomment-2119243843

## Proposed changes

- Turn script option `{SelectedFiles}` into `{SelectedRelativePaths}` without resolving full paths
  in order to emphasize that these paths are valid for the selected commit (and might not apply to the working directory)
- Always replace the provided options `{SelectedRelativePaths}` and `{LineNumber}` if an according `ScriptOptionsProvider` exists - at least with an empty string
  Otherwise, "{SelectedRelativePaths}" was passed as is to the script, which f.i. makes VS Code open a new file with the option as name.

E.g. in order to open a file in VS Code, the following background script command can be used (if the file has not been renamed or deleted; works best with VS Code setting `window.restoreWindows` set to `preserve`):
```
cmd /c code . --goto {SelectedRelativePaths}:{LineNumber}
```
(`{LineNumber}` may not exactly match for older commits and may not apply at all if multiple files are selected in the wrong sequence.)

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).