### PR TITLE
Change diff.wordRegex to match words

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -43,7 +43,7 @@ public abstract class DiffHighlightService : TextHighlightService
 
         // https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-diffwordRegex
         // Set to "minimal" diff unless configured.
-        SetIfUnsetInGit(key: "diff.wordRegex", value: ".");
+        SetIfUnsetInGit(key: "diff.wordRegex", value: "\"[a-z0-9_]+|.\"");
 
         // dimmed-zebra highlights borders better than the default "zebra"
         SetIfUnsetInGit(key: "diff.colorMoved", value: "dimmed-zebra");


### PR DESCRIPTION
(https://github.com/gitextensions/gitextensions/issues/11634#issuecomment-1995477095)

## Proposed changes

This affects git-word-diff output. (Ctrl-D in diffviewer) 
Suggested by @mstv , I had been testing this some time too. Not convinced it is better but maybe easier to understand

As it is now, as much as possible commonalities are chown, so changed suffixes are listed.
However, the current could also show slightly chopped up if some chars matched.

## Screenshots <!-- Remove this section if PR does not change UI -->

The first diff is better after this change, I prefer the second occurrence

### Before

![image](https://github.com/user-attachments/assets/2abb1466-fb5a-4688-ac31-4a4df5dd1242)

### After

![image](https://github.com/user-attachments/assets/fd68f544-cf86-43ed-bd21-903e72423533)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
