### PR TITLE
fix(file tree): Do not force line first line when changing commit

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -451,7 +451,7 @@ See the changes in the commit form.");
                     {
                         if (!blameToolStripMenuItem1.Checked)
                         {
-                            return ViewGitItemAsync(gitItem, line ?? 1);
+                            return ViewGitItemAsync(gitItem, line);
                         }
 
                         FileText.Visible = false;


### PR DESCRIPTION
## Proposed changes

Keep the current linenumber when switching to a new commit in file tree, instead of always resetting to first line.

This is a regression from 9bbd08ff2985e46df1a30edc94f1dddb3ba9d247 in 4.2
(The change in that commit is otherwise OK. cc @pmiossec)

This is useful when viewing a file in the file tree (possibly filtered the revision grid), then selecting various commits.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![filetree-reset-lineno](https://github.com/user-attachments/assets/7ddc39c9-8c5b-410f-8f77-b0f41844b965)

### After

![filetree-keep-lineno](https://github.com/user-attachments/assets/6611d26c-1215-4bd1-a5d9-e774f0875528)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
