### PR TITLE
fix: WslGitPath in FormProcess

### DIFF
--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -35,7 +35,7 @@ namespace GitUI.HelperDialogs
                 if (!string.IsNullOrEmpty(wslDistro))
                 {
                     process = AppSettings.WslGitCommand;
-                    arguments = $"-d {wslDistro} git {arguments}";
+                    arguments = $"-d {wslDistro} {AppSettings.WslGitPath} {arguments}";
                 }
             }
 


### PR DESCRIPTION
Fixes #11839

## Proposed changes

Use the hidden read-only setting WslGitPath also in FormPath ("popup" commands like push and fetch) as all other Git commands executed in WSL (a few commands in WSL uses Windows Git).

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
