### PR TITLE
Improve sorting in quick git ref selector dialog

### DIFF
--- a/src/app/GitExtensions.Extensibility/Git/IGitRef.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitRef.cs
@@ -11,15 +11,30 @@ public interface IGitRef : INamedGitItem
     bool IsStash { get; }
 
     /// <summary>
-    /// True when Guid is a checksum of an object (e.g. commit) to which another object
-    /// with Name (e.g. annotated tag) is applied.
-    /// <para>False when Name and Guid are denoting the same object.</para>
+    ///  Indicates whether it is a checksum of an object (e.g., commit) to which another object
+    ///  with <c>name</c> (e.g. annotated tag) is applied.
     /// </summary>
+    /// <value>
+    ///  <see langword="true"/> if it is a checksum of an object to which another object with <c>name</c> is applied;
+    ///  <see langword="false"/> when <c>name</c> and <c>guid</c> are denoting the same object.
+    /// </value>
     bool IsDereference { get; }
 
+    /// <summary>
+    ///  Indicates whether the ref is a local, i.e., it is a <c>refs/heads/xyz</c>.
+    /// </summary>
     bool IsHead { get; }
+
+    /// <summary>
+    ///  Indicates whether the ref is a remote, i.e., it is a <c>refs/remotes/origin/xyz</c>.
+    /// </summary>
     bool IsRemote { get; }
+
+    /// <summary>
+    ///  Indicates whether the ref is a tag, i.e., it is a <c>refs/tags/xyz</c>.
+    /// </summary>
     bool IsTag { get; }
+
     string LocalName { get; }
     string MergeWith { get; set; }
     IGitModule Module { get; }

--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
@@ -174,7 +174,7 @@ namespace GitUI.ScriptsEngine
 
             using FormQuickGitRefSelector f = new();
             f.Location = uiCommands.BrowseRepo?.GetQuickItemSelectorLocation() ?? new Point();
-            f.Init(FormQuickGitRefSelector.Action.Select, items);
+            f.Init(FormQuickGitRefSelector.QuickAction.Select, items);
             f.ShowDialog(owner);
             return f.SelectedRef?.Name ?? "";
         }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6011,6 +6011,14 @@ Would you like to do it now?</source>
         <source>Select</source>
         <target />
       </trans-unit>
+      <trans-unit id="_local.Text">
+        <source>local</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_remote.Text">
+        <source>remote</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_tag.Text">
         <source>tag</source>
         <target />

