### PR TITLE
fix(scripts): Do not quote {SelectedRelativePaths}

### DIFF
--- a/src/app/GitCommands/StringExtensions.cs
+++ b/src/app/GitCommands/StringExtensions.cs
@@ -191,12 +191,12 @@ namespace System
         }
 
         /// <summary>
-        /// Quotes and escapes this string for use as a command line argument.
+        ///  Escapes this string for use as a command line argument.
         /// </summary>
         [Pure]
-        public static string QuoteForCommandLine(this string s, bool? forWindows = null)
+        public static string EscapeForCommandLine(this string s, bool? forWindows = null)
         {
-            return $"\"{((forWindows ?? EnvUtils.RunningOnWindows()) ? EscapeForWindowsCommandLine(s) : EscapeForPosixCommandLine(s))}\"";
+            return (forWindows ?? EnvUtils.RunningOnWindows()) ? EscapeForWindowsCommandLine(s) : EscapeForPosixCommandLine(s);
 
             static string EscapeForWindowsCommandLine(string s) => s.Replace("\"", "\"\"");
             static string EscapeForPosixCommandLine(string s) => s.Replace(@"\", @"\\").Replace("\"", "\\\"").Replace("'", @"\'");

--- a/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
+++ b/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
@@ -24,14 +24,14 @@ internal class ScriptOptionsProvider : IScriptOptionsProvider
 
     IReadOnlyList<string> IScriptOptionsProvider.Options { get; } = new[] { _selectedRelativePaths, _lineNumber };
 
-    string? IScriptOptionsProvider.GetValue(string option)
+    IEnumerable<string> IScriptOptionsProvider.GetValue(string option)
     {
         switch (option)
         {
             case _selectedRelativePaths:
-                return string.Join(" ", _getSelectedRelativePaths().Select(item => item.EscapeForCommandLine()));
+                return _getSelectedRelativePaths().Select(item => item.EscapeForCommandLine());
             case _lineNumber:
-                return _getCurrentLineNumber()?.ToString() ?? "";
+                return _getCurrentLineNumber() is int lineNumber ? [lineNumber.ToString()] : [];
             default:
                 throw new NotImplementedException(option);
         }

--- a/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
+++ b/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
@@ -24,7 +24,7 @@ internal class ScriptOptionsProvider : IScriptOptionsProvider
 
     IReadOnlyList<string> IScriptOptionsProvider.Options { get; } = new[] { _selectedRelativePaths, _lineNumber };
 
-    IEnumerable<string> IScriptOptionsProvider.GetValue(string option)
+    IEnumerable<string> IScriptOptionsProvider.GetValues(string option)
     {
         switch (option)
         {

--- a/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
+++ b/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
@@ -29,7 +29,7 @@ internal class ScriptOptionsProvider : IScriptOptionsProvider
         switch (option)
         {
             case _selectedRelativePaths:
-                return string.Join(" ", _getSelectedRelativePaths().Select(item => item.QuoteForCommandLine()));
+                return string.Join(" ", _getSelectedRelativePaths().Select(item => item.EscapeForCommandLine()));
             case _lineNumber:
                 return _getCurrentLineNumber()?.ToString() ?? "";
             default:

--- a/src/app/GitUI/ScriptsEngine/IScriptOptionsProvider.cs
+++ b/src/app/GitUI/ScriptsEngine/IScriptOptionsProvider.cs
@@ -11,6 +11,6 @@ public interface IScriptOptionsProvider
     ///  Retrieves the information for placeholders in script arguments.
     /// </summary>
     /// <param name="option">The option identifier which is to be replaced.</param>
-    /// <returns>The value to be used for the script argument.</returns>
-    string? GetValue(string option);
+    /// <returns>The value(s) to be used for the script argument.</returns>
+    IEnumerable<string> GetValue(string option);
 }

--- a/src/app/GitUI/ScriptsEngine/IScriptOptionsProvider.cs
+++ b/src/app/GitUI/ScriptsEngine/IScriptOptionsProvider.cs
@@ -12,5 +12,5 @@ public interface IScriptOptionsProvider
     /// </summary>
     /// <param name="option">The option identifier which is to be replaced.</param>
     /// <returns>The value(s) to be used for the script argument.</returns>
-    IEnumerable<string> GetValue(string option);
+    IEnumerable<string> GetValues(string option);
 }

--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
@@ -478,7 +478,7 @@ namespace GitUI.ScriptsEngine
                     break;
 
                 default:
-                    newStrings = scriptOptionsProvider?.GetValue(option);
+                    newStrings = scriptOptionsProvider?.GetValues(option);
                     break;
             }
 

--- a/src/app/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -65,8 +65,8 @@ namespace GitUI.ScriptsEngine
                             return (arguments: null, abort: false, cancel: true);
                         }
 
-                        arguments = ScriptOptionsParser.ReplaceOption($"UserInput:{label}", arguments, prompt.UserInput);
-                        arguments = ScriptOptionsParser.ReplaceOption(match.Value.Substring(1, match.Value.Length - 2), arguments, prompt.UserInput);
+                        arguments = ScriptOptionsParser.ReplaceOption($"UserInput:{label}", arguments, [prompt.UserInput]);
+                        arguments = ScriptOptionsParser.ReplaceOption(match.Value.Substring(1, match.Value.Length - 2), arguments, [prompt.UserInput]);
                     }
                 }
 
