### PR TITLE
fix(avatars/initials): fix a special case causing an exception

### DIFF
--- a/src/app/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/src/app/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -57,7 +57,7 @@ namespace GitUI.Avatars
             }
         }
 
-        protected internal (string? initials, int hashCode) GetInitialsAndColorIndex(string email, string? name)
+        protected internal (string initials, int hashCode) GetInitialsAndColorIndex(string email, string? name)
         {
             (string selectedName, char[] separator) = NameSelector(name, email);
 
@@ -88,14 +88,21 @@ namespace GitUI.Avatars
             return (null, null);
         }
 
-        private static string? GetInitialsFromNames(string[]? names)
+        private static string GetInitialsFromNames(string[]? possibleNames)
         {
-            names = names?.Where(s => !string.IsNullOrWhiteSpace(s) && char.IsLetter(s[0])).ToArray();
+            possibleNames = possibleNames?.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
 
-            // if no valid name-elements are found, return null
+            if (possibleNames?.Length is not > 0)
+            {
+                return "?";
+            }
+
+            string[]? names = possibleNames?.Where(s => char.IsLetter(s[0]) || char.IsDigit(s[0])).ToArray();
+
+            // if no valid name-elements are found, return acceptable fallback
             if (names?.Length is not > 0)
             {
-                return null;
+                return possibleNames.Length > 1 ? $"{possibleNames[0][0]}{possibleNames[1][0]}" : $"{possibleNames[0][0]}";
             }
 
             string name = names[0];
@@ -159,6 +166,8 @@ namespace GitUI.Avatars
 
         private Image DrawText(string? text, Brush foreColor, Color backColor, int avatarSize)
         {
+            text ??= "?";
+
             Bitmap bitmap = new(avatarSize, avatarSize);
             using Graphics graphics = Graphics.FromImage(bitmap);
             graphics.Clear(backColor);

--- a/tests/app/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
@@ -22,6 +22,12 @@ namespace GitUITests.Avatars
         [TestCase("", "A-Einstein", "AE")]
         [TestCase("", "Alb-Einstein", "AE")]
         [TestCase("", "AEinstein", "AE")]
+        [TestCase("1-pass@noreply.com", "1-pass", "1P")]
+        [TestCase("", "1-pass", "1P")]
+        [TestCase("1-pass@noreply.com", "", "1P")]
+        [TestCase("/*+=/°¨", "'µ*", "'")] // Fallback when no letters or digit found
+        [TestCase("/*+=/°¨", "'µ *", "'*")] // Fallback when no letters or digit found
+        [TestCase("", "", "?")]
         [TestCase(null, null, "?")]
         public void GetInitialsAndHashCode_return_initials_of_a_user(string email, string name, string expected)
         {


### PR DESCRIPTION
when generating the initials
where none of the email and name starts by a letter

and add better fallback to always return a not empty string

## Test methodology <!-- How did you ensure quality? -->

- unit tests (I don't remember the repository where I encounter this case to manual test the case)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