--- a/src/app/GitUI/UserControls/RevisionGrid/FormQuickItemSelector.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FormQuickItemSelector.cs
@@ -1,6 +1,6 @@
 ﻿namespace GitUI.UserControls.RevisionGrid
 {
-    public partial class FormQuickItemSelector : GitExtensionsForm
+    internal partial class FormQuickItemSelector : GitExtensionsForm
     {
         private const short MaxVisibleItemsWithoutScroll = 8;
         private const short MaxRefLength = 100;
@@ -18,12 +18,12 @@
         /// </summary>
         public object? SelectedItem => (lbxRefs.SelectedItem as ItemData)?.Item;
 
-        protected void Init(IReadOnlyList<ItemData> items, string buttonText)
+        protected void Init(IReadOnlyList<ItemData> items, string buttonText, int selectedIndex = 0)
         {
             btnAction.Text = buttonText;
 
             lbxRefs.Items.Clear();
-            if (items?.Count is not > 0)
+            if (items.Count == 0)
             {
                 DialogResult = DialogResult.Cancel;
                 Close();
@@ -49,18 +49,27 @@
             }
             finally
             {
-                // what is this magic number "MaxVisibleItemsWithoutScroll + 0.5"?
-                // we are limiting number of visible items in the listbox before enabling vscroll, this is to reduce the risk of not fitting on user's screen.
-                // when listbox.IntegralHeight=true, the listbox automatically calculates its size and only show full items (i.e. you can't render it
+                // What is this magic number "MaxVisibleItemsWithoutScroll + 0.5"?
+                //
+                // We are limiting number of visible items in the listbox before enabling vscroll, this is to reduce the risk of not fitting on user's screen.
+                // When listbox.IntegralHeight=true, the listbox automatically calculates its size and only show full items (i.e. you can't render it
                 // at 20px high if the ItemHeight=13px, it can only be 13, 26, 39 etc (NB: slightly more if you account for the furniture)).
                 // listbox.PreferredHeight returns the height of the listbox showing all items.
-                // for some strange reason, MaxVisibleItemsWithoutScroll*listbox.ItemHeight renders the listbox showing MaxVisibleItemsWithoutScroll-1 items.
-                // to fix this, trick the listbox and set its height to show MaxVisibleItemsWithoutScroll+0.5
-                // this internally forces it to re-calculates its bounds and then to calculate its preferred height
+                //
+                // For some strange reason, MaxVisibleItemsWithoutScroll*listbox.ItemHeight renders the listbox showing MaxVisibleItemsWithoutScroll-1 items.
+                //
+                // To fix this, trick the listbox and set its height to show MaxVisibleItemsWithoutScroll+0.5
+                // this internally forces it to re-calculates its bounds and then to calculate its preferred height.
+
                 lbxRefs.Height = Math.Min(lbxRefs.PreferredHeight, (int)((MaxVisibleItemsWithoutScroll + 0.5) * lbxRefs.ItemHeight));
                 lbxRefs.Width = (int)longestItemWidth;
                 lbxRefs.EndUpdate();
-                lbxRefs.SelectedIndex = 0;
+
+                if (selectedIndex >= 0 && selectedIndex < lbxRefs.Items.Count)
+                {
+                    lbxRefs.SelectedIndex = selectedIndex;
+                }
+
                 lbxRefs.Focus();
 
                 // resize the form to look nice
@@ -86,7 +95,7 @@
             AcceptButton.PerformClick();
         }
 
-        public class ItemData
+        internal sealed class ItemData
         {
             public string Label { get; }
             public object Item { get; }

--- a/src/app/GitUI/UserControls/RevisionGrid/FormQuickStringSelector.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FormQuickStringSelector.cs
@@ -2,12 +2,12 @@
 
 namespace GitUI.UserControls.RevisionGrid
 {
-    public class FormQuickStringSelector : FormQuickItemSelector
+    internal class FormQuickStringSelector : FormQuickItemSelector
     {
         private readonly TranslationString _actionSelect = new("Select");
 
         /// <summary>
-        /// Gets the string selected by the user.
+        ///  Gets the string selected by the user.
         /// </summary>
         public string? SelectedString => SelectedItem as string;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -417,7 +417,7 @@ namespace GitUI
             PerformRefreshRevisions();
         }
 
-        private void InitiateRefAction(IReadOnlyList<IGitRef>? gitRefs, Action<IGitRef> action, FormQuickGitRefSelector.Action actionLabel)
+        private void InitiateRefAction(IReadOnlyList<IGitRef>? gitRefs, Action<IGitRef> action, FormQuickGitRefSelector.QuickAction actionLabel)
         {
             if (gitRefs?.Count is not > 0)
             {
@@ -1696,7 +1696,7 @@ namespace GitUI
             InitiateRefAction(
                 new GitRefListsForRevision(selectedRevision).GetRenameableLocalBranches(),
                 gitRef => UICommands.StartRenameDialog(ParentForm, gitRef.Name),
-                FormQuickGitRefSelector.Action.Rename);
+                FormQuickGitRefSelector.QuickAction.Rename);
         }
 
         private void DeleteRef()
@@ -1724,7 +1724,7 @@ namespace GitUI
                         UICommands.StartDeleteBranchDialog(ParentForm, gitRef.Name);
                     }
                 },
-                FormQuickGitRefSelector.Action.Delete);
+                FormQuickGitRefSelector.QuickAction.Delete);
         }
 
         private void OnGridViewMouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION



## Proposed changes

- Sort refs in the following order: local/remote/tags. Then sort by local ref name within each group.
- Add group separators for ease management.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/4403806/e436a2b3-f2d8-423e-a727-6d9d9715c4dc)
![image](https://github.com/gitextensions/gitextensions/assets/4403806/2516d960-8745-4c71-969d-9fb99e3a9250)

### After

![image](https://github.com/gitextensions/gitextensions/assets/4403806/ec1e94c4-7321-46d4-a008-4318846aeeae)
![image](https://github.com/gitextensions/gitextensions/assets/4403806/448cb92b-0c1d-42ec-bc7c-58e990b072ec)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
