### PR TITLE
Improve Quick Search keyboard interaction

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -99,20 +99,6 @@ namespace GitUI
             }
         }
 
-        public void OnKeyDown(KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Up && _quickSearchString != "")
-            {
-                e.Handled = true;
-                NextResult(down: false);
-            }
-            else if (e.KeyCode == Keys.Down && _quickSearchString != "")
-            {
-                e.Handled = true;
-                NextResult(down: true);
-            }
-        }
-
         public void NextResult(bool down)
         {
             int curIndex = -1;

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -60,6 +60,12 @@ namespace GitUI
                 // backspace
                 UpdateQuickSearchString(_quickSearchString[..^1]);
             }
+            else if (e.KeyChar == 22 && Control.ModifierKeys == Keys.Control && Clipboard.ContainsText())
+            {
+                // paste
+                string text = Clipboard.GetText();
+                UpdateQuickSearchString(string.Concat(_quickSearchString, text));
+            }
             else if (!char.IsControl(e.KeyChar))
             {
                 // The code below is meant to fix the weird key values when pressing keys e.g. ".".

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -49,6 +49,9 @@ namespace GitUI
 
         public void OnKeyPress(KeyPressEventArgs e)
         {
+            // SYN char is issued when pasting
+            const char SynChar = (char)22;
+
             int curIndex = _gridView.SelectedRows.Count > 0
                 ? _gridView.SelectedRows[0].Index
                 : -1;
@@ -60,7 +63,7 @@ namespace GitUI
                 // backspace
                 UpdateQuickSearchString(_quickSearchString[..^1]);
             }
-            else if (e.KeyChar == 22 && Control.ModifierKeys == Keys.Control && Clipboard.ContainsText())
+            else if (Control.ModifierKeys == Keys.Control && e.KeyChar == SynChar && Clipboard.ContainsText())
             {
                 // paste
                 string text = Clipboard.GetText();
@@ -76,6 +79,8 @@ namespace GitUI
                 HideQuickSearchString();
                 e.Handled = false;
             }
+
+            return;
 
             void UpdateQuickSearchString(string newValue)
             {

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -41,7 +41,6 @@ namespace GitUI
             _quickSearchTimer.Tick += (sender, e) =>
             {
                 _quickSearchTimer.Stop();
-                _quickSearchString = "";
                 HideQuickSearchString();
             };
 
@@ -84,7 +83,6 @@ namespace GitUI
             }
             else
             {
-                _quickSearchString = "";
                 HideQuickSearchString();
                 e.Handled = false;
             }
@@ -122,6 +120,7 @@ namespace GitUI
 
         private void HideQuickSearchString()
         {
+            _quickSearchString = "";
             _label.Visible = false;
         }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -55,36 +55,33 @@ namespace GitUI
 
             curIndex = curIndex >= 0 ? curIndex : 0;
 
-            if (e.KeyChar == 8 && _quickSearchString.Length > 1)
+            if (e.KeyChar == (char)Keys.Back && _quickSearchString.Length > 1)
             {
                 // backspace
-                RestartQuickSearchTimer();
-
-                _quickSearchString = _quickSearchString[..^1];
-
-                FindNextMatch(curIndex, _quickSearchString, false);
-                _lastQuickSearchString = _quickSearchString;
-
-                e.Handled = true;
-                ShowQuickSearchString();
+                UpdateQuickSearchString(_quickSearchString[..^1]);
             }
             else if (!char.IsControl(e.KeyChar))
             {
-                RestartQuickSearchTimer();
-
                 // The code below is meant to fix the weird key values when pressing keys e.g. ".".
-                _quickSearchString = string.Concat(_quickSearchString, char.ToLower(e.KeyChar));
-
-                FindNextMatch(curIndex, _quickSearchString, false);
-                _lastQuickSearchString = _quickSearchString;
-
-                e.Handled = true;
-                ShowQuickSearchString();
+                UpdateQuickSearchString(string.Concat(_quickSearchString, char.ToLower(e.KeyChar)));
             }
             else
             {
                 HideQuickSearchString();
                 e.Handled = false;
+            }
+
+            void UpdateQuickSearchString(string newValue)
+            {
+                RestartQuickSearchTimer();
+
+                _quickSearchString = newValue;
+
+                FindNextMatch(curIndex, _quickSearchString, false);
+                _lastQuickSearchString = _quickSearchString;
+
+                e.Handled = true;
+                ShowQuickSearchString();
             }
         }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -99,6 +99,20 @@ namespace GitUI
             }
         }
 
