### PR TITLE
fix: Force black foreground colors for bold in moved diff

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -54,10 +54,14 @@ public abstract class DiffHighlightService : TextHighlightService
         SetIfUnsetInGit(key: "color.diff.old", value: $"red {reverse}");
         SetIfUnsetInGit(key: "color.diff.new", value: $"green {reverse}");
 
-        SetIfUnsetInGit(key: "color.diff.oldMoved", value: $"magenta bold {reverse}");
-        SetIfUnsetInGit(key: "color.diff.newMoved", value: $"blue bold {reverse}");
-        SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: $"cyan bold {reverse}");
-        SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: $"yellow bold {reverse}");
+        if (AppSettings.ReverseGitColoring.Value)
+        {
+            // Fix: Force black foreground to avoid that foreground is calculated to white
+            SetIfUnsetInGit(key: "color.diff.oldMoved", value: "black brightmagenta");
+            SetIfUnsetInGit(key: "color.diff.newMoved", value: "black brightblue");
+            SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: "black brightcyan");
+            SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: "black brightyellow");
+        }
 
         // Set dimmed colors, default is gray dimmed/italic
         SetIfUnsetInGit(key: "color.diff.oldMovedDimmed", value: $"magenta dim {reverse}");
@@ -69,8 +73,8 @@ public abstract class DiffHighlightService : TextHighlightService
         if (command == "range-diff")
         {
             SetIfUnsetInGit(key: "color.diff.contextBold", value: $"normal bold {reverse}");
-            SetIfUnsetInGit(key: "color.diff.oldBold", value: $"red bold {reverse}");
-            SetIfUnsetInGit(key: "color.diff.newBold", value: $"green bold {reverse}");
+            SetIfUnsetInGit(key: "color.diff.oldBold", value: $"brightred {reverse}");
+            SetIfUnsetInGit(key: "color.diff.newBold", value: $"brightgreen  {reverse}");
         }
 
         return commandConfiguration;


### PR DESCRIPTION

## Proposed changes

Always use black as foreground colors for moved lines. GE may calculate the color to be white, this is a an override to avoid the low contrast without risking breaking other scenarios.

This can be seen in https://github.com/gitextensions/gitextensions/issues/11843#issue-2473084897
even if that issue is about something related.
I cannot reproduce, this is a good enough default configuration as theming is limited anyway.
(and colors can be overridden with git-config)

Note that colors set as "black brightyellow" instead of "black yellow bold" as that has a separate meaning - a separate PR will clarify.

## Screenshots <!-- Remove this section if PR does not change UI -->
white foreground is configured in debugger, cannot reproduce.

![image](https://github.com/user-attachments/assets/4f137997-fb5d-4b52-b925-832c1df12aa0)
![image](https://github.com/user-attachments/assets/c7303c7a-8b34-4cdb-af32-e349d0afd3ed)

![image](https://github.com/user-attachments/assets/dd004c3e-6f4f-4f7e-a49e-7749801c8370)
![image](https://github.com/user-attachments/assets/4c44acb6-eba6-4835-a338-9ec1bfa87255)

![image](https://github.com/user-attachments/assets/31223b74-4458-4bcd-b11a-5b6c0c88a92e)
![image](https://github.com/user-attachments/assets/1301d5c6-b7f6-4b94-9a10-e64fd74ef3a9)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
