### PR TITLE
feat: moved lines in diff as reverse

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -48,24 +48,27 @@ public abstract class DiffHighlightService : TextHighlightService
         // dimmed-zebra highlights borders better than the default "zebra"
         SetIfUnsetInGit(key: "diff.colorMoved", value: "dimmed-zebra");
 
-        // Change bold to normal, hard to see in fileviewer
-        SetIfUnsetInGit(key: "color.diff.oldMoved", value: "magenta");
-        SetIfUnsetInGit(key: "color.diff.newMoved", value: "blue");
-        SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: "cyan");
-        SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: "yellow");
+        // Use reverse color to follow GE theme
+        string reverse = AppSettings.UseGEThemeGitColoring.Value ? "reverse" : "";
 
-        // Set dimmed colors, default is gray dimmed/talic and italic is same as dimmed
-        SetIfUnsetInGit(key: "color.diff.oldMovedDimmed", value: "magenta dim");
-        SetIfUnsetInGit(key: "color.diff.newMovedDimmed", value: "blue dim");
-        SetIfUnsetInGit(key: "color.diff.oldMovedAlternativeDimmed", value: "cyan dim");
-        SetIfUnsetInGit(key: "color.diff.newMovedAlternativeDimmed", value: "yellow dim");
+        // Change bold to normal, hard to see in fileviewer
+        SetIfUnsetInGit(key: "color.diff.oldMoved", value: $"magenta {reverse}");
+        SetIfUnsetInGit(key: "color.diff.newMoved", value: $"blue {reverse}");
+        SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: $"cyan {reverse}");
+        SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: $"yellow {reverse}");
+
+        // Set dimmed colors, default is gray dimmed/italic and italic is implemented as dimmed
+        SetIfUnsetInGit(key: "color.diff.oldMovedDimmed", value: $"magenta dim {reverse}");
+        SetIfUnsetInGit(key: "color.diff.newMovedDimmed", value: $"blue dim {reverse}");
+        SetIfUnsetInGit(key: "color.diff.oldMovedAlternativeDimmed", value: $"cyan dim {reverse}");
+        SetIfUnsetInGit(key: "color.diff.newMovedAlternativeDimmed", value: $"yellow dim {reverse}");
 
         // range-diff
         if (command == "range-diff")
         {
-            SetIfUnsetInGit(key: "color.diff.contextBold", value: "normal");
-            SetIfUnsetInGit(key: "color.diff.oldBold", value: "red");
-            SetIfUnsetInGit(key: "color.diff.newBold", value: "green");
+            SetIfUnsetInGit(key: "color.diff.contextBold", value: $"normal bold {reverse}");
+            SetIfUnsetInGit(key: "color.diff.oldBold", value: $"red bold {reverse}");
+            SetIfUnsetInGit(key: "color.diff.newBold", value: $"green bold {reverse}");
         }
 
         // Override Git default coloring to "theme" colors for those that are defined


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/issues/11821#issuecomment-2266663665

Fixes #11821

## Proposed changes

If GE theme colors are applied, also set moved lines as reverse video (colored background) to match the appearances

Not sure if I want this, the moved lines are less important.
(The default colors are slightly to bold though, also as reverse)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/cd8fb2a5-b2f2-418e-afd8-558cabe6b573)

### After

![image](https://github.com/user-attachments/assets/d4eef542-8edd-4073-abb9-ea1aef11fa3a)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
