### PR TITLE
fix(AnsiEscapeUtilities): Limit error tracing

### DIFF
--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -114,8 +114,9 @@ public partial class AnsiEscapeUtilities
     /// <param name="text">The text to parse.</param>
     /// <param name="sb">StringBuilder to appened the text with with the escape sequences removed.</param>
     /// <param name="textMarkers">Detected and current started highlight info for the document.</param>
-    public static void ParseEscape(string text, StringBuilder sb, List<TextMarker> textMarkers, bool themeColors = false)
+    public static void ParseEscape(string text, StringBuilder sb, List<TextMarker> textMarkers, bool themeColors = false, bool traceErrors = true)
     {
+        int errorCount = 0;
         int prevLineOffset = 0;
         int currentColorId = 0; // current color, used when just bold etc is set
         HighlightInfo currentHighlight = new()
@@ -140,7 +141,8 @@ public partial class AnsiEscapeUtilities
                 {
                     // End current match so new can be started, this is expected but normally not used by Git (?).
                     // Also assume that the new colors are "complete", not just overlay.
-                    Trace.WriteLine($"New start marker without end for grep ({sb.Length},{match.Index}) {text}");
+                    ++errorCount;
+                    Trace.WriteLineIf(traceErrors && errorCount <= 3, $"New start marker without end for grep ({sb.Length}, {match.Index}){(errorCount == 1 ? " in:\n" + text : "")}");
 
                     currentHighlight.Length = sb.Length - currentHighlight.DocOffset;
                     if (TryGetTextMarker(currentHighlight, out TextMarker tm))


### PR DESCRIPTION
Fixes #11774

## Proposed changes

- `AnsiEscapeUtilities.ParseEscape`: Limit error tracing

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

you don't want to see it

### After

```
New start marker without end for grep (270, 308) in:
diff --git a/UnitTests/GitCommands.Tests/Patches/testdata/color.diff b/UnitTests/GitCommands.Tests/Patches/testdata/color.diff
new file mode 100644
index 000000000..0bfb32613
--- /dev/null
+++ b/UnitTests/GitCommands.Tests/Patches/testdata/color.diff
[36m@@ -0,0 +1,325 @@[m
[38;2;0;0;0;48;2;200;255;200m+[1mdiff --git a/GitCommands/Patches/PatchProcessor.cs b/GitCommands/Patches/PatchProcessor.cs[m[m
[38;2;0;0;0;48;2;200;255;200m+[1mindex 70b40..c1e6c 100644[m[m
[38;2;0;0;0;48;2;200;255;200m+[1m--- a/GitCommands/Patches/PatchProcessor.cs[m[m
[38;2;0;0;0;48;2;200;255;200m+[1m+++ b/GitCommands/Patches/PatchProcessor.cs[m[m
[38;2;0;0;0;48;2;200;255;200m+[36m@@ -15,19 +15,29 @@[m [mprivate enum PatchProcessorState[m[m
[38;2;0;0;0;48;2;200;255;200m+             OutsidePatch[m[m
[38;2;0;0;0;48;2;200;255;200m+         }[m[m
[38;2;0;0;0;48;2;200;255;200m+ [m[m
<snip />
[38;2;0;0;0;48;2;200;255;200m+ }[m[m


New start marker without end for grep (362, 440)

New start marker without end for grep (389, 507)

```
## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).