@@ -81,7 +81,7 @@ namespace GitUI.ScriptsEngine
                             return (arguments: null, abort: false, cancel: true);
                         }
 
-                        arguments = ScriptOptionsParser.ReplaceOption(userInput, arguments, prompt.UserInput);
+                        arguments = ScriptOptionsParser.ReplaceOption(userInput, arguments, [prompt.UserInput]);
                     }
                 }
 
@@ -94,7 +94,7 @@ namespace GitUI.ScriptsEngine
                             return (arguments: null, abort: false, cancel: true);
                         }
 
-                        arguments = ScriptOptionsParser.ReplaceOption(userFiles, arguments, prompt.UserInput);
+                        arguments = ScriptOptionsParser.ReplaceOption(userFiles, arguments, [prompt.UserInput]);
                     }
                 }
 

--- a/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
@@ -131,22 +131,22 @@
             Assert.AreEqual(expected, str.SubstringAfterLast(s));
         }
 
-        [TestCase("/usr/bin", false, "\"/usr/bin\"")]
-        [TestCase("/usr/bin", true, "\"/usr/bin\"")]
-        [TestCase("\\usr\\bin", false, "\"\\\\usr\\\\bin\"")]
-        [TestCase("\\usr\\bin", true, "\"\\usr\\bin\"")]
-        [TestCase("C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\setup.exe", true, "\"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\setup.exe\"")]
-        [TestCase("echo \"Hello world\"", false, "\"echo \\\"Hello world\\\"\"")]
-        [TestCase("echo \"Hello world\"", true, "\"echo \"\"Hello world\"\"\"")]
-        [TestCase("echo \'Hello world\'", false, "\"echo \\\'Hello world\\\'\"")]
-        [TestCase("echo \'Hello world\'", true, "\"echo \'Hello world\'\"")]
-        [TestCase("cmd /c \"echo \\\"Hello world\\\"\"", false, "\"cmd /c \\\"echo \\\\\\\"Hello world\\\\\\\"\\\"\"")]
-        [TestCase("cmd /c \"echo \\\"Hello world\\\"\"", true, "\"cmd /c \"\"echo \\\"\"Hello world\\\"\"\"\"\"")]
-        [TestCase("cmd /c \"echo \"\"Hello world\"\"\"", false, "\"cmd /c \\\"echo \\\"\\\"Hello world\\\"\\\"\\\"\"")]
-        [TestCase("cmd /c \"echo \"\"Hello world\"\"\"", true, "\"cmd /c \"\"echo \"\"\"\"Hello world\"\"\"\"\"\"\"")]
+        [TestCase("/usr/bin", false, "/usr/bin")]
+        [TestCase("/usr/bin", true, "/usr/bin")]
+        [TestCase("\\usr\\bin", false, "\\\\usr\\\\bin")]
+        [TestCase("\\usr\\bin", true, "\\usr\\bin")]
+        [TestCase("C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\setup.exe", true, "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\setup.exe")]
+        [TestCase("echo \"Hello world\"", false, "echo \\\"Hello world\\\"")]
+        [TestCase("echo \"Hello world\"", true, "echo \"\"Hello world\"\"")]
+        [TestCase("echo \'Hello world\'", false, "echo \\\'Hello world\\\'")]
+        [TestCase("echo \'Hello world\'", true, "echo \'Hello world\'")]
+        [TestCase("cmd /c \"echo \\\"Hello world\\\"\"", false, "cmd /c \\\"echo \\\\\\\"Hello world\\\\\\\"\\\"")]
+        [TestCase("cmd /c \"echo \\\"Hello world\\\"\"", true, "cmd /c \"\"echo \\\"\"Hello world\\\"\"\"\"")]
+        [TestCase("cmd /c \"echo \"\"Hello world\"\"\"", false, "cmd /c \\\"echo \\\"\\\"Hello world\\\"\\\"\\\"")]
+        [TestCase("cmd /c \"echo \"\"Hello world\"\"\"", true, "cmd /c \"\"echo \"\"\"\"Hello world\"\"\"\"\"\"")]
         public void QuoteForCommandLine_works_as_expected(string s, bool forWindows, string expected)
         {
-            Assert.AreEqual(expected, s.QuoteForCommandLine(forWindows));
+            Assert.AreEqual(expected, s.EscapeForCommandLine(forWindows));
         }
     }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
