### PR TITLE
fix(DiffHighlightService): Skip unchanged char after pure addition/removal

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -244,12 +244,20 @@ public abstract class DiffHighlightService : TextHighlightService
             beginOffset++;
         }
 
-        while (lineAddedEndOffset > beginOffset && lineRemovedEndOffset > beginOffset)
+        while (lineAddedEndOffset >= beginOffset && lineRemovedEndOffset >= beginOffset)
         {
             reverseOffset = lineAdded.Length - lineAddedEndOffset;
 
-            char a = document.GetCharAt(lineAdded.Offset + lineAdded.Length - 1 - reverseOffset);
-            char r = document.GetCharAt(lineRemoved.Offset + lineRemoved.Length - 1 - reverseOffset);
+            int addedOffset = lineAdded.Length - 1 - reverseOffset;
+            int removedOffset = lineRemoved.Length - 1 - reverseOffset;
+
+            if (addedOffset < beginOffset || removedOffset < beginOffset)
+            {
+                break;
+            }
+
+            char a = document.GetCharAt(lineAdded.Offset + addedOffset);
+            char r = document.GetCharAt(lineRemoved.Offset + removedOffset);
 
             if (a != r)
             {


### PR DESCRIPTION
## Proposed changes

`DiffHighlightService.MarkDifference`:
- search the end of the diff back to `beginOffset` including
- avoid accessing characters out of range, i.e. before `beginOffset`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/69c8c294-67d9-42a5-aafa-9d83b8803b45)

### After

![image](https://github.com/user-attachments/assets/dc1f9800-9193-4dce-8128-56033f72113c)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).