### PR TITLE
Fix FormRevertCommit dpi

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -56,7 +56,7 @@
             MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             MainPanel.Controls.Add(tlPnlMain);
             MainPanel.Size = new Size(614, 372);
-            MainPanel.TabIndex = 0;
+            MainPanel.TabIndex = 1;
             // 
             // ControlsPanel
             // 
@@ -64,7 +64,7 @@
             ControlsPanel.Controls.Add(btnPick);
             ControlsPanel.Location = new Point(0, 372);
             ControlsPanel.Size = new Size(614, 41);
-            ControlsPanel.TabIndex = 1;
+            ControlsPanel.TabIndex = 0;
             // 
             // btnPick
             // 
@@ -95,7 +95,7 @@
             btnChooseRevision.Location = new Point(556, 3);
             btnChooseRevision.Name = "btnChooseRevision";
             btnChooseRevision.Size = new Size(25, 24);
-            btnChooseRevision.TabIndex = 1;
+            btnChooseRevision.TabIndex = 5;
             btnChooseRevision.UseVisualStyleBackColor = true;
             btnChooseRevision.Click += btnChooseRevision_Click;
             // 
@@ -106,7 +106,7 @@
             lblParents.Location = new Point(3, 217);
             lblParents.Name = "lblParents";
             lblParents.Size = new Size(584, 15);
-            lblParents.TabIndex = 3;
+            lblParents.TabIndex = 6;
             lblParents.Text = "This commit is a merge, select &parent:";
             // 
             // lvParentsList
@@ -119,7 +119,7 @@
             lvParentsList.MultiSelect = false;
             lvParentsList.Name = "lvParentsList";
             lvParentsList.Size = new Size(578, 54);
-            lvParentsList.TabIndex = 4;
+            lvParentsList.TabIndex = 7;
             lvParentsList.UseCompatibleStateImageBehavior = false;
             lvParentsList.View = View.Details;
             // 
@@ -150,7 +150,7 @@
             cbxAddReference.Location = new Point(3, 326);
             cbxAddReference.Name = "cbxAddReference";
             cbxAddReference.Size = new Size(584, 19);
-            cbxAddReference.TabIndex = 6;
+            cbxAddReference.TabIndex = 9;
             cbxAddReference.Text = "A&dd commit reference to commit message";
             cbxAddReference.UseVisualStyleBackColor = true;
             // 
@@ -161,7 +161,7 @@
             cbxAutoCommit.Location = new Point(3, 301);
             cbxAutoCommit.Name = "cbxAutoCommit";
             cbxAutoCommit.Size = new Size(584, 19);
-            cbxAutoCommit.TabIndex = 5;
+            cbxAutoCommit.TabIndex = 8;
             cbxAutoCommit.Text = "&Automatically create a commit";
             cbxAutoCommit.UseVisualStyleBackColor = true;
             // 
@@ -172,7 +172,7 @@
             lblBranchInfo.Location = new Point(3, 0);
             lblBranchInfo.Name = "lblBranchInfo";
             lblBranchInfo.Size = new Size(584, 15);
-            lblBranchInfo.TabIndex = 0;
+            lblBranchInfo.TabIndex = 1;
             lblBranchInfo.Text = "Cherry pick this commit:";
             // 
             // commitSummaryUserControl1
@@ -186,7 +186,7 @@
             commitSummaryUserControl1.Name = "commitSummaryUserControl1";
             commitSummaryUserControl1.Revision = null;
             commitSummaryUserControl1.Size = new Size(571, 160);
-            commitSummaryUserControl1.TabIndex = 1;
+            commitSummaryUserControl1.TabIndex = 2;
             // 
             // tlPnlMain
             // 
@@ -226,7 +226,7 @@
             chooseRevPanel.Location = new Point(3, 184);
             chooseRevPanel.Name = "chooseRevPanel";
             chooseRevPanel.Size = new Size(584, 30);
-            chooseRevPanel.TabIndex = 2;
+            chooseRevPanel.TabIndex = 3;
             // 
             // lblAnotherRev
             // 
@@ -235,7 +235,7 @@
             lblAnotherRev.Location = new Point(412, 0);
             lblAnotherRev.Name = "lblAnotherRev";
             lblAnotherRev.Size = new Size(138, 30);
-            lblAnotherRev.TabIndex = 0;
+            lblAnotherRev.TabIndex = 4;
             lblAnotherRev.Text = "C&hoose another revision:";
             lblAnotherRev.TextAlign = ContentAlignment.MiddleCenter;
             // 