+        public void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Up && _quickSearchString != "")
+            {
+                e.Handled = true;
+                NextResult(down: false);
+            }
+            else if (e.KeyCode == Keys.Down && _quickSearchString != "")
+            {
+                e.Handled = true;
+                NextResult(down: true);
+            }
+        }
+
         public void NextResult(bool down)
         {
             int curIndex = -1;

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -88,6 +88,14 @@ namespace GitUI
             }
         }
 
+        public void OnPreviewKeyDown(PreviewKeyDownEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape)
+            {
+                HideQuickSearchString();
+            }
+        }
+
         public void NextResult(bool down)
         {
             int curIndex = -1;

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -49,8 +49,8 @@ namespace GitUI
 
         public void OnKeyPress(KeyPressEventArgs e)
         {
-            // SYN char is issued when pasting
-            const char SynChar = (char)22;
+            // Ctrl+A to Ctrl+Z have codes 1..26 with Ctrl+V being 22
+            const char ctrlVChar = (char)('V' - 'A' + 1);
 
             int curIndex = _gridView.SelectedRows.Count > 0
                 ? _gridView.SelectedRows[0].Index
@@ -63,7 +63,7 @@ namespace GitUI
                 // backspace
                 UpdateQuickSearchString(_quickSearchString[..^1]);
             }
-            else if (Control.ModifierKeys == Keys.Control && e.KeyChar == SynChar && Clipboard.ContainsText())
+            else if (Control.ModifierKeys == Keys.Control && e.KeyChar == ctrlVChar && Clipboard.ContainsText())
             {
                 // paste
                 string text = Clipboard.GetText();

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -231,6 +231,7 @@ namespace GitUI
             _gridView.AuthorHighlighting = _authorHighlighting;
 
             _gridView.PreviewKeyDown += (_, e) => _quickSearchProvider.OnPreviewKeyDown(e);
+            _gridView.KeyDown += (_, e) => _quickSearchProvider.OnKeyDown(e);
             _gridView.KeyPress += (_, e) => _quickSearchProvider.OnKeyPress(e);
             _gridView.MouseDown += OnGridViewMouseDown;
             _gridView.CellMouseDown += OnGridViewCellMouseDown;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -230,6 +230,7 @@ namespace GitUI
             _gridView.ShowCellToolTips = false;
             _gridView.AuthorHighlighting = _authorHighlighting;
 
+            _gridView.PreviewKeyDown += (_, e) => _quickSearchProvider.OnPreviewKeyDown(e);
             _gridView.KeyPress += (_, e) => _quickSearchProvider.OnKeyPress(e);
             _gridView.MouseDown += OnGridViewMouseDown;
             _gridView.CellMouseDown += OnGridViewCellMouseDown;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -231,7 +231,6 @@ namespace GitUI
             _gridView.AuthorHighlighting = _authorHighlighting;
 
             _gridView.PreviewKeyDown += (_, e) => _quickSearchProvider.OnPreviewKeyDown(e);
-            _gridView.KeyDown += (_, e) => _quickSearchProvider.OnKeyDown(e);
             _gridView.KeyPress += (_, e) => _quickSearchProvider.OnKeyPress(e);
             _gridView.MouseDown += OnGridViewMouseDown;
             _gridView.CellMouseDown += OnGridViewCellMouseDown;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Enable cancelling of Quick Search via `Esc` key
- Allow pasting text as Quick Search value
- ~~While Quick Search is active, enable moving through the results using `up` / `down` arrow keys~~

I've personally found that these changes have greatly improved Quick Search usability.

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

In here I show how pasting could be useful (works great with pasting `sha` too); how `Esc` terminates quick search and how movement through results via `up` / `down` works

https://github.com/gitextensions/gitextensions/assets/483659/2924d532-9eb8-4dab-8f36-686b69e0494c

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
