### PR TITLE
fix: Keep linenumber when switching viewer

### DIFF
--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -591,7 +591,7 @@ namespace GitUI.Editor
                     }
                     else
                     {
-                        internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring: false);
+                        internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring: false, contentIdentification: fileName);
 
                         if (line is not null)
                         {
@@ -871,7 +871,7 @@ namespace GitUI.Editor
                 () =>
                 {
                     ResetView(viewMode, fileName, item: item, text: text);
-                    internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring);
+                    internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring, contentIdentification: fileName);
                     if (line is not null)
                     {
                         GoToLine(line.Value);

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -158,7 +158,7 @@ namespace GitUI
                 bool isTracked = item.Item.IsTracked || (item.Item.TreeGuid is not null && item.SecondRevision.ObjectId is not null);
                 string diffArgs = fileViewer.GetDifftasticArguments();
 
-                await fileViewer.ViewTextAsync("git-difftool.sh", $"git difftool {diffArgs} -- {item.Item.Name}");
+                await fileViewer.ViewTextAsync(item.Item.Name, $"git difftool {diffArgs} -- {item.Item.Name}");
 
                 ExecutionResult result = await fileViewer.Module.GetSingleDifftoolAsync(firstId, item.SecondRevision.ObjectId, item.Item.Name, item.Item.OldName,
                     diffArgs,

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -71,7 +71,7 @@ namespace GitUI
                 string range = item.BaseA is null || item.BaseB is null
                     ? $"{firstId}...{item.SecondRevision.ObjectId}"
                     : $"{item.BaseA}..{firstId} {item.BaseB}..{item.SecondRevision.ObjectId}";
-                await fileViewer.ViewTextAsync("git-range-diff.sh", $"git range-diff {range} -- {additionalCommandInfo}");
+                await fileViewer.ViewTextAsync(null, $"git range-diff {range} -- {additionalCommandInfo}");
 
                 ExecutionResult result = await fileViewer.Module.GetRangeDiffAsync(
                         firstId,
@@ -158,7 +158,8 @@ namespace GitUI
                 bool isTracked = item.Item.IsTracked || (item.Item.TreeGuid is not null && item.SecondRevision.ObjectId is not null);
                 string diffArgs = fileViewer.GetDifftasticArguments();
 
-                await fileViewer.ViewTextAsync(item.Item.Name, $"git difftool {diffArgs} -- {item.Item.Name}");
+                // set file name as null to not change the restore lineno
+                await fileViewer.ViewTextAsync(null, $"git difftool {diffArgs} -- {item.Item.Name}");
 
                 ExecutionResult result = await fileViewer.Module.GetSingleDifftoolAsync(firstId, item.SecondRevision.ObjectId, item.Item.Name, item.Item.OldName,
                     diffArgs,

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -71,7 +71,7 @@ namespace GitUI
                 string range = item.BaseA is null || item.BaseB is null
                     ? $"{firstId}...{item.SecondRevision.ObjectId}"
                     : $"{item.BaseA}..{firstId} {item.BaseB}..{item.SecondRevision.ObjectId}";
-                await fileViewer.ViewTextAsync(null, $"git range-diff {range} -- {additionalCommandInfo}");
+                await fileViewer.ViewTextAsync(fileName: null, $"git range-diff {range} -- {additionalCommandInfo}");
 
                 ExecutionResult result = await fileViewer.Module.GetRangeDiffAsync(
                         firstId,
@@ -159,7 +159,7 @@ namespace GitUI
                 string diffArgs = fileViewer.GetDifftasticArguments();
 
                 // set file name as null to not change the restore lineno
-                await fileViewer.ViewTextAsync(null, $"git difftool {diffArgs} -- {item.Item.Name}");
+                await fileViewer.ViewTextAsync(fileName: null, $"git difftool {diffArgs} -- {item.Item.Name}");
 
                 ExecutionResult result = await fileViewer.Module.GetSingleDifftoolAsync(firstId, item.SecondRevision.ObjectId, item.Item.Name, item.Item.OldName,
                     diffArgs,

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
@@ -72,13 +72,13 @@ namespace GitExtensions.UITests.CommandsDialogs
 
             try
             {
-                const int lineNumerDefault = 2;
+                const int lineNumberDefault = 2;
                 File.WriteAllText(filePath, "Hello↔world\nline2\nline3\n\n\n", _commands.Module.FilesEncoding);
 
                 UITest.RunForm<FormEditor>(
                     () =>
                     {
-                        using FormEditor formEditor = new(_commands, filePath, showWarning: false, lineNumber: lineNumerDefault);
+                        using FormEditor formEditor = new(_commands, filePath, showWarning: false, lineNumber: lineNumberDefault);
                         formEditor.ShowDialog();
                     },
                     form =>
@@ -86,7 +86,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                         Assert.False(form.GetTestAccessor().HasChanges);
 
                         FileViewerInternal fileViewerInternal = form.GetTestAccessor().FileViewer.GetTestAccessor().FileViewerInternal;
-                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null);
+                        fileViewerInternal.GetTestAccessor().UpdateContentIdentification("hello-world");
+                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null, ViewMode.Text, true, "hello-world");
 
                         Assert.True(form.GetTestAccessor().HasChanges);
 
@@ -94,7 +95,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                         Assert.False(form.GetTestAccessor().HasChanges);
 
-                        Assert.AreEqual(lineNumerDefault, fileViewerInternal.CurrentFileLine());
+                        Assert.AreEqual(lineNumberDefault, fileViewerInternal.CurrentFileLine());
 
                         return Task.CompletedTask;
                     });

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
@@ -86,7 +86,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                         Assert.False(form.GetTestAccessor().HasChanges);
 
                         FileViewerInternal fileViewerInternal = form.GetTestAccessor().FileViewer.GetTestAccessor().FileViewerInternal;
-                        fileViewerInternal.GetTestAccessor().UpdateContentIdentification("hello-world");
+                        fileViewerInternal.GetTestAccessor().CurrentViewPositionCache.GetTestAccessor().SetCurrentIdentification("hello-world");
                         fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null, ViewMode.Text, true, "hello-world");
 
                         Assert.True(form.GetTestAccessor().HasChanges);

--- a/tests/app/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
@@ -55,6 +55,7 @@ namespace GitUITests.Editor
             test.TextEditor.ShowLineNumbers = true;
             test.TextEditor.Text = "a\r\nb\r\nc\r\n";
 
+            _viewPositionCache.GetTestAccessor().SetCurrentIdentification("dummy");
             _viewPositionCache.Capture();
 
             test.ViewPosition.ActiveLineNum.Should().BeNull();
@@ -75,6 +76,7 @@ namespace GitUITests.Editor
             test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
             test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 22;
 
+            _viewPositionCache.GetTestAccessor().SetCurrentIdentification("dummy");
             _viewPositionCache.Capture();
 
             test.ViewPosition.ActiveLineNum.Should().BeNull();
@@ -96,6 +98,7 @@ namespace GitUITests.Editor
             test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
             test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 22;
 
+            _viewPositionCache.GetTestAccessor().SetCurrentIdentification("dummy");
             _viewPositionCache.Capture();
 
             test.ViewPosition.ActiveLineNum.Should().BeNull();
@@ -120,6 +123,7 @@ namespace GitUITests.Editor
             DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(test.TextEditor, isCombinedDiff: false);
             test.LineNumberControl.DisplayLineNum(result, showLeftColumn: true);
 
+            _viewPositionCache.GetTestAccessor().SetCurrentIdentification("dummy");
             _viewPositionCache.Capture();
 
             test.ViewPosition.ActiveLineNum.Should().NotBeNull();
@@ -163,26 +167,24 @@ namespace GitUITests.Editor
             test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Line.Should().Be(0);
             test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Column.Should().Be(0);
 
-            _viewPositionCache.UpdateContentIdentification("current");
+            _viewPositionCache.GetTestAccessor().SetCapturedIdentification("current");
 
             ITextHighlightService highlightService = new PatchHighlightService(ref text, true);
             test.LineNumberControl.Clear();
             highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
             _viewPositionCache.Restore("current");
-            _viewPositionCache.UpdateContentIdentification("current");
 
-            // position should be restored to the (inserted) existingViewPosition
-            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition);
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition,
+                "position should be restored to the (inserted) existingViewPosition");
 
             _viewPositionCache.Capture();
             test.TextEditor.Text = "";
             test.LineNumberControl.Clear();
             highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
             _viewPositionCache.Restore("empty");
-            _viewPositionCache.UpdateContentIdentification("empty");
 
-            // empty file, set the position to the first
-            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0));
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0),
+                "empty file, set the position to the first");
 
             highlightService = new PatchHighlightService(ref text, true);
             _viewPositionCache.Capture();
