### PR TITLE
FormCommit: Fixup cursor movement in message editor

### DIFF
--- a/src/app/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -65,6 +65,7 @@
             TextBox.GotFocus += TextBox_GotFocus;
             TextBox.LostFocus += TextBox_LostFocus;
             TextBox.MouseDown += TextBox_MouseDown;
+            TextBox.WordWrap = false;
             // 
             // AutoComplete
             // 

--- a/src/app/GitUI/UserControls/TextBoxSilencer.cs
+++ b/src/app/GitUI/UserControls/TextBoxSilencer.cs
@@ -11,47 +11,38 @@ namespace GitUI.UserControls
     {
         private RichTextBox _textBox;
 
-        private bool _isAtFirstColumn;
-        private bool _isAtEndColumn;
-        private bool _isAtFirstLine;
-        private bool _isAtLastLine;
-
         public TextBoxSilencer(RichTextBox textBox)
         {
             _textBox = textBox;
-            _textBox.SelectionChanged += (s, e) => UpdatePositionFlags();
             _textBox.KeyDown += OnKeyDown;
         }
 
         private void OnKeyDown(object? sender, KeyEventArgs e)
         {
-            if (e.Handled)
+            if (e.Handled || _textBox.SelectionLength > 0)
             {
                 return;
             }
 
-            switch (e.KeyCode)
-            {
-                case Keys.Up when _isAtFirstLine:
-                case Keys.Down when _isAtLastLine:
-                case Keys.Home when _isAtFirstColumn:
-                case Keys.End when _isAtEndColumn:
-                case Keys.Left or Keys.PageUp when _isAtFirstLine && _isAtFirstColumn:
-                case Keys.Right or Keys.PageDown when _isAtLastLine && _isAtEndColumn:
-                    e.Handled = true;
-                    break;
-            }
-        }
-
-        private void UpdatePositionFlags()
-        {
             string text = _textBox.Text;
             int position = _textBox.SelectionStart;
 
-            _isAtFirstColumn = position == _textBox.GetFirstCharIndexOfCurrentLine();
-            _isAtEndColumn = position == GetLineEnd(text, startIndex: position);
-            _isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
-            _isAtLastLine = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex: position) < 0;
+            bool isAtFirstColumn = position == _textBox.GetFirstCharIndexOfCurrentLine();
+            bool isAtEndColumn = position == GetLineEnd(text, startIndex: position);
+            bool isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
+            bool isAtLastLine = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex: position) < 0;
+
+            switch (e.KeyCode)
+            {
+                case Keys.Up when isAtFirstLine:
+                case Keys.Down when isAtLastLine:
+                case Keys.Home when isAtFirstColumn:
+                case Keys.End when isAtEndColumn:
+                case Keys.Left or Keys.PageUp when isAtFirstLine && isAtFirstColumn:
+                case Keys.Right or Keys.PageDown when isAtLastLine && isAtEndColumn:
+                    e.Handled = true;
+                    break;
+            }
         }
 
         private static int GetLineEnd(string text, int startIndex)


### PR DESCRIPTION
Fixes #11784
and further regression from #10730

## Proposed changes

- `EditNetSpell`:
  - disable `RichTextBox.WordWrap` in order to avoid issues with cursor position calculation (not made public by `RichTextBox`)
- `TextBoxSilencer`:
  - do not suppress keypress if there is a selection
  - evaluate position on `KeyDown` not on `SelectionChanged`
    because `RichTextBox.Text` can be empty yet on `SelectionChanged` and the selection does not change on setting `Text`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).