@@ -245,6 +245,7 @@
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
+            CancelButton = btnAbort;
             ClientSize = new Size(614, 413);
             HelpButton = true;
             ManualSectionAnchorName = "cherry-pick-commit";

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Forms;
-
-namespace GitUI.CommandsDialogs
+﻿namespace GitUI.CommandsDialogs
 {
     partial class FormCherryPick
     {
@@ -30,8 +28,8 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void InitializeComponent()
         {
-            Label label2;
             btnPick = new Button();
+            btnAbort = new Button();
             btnChooseRevision = new Button();
             lblParents = new Label();
             lvParentsList = new UserControls.NativeListView();
@@ -43,42 +41,30 @@ namespace GitUI.CommandsDialogs
             cbxAutoCommit = new CheckBox();
             lblBranchInfo = new Label();
             commitSummaryUserControl1 = new UserControls.CommitSummaryUserControl();
-            tlpnlMain = new TableLayoutPanel();
-            flowLayoutPanel1 = new FlowLayoutPanel();
-            btnAbort = new Button();
-            label2 = new Label();
+            tlPnlMain = new TableLayoutPanel();
+            chooseRevPanel = new FlowLayoutPanel();
+            lblAnotherRev = new Label();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
-            tlpnlMain.SuspendLayout();
-            flowLayoutPanel1.SuspendLayout();
+            tlPnlMain.SuspendLayout();
+            chooseRevPanel.SuspendLayout();
             SuspendLayout();
             // 
             // MainPanel
             // 
             MainPanel.AutoSize = true;
             MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            MainPanel.Controls.Add(tlpnlMain);
-            MainPanel.Size = new Size(614, 379);
+            MainPanel.Controls.Add(tlPnlMain);
+            MainPanel.Size = new Size(614, 372);
             MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(btnAbort);
             ControlsPanel.Controls.Add(btnPick);
-            ControlsPanel.Location = new Point(0, 379);
+            ControlsPanel.Location = new Point(0, 372);
             ControlsPanel.Size = new Size(614, 41);
             ControlsPanel.TabIndex = 1;
-            // 
-            // label2
-            // 
-            label2.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
-            label2.AutoSize = true;
-            label2.Location = new Point(412, 0);
-            label2.Name = "label2";
-            label2.Size = new Size(138, 30);
-            label2.TabIndex = 0;
-            label2.Text = "C&hoose another revision:";
-            label2.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // btnPick
             // 
@@ -90,6 +76,17 @@ namespace GitUI.CommandsDialogs
             btnPick.Text = "&Cherry pick";
             btnPick.UseVisualStyleBackColor = true;
             btnPick.Click += btnPick_Click;
+            // 
+            // btnAbort
+            // 
+            btnAbort.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnAbort.Location = new Point(526, 8);
+            btnAbort.Name = "btnAbort";
+            btnAbort.Size = new Size(75, 25);
+            btnAbort.TabIndex = 1;
+            btnAbort.Text = "A&bort";
+            btnAbort.UseVisualStyleBackColor = true;
+            btnAbort.Click += btnAbort_Click;
             // 
             // btnChooseRevision
             // 
@@ -121,7 +118,7 @@ namespace GitUI.CommandsDialogs
             lvParentsList.Margin = new Padding(6);
             lvParentsList.MultiSelect = false;
             lvParentsList.Name = "lvParentsList";
-            lvParentsList.Size = new Size(578, 61);
+            lvParentsList.Size = new Size(578, 54);
             lvParentsList.TabIndex = 4;
             lvParentsList.UseCompatibleStateImageBehavior = false;
             lvParentsList.View = View.Details;
@@ -150,7 +147,7 @@ namespace GitUI.CommandsDialogs
             // 
             cbxAddReference.AutoSize = true;
             cbxAddReference.Dock = DockStyle.Fill;
-            cbxAddReference.Location = new Point(3, 308);
+            cbxAddReference.Location = new Point(3, 326);
             cbxAddReference.Name = "cbxAddReference";
             cbxAddReference.Size = new Size(584, 19);
             cbxAddReference.TabIndex = 6;
@@ -161,7 +158,7 @@ namespace GitUI.CommandsDialogs
             // 
             cbxAutoCommit.AutoSize = true;
             cbxAutoCommit.Dock = DockStyle.Fill;
-            cbxAutoCommit.Location = new Point(3, 333);
+            cbxAutoCommit.Location = new Point(3, 301);
             cbxAutoCommit.Name = "cbxAutoCommit";
             cbxAutoCommit.Size = new Size(584, 19);
             cbxAutoCommit.TabIndex = 5;
@@ -191,56 +188,56 @@ namespace GitUI.CommandsDialogs
             commitSummaryUserControl1.Size = new Size(571, 160);
             commitSummaryUserControl1.TabIndex = 1;
             // 
-            // tlpnlMain
+            // tlPnlMain
             // 
-            tlpnlMain.AutoSize = true;
-            tlpnlMain.ColumnCount = 1;
-            tlpnlMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tlpnlMain.Controls.Add(lblBranchInfo, 0, 0);
-            tlpnlMain.Controls.Add(commitSummaryUserControl1, 0, 1);
-            tlpnlMain.Controls.Add(flowLayoutPanel1, 0, 2);
-            tlpnlMain.Controls.Add(lblParents, 0, 3);
-            tlpnlMain.Controls.Add(lvParentsList, 0, 4);
-            tlpnlMain.Controls.Add(cbxAutoCommit, 0, 5);
-            tlpnlMain.Controls.Add(cbxAddReference, 0, 6);
-            tlpnlMain.Dock = DockStyle.Fill;
-            tlpnlMain.Location = new Point(12, 12);
-            tlpnlMain.Margin = new Padding(0);
-            tlpnlMain.Name = "tlpnlMain";
-            tlpnlMain.RowCount = 5;
-            tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.Size = new Size(590, 355);
-            tlpnlMain.TabIndex = 0;
+            tlPnlMain.AutoSize = true;
+            tlPnlMain.ColumnCount = 1;
+            tlPnlMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tlPnlMain.Controls.Add(lblBranchInfo, 0, 0);
+            tlPnlMain.Controls.Add(commitSummaryUserControl1, 0, 1);
+            tlPnlMain.Controls.Add(chooseRevPanel, 0, 2);
+            tlPnlMain.Controls.Add(lblParents, 0, 3);
+            tlPnlMain.Controls.Add(lvParentsList, 0, 4);
+            tlPnlMain.Controls.Add(cbxAutoCommit, 0, 5);
+            tlPnlMain.Controls.Add(cbxAddReference, 0, 6);
+            tlPnlMain.Dock = DockStyle.Fill;
+            tlPnlMain.Location = new Point(12, 12);
+            tlPnlMain.Margin = new Padding(0);
+            tlPnlMain.Name = "tlPnlMain";
+            tlPnlMain.RowCount = 7;
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.Size = new Size(590, 348);
+            tlPnlMain.TabIndex = 0;
             // 
-            // flowLayoutPanel1
+            // chooseRevPanel
             // 
-            flowLayoutPanel1.AutoSize = true;
-            flowLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            flowLayoutPanel1.Controls.Add(btnChooseRevision);
-            flowLayoutPanel1.Controls.Add(label2);
-            flowLayoutPanel1.Dock = DockStyle.Fill;
-            flowLayoutPanel1.FlowDirection = FlowDirection.RightToLeft;
-            flowLayoutPanel1.Location = new Point(3, 184);
-            flowLayoutPanel1.Name = "flowLayoutPanel1";
-            flowLayoutPanel1.Size = new Size(584, 30);
-            flowLayoutPanel1.TabIndex = 2;
+            chooseRevPanel.AutoSize = true;
+            chooseRevPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            chooseRevPanel.Controls.Add(btnChooseRevision);
+            chooseRevPanel.Controls.Add(lblAnotherRev);
+            chooseRevPanel.Dock = DockStyle.Fill;
+            chooseRevPanel.FlowDirection = FlowDirection.RightToLeft;
+            chooseRevPanel.Location = new Point(3, 184);
+            chooseRevPanel.Name = "chooseRevPanel";
+            chooseRevPanel.Size = new Size(584, 30);
+            chooseRevPanel.TabIndex = 2;
             // 
-            // btnAbort
+            // lblAnotherRev
             // 
-            btnAbort.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            btnAbort.Location = new Point(526, 8);
-            btnAbort.Name = "btnAbort";
-            btnAbort.Size = new Size(75, 25);
-            btnAbort.TabIndex = 1;
-            btnAbort.Text = "A&bort";
-            btnAbort.UseVisualStyleBackColor = true;
-            btnAbort.Click += btnAbort_Click;
+            lblAnotherRev.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
+            lblAnotherRev.AutoSize = true;
+            lblAnotherRev.Location = new Point(412, 0);
+            lblAnotherRev.Name = "lblAnotherRev";
+            lblAnotherRev.Size = new Size(138, 30);
+            lblAnotherRev.TabIndex = 0;
+            lblAnotherRev.Text = "C&hoose another revision:";
+            lblAnotherRev.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // FormCherryPick
             // 
@@ -248,7 +245,7 @@ namespace GitUI.CommandsDialogs
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
-            ClientSize = new Size(614, 420);
+            ClientSize = new Size(614, 413);
             HelpButton = true;
             ManualSectionAnchorName = "cherry-pick-commit";
             ManualSectionSubfolder = "modify_history";
@@ -264,10 +261,10 @@ namespace GitUI.CommandsDialogs
             MainPanel.ResumeLayout(false);
             MainPanel.PerformLayout();
             ControlsPanel.ResumeLayout(false);
-            tlpnlMain.ResumeLayout(false);
-            tlpnlMain.PerformLayout();
-            flowLayoutPanel1.ResumeLayout(false);
-            flowLayoutPanel1.PerformLayout();
+            tlPnlMain.ResumeLayout(false);
+            tlPnlMain.PerformLayout();
+            chooseRevPanel.ResumeLayout(false);
+            chooseRevPanel.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -275,19 +272,20 @@ namespace GitUI.CommandsDialogs
         #endregion
 
         private Label lblBranchInfo;
+        private Label lblAnotherRev;
         private Button btnPick;
+        private Button btnAbort;
         private CheckBox cbxAutoCommit;
+        private Label lblParents;
         private UserControls.NativeListView lvParentsList;
         private ColumnHeader columnHeader1;
         private ColumnHeader columnHeader2;
         private ColumnHeader columnHeader3;
         private ColumnHeader columnHeader4;
-        private Label lblParents;
         private CheckBox cbxAddReference;
         private GitUI.UserControls.CommitSummaryUserControl commitSummaryUserControl1;
         private Button btnChooseRevision;
-        private TableLayoutPanel tlpnlMain;
-        private FlowLayoutPanel flowLayoutPanel1;
-        private Button btnAbort;
+        private TableLayoutPanel tlPnlMain;
+        private FlowLayoutPanel chooseRevPanel;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -56,7 +56,7 @@
             MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             MainPanel.Controls.Add(tlPnlMain);
             MainPanel.Size = new Size(614, 372);
-            MainPanel.TabIndex = 1;
+            MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
             // 
@@ -64,7 +64,7 @@
             ControlsPanel.Controls.Add(btnPick);
             ControlsPanel.Location = new Point(0, 372);
             ControlsPanel.Size = new Size(614, 41);
-            ControlsPanel.TabIndex = 0;
+            ControlsPanel.TabIndex = 1;
             // 
             // btnPick
             // 
@@ -187,6 +187,7 @@
             commitSummaryUserControl1.Revision = null;
             commitSummaryUserControl1.Size = new Size(571, 160);
             commitSummaryUserControl1.TabIndex = 2;
+            commitSummaryUserControl1.TabStop = false;
             // 
             // tlPnlMain
             // 
@@ -259,6 +260,7 @@
             Text = "Cherry pick commit";
             FormClosing += Form_Closing;
             Load += Form_Load;
+            Shown += Form_Shown;
             MainPanel.ResumeLayout(false);
             MainPanel.PerformLayout();
             ControlsPanel.ResumeLayout(false);

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -48,6 +48,18 @@ namespace GitUI.CommandsDialogs
             OnRevisionChanged();
         }
 
+        private void Form_Shown(object? sender, EventArgs e)
+        {
+            if (lvParentsList.Visible)
+            {
+                lvParentsList.Focus();
+            }
+            else
+            {
+                cbxAutoCommit.Focus();
+            }
+        }
+
         private void Form_Closing(object sender, FormClosingEventArgs e)
         {
             SaveSettings();

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -28,6 +28,7 @@ namespace GitUI.CommandsDialogs
             : base(commands, enablePositionRestore: false)
         {
             Revision = revision;
+
             InitializeComponent();
 
             columnHeader1.Width = DpiUtil.Scale(columnHeader1.Width);
@@ -36,13 +37,13 @@ namespace GitUI.CommandsDialogs
             columnHeader4.Width = DpiUtil.Scale(columnHeader4.Width);
 
             InitializeComplete();
-
-            _lblParentsControlHeight = lblParents.Size.Height;
-            _lvParentsListControlHeight = lvParentsList.Size.Height;
         }
 
         private void Form_Load(object sender, EventArgs e)
         {
+            _lblParentsControlHeight = lblParents.Size.Height;
+            _lvParentsListControlHeight = lvParentsList.Size.Height;
+
             LoadSettings();
             OnRevisionChanged();
         }
@@ -118,7 +119,7 @@ namespace GitUI.CommandsDialogs
 
                     lvParentsList.TopItem.Selected = true;
                     Size size = MinimumSize;
-                    size.Height += DpiUtil.Scale(_parentsListItemHeight * (parents.Count - 1));
+                    size.Height += DpiUtil.Scale(_parentsListItemHeight * parents.Count);
                     Size = size;
                     MinimumSize = size;
                 }

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.resx
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.resx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
@@ -117,7 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="label2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
 </root>

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
@@ -28,70 +28,89 @@
         /// </summary>
         private void InitializeComponent()
         {
-            commitSummaryUserControl1 = new GitUI.UserControls.CommitSummaryUserControl();
-            ParentsLabel = new Label();
-            ParentsList = new UserControls.NativeListView();
-            columnHeader1 = ((ColumnHeader)(new ColumnHeader()));
-            columnHeader2 = ((ColumnHeader)(new ColumnHeader()));
-            columnHeader3 = ((ColumnHeader)(new ColumnHeader()));
-            columnHeader4 = ((ColumnHeader)(new ColumnHeader()));
-            AutoCommit = new CheckBox();
             Revert = new Button();
+            btnAbort = new Button();
+            ParentsLabel = new Label();
+            lvParentsList = new UserControls.NativeListView();
+            columnHeader1 = new ColumnHeader();
+            columnHeader2 = new ColumnHeader();
+            columnHeader3 = new ColumnHeader();
+            columnHeader4 = new ColumnHeader();
+            AutoCommit = new CheckBox();
             BranchInfo = new Label();
-            tableLayoutPanel1 = new TableLayoutPanel();
-            parentListPanel = new TableLayoutPanel();
-            tableLayoutPanel3 = new TableLayoutPanel();
-            tableLayoutPanel1.SuspendLayout();
-            parentListPanel.SuspendLayout();
-            tableLayoutPanel3.SuspendLayout();
+            commitSummaryUserControl1 = new UserControls.CommitSummaryUserControl();
+            tlPnlMain = new TableLayoutPanel();
+            ControlsPanel.SuspendLayout();
+            MainPanel.SuspendLayout();
+            tlPnlMain.SuspendLayout();
             SuspendLayout();
             // 
-            // commitSummaryUserControl1
+            // MainPanel
             // 
-            commitSummaryUserControl1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
-            commitSummaryUserControl1.AutoSize = true;
-            commitSummaryUserControl1.Location = new Point(20, 27);
-            commitSummaryUserControl1.Margin = new Padding(20, 4, 4, 4);
-            commitSummaryUserControl1.MinimumSize = new Size(550, 200);
-            commitSummaryUserControl1.Name = "commitSummaryUserControl1";
-            commitSummaryUserControl1.Revision = null;
-            commitSummaryUserControl1.Size = new Size(658, 200);
-            commitSummaryUserControl1.TabIndex = 16;
+            MainPanel.AutoSize = true;
+            MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            MainPanel.Controls.Add(tlPnlMain);
+            MainPanel.Size = new Size(614, 311);
+            MainPanel.TabIndex = 0;
+            // 
+            // ControlsPanel
+            // 
+            ControlsPanel.Controls.Add(btnAbort);
+            ControlsPanel.Controls.Add(Revert);
+            ControlsPanel.Location = new Point(0, 379);
+            ControlsPanel.Size = new Size(614, 41);
+            ControlsPanel.TabIndex = 1;
+            // 
+            // Revert
+            // 
+            Revert.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            Revert.Location = new Point(403, 8);
+            Revert.Name = "Revert";
+            Revert.Size = new Size(117, 25);
+            Revert.TabIndex = 10;
+            Revert.Text = "&Revert this commit";
+            Revert.UseVisualStyleBackColor = true;
+            Revert.Click += Revert_Click;
+            // 
+            // btnAbort
+            // 
+            btnAbort.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnAbort.Location = new Point(526, 8);
+            btnAbort.Name = "btnAbort";
+            btnAbort.Size = new Size(75, 25);
+            btnAbort.TabIndex = 1;
+            btnAbort.Text = "A&bort";
+            btnAbort.UseVisualStyleBackColor = true;
+            btnAbort.Click += btnAbort_Click;
             // 
             // ParentsLabel
             // 
             ParentsLabel.AutoSize = true;
-            ParentsLabel.Location = new Point(4, 0);
-            ParentsLabel.Margin = new Padding(4, 0, 4, 0);
+            ParentsLabel.Dock = DockStyle.Fill;
+            ParentsLabel.Location = new Point(3, 181);
             ParentsLabel.Name = "ParentsLabel";
-            ParentsLabel.Size = new Size(298, 23);
+            ParentsLabel.Size = new Size(584, 15);
             ParentsLabel.TabIndex = 14;
             ParentsLabel.Text = "This commit is a merge, select &parent:";
             // 
-            // ParentsList
+            // lvParentsList
             // 
-            ParentsList.BorderStyle = BorderStyle.FixedSingle;
-            ParentsList.Columns.AddRange(new ColumnHeader[] {
-            columnHeader1,
-            columnHeader2,
-            columnHeader3,
-            columnHeader4});
-            ParentsList.Dock = DockStyle.Fill;
-            ParentsList.FullRowSelect = true;
-            ParentsList.HideSelection = false;
-            ParentsList.Location = new Point(4, 27);
-            ParentsList.Margin = new Padding(4);
-            ParentsList.MultiSelect = false;
-            ParentsList.Name = "ParentsList";
-            ParentsList.Size = new Size(668, 75);
-            ParentsList.TabIndex = 15;
-            ParentsList.UseCompatibleStateImageBehavior = false;
-            ParentsList.View = View.Details;
+            lvParentsList.Columns.AddRange(new ColumnHeader[] { columnHeader1, columnHeader2, columnHeader3, columnHeader4 });
+            lvParentsList.Dock = DockStyle.Fill;
+            lvParentsList.FullRowSelect = true;
+            lvParentsList.Location = new Point(6, 202);
+            lvParentsList.Margin = new Padding(6);
+            lvParentsList.MultiSelect = false;
+            lvParentsList.Name = "lvParentsList";
+            lvParentsList.Size = new Size(578, 54);
+            lvParentsList.TabIndex = 15;
+            lvParentsList.UseCompatibleStateImageBehavior = false;
+            lvParentsList.View = View.Details;
             // 
             // columnHeader1
             // 
             columnHeader1.Text = "No.";
-            columnHeader1.Width = 50;
+            columnHeader1.Width = 43;
             // 
             // columnHeader2
             // 
@@ -110,130 +129,98 @@
             // 
             // AutoCommit
             // 
-            AutoCommit.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
             AutoCommit.AutoSize = true;
-            AutoCommit.Location = new Point(4, 10);
-            AutoCommit.Margin = new Padding(4);
+            AutoCommit.Dock = DockStyle.Fill;
+            AutoCommit.Location = new Point(3, 265);
             AutoCommit.Name = "AutoCommit";
-            AutoCommit.Size = new Size(265, 27);
+            AutoCommit.Size = new Size(584, 19);
             AutoCommit.TabIndex = 11;
             AutoCommit.Text = "&Automatically create a commit";
             AutoCommit.UseVisualStyleBackColor = true;
             // 
-            // Revert
-            // 
-            Revert.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            Revert.AutoSize = true;
-            Revert.Location = new Point(501, 4);
-            Revert.Margin = new Padding(4);
-            Revert.Name = "Revert";
-            Revert.Size = new Size(171, 33);
-            Revert.TabIndex = 10;
-            Revert.Text = "&Revert this commit";
-            Revert.UseVisualStyleBackColor = true;
-            Revert.Click += Revert_Click;
-            // 
             // BranchInfo
             // 
             BranchInfo.AutoSize = true;
-            BranchInfo.Location = new Point(4, 0);
-            BranchInfo.Margin = new Padding(4, 0, 4, 0);
+            BranchInfo.Dock = DockStyle.Fill;
+            BranchInfo.Location = new Point(3, 0);
             BranchInfo.Name = "BranchInfo";
-            BranchInfo.Size = new Size(157, 23);
+            BranchInfo.Size = new Size(584, 15);
             BranchInfo.TabIndex = 5;
             BranchInfo.Text = "Revert this commit:";
             // 
-            // tableLayoutPanel1
+            // commitSummaryUserControl1
             // 
-            tableLayoutPanel1.ColumnCount = 1;
-            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tableLayoutPanel1.Controls.Add(BranchInfo, 0, 0);
-            tableLayoutPanel1.Controls.Add(commitSummaryUserControl1, 0, 1);
-            tableLayoutPanel1.Controls.Add(parentListPanel, 0, 2);
-            tableLayoutPanel1.Controls.Add(tableLayoutPanel3, 0, 3);
-            tableLayoutPanel1.Dock = DockStyle.Fill;
-            tableLayoutPanel1.Location = new Point(0, 0);
-            tableLayoutPanel1.Name = "tableLayoutPanel1";
-            tableLayoutPanel1.RowCount = 4;
-            tableLayoutPanel1.RowStyles.Add(new RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            tableLayoutPanel1.RowStyles.Add(new RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel1.Size = new Size(682, 390);
-            tableLayoutPanel1.TabIndex = 17;
+            commitSummaryUserControl1.AutoSize = true;
+            commitSummaryUserControl1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            commitSummaryUserControl1.Dock = DockStyle.Fill;
+            commitSummaryUserControl1.Location = new Point(16, 18);
+            commitSummaryUserControl1.Margin = new Padding(16, 3, 3, 3);
+            commitSummaryUserControl1.MinimumSize = new Size(440, 160);
+            commitSummaryUserControl1.Name = "commitSummaryUserControl1";
+            commitSummaryUserControl1.Revision = null;
+            commitSummaryUserControl1.Size = new Size(571, 160);
+            commitSummaryUserControl1.TabIndex = 16;
             // 
-            // parentListPanel
+            // tlPnlMain
             // 
-            parentListPanel.AutoSize = true;
-            parentListPanel.ColumnCount = 1;
-            parentListPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            parentListPanel.Controls.Add(ParentsLabel, 0, 0);
-            parentListPanel.Controls.Add(ParentsList, 0, 1);
-            parentListPanel.Dock = DockStyle.Fill;
-            parentListPanel.Location = new Point(3, 234);
-            parentListPanel.Name = "parentListPanel";
-            parentListPanel.RowCount = 2;
-            parentListPanel.RowStyles.Add(new RowStyle());
-            parentListPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            parentListPanel.Size = new Size(676, 106);
-            parentListPanel.TabIndex = 17;
-            // 
-            // tableLayoutPanel3
-            // 
-            tableLayoutPanel3.AutoSize = true;
-            tableLayoutPanel3.ColumnCount = 2;
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle());
-            tableLayoutPanel3.Controls.Add(Revert, 1, 0);
-            tableLayoutPanel3.Controls.Add(AutoCommit, 0, 0);
-            tableLayoutPanel3.Dock = DockStyle.Fill;
-            tableLayoutPanel3.Location = new Point(3, 346);
-            tableLayoutPanel3.Name = "tableLayoutPanel3";
-            tableLayoutPanel3.RowCount = 1;
-            tableLayoutPanel3.RowStyles.Add(new RowStyle());
-            tableLayoutPanel3.Size = new Size(676, 41);
-            tableLayoutPanel3.TabIndex = 18;
+            tlPnlMain.AutoSize = true;
+            tlPnlMain.ColumnCount = 1;
+            tlPnlMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tlPnlMain.Controls.Add(BranchInfo, 0, 0);
+            tlPnlMain.Controls.Add(commitSummaryUserControl1, 0, 1);
+            tlPnlMain.Controls.Add(ParentsLabel, 0, 2);
+            tlPnlMain.Controls.Add(lvParentsList, 0, 3);
+            tlPnlMain.Controls.Add(AutoCommit, 0, 4);
+            tlPnlMain.Dock = DockStyle.Fill;
+            tlPnlMain.Location = new Point(12, 12);
+            tlPnlMain.Margin = new Padding(0);
+            tlPnlMain.Name = "tlPnlMain";
+            tlPnlMain.RowCount = 5;
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            tlPnlMain.RowStyles.Add(new RowStyle());
+            tlPnlMain.Size = new Size(590, 287);
+            tlPnlMain.TabIndex = 17;
             // 
             // FormRevertCommit
             // 
-            AutoScaleDimensions = new SizeF(120F, 120F);
+            AcceptButton = Revert;
+            AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(682, 390);
-            Controls.Add(tableLayoutPanel1);
-            Margin = new Padding(4);
+            AutoSize = true;
+            ClientSize = new Size(614, 352);
             MaximizeBox = false;
             MinimizeBox = false;
-            MinimumSize = new Size(700, 330);
+            MinimumSize = new Size(630, 362);
             Name = "FormRevertCommit";
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;
             Text = "Revert commit";
             Load += FormRevertCommit_Load;
-            tableLayoutPanel1.ResumeLayout(false);
-            tableLayoutPanel1.PerformLayout();
-            parentListPanel.ResumeLayout(false);
-            parentListPanel.PerformLayout();
-            tableLayoutPanel3.ResumeLayout(false);
-            tableLayoutPanel3.PerformLayout();
+            MainPanel.ResumeLayout(false);
+            MainPanel.PerformLayout();
+            ControlsPanel.ResumeLayout(false);
+            tlPnlMain.ResumeLayout(false);
+            tlPnlMain.PerformLayout();
             ResumeLayout(false);
-
+            PerformLayout();
         }
 
         #endregion
 
+        private Label BranchInfo;
         private Button Revert;
+        private Button btnAbort;
         private CheckBox AutoCommit;
         private Label ParentsLabel;
-        private UserControls.NativeListView ParentsList;
+        private UserControls.NativeListView lvParentsList;
         private ColumnHeader columnHeader1;
         private ColumnHeader columnHeader2;
         private ColumnHeader columnHeader3;
         private ColumnHeader columnHeader4;
-        private Label BranchInfo;
         private GitUI.UserControls.CommitSummaryUserControl commitSummaryUserControl1;
-        private TableLayoutPanel tableLayoutPanel1;
-        private TableLayoutPanel parentListPanel;
-        private TableLayoutPanel tableLayoutPanel3;
+        private TableLayoutPanel tlPnlMain;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
@@ -51,7 +51,7 @@
             MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             MainPanel.Controls.Add(tlPnlMain);
             MainPanel.Size = new Size(614, 311);
-            MainPanel.TabIndex = 1;
+            MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
             // 
@@ -59,7 +59,7 @@
             ControlsPanel.Controls.Add(Revert);
             ControlsPanel.Location = new Point(0, 379);
             ControlsPanel.Size = new Size(614, 41);
-            ControlsPanel.TabIndex = 0;
+            ControlsPanel.TabIndex = 1;
             // 
             // Revert
             // 
@@ -67,7 +67,7 @@
             Revert.Location = new Point(403, 8);
             Revert.Name = "Revert";
             Revert.Size = new Size(117, 25);
-            Revert.TabIndex = 1;
+            Revert.TabIndex = 0;
             Revert.Text = "&Revert this commit";
             Revert.UseVisualStyleBackColor = true;
             Revert.Click += Revert_Click;
@@ -78,7 +78,7 @@
             btnAbort.Location = new Point(526, 8);
             btnAbort.Name = "btnAbort";
             btnAbort.Size = new Size(75, 25);
-            btnAbort.TabIndex = 0;
+            btnAbort.TabIndex = 1;
             btnAbort.Text = "A&bort";
             btnAbort.UseVisualStyleBackColor = true;
             btnAbort.Click += btnAbort_Click;
@@ -160,6 +160,7 @@
             commitSummaryUserControl1.Revision = null;
             commitSummaryUserControl1.Size = new Size(571, 160);
             commitSummaryUserControl1.TabIndex = 2;
+            commitSummaryUserControl1.TabStop = false;
             // 
             // tlPnlMain
             // 
@@ -199,7 +200,8 @@
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;
             Text = "Revert commit";
-            Load += FormRevertCommit_Load;
+            Load += Form_Load;
+            Shown += Form_Shown;
             MainPanel.ResumeLayout(false);
             MainPanel.PerformLayout();
             ControlsPanel.ResumeLayout(false);

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
@@ -51,7 +51,7 @@
             MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             MainPanel.Controls.Add(tlPnlMain);
             MainPanel.Size = new Size(614, 311);
-            MainPanel.TabIndex = 0;
+            MainPanel.TabIndex = 1;
             // 
             // ControlsPanel
             // 
@@ -59,7 +59,7 @@
             ControlsPanel.Controls.Add(Revert);
             ControlsPanel.Location = new Point(0, 379);
             ControlsPanel.Size = new Size(614, 41);
-            ControlsPanel.TabIndex = 1;
+            ControlsPanel.TabIndex = 0;
             // 
             // Revert
             // 
@@ -67,7 +67,7 @@
             Revert.Location = new Point(403, 8);
             Revert.Name = "Revert";
             Revert.Size = new Size(117, 25);
-            Revert.TabIndex = 10;
+            Revert.TabIndex = 1;
             Revert.Text = "&Revert this commit";
             Revert.UseVisualStyleBackColor = true;
             Revert.Click += Revert_Click;
@@ -78,7 +78,7 @@
             btnAbort.Location = new Point(526, 8);
             btnAbort.Name = "btnAbort";
             btnAbort.Size = new Size(75, 25);
-            btnAbort.TabIndex = 1;
+            btnAbort.TabIndex = 0;
             btnAbort.Text = "A&bort";
             btnAbort.UseVisualStyleBackColor = true;
             btnAbort.Click += btnAbort_Click;
@@ -90,7 +90,7 @@
             ParentsLabel.Location = new Point(3, 181);
             ParentsLabel.Name = "ParentsLabel";
             ParentsLabel.Size = new Size(584, 15);
-            ParentsLabel.TabIndex = 14;
+            ParentsLabel.TabIndex = 3;
             ParentsLabel.Text = "This commit is a merge, select &parent:";
             // 
             // lvParentsList
@@ -103,7 +103,7 @@
             lvParentsList.MultiSelect = false;
             lvParentsList.Name = "lvParentsList";
             lvParentsList.Size = new Size(578, 54);
-            lvParentsList.TabIndex = 15;
+            lvParentsList.TabIndex = 4;
             lvParentsList.UseCompatibleStateImageBehavior = false;
             lvParentsList.View = View.Details;
             // 
@@ -134,7 +134,7 @@
             AutoCommit.Location = new Point(3, 265);
             AutoCommit.Name = "AutoCommit";
             AutoCommit.Size = new Size(584, 19);
-            AutoCommit.TabIndex = 11;
+            AutoCommit.TabIndex = 5;
             AutoCommit.Text = "&Automatically create a commit";
             AutoCommit.UseVisualStyleBackColor = true;
             // 
@@ -145,7 +145,7 @@
             BranchInfo.Location = new Point(3, 0);
             BranchInfo.Name = "BranchInfo";
             BranchInfo.Size = new Size(584, 15);
-            BranchInfo.TabIndex = 5;
+            BranchInfo.TabIndex = 1;
             BranchInfo.Text = "Revert this commit:";
             // 
             // commitSummaryUserControl1
@@ -159,7 +159,7 @@
             commitSummaryUserControl1.Name = "commitSummaryUserControl1";
             commitSummaryUserControl1.Revision = null;
             commitSummaryUserControl1.Size = new Size(571, 160);
-            commitSummaryUserControl1.TabIndex = 16;
+            commitSummaryUserControl1.TabIndex = 2;
             // 
             // tlPnlMain
             // 
@@ -182,7 +182,7 @@
             tlPnlMain.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             tlPnlMain.RowStyles.Add(new RowStyle());
             tlPnlMain.Size = new Size(590, 287);
-            tlPnlMain.TabIndex = 17;
+            tlPnlMain.TabIndex = 0;
             // 
             // FormRevertCommit
             // 
@@ -190,6 +190,7 @@
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
+            CancelButton = btnAbort;
             ClientSize = new Size(614, 352);
             MaximizeBox = false;
             MinimizeBox = false;

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -37,12 +37,24 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
         }
 
-        private void FormRevertCommit_Load(object sender, EventArgs e)
+        private void Form_Load(object sender, EventArgs e)
         {
             _parentsLabelControlHeight = ParentsLabel.Size.Height;
             _lvParentsListControlHeight = lvParentsList.Size.Height;
 
             LoadRevisionInfo();
+        }
+
+        private void Form_Shown(object? sender, EventArgs e)
+        {
+            if (lvParentsList.Visible)
+            {
+                lvParentsList.Focus();
+            }
+            else
+            {
+                AutoCommit.Focus();
+            }
         }
 
         private void LoadRevisionInfo()

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -2,6 +2,7 @@
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
@@ -9,52 +10,97 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public partial class FormRevertCommit : GitModuleForm
+    public partial class FormRevertCommit : GitExtensionsDialog
     {
         private readonly TranslationString _noneParentSelectedText = new("None parent is selected!");
 
         private bool _isMerge;
+        private int _parentsLabelControlHeight;
+        private int _lvParentsListControlHeight;
+
+        private const int _parentsListItemHeight = 18;
+
+        public GitRevision Revision { get; }
 
         public FormRevertCommit(IGitUICommands commands, GitRevision revision)
-            : base(commands)
+            : base(commands, enablePositionRestore: false)
         {
             Revision = revision;
 
             InitializeComponent();
+
+            columnHeader1.Width = DpiUtil.Scale(columnHeader1.Width);
+            columnHeader2.Width = DpiUtil.Scale(columnHeader2.Width);
+            columnHeader3.Width = DpiUtil.Scale(columnHeader3.Width);
+            columnHeader4.Width = DpiUtil.Scale(columnHeader4.Width);
+
             InitializeComplete();
         }
 
-        public GitRevision Revision { get; }
-
         private void FormRevertCommit_Load(object sender, EventArgs e)
         {
-            commitSummaryUserControl1.Revision = Revision;
+            _parentsLabelControlHeight = ParentsLabel.Size.Height;
+            _lvParentsListControlHeight = lvParentsList.Size.Height;
 
-            ParentsList.Items.Clear(); // TODO: search this line and the ones below to find code duplication
+            LoadRevisionInfo();
+        }
 
-            _isMerge = Module.IsMerge(Revision.ObjectId);
-            parentListPanel.Visible = _isMerge;
-            if (_isMerge)
+        private void LoadRevisionInfo()
+        {
+            try
             {
-                IReadOnlyList<GitRevision> parents = Module.GetParentRevisions(Revision.ObjectId);
+                SuspendLayout();
 
-                for (int i = 0; i < parents.Count; i++)
+                commitSummaryUserControl1.Revision = Revision;
+
+                lvParentsList.Items.Clear();
+
+                _isMerge = Module.IsMerge(Revision.ObjectId);
+
+                // We need to hide these optional components first to get a correct base value of PreferredMinimumHeight
+                ParentsLabel.Visible = false;
+                lvParentsList.Visible = false;
+
+                if (_isMerge)
                 {
-                    ParentsList.Items.Add(new ListViewItem((i + 1).ToString())
-                    {
-                        SubItems =
-                        {
-                            parents[i].Subject,
-                            parents[i].Author,
-                            parents[i].CommitDate.ToShortDateString()
-                        }
-                    });
+                    MinimumSize = new Size(MinimumSize.Width, PreferredMinimumHeight + _parentsLabelControlHeight + _lvParentsListControlHeight);
+                    Size = MinimumSize;
+                    ParentsLabel.Visible = true;
+                    lvParentsList.Visible = true;
+                }
+                else
+                {
+                    MinimumSize = new Size(MinimumSize.Width, PreferredMinimumHeight - _parentsLabelControlHeight - _lvParentsListControlHeight);
+                    Size = MinimumSize;
                 }
 
-                ParentsList.TopItem.Selected = true;
-                Size size = MinimumSize;
-                size.Height += 100;
-                MinimumSize = size;
+                if (_isMerge)
+                {
+                    IReadOnlyList<GitRevision> parents = Module.GetParentRevisions(Revision.ObjectId);
+
+                    for (int i = 0; i < parents.Count; i++)
+                    {
+                        lvParentsList.Items.Add(new ListViewItem((i + 1).ToString())
+                        {
+                            SubItems =
+                            {
+                                parents[i].Subject,
+                                parents[i].Author,
+                                parents[i].CommitDate.ToShortDateString()
+                            }
+                        });
+                    }
+
+                    lvParentsList.TopItem.Selected = true;
+                    Size size = MinimumSize;
+                    size.Height += DpiUtil.Scale(_parentsListItemHeight * parents.Count);
+                    Size = size;
+                    MinimumSize = size;
+                }
+            }
+            finally
+            {
+                ResumeLayout(performLayout: true);
             }
         }
 
@@ -63,14 +109,14 @@ namespace GitUI.CommandsDialogs
             int parentIndex = 0;
             if (_isMerge)
             {
-                if (ParentsList.SelectedItems.Count != 1)
+                if (lvParentsList.SelectedItems.Count != 1)
                 {
                     MessageBox.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
                 else
                 {
-                    parentIndex = ParentsList.SelectedItems[0].Index + 1;
+                    parentIndex = lvParentsList.SelectedItems[0].Index + 1;
                 }
             }
 
@@ -106,6 +152,11 @@ namespace GitUI.CommandsDialogs
             MergeConflictHandler.HandleMergeConflicts(UICommands, this, AutoCommit.Checked);
             DialogResult = DialogResult.OK;
             Close();
+        }
+
+        private void btnAbort_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
         }
     }
 }

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.resx
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -3250,6 +3250,10 @@ Are you sure?</source>
         <source>Date</source>
         <target />
       </trans-unit>