@@ -190,10 +192,47 @@ namespace GitUITests.Editor
             test.LineNumberControl.Clear();
             highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
             _viewPositionCache.Restore("current");
-            _viewPositionCache.UpdateContentIdentification("current");
 
-            // the captured position should not be reset by an empty text
-            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition);
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition,
+                "the captured position should not be reset by an empty text");
+
+            _viewPositionCache.Capture();
+            test.TextEditor.Text = "some\ninfo\n\nnot empty";
+            test.LineNumberControl.Clear();
+            highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
+            _viewPositionCache.Restore("");
+
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0),
+                "Empty name, position should be the first");
+
+            highlightService = new PatchHighlightService(ref text, true);
+            _viewPositionCache.Capture();
+            test.TextEditor.Text = text;
+            test.LineNumberControl.Clear();
+            highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
+            _viewPositionCache.Restore("current");
+
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition,
+                "the captured position should not be reset by empty name");
+
+            _viewPositionCache.Capture();
+            test.TextEditor.Text = "some\ninfo\n\nnot empty";
+            test.LineNumberControl.Clear();
+            highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
+            _viewPositionCache.Restore(null);
+
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0),
+                "null name, set the position to the first");
+
+            highlightService = new PatchHighlightService(ref text, true);
+            _viewPositionCache.Capture();
+            test.TextEditor.Text = text;
+            test.LineNumberControl.Clear();
+            highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
+            _viewPositionCache.Restore("current");
+
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition,
+                "the captured position should not be reset by null identification");
 
             string text2 = "dummy text\ndummy";
             _viewPositionCache.Capture();
