### PR TITLE
RecentReposSettings: Streamline naming

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -360,19 +360,19 @@ namespace GitCommands
             }
         }
 
-        // Currently not configurable
+        // Currently not configurable in UI (Set manually in settings file)
         public static bool WslGitEnabled
         {
             get => GetBool("WslGitEnabled", true);
         }
 
-        // Currently not configurable
+        // Currently not configurable in UI (Set manually in settings file)
         public static string WslGitCommand
         {
             get => GetString("WslGitCommand", "wsl");
         }
 
-        // Currently not configurable
+        // Currently not configurable in UI (Set manually in settings file)
         public static string WslGitPath
         {
             get => GetString("WslGitPath", "git");
@@ -386,7 +386,7 @@ namespace GitCommands
 
         public static bool DontConfirmStashDrop
         {
-            // The settings was originally was called 'StashConfirmDropShow', and then it was inverted.
+            // History Compatibility: The settings was originally was called 'StashConfirmDropShow', and then it was inverted.
             // To maintain the compat with the existing user settings negate the retrieved value.
             get => !GetBool("stashconfirmdropshow", true);
             set => SetBool("stashconfirmdropshow", !value);
@@ -406,7 +406,7 @@ namespace GitCommands
 
         public static bool UseHistogramDiffAlgorithm
         {
-            // The settings key has patience in the name for historical reasons
+            // History Compatibility: The settings key has patience in the name for historical reasons
             get => GetBool("usepatiencediffalgorithm", false);
             set => SetBool("usepatiencediffalgorithm", value);
         }
@@ -615,7 +615,7 @@ namespace GitCommands
             set => SetInt("Appearance.AvatarCacheSize", value);
         }
 
-        // Currently not configurable in UI
+        // Currently not configurable in UI (Set manually in settings file)
         // Names from here: https://learn.microsoft.com/en-us/dotnet/api/system.windows.media.brushes?view=windowsdesktop-7.0
         // or #AARRGGBB code
         public static string AvatarAuthorInitialsPalette
@@ -624,7 +624,7 @@ namespace GitCommands
             set => SetString("Appearance.AvatarAuthorInitialsPalette", value);
         }
 
-        // Currently not configurable in UI
+        // Currently not configurable in UI (Set manually in settings file)
         public static float AvatarAuthorInitialsLuminanceThreshold => GetFloat("AvatarAuthorInitialsLuminanceThreshold", 0.5f);
 
         /// <summary>
@@ -1109,7 +1109,7 @@ namespace GitCommands
             set => SetBool("showStashes", value);
         }
 
-        // Set manually in settings file
+        // Currently not configurable in UI (Set manually in settings file)
         public static int MaxStashesWithUntrackedFiles
         {
             get => GetInt("maxStashesWithUntrackedFiles", 10);
@@ -1193,7 +1193,7 @@ namespace GitCommands
             set => SetBool("showannotatedtagsmessages", value);
         }
 
