### PR TITLE
fix(FileSettingsCache): Always watch repo-local settings

### DIFF
--- a/tests/app/UnitTests/GitCommands.Tests/Settings/FileSettingsCacheTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/FileSettingsCacheTests.cs
@@ -37,14 +37,6 @@ namespace GitCommandsTests.Settings
 
         [TestCase(null)]
         [TestCase("")]
-        [TestCase("boo")]
-        public void ctor_CanEnableFileWatcher_should_be_false_if_invalid_dir(string settingsFilePath)
-        {
-            new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor().CanEnableFileWatcher.Should().BeFalse();
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
         public void SaveImpl_should_throw_if_invalid_path(string settingsFilePath)
         {
             FileSettingsCache.TestAccessor cache = new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor();


### PR DESCRIPTION
Fixes #11720

## Proposed changes

Cleanup `FileSettingsCache`:
- Always watch the settings file also if the checkout does not contain that file on startup (repo open) 
- Hence remove `_canEnableFileWatcher`
- React on deletion, too
- There is no need to distinguish the kind of file change because we just need to know whether to refresh the settings or not
- Use `FileChanged` instead of assigning `_lastFileModificationDate`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- Remove obsolete testcase `ctor_CanEnableFileWatcher_should_be_false_if_invalid_dir` which is redundant with the existing
  `ctor_FileWatcher_EnableRaisingEvents_should_be_false_if_invalid_dir`

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).