@@ -202,10 +241,9 @@ namespace GitUITests.Editor
             test.LineNumberControl.Clear();
             highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
             _viewPositionCache.Restore("dummy");
-            _viewPositionCache.UpdateContentIdentification("dummy");
 
-            // a new file will set the position back to 0,0
-            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0));
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0),
+                "a new file will set the position back to 0,0");
 
             highlightService = new PatchHighlightService(ref text, true);
             _viewPositionCache.Capture();
@@ -213,10 +251,9 @@ namespace GitUITests.Editor
             test.LineNumberControl.Clear();
             highlightService.SetLineControl(test.LineNumberControl, test.TextEditor);
             _viewPositionCache.Restore("current");
-            _viewPositionCache.UpdateContentIdentification("current");
 
-            // reset to 0,0. the cached position is not retained
-            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0));
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(new TextLocation(0, 0),
+                "reset to 0,0. the cached position is not restored");
         }
 
         private static class Given


### PR DESCRIPTION
Related to https://github.com/gitextensions/gitextensions/pull/11832#issuecomment-2278328551

## Proposed changes

Try to keep the linenumber in the fileviewer if the identification for the contents is the same (using the filename as identification).

Previously the line was restored if the number of lines were the same or if it was a diff and the first line matched.
Some situations where this did not work:
* Switch diffviewer to/from difftastic (as header differs)
* Select a new commit for a file in the file tree, where the number of lines differed in the other commit.

## Screenshots <!-- Remove this section if PR does not change UI -->

![filetree-nostore-changed-file](https://github.com/user-attachments/assets/5ae62857-ac77-42c0-a571-bcdf03135f99) ![filetree-restore-changed-file](https://github.com/user-attachments/assets/4f7273bc-0a4b-428d-80d2-8336b4b96926)

![difftastic-norestore](https://github.com/user-attachments/assets/3ad98474-d63c-4536-ae07-9ef2c939e09f) ![difftastic-restore](https://github.com/user-attachments/assets/94cb92a4-85a5-4cd9-a90b-eeb2e4959f3e)

## Test methodology <!-- How did you ensure quality? -->

Tests updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