@@ -144,7 +144,7 @@
         [TestCase("cmd /c \"echo \\\"Hello world\\\"\"", true, "cmd /c \"\"echo \\\"\"Hello world\\\"\"\"\"")]
         [TestCase("cmd /c \"echo \"\"Hello world\"\"\"", false, "cmd /c \\\"echo \\\"\\\"Hello world\\\"\\\"\\\"")]
         [TestCase("cmd /c \"echo \"\"Hello world\"\"\"", true, "cmd /c \"\"echo \"\"\"\"Hello world\"\"\"\"\"\"")]
-        public void QuoteForCommandLine_works_as_expected(string s, bool forWindows, string expected)
+        public void EscapeForCommandLine_works_as_expected(string s, bool forWindows, string expected)
         {
             Assert.AreEqual(expected, s.EscapeForCommandLine(forWindows));
         }

--- a/tests/app/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -418,15 +418,16 @@ namespace GitUITests.Script
         {
             const string option1 = nameof(option1);
             const string option2 = nameof(option2);
-            const string value1 = nameof(value1);
+            const string value1a = nameof(value1a);
+            const string value1b = nameof(value1b);
             const string value2 = nameof(value2);
             _scriptOptionsProvider.Options.Returns(new string[] { option1, option2 });
-            _scriptOptionsProvider.GetValue(option1).Returns(value1);
-            _scriptOptionsProvider.GetValue(option2).Returns(value2);
+            _scriptOptionsProvider.GetValue(option1).Returns([value1a, value1b]);
+            _scriptOptionsProvider.GetValue(option2).Returns([value2]);
 
             (string? arguments, bool abort) = ScriptOptionsParser.Parse("foo {{" + option1 + "}} bar {" + option2 + "}", Substitute.For<IGitUICommands>(), owner: null, _scriptOptionsProvider);
 
-            arguments.Should().Be($"foo \"{value1}\" bar {value2}");
+            arguments.Should().Be($"foo \"{value1a}\" \"{value1b}\" bar {value2}");
             abort.Should().BeFalse();
         }
     }

--- a/tests/app/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -422,8 +422,8 @@ namespace GitUITests.Script
             const string value1b = nameof(value1b);
             const string value2 = nameof(value2);
             _scriptOptionsProvider.Options.Returns(new string[] { option1, option2 });
-            _scriptOptionsProvider.GetValue(option1).Returns([value1a, value1b]);
-            _scriptOptionsProvider.GetValue(option2).Returns([value2]);
+            _scriptOptionsProvider.GetValues(option1).Returns([value1a, value1b]);
+            _scriptOptionsProvider.GetValues(option2).Returns([value2]);
 
             (string? arguments, bool abort) = ScriptOptionsParser.Parse("foo {{" + option1 + "}} bar {" + option2 + "}", Substitute.For<IGitUICommands>(), owner: null, _scriptOptionsProvider);
 


### PR DESCRIPTION
Fixes #11794

## Proposed changes

- fix(scripts): Do not quote `{SelectedRelativePaths}`
- fix(scripts): Support multiple values in `IScriptOptionsProvider`
  each value quoted for `{{SelectedRelativePaths}}`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- extended test

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).