### PR TITLE
fix: bold attributes applies to both fore/back

### DIFF
--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -212,7 +212,7 @@ public partial class AnsiEscapeUtilities
                 case 7: // reverse
                     reverse = true;
                     break;
-                case 22:
+                case 22: // normal color, intensity
                     bold = false;
                     dim = false;
                     break;

--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -14,6 +14,8 @@ public partial class AnsiEscapeUtilities
 {
     [GeneratedRegex(@"\u001b\[((?<escNo>\d+)\s*[:;]?\s*)*m", RegexOptions.ExplicitCapture)]
     private static partial Regex EscapeRegex();
+    private static readonly List<bool> _fores = [true, false];
+    private static readonly List<bool> _bolds = [false, true];
 
     // Color code definitions
     private const int _blackId = 0;
@@ -36,9 +38,9 @@ public partial class AnsiEscapeUtilities
         sb.Append('\n');
 
         // color id (standard) colors
-        foreach (bool fore in new List<bool>() { true, false })
+        foreach (bool fore in _fores)
         {
-            foreach (bool bold in new List<bool>() { false, true })
+            foreach (bool bold in _bolds)
             {
                 foreach (int dim in new List<int>() { 0, 2 })
                 {

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.Get8bitColor.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.Get8bitColor.cs
@@ -9,7 +9,6 @@ namespace GitUITests.Editor.Diff;
 [TestFixture]
 public class AnsiEscapeUtilitiesTest_Get8bitColor
 {
-    private const int _blackId = 0;
     private const int _redId = 1;
     private readonly List<Color> _redAnsiTheme = [Color.FromArgb(211, 0, 11), Color.FromArgb(232, 127, 132), Color.FromArgb(255, 94, 94), Color.FromArgb(254, 174, 174),
         Color.FromArgb(255, 200, 200), Color.FromArgb(254, 227, 227), Color.FromArgb(255, 165, 165), Color.FromArgb(254, 209, 209)];
@@ -37,25 +36,23 @@ public class AnsiEscapeUtilitiesTest_Get8bitColor
     [Test]
     public void Get8bitColor_ShouldReturnBuiltinThemeColors()
     {
-        List<int> offsets = [0, AnsiEscapeUtilities.TestAccessor.GetBoldOffset()];
         for (int colorId = 0; colorId < 8; ++colorId)
         {
             foreach (bool fore in new List<bool>() { true, false })
             {
-                foreach (int offset in offsets)
+                foreach (bool bold in new List<bool>() { true, false })
                 {
                     foreach (bool dim in new List<bool>() { false, true })
                     {
-                        // Only check the result for red, the other should just get a value and set the id
+                        // Only check the result for red, the other should just get a value
                         // (No need to maintain all ANSI theme colors in parallel)
-                        Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(colorId + offset, fore, dim, out int seenColorId);
-                        colorId.Should().Be(seenColorId);
+                        Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(colorId, fore, bold, dim);
                         if (colorId != _redId)
                         {
                             continue;
                         }
 
-                        int themeOffset = (dim ? 1 : 0) + (offset == 0 ? 0 : 2) + (fore ? 0 : 4);
+                        int themeOffset = (dim ? 1 : 0) + (bold ? 2 : 0) + (fore ? 0 : 4);
                         result.Should().Be(_redAnsiTheme[themeOffset], $"Failed for {themeOffset}");
                     }
                 }
@@ -66,16 +63,12 @@ public class AnsiEscapeUtilitiesTest_Get8bitColor
     [Test]
     public void Get8bitColor_ShouldReturnCorrect6bitColor()
     {
-        // currentColorId is always reset, no named color
-        const int currentColorId = _blackId;
-
         for (int i = 16; i < 232; ++i)
         {
-            Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(i, fore: true, dim: false, out int colorId);
+            Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(i, fore: true, bold: false, dim: false);
             result.Should().Be(GetExpectedColor(i));
-            colorId.Should().Be(currentColorId);
 
-            // sample colors
+            // sample specific colors only
             if (i == 196)
             {
                 result.Should().Be(Color.FromArgb(255, 0, 0));
@@ -105,14 +98,10 @@ public class AnsiEscapeUtilitiesTest_Get8bitColor
     [Test]
     public void Get8bitColor_ShouldReturnCorrect4bitGrey()
     {
-        // currentColorId is always rest, no named color
-        const int currentColorId = _blackId;
-
         for (int i = 232; i <= 255; ++i)
         {
-            Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(i, fore: true, dim: false, out int colorId);
+            Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(i, fore: true, bold: false, dim: false);
             result.Should().Be(Get24StepGray(i));
-            colorId.Should().Be(currentColorId);
 
             // border
             if (i == 232)
@@ -141,7 +130,7 @@ public class AnsiEscapeUtilitiesTest_Get8bitColor
 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
         {
-            AnsiEscapeUtilities.TestAccessor.Get8bitColor(colorCode, fore: true, dim: false, out int colorId);
+            AnsiEscapeUtilities.TestAccessor.Get8bitColor(colorCode, fore: true, bold: false, dim: false);
         });
     }
 }


### PR DESCRIPTION

## Proposed changes

Related to #11847 

The handling of ANSI escape sequences was probably not completely correct (there is no clear spec...).
All direct attributes applies to all colors specified.

So git colors "black bold red" and "black bold red" are translated to the sequence "1, 30, 41" which will render the same as  "brightblack brightred" ("90, 101"), but "black brightred" ("30, 101") is different.
Attributes should not be "persistent" if a "bright" color is set explicitly.

The implementation is slightly simplified too.

In reality, the implementation would not be a major issue as attributes are not often used in combination like this.

## Test methodology <!-- How did you ensure quality? -->

Tests are mostly unchanged.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
