### PR TITLE
fix: Allow user to override git-grep color

### DIFF
--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -17,25 +17,6 @@ public partial class AnsiEscapeUtilities
     private const int _boldOffset = 8;
 
     /// <summary>
-    /// Override Git colors from GE theme color.
-    /// </summary>
-    /// <param name="key">The Git config key: https://git-scm.com/docs/git-config#Documentation/git-config.txt-colordiffltslotgt.</param>
-    /// <param name="appBackColor">The back color to add, fore color to be derived from it.</param>
-    /// <returns>The GitConfigItem.</returns>
-    public static GitConfigItem SetUnsetGitColor(
-                    string key,
-                    AppColor appBackColor)
-    {
-        // Override the Git default coloring (mask the alpha for Git)
-        Color backColor = appBackColor.GetThemeColor();
-        int back = backColor.ToArgb() & 0xffffff;
-        Color foreColor = ColorHelper.GetForeColorForBackColor(backColor);
-        int fore = foreColor.ToArgb() & 0xffffff;
-
-        return new GitConfigItem(key, $"#{fore:x6} #{back:x6}");
-    }
-
-    /// <summary>
     /// Debug print colors similar to https://github.com/robertknight/konsole/raw/master/tests/color-spaces.pl
     /// </summary>
     public static void PrintColors(StringBuilder sb, List<TextMarker> textMarkers)

--- a/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
@@ -67,7 +67,7 @@ public partial class GrepHighlightService : TextHighlightService
 
         if (AppSettings.ReverseGitColoring.Value)
         {
-            SetIfUnsetInGit(key: "color.grep.matchSelected", value: $"red bold reverse");
+            SetIfUnsetInGit(key: "color.grep.matchSelected", value: "red bold reverse");
         }
 
         return commandConfiguration;

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -103,7 +103,7 @@ namespace GitUI
 
             if (!string.IsNullOrWhiteSpace(item.Item.GrepString))
             {
-                IGitCommandConfiguration commandConfiguration = GrepHighlightService.GetGitCommandConfiguration();
+                IGitCommandConfiguration commandConfiguration = GrepHighlightService.GetGitCommandConfiguration(fileViewer.Module);
                 ExecutionResult result = await fileViewer.Module.GetGrepFileAsync(
                         item.SecondRevision.ObjectId,
                         item.Item.Name,


### PR DESCRIPTION
## Proposed changes

The intention was to allow the user to override the git-grep color, this was not implemented.
Also allows for removal of a routine.

Note: SetIfUnsetInGit() is used in DiffHighlightService too, but it is not worth it to share the method.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
