### PR TITLE
fix: Migrate core.editor settings from GE x86 path

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -42,6 +42,8 @@ namespace GitCommands
         private static readonly SettingsPath RevisionGraphSettingsPath = new AppSettingsPath(AppearanceSettingsPath, "RevisionGraph");
         private static readonly SettingsPath RecentRepositories = new AppSettingsPath("RecentRepositories");
         private static readonly SettingsPath RootSettingsPath = new AppSettingsPath(pathName: "");
+        private static readonly SettingsPath HiddenSettingsPath = new AppSettingsPath("Hidden");
+        private static readonly SettingsPath MigrationSettingsPath = new AppSettingsPath(HiddenSettingsPath, "Migration");
 
         private static Mutex _globalMutex;
 
@@ -739,7 +741,7 @@ namespace GitCommands
             }
 
             EnvironmentConfiguration.SetEnvironmentVariables();
-            ConfigFileSettings configFileGlobalSettings = ConfigFileSettings.CreateGlobal(false);
+            ConfigFileSettings configFileGlobalSettings = ConfigFileSettings.CreateGlobal(useSharedCache: false);
 
             string path = configFileGlobalSettings.GetValue("core.editor");
             if (!path.Contains("Program Files (x86)/GitExtensions", StringComparison.CurrentCultureIgnoreCase))
@@ -2089,9 +2091,7 @@ namespace GitCommands
             get => GetBool("GitAsyncWhenMinimized", false);
         }
 
-        private static readonly SettingsPath HiddenSettingsPath = new AppSettingsPath("Hidden");
-        private static readonly SettingsPath MigrationSettingsPath = new AppSettingsPath(HiddenSettingsPath, "Migration");
-        public static ISetting<bool> IsEditorSettingsMigrated { get; set; } = Setting.Create(MigrationSettingsPath, nameof(IsEditorSettingsMigrated), false);
+        public static ISetting<bool> IsEditorSettingsMigrated { get; } = Setting.Create(MigrationSettingsPath, nameof(IsEditorSettingsMigrated), false);
 
         private static IEnumerable<(string name, string value)> GetSettingsFromRegistry()
         {

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -376,7 +376,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.BlameShowAuthorAvatar)], true, false, false);
                 yield return (properties[nameof(AppSettings.AutomaticContinuousScroll)], false, false, false);
                 yield return (properties[nameof(AppSettings.AutomaticContinuousScrollDelay)], 600, false, false);
-                yield return (properties[nameof(AppSettings.IsEditorSettingsMigrated)], false, false, false);
+                yield return (properties[nameof(AppSettings.IsEditorSettingsMigrated)], false, isNotNullable, isISetting);
             }
 
             static IEnumerable<object> Values()

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -376,6 +376,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.BlameShowAuthorAvatar)], true, false, false);
                 yield return (properties[nameof(AppSettings.AutomaticContinuousScroll)], false, false, false);
                 yield return (properties[nameof(AppSettings.AutomaticContinuousScrollDelay)], 600, false, false);
+                yield return (properties[nameof(AppSettings.IsEditorSettingsMigrated)], false, false, false);
             }
 
             static IEnumerable<object> Values()


### PR DESCRIPTION
Fixes #11819

## Proposed changes

Migrate editor settings if GE was installed in 'Program Files (x86)' before 4.3.
Only check and update global Git settings in Windows, the only set by GE.
Guess previous, migrate to current path (i.e. the first usage).

When running in debug, migration is not automatic as the debug path is probably not what should be used.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
