### PR TITLE
Make graph settings non-experimental

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1523,9 +1523,9 @@ namespace GitCommands
 
         public static ISetting<bool> MergeGraphLanesHavingCommonParent { get; } = Setting.Create(RevisionGraphSettingsPath, nameof(MergeGraphLanesHavingCommonParent), true);
 
-        public static ISetting<bool> RenderGraphWithDiagonals { get; } = Setting.Create(ExperimentalSettingsPath, nameof(RenderGraphWithDiagonals), true);
+        public static ISetting<bool> RenderGraphWithDiagonals { get; } = Setting.Create(RevisionGraphSettingsPath, nameof(RenderGraphWithDiagonals), true);
 
-        public static ISetting<bool> StraightenGraphDiagonals { get; } = Setting.Create(ExperimentalSettingsPath, nameof(StraightenGraphDiagonals), true);
+        public static ISetting<bool> StraightenGraphDiagonals { get; } = Setting.Create(RevisionGraphSettingsPath, nameof(StraightenGraphDiagonals), true);
 
         /// <summary>
         ///  The limit when to skip the straightening of revision graph segments.


### PR DESCRIPTION
## Proposed changes

in preparation of upcoming release:
- Move `RenderGraphWithDiagonals` and `StraightenGraphDiagonals` to non-experimental settings

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).