-        // Note: The meaning of this value is changed in the GUI, setting name is kept for compatibility
+        // History Compatibility: The meaning of this value is changed in the GUI, setting name is kept for compatibility
         public static bool HideMergeCommits
         {
             get => !GetBool("showmergecommits", true);
@@ -1313,7 +1313,7 @@ namespace GitCommands
         /// <summary>Gets or sets the path to the GNU/Linux tools (bash, ps, sh, ssh, etc.), e.g. "C:\Program Files\Git\usr\bin\"</summary>
         public static string LinuxToolsDir
         {
-            // Migrate the setting value from the from the former "gitbindir"
+            // History Compatibility: Migrate the setting value from the from the former "gitbindir"
             get => GetString(nameof(LinuxToolsDir), defaultValue: null) ?? GetString("gitbindir", "");
             set
             {
@@ -1680,6 +1680,7 @@ namespace GitCommands
 
         public static int MaxTopRepositories
         {
+            // History Compatibility: Keep original key to maintain the compatibility with the existing user settings
             get => GetInt("MaxMostRecentRepositories", 0);
             set => SetInt("MaxMostRecentRepositories", value);
         }
@@ -1690,7 +1691,7 @@ namespace GitCommands
             set => SetInt("history size", value);
         }
 
-        // (Currently) hidden configuration
+        // Currently not configurable in UI (Set manually in settings file)
         public static int RemotesCacheLength
         {
             get => GetInt("RemotesCacheLength", 30);
@@ -2030,13 +2031,13 @@ namespace GitCommands
         // Return false whilst we're in the designer.
         public static bool IsPortable() => !IsDesignMode && Properties.Settings.Default.IsPortable;
 
-        // Set manually in settings file
+        // Currently not configurable in UI (Set manually in settings file)
         public static bool WriteErrorLog
         {
             get => GetBool("WriteErrorLog", false);
         }
 
-        // Set manually in settings file
+        // Currently not configurable in UI (Set manually in settings file)
         public static bool WorkaroundActivateFromMinimize
         {
             get => GetBool("WorkaroundActivateFromMinimize", false);

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1678,7 +1678,7 @@ namespace GitCommands
             set => SetEnum("ShorteningRecentRepoPathStrategy", value);
         }
 
-        public static int MaxPinnedRepositories
+        public static int MaxTopRepositories
         {
             get => GetInt("MaxMostRecentRepositories", 0);
             set => SetInt("MaxMostRecentRepositories", value);
@@ -1709,13 +1709,13 @@ namespace GitCommands
             set => SetString("SerializedHotkeys", value);
         }
 
-        public static bool SortPinnedRepos
+        public static bool SortTopRepos
         {
             get => GetBool("SortMostRecentRepos", false);
             set => SetBool("SortMostRecentRepos", value);
         }
 
-        public static bool SortAllRecentRepos
+        public static bool SortRecentRepos
         {
             get => GetBool("SortLessRecentRepos", false);
             set => SetBool("SortLessRecentRepos", value);

--- a/src/app/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
@@ -39,47 +39,47 @@
 
     public class RecentRepoSplitter
     {
-        public int MaxPinnedRepositories { get; set; }
+        public int MaxTopRepositories { get; set; }
         public ShorteningRecentRepoPathStrategy ShorteningStrategy { get; set; }
-        public bool SortPinnedRepos { get; set; }
-        public bool SortAllRecentRepos { get; set; }
+        public bool SortTopRepos { get; set; }
+        public bool SortRecentRepos { get; set; }
         public int RecentReposComboMinWidth { get; set; }
 
         public Font? MeasureFont { get; set; }
 
         public RecentRepoSplitter()
         {
-            MaxPinnedRepositories = AppSettings.MaxPinnedRepositories;
+            MaxTopRepositories = AppSettings.MaxTopRepositories;
             ShorteningStrategy = AppSettings.ShorteningRecentRepoPathStrategy;
-            SortPinnedRepos = AppSettings.SortPinnedRepos;
-            SortAllRecentRepos = AppSettings.SortAllRecentRepos;
+            SortTopRepos = AppSettings.SortTopRepos;
+            SortRecentRepos = AppSettings.SortRecentRepos;
             RecentReposComboMinWidth = AppSettings.RecentReposComboMinWidth;
         }
 
-        public void SplitRecentRepos(IList<Repository> recentRepositories, List<RecentRepoInfo> pinnedRepoList, List<RecentRepoInfo> allRecentRepoList)
+        public void SplitRecentRepos(IList<Repository> repositories, List<RecentRepoInfo> topRepoList, List<RecentRepoInfo> recentRepoList)
         {
             SortedList<string, List<RecentRepoInfo>> orderedRepos = [];
-            List<RecentRepoInfo> pinnedRepos = [];
-            List<RecentRepoInfo> allRecentRepos = [];
+            List<RecentRepoInfo> topRepos = [];
+            List<RecentRepoInfo> recentRepos = [];
 
             bool middleDot = ShorteningStrategy == ShorteningRecentRepoPathStrategy.MiddleDots;
             bool signDir = ShorteningStrategy == ShorteningRecentRepoPathStrategy.MostSignDir;
 
-            int n = Math.Min(MaxPinnedRepositories, recentRepositories.Count);
+            int n = Math.Min(MaxTopRepositories, repositories.Count);
 
-            // the maxRecentRepositories repositories will be added at beginning
+            // the topRepositories repositories will be added at beginning
             // rest will be added in alphabetical order
-            foreach (Repository repository in recentRepositories)
+            foreach (Repository repository in repositories)
             {
-                bool mostRecent = (pinnedRepos.Count < n && repository.Anchor == Repository.RepositoryAnchor.None) ||
-                    repository.Anchor == Repository.RepositoryAnchor.Pinned;
+                bool mostRecent = (topRepos.Count < n && repository.Anchor == Repository.RepositoryAnchor.None) ||
+                    repository.Anchor == Repository.RepositoryAnchor.AnchoredInTop;
                 RecentRepoInfo ri = new(repository, mostRecent);
                 if (ri.MostRecent)
                 {
-                    pinnedRepos.Add(ri);
+                    topRepos.Add(ri);
                 }
 
-                allRecentRepos.Add(ri);
+                recentRepos.Add(ri);
 
                 if (middleDot)
                 {
@@ -96,20 +96,20 @@
                 }
             }
 
-            int r = pinnedRepos.Count - 1;
+            int r = topRepos.Count - 1;
 
             // remove not anchored repos if there is more than maxRecentRepositories repos
-            while (pinnedRepos.Count > n && r >= 0)
+            while (topRepos.Count > n && r >= 0)
             {
-                RecentRepoInfo repo = pinnedRepos[r];
-                if (repo.Repo.Anchor == Repository.RepositoryAnchor.Pinned)
+                RecentRepoInfo repo = topRepos[r];
+                if (repo.Repo.Anchor == Repository.RepositoryAnchor.AnchoredInTop)
                 {
                     r--;
                 }
                 else
                 {
                     repo.MostRecent = false;
-                    pinnedRepos.RemoveAt(r);
+                    topRepos.RemoveAt(r);
                 }
             }
 
@@ -127,22 +127,22 @@
                 addToList.AddRange(list);
             }
 
-            if (SortPinnedRepos)
+            if (SortTopRepos)
             {
-                AddSortedRepos(true, pinnedRepoList);
+                AddSortedRepos(true, topRepoList);
             }
             else
             {
-                AddNotSortedRepos(pinnedRepos, pinnedRepoList);
+                AddNotSortedRepos(topRepos, topRepoList);
             }
 
-            if (SortAllRecentRepos)
+            if (SortRecentRepos)
             {
-                AddSortedRepos(false, allRecentRepoList);
+                AddSortedRepos(false, recentRepoList);
             }
             else
             {
-                AddNotSortedRepos(allRecentRepos, allRecentRepoList);
+                AddNotSortedRepos(recentRepos, recentRepoList);
             }
         }
 

--- a/src/app/GitCommands/UserRepositoryHistory/Repository.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/Repository.cs
@@ -1,4 +1,6 @@
-﻿namespace GitCommands.UserRepositoryHistory
+﻿using System.Xml.Serialization;
+
+namespace GitCommands.UserRepositoryHistory
 {
     [Serializable]
     public class Repository
@@ -7,8 +9,10 @@
 
         public enum RepositoryAnchor
         {
-            Pinned,
-            AllRecent,
+            [XmlEnum(Name = "Pinned")]
+            AnchoredInTop,
+            [XmlEnum(Name = "AllRecent")]
+            AnchoredInRecent,
             None
         }
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -65,31 +65,31 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public (IReadOnlyList<RecentRepoInfo> recentRepositories, IReadOnlyList<RecentRepoInfo> favouriteRepositories) PreRenderRepositories(string pattern)
         {
-            List<RecentRepoInfo> pinnedRepos = [];
-            List<RecentRepoInfo> allRecentRepos = [];
+            List<RecentRepoInfo> topRepos = [];
+            List<RecentRepoInfo> recentRepos = [];
 
             RecentRepoSplitter splitter = new()
             {
                 MeasureFont = AppSettings.Font,
 
-                MaxPinnedRepositories = AppSettings.MaxPinnedRepositories,
+                MaxTopRepositories = AppSettings.MaxTopRepositories,
                 RecentReposComboMinWidth = AppSettings.RecentReposComboMinWidth,
                 ShorteningStrategy = AppSettings.ShorteningRecentRepoPathStrategy,
-                SortAllRecentRepos = AppSettings.SortAllRecentRepos,
-                SortPinnedRepos = AppSettings.SortPinnedRepos
+                SortRecentRepos = AppSettings.SortRecentRepos,
+                SortTopRepos = AppSettings.SortTopRepos
             };
 
             _allRecentRepositories ??= ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
             IList<Repository> repositories = Filter(_allRecentRepositories, pattern);
-            splitter.SplitRecentRepos(repositories, pinnedRepos, allRecentRepos);
-            List<RecentRepoInfo> recentRepositories = pinnedRepos.Union(allRecentRepos).ToList();
+            splitter.SplitRecentRepos(repositories, topRepos, recentRepos);
+            List<RecentRepoInfo> recentRepositories = topRepos.Union(recentRepos).ToList();
 
             _allFavoriteRepositories ??= ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync);
             repositories = Filter(_allFavoriteRepositories, pattern);
-            pinnedRepos.Clear();
-            allRecentRepos.Clear();
-            splitter.SplitRecentRepos(repositories, pinnedRepos, allRecentRepos);
-            List<RecentRepoInfo> favouriteRepositories = pinnedRepos.Union(allRecentRepos).ToList();
+            topRepos.Clear();
+            recentRepos.Clear();
+            splitter.SplitRecentRepos(repositories, topRepos, recentRepos);
+            List<RecentRepoInfo> favouriteRepositories = topRepos.Union(recentRepos).ToList();
 
             return (recentRepositories, favouriteRepositories);
         }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
@@ -39,27 +39,27 @@
             maxRecentRepositories = new Label();
             _NO_TRANSLATE_maxRecentRepositories = new NumericUpDown();
             comboMinWidthEdit = new NumericUpDown();
-            sortPinnedRepos = new CheckBox();
+            sortTopRepos = new CheckBox();
             comboMinWidthLabel = new Label();
-            sortAllRecentRepos = new CheckBox();
+            sortRecentRepos = new CheckBox();
             shorteningGB = new GroupBox();
             dontShortenRB = new RadioButton();
             middleDotRB = new RadioButton();
             mostSigDirRB = new RadioButton();
             comboPanel = new Panel();
-            AllRecentLB = new ListView();
+            RecentLB = new ListView();
             chdrRepository1 = new ColumnHeader();
             contextMenuStrip1 = new ContextMenuStrip(components);
-            anchorToPinnedReposToolStripMenuItem = new ToolStripMenuItem();
-            anchorToAllRecentReposToolStripMenuItem = new ToolStripMenuItem();
+            anchorToTopReposToolStripMenuItem = new ToolStripMenuItem();
+            anchorToRecentReposToolStripMenuItem = new ToolStripMenuItem();
             removeAnchorToolStripMenuItem = new ToolStripMenuItem();
             removeRecentToolStripMenuItem = new ToolStripMenuItem();
             panel3 = new Panel();
             label1 = new Label();
-            PinnedLB = new ListView();
+            TopLB = new ListView();
             chdrRepository = new ColumnHeader();
             panel2 = new Panel();
-            PinnedLabel = new Label();
+            TopLabel = new Label();
             flpnlControls = new FlowLayoutPanel();
             tableLayoutPanel1 = new TableLayoutPanel();
             flpnlControls.SuspendLayout();
@@ -121,15 +121,15 @@
             tableLayoutPanel1.ColumnCount = 2;
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
-            tableLayoutPanel1.Controls.Add(_NO_TRANSLATE_RecentRepositoriesHistorySize, 1, 0);
-            tableLayoutPanel1.Controls.Add(lblRecentRepositoriesHistorySize, 0, 0);
+            tableLayoutPanel1.Controls.Add(_NO_TRANSLATE_RecentRepositoriesHistorySize, 1, 1);
+            tableLayoutPanel1.Controls.Add(lblRecentRepositoriesHistorySize, 0, 1);
             tableLayoutPanel1.Controls.Add(comboMinWidthNote, 0, 6);
-            tableLayoutPanel1.Controls.Add(maxRecentRepositories, 0, 1);
-            tableLayoutPanel1.Controls.Add(_NO_TRANSLATE_maxRecentRepositories, 1, 1);
+            tableLayoutPanel1.Controls.Add(maxRecentRepositories, 0, 0);
+            tableLayoutPanel1.Controls.Add(_NO_TRANSLATE_maxRecentRepositories, 1, 0);
             tableLayoutPanel1.Controls.Add(comboMinWidthEdit, 1, 5);
-            tableLayoutPanel1.Controls.Add(sortPinnedRepos, 0, 2);
+            tableLayoutPanel1.Controls.Add(sortTopRepos, 0, 2);
             tableLayoutPanel1.Controls.Add(comboMinWidthLabel, 0, 5);
-            tableLayoutPanel1.Controls.Add(sortAllRecentRepos, 0, 3);
+            tableLayoutPanel1.Controls.Add(sortRecentRepos, 0, 3);
             tableLayoutPanel1.Controls.Add(shorteningGB, 0, 4);
             tableLayoutPanel1.Dock = DockStyle.Left;
             tableLayoutPanel1.Location = new Point(0, 0);
@@ -164,7 +164,7 @@
             lblRecentRepositoriesHistorySize.Name = "lblRecentRepositoriesHistorySize";
             lblRecentRepositoriesHistorySize.Size = new Size(168, 15);
             lblRecentRepositoriesHistorySize.TabIndex = 0;
-            lblRecentRepositoriesHistorySize.Text = "Recent repositories history size";
+            lblRecentRepositoriesHistorySize.Text = "Maximum number of recent repositories";
             // 
             // comboMinWidthNote
             // 
@@ -185,7 +185,7 @@
             maxRecentRepositories.Name = "maxRecentRepositories";
             maxRecentRepositories.Size = new Size(261, 15);
             maxRecentRepositories.TabIndex = 2;
-            maxRecentRepositories.Text = "Maximum number of pinned recent repositories";
+            maxRecentRepositories.Text = "Maximum number of top repositories";
             // 
             // _NO_TRANSLATE_maxRecentRepositories
             // 
@@ -194,7 +194,7 @@
             _NO_TRANSLATE_maxRecentRepositories.Name = "_NO_TRANSLATE_maxRecentRepositories";
             _NO_TRANSLATE_maxRecentRepositories.Size = new Size(61, 23);
             _NO_TRANSLATE_maxRecentRepositories.TabIndex = 3;
-            _NO_TRANSLATE_maxRecentRepositories.ValueChanged += sortPinnedRepos_CheckedChanged;
+            _NO_TRANSLATE_maxRecentRepositories.ValueChanged += sortTopRepos_CheckedChanged;
             // 
             // comboMinWidthEdit
             // 
@@ -205,19 +205,19 @@
             comboMinWidthEdit.TabIndex = 8;
             comboMinWidthEdit.ValueChanged += comboMinWidthEdit_ValueChanged;
             // 
-            // sortPinnedRepos
+            // sortTopRepos
             // 
-            sortPinnedRepos.AutoSize = true;
-            sortPinnedRepos.CheckAlign = ContentAlignment.MiddleRight;
-            tableLayoutPanel1.SetColumnSpan(sortPinnedRepos, 2);
-            sortPinnedRepos.Location = new Point(11, 69);
-            sortPinnedRepos.Name = "sortPinnedRepos";
-            sortPinnedRepos.RightToLeft = RightToLeft.Yes;
-            sortPinnedRepos.Size = new Size(227, 19);
-            sortPinnedRepos.TabIndex = 4;
-            sortPinnedRepos.Text = "Sort pinned repositories alphabetically";
-            sortPinnedRepos.UseVisualStyleBackColor = true;
-            sortPinnedRepos.CheckedChanged += sortPinnedRepos_CheckedChanged;
+            sortTopRepos.AutoSize = true;
+            sortTopRepos.CheckAlign = ContentAlignment.MiddleRight;
+            tableLayoutPanel1.SetColumnSpan(sortTopRepos, 2);
+            sortTopRepos.Location = new Point(11, 69);
+            sortTopRepos.Name = "sortTopRepos";
+            sortTopRepos.RightToLeft = RightToLeft.Yes;
+            sortTopRepos.Size = new Size(227, 19);
+            sortTopRepos.TabIndex = 4;
+            sortTopRepos.Text = "Sort top repositories alphabetically";
+            sortTopRepos.UseVisualStyleBackColor = true;
+            sortTopRepos.CheckedChanged += sortTopRepos_CheckedChanged;
             // 
             // comboMinWidthLabel
             // 
@@ -229,19 +229,19 @@
             comboMinWidthLabel.TabIndex = 7;
             comboMinWidthLabel.Text = "Combobox minimum width (0 = Autosize)";
             // 
-            // sortAllRecentRepos
+            // sortRecentRepos
             // 
-            sortAllRecentRepos.AutoSize = true;
-            sortAllRecentRepos.CheckAlign = ContentAlignment.MiddleRight;
-            tableLayoutPanel1.SetColumnSpan(sortAllRecentRepos, 2);
-            sortAllRecentRepos.Location = new Point(11, 94);
-            sortAllRecentRepos.Name = "sortAllRecentRepos";
-            sortAllRecentRepos.RightToLeft = RightToLeft.Yes;
-            sortAllRecentRepos.Size = new Size(223, 19);
-            sortAllRecentRepos.TabIndex = 5;
-            sortAllRecentRepos.Text = "Sort recent repositories alphabetically";
-            sortAllRecentRepos.UseVisualStyleBackColor = true;
-            sortAllRecentRepos.CheckedChanged += sortPinnedRepos_CheckedChanged;
+            sortRecentRepos.AutoSize = true;
+            sortRecentRepos.CheckAlign = ContentAlignment.MiddleRight;
+            tableLayoutPanel1.SetColumnSpan(sortRecentRepos, 2);
+            sortRecentRepos.Location = new Point(11, 94);
+            sortRecentRepos.Name = "sortRecentRepos";
+            sortRecentRepos.RightToLeft = RightToLeft.Yes;
+            sortRecentRepos.Size = new Size(223, 19);
+            sortRecentRepos.TabIndex = 5;
+            sortRecentRepos.Text = "Sort recent repositories alphabetically";
+            sortRecentRepos.UseVisualStyleBackColor = true;
+            sortRecentRepos.CheckedChanged += sortTopRepos_CheckedChanged;
             // 
             // shorteningGB
             // 
@@ -269,7 +269,7 @@
             dontShortenRB.TabStop = true;
             dontShortenRB.Text = "Do not shorten  ";
             dontShortenRB.UseVisualStyleBackColor = true;
-            dontShortenRB.CheckedChanged += sortPinnedRepos_CheckedChanged;
+            dontShortenRB.CheckedChanged += sortTopRepos_CheckedChanged;
             // 
             // middleDotRB
             // 
@@ -281,7 +281,7 @@
             middleDotRB.TabStop = true;
             middleDotRB.Text = "Replace middle part with dots ";
             middleDotRB.UseVisualStyleBackColor = true;
-            middleDotRB.CheckedChanged += sortPinnedRepos_CheckedChanged;
+            middleDotRB.CheckedChanged += sortTopRepos_CheckedChanged;
             // 
             // mostSigDirRB
             // 
@@ -293,13 +293,13 @@
             mostSigDirRB.TabStop = true;
             mostSigDirRB.Text = "The most significant directory ";
             mostSigDirRB.UseVisualStyleBackColor = true;
-            mostSigDirRB.CheckedChanged += sortPinnedRepos_CheckedChanged;
+            mostSigDirRB.CheckedChanged += sortTopRepos_CheckedChanged;
             // 
             // comboPanel
             // 
-            comboPanel.Controls.Add(AllRecentLB);
+            comboPanel.Controls.Add(RecentLB);
             comboPanel.Controls.Add(panel3);
-            comboPanel.Controls.Add(PinnedLB);
+            comboPanel.Controls.Add(TopLB);
             comboPanel.Controls.Add(panel2);
             comboPanel.Dock = DockStyle.Fill;
             comboPanel.Location = new Point(350, 0);
@@ -307,24 +307,24 @@
             comboPanel.Size = new Size(326, 327);
             comboPanel.TabIndex = 1;
             // 
-            // AllRecentLB
+            // RecentLB
             // 
-            AllRecentLB.Columns.AddRange(new ColumnHeader[] { chdrRepository1 });
-            AllRecentLB.ContextMenuStrip = contextMenuStrip1;
-            AllRecentLB.Dock = DockStyle.Fill;
-            AllRecentLB.FullRowSelect = true;
-            AllRecentLB.GridLines = true;
-            AllRecentLB.HeaderStyle = ColumnHeaderStyle.None;
-            AllRecentLB.LabelWrap = false;
-            AllRecentLB.Location = new Point(0, 166);
-            AllRecentLB.Name = "AllRecentLB";
-            AllRecentLB.ShowItemToolTips = true;
-            AllRecentLB.Size = new Size(326, 161);
-            AllRecentLB.TabIndex = 2;
-            AllRecentLB.UseCompatibleStateImageBehavior = false;
-            AllRecentLB.View = View.Details;
-            AllRecentLB.DrawItem += listView_DrawItem;
-            AllRecentLB.DoubleClick += AllRecentLB_DoubleClick;
+            RecentLB.Columns.AddRange(new ColumnHeader[] { chdrRepository1 });
+            RecentLB.ContextMenuStrip = contextMenuStrip1;
+            RecentLB.Dock = DockStyle.Fill;
+            RecentLB.FullRowSelect = true;
+            RecentLB.GridLines = true;
+            RecentLB.HeaderStyle = ColumnHeaderStyle.None;
+            RecentLB.LabelWrap = false;
+            RecentLB.Location = new Point(0, 166);
+            RecentLB.Name = "AllRecentLB";
+            RecentLB.ShowItemToolTips = true;
+            RecentLB.Size = new Size(326, 161);
+            RecentLB.TabIndex = 2;
+            RecentLB.UseCompatibleStateImageBehavior = false;
+            RecentLB.View = View.Details;
+            RecentLB.DrawItem += listView_DrawItem;
+            RecentLB.DoubleClick += AllRecentLB_DoubleClick;
             // 
             // chdrRepository1
             // 
@@ -332,24 +332,24 @@
             // 
             // contextMenuStrip1
             // 
-            contextMenuStrip1.Items.AddRange(new ToolStripItem[] { anchorToPinnedReposToolStripMenuItem, anchorToAllRecentReposToolStripMenuItem, removeAnchorToolStripMenuItem, removeRecentToolStripMenuItem });
+            contextMenuStrip1.Items.AddRange(new ToolStripItem[] { anchorToTopReposToolStripMenuItem, anchorToRecentReposToolStripMenuItem, removeAnchorToolStripMenuItem, removeRecentToolStripMenuItem });
             contextMenuStrip1.Name = "contextMenuStrip1";
             contextMenuStrip1.Size = new Size(247, 92);
             contextMenuStrip1.Opening += contextMenuStrip1_Opening;
             // 
-            // anchorToPinnedReposToolStripMenuItem
+            // anchorToTopReposToolStripMenuItem
             // 
-            anchorToPinnedReposToolStripMenuItem.Name = "anchorToPinnedReposToolStripMenuItem";
-            anchorToPinnedReposToolStripMenuItem.Size = new Size(246, 22);
-            anchorToPinnedReposToolStripMenuItem.Text = "Anchor to pinned repositories";
-            anchorToPinnedReposToolStripMenuItem.Click += anchorToMostToolStripMenuItem_Click;
+            anchorToTopReposToolStripMenuItem.Name = "anchorToTopReposToolStripMenuItem";
+            anchorToTopReposToolStripMenuItem.Size = new Size(246, 22);
+            anchorToTopReposToolStripMenuItem.Text = "Anchor to top repositories";
+            anchorToTopReposToolStripMenuItem.Click += anchorToMostToolStripMenuItem_Click;
             // 
-            // anchorToAllRecentReposToolStripMenuItem
+            // anchorToRecentReposToolStripMenuItem
             // 
-            anchorToAllRecentReposToolStripMenuItem.Name = "anchorToAllRecentReposToolStripMenuItem";
-            anchorToAllRecentReposToolStripMenuItem.Size = new Size(246, 22);
-            anchorToAllRecentReposToolStripMenuItem.Text = "Anchor to recent repositories";
-            anchorToAllRecentReposToolStripMenuItem.Click += anchorToLessToolStripMenuItem_Click;
+            anchorToRecentReposToolStripMenuItem.Name = "anchorToRecentReposToolStripMenuItem";
+            anchorToRecentReposToolStripMenuItem.Size = new Size(246, 22);
+            anchorToRecentReposToolStripMenuItem.Text = "Anchor to recent repositories";
+            anchorToRecentReposToolStripMenuItem.Click += anchorToLessToolStripMenuItem_Click;
             // 
             // removeAnchorToolStripMenuItem
             // 
@@ -384,24 +384,24 @@
             label1.TabIndex = 0;
             label1.Text = "Recent repositories";
             // 
-            // PinnedLB
+            // TopLB
             // 
-            PinnedLB.Columns.AddRange(new ColumnHeader[] { chdrRepository });
-            PinnedLB.ContextMenuStrip = contextMenuStrip1;
-            PinnedLB.Dock = DockStyle.Top;
-            PinnedLB.FullRowSelect = true;
-            PinnedLB.GridLines = true;
-            PinnedLB.HeaderStyle = ColumnHeaderStyle.None;
-            PinnedLB.LabelWrap = false;
-            PinnedLB.Location = new Point(0, 21);
-            PinnedLB.Name = "PinnedLB";
-            PinnedLB.ShowItemToolTips = true;
-            PinnedLB.Size = new Size(326, 121);
-            PinnedLB.TabIndex = 0;
-            PinnedLB.UseCompatibleStateImageBehavior = false;
-            PinnedLB.View = View.Details;
-            PinnedLB.DrawItem += listView_DrawItem;
-            PinnedLB.DoubleClick += PinnedLB_DoubleClick;
+            TopLB.Columns.AddRange(new ColumnHeader[] { chdrRepository });
+            TopLB.ContextMenuStrip = contextMenuStrip1;
+            TopLB.Dock = DockStyle.Top;
+            TopLB.FullRowSelect = true;
+            TopLB.GridLines = true;
+            TopLB.HeaderStyle = ColumnHeaderStyle.None;
+            TopLB.LabelWrap = false;
+            TopLB.Location = new Point(0, 21);
+            TopLB.Name = "TopLB";
+            TopLB.ShowItemToolTips = true;
+            TopLB.Size = new Size(326, 121);
+            TopLB.TabIndex = 0;
+            TopLB.UseCompatibleStateImageBehavior = false;
+            TopLB.View = View.Details;
+            TopLB.DrawItem += listView_DrawItem;
+            TopLB.DoubleClick += TopLB_DoubleClick;
             // 
             // chdrRepository
             // 
@@ -411,21 +411,21 @@
             // 
             panel2.AutoSize = true;
             panel2.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            panel2.Controls.Add(PinnedLabel);
+            panel2.Controls.Add(TopLabel);
             panel2.Dock = DockStyle.Top;
             panel2.Location = new Point(0, 0);
             panel2.Name = "panel2";
             panel2.Size = new Size(326, 21);
             panel2.TabIndex = 0;
             // 
-            // PinnedLabel
+            // TopLabel
             // 
-            PinnedLabel.AutoSize = true;
-            PinnedLabel.Location = new Point(3, 6);
-            PinnedLabel.Name = "PinnedLabel";
-            PinnedLabel.Size = new Size(108, 15);
-            PinnedLabel.TabIndex = 0;
-            PinnedLabel.Text = "Pinned repositories";
+            TopLabel.AutoSize = true;
+            TopLabel.Location = new Point(3, 6);
+            TopLabel.Name = "TopLabel";
+            TopLabel.Size = new Size(108, 15);
+            TopLabel.TabIndex = 0;
+            TopLabel.Text = "Top repositories";
             // 
             // FormRecentReposSettings
             // 
@@ -468,13 +468,13 @@
 
         private NumericUpDown _NO_TRANSLATE_maxRecentRepositories;
         private Label maxRecentRepositories;
-        private CheckBox sortAllRecentRepos;
-        private CheckBox sortPinnedRepos;
+        private CheckBox sortRecentRepos;
+        private CheckBox sortTopRepos;
         private Panel comboPanel;
-        private ListView AllRecentLB;
-        private ListView PinnedLB;
+        private ListView RecentLB;
+        private ListView TopLB;
         private Panel panel2;
-        private Label PinnedLabel;
+        private Label TopLabel;
         protected Button Abort;
         private GroupBox shorteningGB;
         private RadioButton mostSigDirRB;
@@ -485,10 +485,10 @@
         private Panel panel3;
         private Label label1;
         private ContextMenuStrip contextMenuStrip1;
-        private ToolStripMenuItem anchorToPinnedReposToolStripMenuItem;
+        private ToolStripMenuItem anchorToTopReposToolStripMenuItem;
         private ToolStripMenuItem removeAnchorToolStripMenuItem;
         private ToolStripMenuItem removeRecentToolStripMenuItem;
-        private ToolStripMenuItem anchorToAllRecentReposToolStripMenuItem;
+        private ToolStripMenuItem anchorToRecentReposToolStripMenuItem;
         private Button Ok;
         private ColumnHeader chdrRepository;
         private ColumnHeader chdrRepository1;

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1170,15 +1170,15 @@ namespace GitUI.CommandsDialogs
             IList<Repository> recentRepositoryHistory = ThreadHelper.JoinableTaskFactory.Run(
                 () => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
 
-            List<RecentRepoInfo> pinnedRepos = new();
+            List<RecentRepoInfo> topRepos = new();
             RecentRepoSplitter splitter = new()
             {
                 MeasureFont = _NO_TRANSLATE_WorkingDir.Font,
             };
 
-            splitter.SplitRecentRepos(recentRepositoryHistory, pinnedRepos, pinnedRepos);
+            splitter.SplitRecentRepos(recentRepositoryHistory, topRepos, topRepos);
 
-            RecentRepoInfo ri = pinnedRepos.Find(e => e.Repo.Path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
+            RecentRepoInfo ri = topRepos.Find(e => e.Repo.Path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
 
             _NO_TRANSLATE_WorkingDir.Text = PathUtil.GetDisplayPath(ri?.Caption ?? path);
 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6199,16 +6199,16 @@ commit date), ignoring the original author date.</source>
         <source>OK</source>
         <target />
       </trans-unit>
-      <trans-unit id="PinnedLabel.Text">
-        <source>Pinned repositories</source>
+      <trans-unit id="TopLabel.Text">
+        <source>Top repositories</source>
         <target />
       </trans-unit>
-      <trans-unit id="anchorToAllRecentReposToolStripMenuItem.Text">
+      <trans-unit id="anchorToRecentReposToolStripMenuItem.Text">
         <source>Anchor to recent repositories</source>
         <target />
       </trans-unit>
-      <trans-unit id="anchorToPinnedReposToolStripMenuItem.Text">
-        <source>Anchor to pinned repositories</source>
+      <trans-unit id="anchorToTopReposToolStripMenuItem.Text">
+        <source>Anchor to top repositories</source>
         <target />
       </trans-unit>
       <trans-unit id="chdrRepository.Text">
@@ -6236,11 +6236,11 @@ commit date), ignoring the original author date.</source>
         <target />
       </trans-unit>
       <trans-unit id="lblRecentRepositoriesHistorySize.Text">
-        <source>Recent repositories history size</source>
+        <source>Maximum number of recent repositories</source>
         <target />
       </trans-unit>
       <trans-unit id="maxRecentRepositories.Text">
-        <source>Maximum number of pinned recent repositories</source>
+        <source>Maximum number of top repositories</source>
         <target />
       </trans-unit>
       <trans-unit id="middleDotRB.Text">
@@ -6263,12 +6263,12 @@ commit date), ignoring the original author date.</source>
         <source>Shortening strategy</source>
         <target />
       </trans-unit>
-      <trans-unit id="sortAllRecentRepos.Text">
+      <trans-unit id="sortRecentRepos.Text">
         <source>Sort recent repositories alphabetically</source>
         <target />
       </trans-unit>
-      <trans-unit id="sortPinnedRepos.Text">
-        <source>Sort pinned repositories alphabetically</source>
+      <trans-unit id="sortTopRepos.Text">
+        <source>Sort top repositories alphabetically</source>
         <target />
       </trans-unit>
     </body>

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -330,12 +330,12 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.OwnScripts)], string.Empty, true, false);
                 yield return (properties[nameof(AppSettings.RecursiveSubmodules)], 1, false, false);
                 yield return (properties[nameof(AppSettings.ShorteningRecentRepoPathStrategy)], ShorteningRecentRepoPathStrategy.None, false, false);
-                yield return (properties[nameof(AppSettings.MaxPinnedRepositories)], 0, false, false);
+                yield return (properties[nameof(AppSettings.MaxTopRepositories)], 0, false, false);
                 yield return (properties[nameof(AppSettings.RecentRepositoriesHistorySize)], 30, false, false);
                 yield return (properties[nameof(AppSettings.RecentReposComboMinWidth)], 0, false, false);
                 yield return (properties[nameof(AppSettings.SerializedHotkeys)], null, true, false);
-                yield return (properties[nameof(AppSettings.SortPinnedRepos)], false, false, false);
-                yield return (properties[nameof(AppSettings.SortAllRecentRepos)], false, false, false);
+                yield return (properties[nameof(AppSettings.SortTopRepos)], false, false, false);
+                yield return (properties[nameof(AppSettings.SortRecentRepos)], false, false, false);
                 yield return (properties[nameof(AppSettings.DontCommitMerge)], false, false, false);
                 yield return (properties[nameof(AppSettings.CommitValidationMaxCntCharsFirstLine)], 0, false, false);
                 yield return (properties[nameof(AppSettings.CommitValidationMaxCntCharsPerLine)], 0, false, false);

--- a/tests/app/UnitTests/GitCommands.Tests/UserRepositoryHistory/RecentRepoSplitterTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/UserRepositoryHistory/RecentRepoSplitterTests.cs
@@ -8,10 +8,10 @@ public class RecentRepoSplitterTests
 {
     private const string _relativeLongRepoPath = @"this\is\a\very_very_very_very_very_very_very\long\repo_path";
     private static readonly string repoPathInUserFolder = Path.Combine(Path.GetTempPath(), _relativeLongRepoPath);
-    private static readonly string repoPinnedPath1 = @"C:\this\is\a\repo_pinned_path1\";
-    private static readonly string repoPinnedPath2 = @"C:\this\is\a\repo_pinned_path2\";
-    private static readonly string repoUnpinnedPath1 = @"C:\this\is\a\repo_unpinned_path1\";
-    private static readonly string repoUnpinnedPath2 = @"C:\this\is\a\repo_unpinned_path2\";
+    private static readonly string repoAnchoredInTopPath1 = @"C:\this\is\a\repo_anchored_in_top_path1\";
+    private static readonly string repoAnchoredInTopPath2 = @"C:\this\is\a\repo_anchored_in_top_path2\";
+    private static readonly string repoAnchoredInRecentPath = @"C:\this\is\a\repo_anchored_in_recent_path\";
+    private static readonly string repoNotAnchoredPath = @"C:\this\is\a\repo_not_anchored_path\";
 
     #region Shortening strategy
     [Test]
@@ -19,20 +19,20 @@ public class RecentRepoSplitterTests
     {
         List<Repository> history =
         [
-            new Repository(repoPinnedPath1) { Anchor = Repository.RepositoryAnchor.Pinned },
+            new Repository(repoAnchoredInTopPath1) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
         ];
 
         RecentRepoSplitter sut = new();
 
         sut.ShorteningStrategy = GitCommands.ShorteningRecentRepoPathStrategy.MostSignDir;
-        List<RecentRepoInfo> pinnedRepoList = new();
-        List<RecentRepoInfo> allRecentRepoList = new();
+        List<RecentRepoInfo> topRepoList = new();
+        List<RecentRepoInfo> recentRepoList = new();
 
-        sut.SplitRecentRepos(history, pinnedRepoList, allRecentRepoList);
+        sut.SplitRecentRepos(history, topRepoList, recentRepoList);
 
-        pinnedRepoList.Count.Should().Be(1);
-        pinnedRepoList[0].Caption.Should().Be("repo_pinned_path1");
-        allRecentRepoList.Count.Should().Be(1);
+        topRepoList.Count.Should().Be(1);
+        topRepoList[0].Caption.Should().Be("repo_anchored_in_top_path1");
+        recentRepoList.Count.Should().Be(1);
     }
 
     [Test]
@@ -40,20 +40,20 @@ public class RecentRepoSplitterTests
     {
         List<Repository> history =
         [
-            new Repository(repoPinnedPath1) { Anchor = Repository.RepositoryAnchor.Pinned },
+            new Repository(repoAnchoredInTopPath1) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
         ];
 
         RecentRepoSplitter sut = new();
 
         sut.ShorteningStrategy = GitCommands.ShorteningRecentRepoPathStrategy.None;
-        List<RecentRepoInfo> pinnedRepoList = new();
-        List<RecentRepoInfo> allRecentRepoList = new();
+        List<RecentRepoInfo> topRepoList = new();
+        List<RecentRepoInfo> recentRepoList = new();
 
-        sut.SplitRecentRepos(history, pinnedRepoList, allRecentRepoList);
+        sut.SplitRecentRepos(history, topRepoList, recentRepoList);
 
-        pinnedRepoList.Count.Should().Be(1);
-        pinnedRepoList[0].Caption.Should().Be(repoPinnedPath1);
-        allRecentRepoList.Count.Should().Be(1);
+        topRepoList.Count.Should().Be(1);
+        topRepoList[0].Caption.Should().Be(repoAnchoredInTopPath1);
+        recentRepoList.Count.Should().Be(1);
     }
 
     [Test]
@@ -61,20 +61,20 @@ public class RecentRepoSplitterTests
     {
         List<Repository> history =
         [
-            new Repository(repoPathInUserFolder) { Anchor = Repository.RepositoryAnchor.Pinned },
+            new Repository(repoPathInUserFolder) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
         ];
 
         RecentRepoSplitter sut = new();
 
         sut.ShorteningStrategy = GitCommands.ShorteningRecentRepoPathStrategy.None;
-        List<RecentRepoInfo> pinnedRepoList = new();
-        List<RecentRepoInfo> allRecentRepoList = new();
+        List<RecentRepoInfo> topRepoList = new();
+        List<RecentRepoInfo> recentRepoList = new();
 
-        sut.SplitRecentRepos(history, pinnedRepoList, allRecentRepoList);
+        sut.SplitRecentRepos(history, topRepoList, recentRepoList);
 
-        pinnedRepoList.Count.Should().Be(1);
-        pinnedRepoList[0].Caption.Should().StartWith(@"~\AppData").And.EndWith(_relativeLongRepoPath);
-        allRecentRepoList.Count.Should().Be(1);
+        topRepoList.Count.Should().Be(1);
+        topRepoList[0].Caption.Should().StartWith(@"~\AppData").And.EndWith(_relativeLongRepoPath);
+        recentRepoList.Count.Should().Be(1);
     }
 
     [Test]
@@ -85,20 +85,20 @@ public class RecentRepoSplitterTests
 
         List<Repository> history =
         [
-            new Repository(repoPathInUserFolder) { Anchor = Repository.RepositoryAnchor.Pinned },
+            new Repository(repoPathInUserFolder) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
         ];
 
         RecentRepoSplitter sut = new();
 
         sut.ShorteningStrategy = GitCommands.ShorteningRecentRepoPathStrategy.MiddleDots;
-        List<RecentRepoInfo> pinnedRepoList = new();
-        List<RecentRepoInfo> allRecentRepoList = new();
+        List<RecentRepoInfo> topRepoList = new();
+        List<RecentRepoInfo> recentRepoList = new();
 
-        sut.SplitRecentRepos(history, pinnedRepoList, allRecentRepoList);
+        sut.SplitRecentRepos(history, topRepoList, recentRepoList);
 
-        pinnedRepoList.Count.Should().Be(1);
-        pinnedRepoList[0].Caption.Should().Be(@"~\AppData\..\long\repo_path");
-        allRecentRepoList.Count.Should().Be(1);
+        topRepoList.Count.Should().Be(1);
+        topRepoList[0].Caption.Should().Be(@"~\AppData\..\long\repo_path");
+        recentRepoList.Count.Should().Be(1);
     }
     #endregion
 
@@ -108,30 +108,30 @@ public class RecentRepoSplitterTests
     {
         List<Repository> history =
         [
-            new Repository(repoPinnedPath1) { Anchor = Repository.RepositoryAnchor.Pinned },
-            new Repository(repoPinnedPath2) { Anchor = Repository.RepositoryAnchor.Pinned },
-            new Repository(repoUnpinnedPath1) { Anchor = Repository.RepositoryAnchor.AllRecent },
-            new Repository(repoUnpinnedPath2) { Anchor = Repository.RepositoryAnchor.None },
+            new Repository(repoAnchoredInTopPath1) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
+            new Repository(repoAnchoredInTopPath2) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
+            new Repository(repoAnchoredInRecentPath) { Anchor = Repository.RepositoryAnchor.AnchoredInRecent },
+            new Repository(repoNotAnchoredPath) { Anchor = Repository.RepositoryAnchor.None },
         ];
 
         RecentRepoSplitter sut = new();
 
         sut.ShorteningStrategy = GitCommands.ShorteningRecentRepoPathStrategy.MostSignDir;
-        sut.SortPinnedRepos = false;
-        sut.SortAllRecentRepos = false;
-        List<RecentRepoInfo> pinnedRepoList = new();
-        List<RecentRepoInfo> allRecentRepoList = new();
+        sut.SortTopRepos = false;
+        sut.SortRecentRepos = false;
+        List<RecentRepoInfo> topRepoList = new();
+        List<RecentRepoInfo> recentRepoList = new();
 
-        sut.SplitRecentRepos(history, pinnedRepoList, allRecentRepoList);
+        sut.SplitRecentRepos(history, topRepoList, recentRepoList);
 
-        pinnedRepoList.Count.Should().Be(2);
-        pinnedRepoList[0].Caption.Should().Be("repo_pinned_path1");
-        pinnedRepoList[1].Caption.Should().Be("repo_pinned_path2");
-        allRecentRepoList.Count.Should().Be(4);
-        allRecentRepoList[0].Caption.Should().Be("repo_pinned_path1");
-        allRecentRepoList[1].Caption.Should().Be("repo_pinned_path2");
-        allRecentRepoList[2].Caption.Should().Be("repo_unpinned_path1");
-        allRecentRepoList[3].Caption.Should().Be("repo_unpinned_path2");
+        topRepoList.Count.Should().Be(2);
+        topRepoList[0].Caption.Should().Be("repo_anchored_in_top_path1");
+        topRepoList[1].Caption.Should().Be("repo_anchored_in_top_path2");
+        recentRepoList.Count.Should().Be(4);
+        recentRepoList[0].Caption.Should().Be("repo_anchored_in_top_path1");
+        recentRepoList[1].Caption.Should().Be("repo_anchored_in_top_path2");
+        recentRepoList[2].Caption.Should().Be("repo_anchored_in_recent_path");
+        recentRepoList[3].Caption.Should().Be("repo_not_anchored_path");
     }
 
     [Test]
@@ -140,30 +140,30 @@ public class RecentRepoSplitterTests
         List<Repository> history =
         [
             // Unsorted!
-            new Repository(repoUnpinnedPath2) { Anchor = Repository.RepositoryAnchor.None },
-            new Repository(repoUnpinnedPath1) { Anchor = Repository.RepositoryAnchor.AllRecent },
-            new Repository(repoPinnedPath2) { Anchor = Repository.RepositoryAnchor.Pinned },
-            new Repository(repoPinnedPath1) { Anchor = Repository.RepositoryAnchor.Pinned },
+            new Repository(repoNotAnchoredPath) { Anchor = Repository.RepositoryAnchor.None },
+            new Repository(repoAnchoredInRecentPath) { Anchor = Repository.RepositoryAnchor.AnchoredInRecent },
+            new Repository(repoAnchoredInTopPath2) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
+            new Repository(repoAnchoredInTopPath1) { Anchor = Repository.RepositoryAnchor.AnchoredInTop },
         ];
 
         RecentRepoSplitter sut = new();
 
         sut.ShorteningStrategy = GitCommands.ShorteningRecentRepoPathStrategy.MostSignDir;
-        sut.SortAllRecentRepos = true;
-        sut.SortPinnedRepos = true;
-        List<RecentRepoInfo> pinnedRepoList = new();
-        List<RecentRepoInfo> allRecentRepoList = new();
+        sut.SortRecentRepos = true;
+        sut.SortTopRepos = true;
+        List<RecentRepoInfo> topRepoList = new();
+        List<RecentRepoInfo> recentRepoList = new();
 
-        sut.SplitRecentRepos(history, pinnedRepoList, allRecentRepoList);
+        sut.SplitRecentRepos(history, topRepoList, recentRepoList);
 
-        pinnedRepoList.Count.Should().Be(2);
-        pinnedRepoList[0].Caption.Should().Be("repo_pinned_path1");
-        pinnedRepoList[1].Caption.Should().Be("repo_pinned_path2");
-        allRecentRepoList.Count.Should().Be(4);
-        allRecentRepoList[0].Caption.Should().Be("repo_pinned_path1");
-        allRecentRepoList[1].Caption.Should().Be("repo_pinned_path2");
-        allRecentRepoList[2].Caption.Should().Be("repo_unpinned_path1");
-        allRecentRepoList[3].Caption.Should().Be("repo_unpinned_path2");
+        topRepoList.Count.Should().Be(2);
+        topRepoList[0].Caption.Should().Be("repo_anchored_in_top_path1");
+        topRepoList[1].Caption.Should().Be("repo_anchored_in_top_path2");
+        recentRepoList.Count.Should().Be(4);
+        recentRepoList[0].Caption.Should().Be("repo_anchored_in_recent_path");
+        recentRepoList[1].Caption.Should().Be("repo_anchored_in_top_path1");
+        recentRepoList[2].Caption.Should().Be("repo_anchored_in_top_path2");
+        recentRepoList[3].Caption.Should().Be("repo_not_anchored_path");
     }
     #endregion
 }

