### PR TITLE
fix(sidepanel): Await reload before updating visibility

### DIFF
--- a/src/app/GitUI/LeftPanel/BaseRevisionTree.cs
+++ b/src/app/GitUI/LeftPanel/BaseRevisionTree.cs
@@ -30,13 +30,15 @@ namespace GitUI.LeftPanel
         {
             TreeView treeView = TreeViewNode.TreeView;
 
-            if (treeView is null || !IsAttached || IsLoading)
+            if (treeView is null || !IsAttached)
             {
                 return;
             }
 
             _updateTaskRunner.RunDetached(async cancellationToken =>
             {
+                await LoadingCompleted.Task;
+
                 await treeView.SwitchToMainThreadAsync(cancellationToken);
 
                 // Check again after switch to main thread

--- a/src/app/GitUI/LeftPanel/Tree.cs
+++ b/src/app/GitUI/LeftPanel/Tree.cs
@@ -10,7 +10,7 @@ namespace GitUI.LeftPanel
         private readonly IGitUICommandsSource _uiCommandsSource;
         private readonly ExclusiveTaskRunner _reloadTaskRunner = ThreadHelper.CreateExclusiveTaskRunner();
         private bool _firstReloadNodesSinceModuleChanged = true;
-        protected bool IsLoading { get; private set; }
+        protected TaskCompletionSource LoadingCompleted = new();
 
         protected Tree(TreeNode treeNode, IGitUICommandsSource uiCommands)
         {
@@ -49,6 +49,10 @@ namespace GitUI.LeftPanel
         /// </summary>
         public bool IgnoreSelectionChangedEvent { get; set; }
         protected IGitModule Module => UICommands.Module;
+
+        /// <summary>
+        /// Flag if this tree is enabled or invisible.
+        /// </summary>
         protected bool IsAttached { get; private set; }
 
         public void Attached()
@@ -102,7 +106,7 @@ namespace GitUI.LeftPanel
 
                 try
                 {
-                    IsLoading = true;
+                    LoadingCompleted = new();
 
                     // Module is invalid in Dashboard
                     Nodes newNodes = Module.IsValidGitWorkingDir() ? await loadNodesTask(cancellationToken, getRefs) : new(tree: null);
@@ -150,7 +154,7 @@ namespace GitUI.LeftPanel
                 }
                 finally
                 {
-                    IsLoading = false;
+                    LoadingCompleted.TrySetResult();
                 }
             });
         }


### PR DESCRIPTION
Fixes #11796 

## Proposed changes

UpdateVisibility() (started when the grid is loaded) must run after all objects in the sidepanel is loaded.
Previously there could be a race condition, especially when reloading with "current branch only" filter.

An alternative could be to use SlimSemaphore.

Did a quick check for similar uses as in RevisionGrid, TaskCompletionSource is used in Executable.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
