### PR TITLE
fix(DiffMergeTools): path for diff/merge command

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -209,3 +209,4 @@ YYYY/MM/DD, github id, Full name, email
 2024/03/14, rstm-sf, Rustam rstm.sf(at)gmail.com
 2024/03/24, berrs, Per-Erik Stendahl, pererik.stendahl@gmail.com
 2024/05/27, redcatH, Yi Liu, i.hao.lin[at}outlook.com
+2024/06/17, astos-marcb, Marc Becker, marc.becker@astos.de

--- a/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
+++ b/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
@@ -159,8 +159,23 @@ namespace GitCommands.DiffMergeTools
             }
             else
             {
-                IEnumerable<string> pathsToSearch = new[] { UnquoteString(GetToolSetting(diffTool.Name, DiffMergeToolType.Merge, "path")) }.Union(diffTool.SearchPaths);
-                fullPath = _findFileInFolders(diffTool.ExeFileName, pathsToSearch);
+                // query static settings for defined fullPath to executable
+                string? command = UnquoteString(GetToolSetting(diffTool.Name, DiffMergeToolType.Merge, "path"));
+                if (!string.IsNullOrWhiteSpace(command))
+                {
+                    fullPath = command;
+                }
+                else
+                {
+                    // look for executable in (default) search paths
+                    fullPath = _findFileInFolders(diffTool.ExeFileName, diffTool.SearchPaths);
+                }
+            }
+
+            // last resort fallback to avoid empty string for executable
+            if (string.IsNullOrWhiteSpace(fullPath))
+            {
+                fullPath = diffTool.ExeFileName;
             }
 
             return new DiffMergeToolConfiguration(diffTool.ExeFileName, fullPath, diffTool.DiffCommand, diffTool.MergeCommand);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11741

## Proposed changes

- treat `difftool.<tool>.path` as (absolute) executable path (see [difftool doc](https://git-scm.com/docs/git-difftool#Documentation/git-difftool.txt---toollttoolgt))
- add last resort fallback to avoid empty string as command path

## Test methodology <!-- How did you ensure quality? -->

- Verify the _empty path_ mentioned in #11741 is now set correctly

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.45.2.windows.1
- Windows 10.0.19045.4529

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](/gitextensions/gitextensions/blob/master/contributors.txt).