+      <trans-unit id="lblAnotherRev.Text">
+        <source>C&amp;hoose another revision:</source>
+        <target />
+      </trans-unit>
       <trans-unit id="lblBranchInfo.Text">
         <source>Cherry pick this commit:</source>
         <target />
@@ -7144,6 +7148,10 @@ Do you want to use this custom merge script?</source>
       </trans-unit>
       <trans-unit id="_noneParentSelectedText.Text">
         <source>None parent is selected!</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="btnAbort.Text">
+        <source>A&amp;bort</source>
         <target />
       </trans-unit>
       <trans-unit id="columnHeader1.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Convert `FormRevertCommit` to `GitExtensionsDialog`
  - Fix its DPI in a process
  - Add Abort button
  - Align designer/form-sizing code with `FormCherryPick`
- Align forms `FormCherryPick` code with `FormRevertCommit`, they are very similar
  - Designer file mainly had controls moved around
    - `label2` got a proper field and got renamed to `lblAnotherRev`
  - Code file had an improvement for how to calculate controls size (mainly because previous approach for some reason didn't work with `FormRevertCommit`)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

`FormRevertCommit` 100% 1 parent
![revert_old_100_1parent](https://github.com/user-attachments/assets/e46d6b4b-bc27-4ef7-aee1-35d4dee9229b)

`FormRevertCommit` 200% 3 parents (notice column width and button size)
![revert_old_200_3parents](https://github.com/user-attachments/assets/7b48f901-b26c-4a63-bfb9-4340318e3dff)


### After

`FormRevertCommit` 100% 1 parent
![revert_new_100_1parent](https://github.com/user-attachments/assets/c737d703-71b2-4ac5-9b41-ce0028734e6d)

`FormRevertCommit` 100% 2 parents
![revert_new_100_2parents](https://github.com/user-attachments/assets/796422b9-f7b4-4086-9b01-c5e596a6d49c)

`FormRevertCommit` 100% 3 parents
![revert_new_100_3parents](https://github.com/user-attachments/assets/cfce8399-2abd-44d9-a36b-00f67c87b68d)

`FormRevertCommit` 200% 1 parent
![revert_new_200_1parent](https://github.com/user-attachments/assets/9e1b2d28-9b87-4024-870f-019198f2d7f8)

`FormRevertCommit` 200% 2 parents
![revert_new_200_2parents](https://github.com/user-attachments/assets/da1be9fd-8a99-451d-a106-956f23d82457)

`FormRevertCommit` 200% 3 parents
![revert_new_200_3parents](https://github.com/user-attachments/assets/4fac09ca-ae2b-48ac-82c7-2da1e04382ec)

---

The only difference is that parents list view has some extra white-space at the bottom to make it evident that there are no more items

`FormCherryPick` 200% 1 parent
![cherrypick_new_200_1parent](https://github.com/user-attachments/assets/335c8e62-929c-4abf-8131-4adc28c9a16d)

`FormCherryPick` 200% 2 parents
![cherrypick_new_200_2parents](https://github.com/user-attachments/assets/0eaef934-fa54-4a9d-8846-1a036dd6e6d0)

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- Manually at 100% 175% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11 4K 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