--- a/tests/app/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
@@ -53,11 +53,11 @@ namespace GitCommandsTests.UserRepositoryHistory
                 new Repository(@"C:\Development\gitextensions\"),
                 new Repository(@"C:\Development\gitextensions\Externals\NBug\")
                 {
-                    Anchor = Repository.RepositoryAnchor.Pinned,
+                    Anchor = Repository.RepositoryAnchor.AnchoredInTop,
                 },
                 new Repository(@"C:\Development\gitextensions\GitExtensionsDoc\")
                 {
-                    Anchor = Repository.RepositoryAnchor.AllRecent,
+                    Anchor = Repository.RepositoryAnchor.AnchoredInRecent,
                 }
 
             ];

--- a/tests/app/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryXmlSerialiserTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryXmlSerialiserTests.cs
@@ -106,11 +106,11 @@ namespace GitCommandsTests.UserRepositoryHistory
                 new Repository(@"C:\Development\gitextensions\"),
                 new Repository(@"C:\Development\gitextensions\Externals\NBug\")
                 {
-                    Anchor = Repository.RepositoryAnchor.Pinned,
+                    Anchor = Repository.RepositoryAnchor.AnchoredInTop,
                 },
                 new Repository(@"C:\Development\gitextensions\GitExtensionsDoc\")
                 {
-                    Anchor = Repository.RepositoryAnchor.AllRecent,
+                    Anchor = Repository.RepositoryAnchor.AnchoredInRecent,
                 }
 
             ];


### PR DESCRIPTION
between "Top", "Recent" and "Anchored" repositories

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Also:
* inverted the 2 top settings to be in the same order than list it is referring to.
* used similar label as 2 settings are referring the the same behavior for top and recent lists..

Discussed [here](https://github.com/gitextensions/gitextensions/pull/11779#issuecomment-2164942593)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/23f8e588-c563-4d23-bc42-b7e1f00f1592)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/a1a640b5-c36d-4c9b-a961-81e1e5d44b14)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
