### PR TITLE
feat: GitCache: Add current directory to key

### DIFF
--- a/src/app/GitCommands/Git/CommandCache.cs
+++ b/src/app/GitCommands/Git/CommandCache.cs
@@ -32,7 +32,7 @@ namespace GitCommands
         /// </summary>
         public event EventHandler? Changed;
 
-        private readonly MruCache<string, (byte[] output, byte[] error)> _cache;
+        private readonly MruCache<string, (string output, string error)> _cache;
 
         /// <summary>
         /// Initialises a new instance of <see cref="CommandCache"/> with specified <paramref name="capacity"/>.
@@ -40,7 +40,7 @@ namespace GitCommands
         /// <param name="capacity">The maximum number of commands to cache.</param>
         public CommandCache(int capacity = 50)
         {
-            _cache = new MruCache<string, (byte[] output, byte[] error)>(capacity: capacity);
+            _cache = new MruCache<string, (string output, string error)>(capacity: capacity);
         }
 
         /// <summary>
@@ -61,14 +61,14 @@ namespace GitCommands
         /// <param name="output">Stored output bytes of the command, if found.</param>
         /// <param name="error">Stored error bytes of the command, if found.</param>
         /// <returns><c>true</c> if the command was found, otherwise <c>false</c>.</returns>
-        public bool TryGet(string? cmd, [NotNullWhen(returnValue: true)] out byte[]? output, [NotNullWhen(returnValue: true)] out byte[]? error)
+        public bool TryGet(string? cmd, [NotNullWhen(returnValue: true)] out string? output, [NotNullWhen(returnValue: true)] out string? error)
         {
             // Never cache empty commands
             if (!string.IsNullOrEmpty(cmd))
             {
                 lock (_cache)
                 {
-                    if (_cache.TryGetValue(cmd, out (byte[] output, byte[] error) item))
+                    if (_cache.TryGetValue(cmd, out (string output, string error) item))
                     {
                         (output, error) = item;
                         return true;
@@ -87,7 +87,7 @@ namespace GitCommands
         /// <param name="cmd">The command to add to the cache.</param>
         /// <param name="output">Output bytes of the command.</param>
         /// <param name="error">Error bytes of the command.</param>
-        public void Add(string? cmd, byte[] output, byte[] error)
+        public void Add(string? cmd, string output, string error)
         {
             // Never cache empty commands
             if (string.IsNullOrEmpty(cmd))

--- a/src/app/GitCommands/Git/Executable.cs
+++ b/src/app/GitCommands/Git/Executable.cs
@@ -48,6 +48,8 @@ namespace GitCommands
             return new ProcessWrapper(fileName, _prefixArguments, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute, throwOnErrorExit, cancellationToken);
         }
 
+        public string GetWorkingDirectory() => _workingDir;
+
         #region ProcessWrapper
 
         /// <summary>

--- a/src/app/GitCommands/Git/ExecutableExtensions.cs
+++ b/src/app/GitCommands/Git/ExecutableExtensions.cs
@@ -133,7 +133,7 @@ namespace GitCommands
             string outputStr = CleanString(stripAnsiEscapeCodes, EncodingHelper.DecodeString(outputBuffer.ToArray(), Array.Empty<byte>(), ref outputEncoding));
             if (cache is not null && await exitTask == 0)
             {
-                cache.Add(arguments, outputStr, "");
+                cache.Add(arguments, outputStr, error: "");
             }
 
             return outputStr;
@@ -257,7 +257,7 @@ namespace GitCommands
             CancellationToken cancellationToken = default)
         {
             return GitUI.ThreadHelper.JoinableTaskFactory.Run(
-                () => executable.ExecuteAsync(arguments, writeInput, outputEncoding, cache, "", stripAnsiEscapeCodes, throwOnErrorExit, cancellationToken));
+                () => executable.ExecuteAsync(arguments, writeInput, outputEncoding, cache, extraCacheKey: "", stripAnsiEscapeCodes, throwOnErrorExit, cancellationToken));
         }
 
         /// <summary>
@@ -277,14 +277,14 @@ namespace GitCommands
             Action<StreamWriter>? writeInput = null,
             Encoding? outputEncoding = null,
             CommandCache? cache = null,
-            string extraCacheKeys = "",
+            string extraCacheKey = "",
             bool stripAnsiEscapeCodes = true,
             bool throwOnErrorExit = true,
             CancellationToken cancellationToken = default)
         {
             outputEncoding ??= _defaultOutputEncoding.Value;
 
-            string cacheKey = $"{arguments}::{executable.GetWorkingDirectory()}::{stripAnsiEscapeCodes}::{extraCacheKeys}";
+            string cacheKey = $"{arguments}::{executable.GetWorkingDirectory()}::{stripAnsiEscapeCodes}::{extraCacheKey}";
             if (cache?.TryGet(cacheKey, out string? cachedOutput, out string? cachedError) is true)
             {
                 return new ExecutionResult(

--- a/src/app/GitCommands/Git/ExecutableExtensions.cs
+++ b/src/app/GitCommands/Git/ExecutableExtensions.cs
@@ -32,7 +32,7 @@ namespace GitCommands
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="cache">A <see cref="CommandCache"/> to use if command results may be cached, otherwise <c>null</c>.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
-        /// <returns>The concatenation of standard output and standard error. To receive these outputs separately, use <see cref="Execute"/> instead.</returns>
+        /// <returns>The concatenation of standard output (standard error is ignored). To receive these outputs separately, use <see cref="Execute"/> instead.</returns>
         [MustUseReturnValue("If output text is not required, use " + nameof(RunCommand) + " instead")]
         public static string GetOutput(
             this IExecutable executable,
@@ -58,7 +58,7 @@ namespace GitCommands
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from each process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="cache">A <see cref="CommandCache"/> to use if command results may be cached, otherwise <c>null</c>.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
-        /// <returns>The concatenation of standard output and standard error. To receive these outputs separately, use <see cref="Execute"/> instead.</returns>
+        /// <returns>The concatenation of standard output (standard error is ignored). To receive these outputs separately, use <see cref="Execute"/> instead.</returns>
         [MustUseReturnValue("If output text is not required, use " + nameof(RunCommand) + " instead")]
         public static string GetBatchOutput(
             this IExecutable executable,
@@ -86,7 +86,7 @@ namespace GitCommands
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="cache">A <see cref="CommandCache"/> to use if command results may be cached, otherwise <c>null</c>.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
-        /// <returns>A task that yields the concatenation of standard output and standard error. To receive these outputs separately, use <see cref="ExecuteAsync"/> instead.</returns>
+        /// <returns>A task that yields the concatenation of standard output (standard error is ignored). To receive these outputs separately, use <see cref="ExecuteAsync"/> instead.</returns>
         public static async Task<string> GetOutputAsync(
             this IExecutable executable,
             ArgumentString arguments = default,
@@ -130,7 +130,7 @@ namespace GitCommands
 
             await Task.WhenAll(outputTask, exitTask);
 
-            string outputStr = CleanString(stripAnsiEscapeCodes, EncodingHelper.DecodeString(outputBuffer.ToArray(), Array.Empty<byte>(), ref outputEncoding));
+            string outputStr = CleanString(stripAnsiEscapeCodes, EncodingHelper.DecodeString(outputBuffer.ToArray(), error: [], ref outputEncoding));
             if (cache is not null && await exitTask == 0)
             {
                 cache.Add(arguments, outputStr, error: "");

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2186,6 +2186,7 @@ namespace GitCommands
             string? oldFileName,
             ArgumentString extraDiffArguments,
             bool cacheResult,
+            string extraCacheKey,
             bool isTracked,
             bool useGitColoring,
             CancellationToken cancellationToken)
@@ -2217,8 +2218,10 @@ namespace GitCommands
 
             ExecutionResult result = await _gitExecutable.ExecuteAsync(
                 args,
-                cache: cache,
+                writeInput: null,
                 outputEncoding: LosslessEncoding,
+                cache: cache,
+                extraCacheKey,
                 stripAnsiEscapeCodes: !useGitColoring,
                 throwOnErrorExit: false,
                 cancellationToken: cancellationToken);

--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -170,9 +170,10 @@ namespace GitCommands
 
             // output can be cached if Git Notes is not included and hash is valid
             bool canCache = !hasNotes && !string.IsNullOrWhiteSpace(commitHash);
-            if (canCache && GitModule.GitCommandCache.TryGet(arguments.ToString(), out byte[]? commandOutput, out _) is true)
+            ReadOnlyMemory<byte> commandBytes;
+            if (canCache && GitModule.GitCommandCache.TryGet(arguments.ToString(), out string? commandOutput, out _) is true)
             {
-                // OK
+                commandBytes = new ReadOnlyMemory<byte>(Convert.FromBase64String(commandOutput));
             }
             else
             {
@@ -180,20 +181,24 @@ namespace GitCommands
                 Debug.WriteLine($"git {arguments}");
 #endif
                 using IProcess process = _module.GitCommandRunner.RunDetached(cancellationToken, arguments, redirectOutput: true, outputEncoding: null);
-                commandOutput = process.StandardOutput.BaseStream.SplitLogOutput().SingleOrDefault().ToArray();
+                commandBytes = new ReadOnlyMemory<byte>(process.StandardOutput.BaseStream.SplitLogOutput().SingleOrDefault().ToArray());
                 string errorOutput = process.StandardError.ReadToEnd();
                 if (!string.IsNullOrWhiteSpace(errorOutput) && throwOnError)
                 {
                     throw new ExternalOperationException(AppSettings.GitCommand, arguments.ToString(), innerException: new Exception(errorOutput));
                 }
+
+                // store the byte stream as a Base64 string to allow that it can be converted back.
+                // The output is not directly readable in the cache viewer.
+                commandOutput = Convert.ToBase64String(commandBytes.ToArray());
             }
 
-            if (!TryParseRevision(commandOutput, out GitRevision? revision))
+            if (!TryParseRevision(commandBytes, out GitRevision? revision))
             {
                 if (throwOnError)
                 {
                     throw new ExternalOperationException(AppSettings.GitCommand, arguments.ToString(),
-                        innerException: new Exception($"invalid revision{Environment.NewLine}{commandOutput}"));
+                        innerException: new Exception($"invalid revision{Environment.NewLine}{commandBytes}"));
                 }
 
                 return null;
@@ -201,7 +206,7 @@ namespace GitCommands
 
             if (canCache)
             {
-                GitModule.GitCommandCache.Add(arguments.ToString(), output: commandOutput, error: []);
+                GitModule.GitCommandCache.Add(arguments.ToString(), output: commandOutput, error: "");
             }
 
             return revision;

--- a/src/app/GitExtensions.Extensibility/ExecutionResult.cs
+++ b/src/app/GitExtensions.Extensibility/ExecutionResult.cs
@@ -11,7 +11,7 @@ public readonly struct ExecutionResult
     public string StandardError { get; }
     public int? ExitCode { get; }
 
-    public ExecutionResult(IExecutable executable, string arguments, string standardOutput, string standardError, int? exitCode)
+    public ExecutionResult(IExecutable executable, ArgumentString arguments, string standardOutput, string standardError, int? exitCode)
     {
         Command = executable.Command;
         WorkingDir = executable.WorkingDir;

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -254,6 +254,7 @@ public interface IGitModule
         string? oldFileName,
         ArgumentString extraDiffArguments,
         bool cacheResult,
+        string extraCacheKey,
         bool isTracked,
         bool useGitColoring,
         CancellationToken cancellationToken);

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -247,6 +247,20 @@ public interface IGitModule
     /// <returns>the Git output.</returns>
     string GetCustomDiffMergeTools(bool isDiff, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Run a command line difftool async.
+    /// </summary>
+    /// <param name="firstId">The first commit id to compare.</param>
+    /// <param name="secondId">The second commit id.</param>
+    /// <param name="fileName">The current filename.</param>
+    /// <param name="oldFileName">The file name in the first commit or null.</param>
+    /// <param name="extraDiffArguments">git-difftool arguments.</param>
+    /// <param name="cacheResult">If the result may be stored in the command cache.</param>
+    /// <param name="extraCacheKey">Additional cache keeys, like environment variables and values affacting the commend.</param>
+    /// <param name="isTracked">If the file is tracked by Git.</param>
+    /// <param name="useGitColoring">If Git coloring should be used.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The result for the command.</returns>
     Task<ExecutionResult> GetSingleDifftoolAsync(
         ObjectId? firstId,
         ObjectId? secondId,

--- a/src/app/GitExtensions.Extensibility/IExecutable.cs
+++ b/src/app/GitExtensions.Extensibility/IExecutable.cs
@@ -36,4 +36,6 @@ public interface IExecutable
                    bool useShellExecute = false,
                    bool throwOnErrorExit = true,
                    CancellationToken cancellationToken = default);
+
+    string GetWorkingDirectory();
 }

--- a/src/app/GitExtensions.Extensibility/IExecutable.cs
+++ b/src/app/GitExtensions.Extensibility/IExecutable.cs
@@ -37,5 +37,9 @@ public interface IExecutable
                    bool throwOnErrorExit = true,
                    CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Get the directory the execueble is running in.
+    /// </summary>
+    /// <returns>The working directory.</returns>
     string GetWorkingDirectory();
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -116,15 +116,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             string command = (string)CommandCacheItems.SelectedItem;
 
-            if (GitModule.GitCommandCache.TryGet(command, out byte[]? cmdOut, out byte[]? cmdErr))
+            if (GitModule.GitCommandCache.TryGet(command, out string? cmdOut, out string? cmdErr))
             {
                 Encoding encoding = GitModule.SystemEncoding;
                 commandCacheOutput.Text =
-                    command +
+                    PrintableChars(command) +
                     "\n-------------------------------------\n\n" +
-                    PrintableChars(EncodingHelper.DecodeString(cmdOut, [], ref encoding)) +
+                    PrintableChars(cmdOut) +
                     "\n-------------------------------------\n\n" +
-                    PrintableChars(EncodingHelper.DecodeString([], cmdErr, ref encoding));
+                    PrintableChars(cmdErr);
             }
             else
             {

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -460,7 +460,7 @@ namespace GitUI.Editor
             void SetEnvironmentVariable(string variable, string value)
             {
                 env.SetEnvironmentVariable(variable, value);
-                sb.Append(';').Append(variable).Append('=').Append(value);
+                sb.AppendFormat($";{variable}={value}");
             }
         }
 

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -428,7 +428,7 @@ namespace GitUI.Editor
         public (ArgumentString args, string extraCacheKey) GetDifftasticArguments(bool isRangeDiff = false)
         {
             EnvironmentAbstraction env = new();
-            StringBuilder sb = new();
+            StringBuilder extraCacheKeyBuilder = new();
 
             // Difftastic coloring is always used (AppSettings.UseGitColoring.Value is not used).
             // Allow user to override with difftool command line options.
@@ -455,12 +455,12 @@ namespace GitUI.Editor
                 "--tool=difftastic",
                 { TreatAllFilesAsText, "--text" },
             },
-            sb.ToString());
+            extraCacheKeyBuilder.ToString());
 
             void SetEnvironmentVariable(string variable, string value)
             {
                 env.SetEnvironmentVariable(variable, value);
-                sb.AppendFormat($";{variable}={value}");
+                extraCacheKeyBuilder.AppendFormat($";{variable}={value}");
             }
         }
 

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -425,10 +425,10 @@ namespace GitUI.Editor
             };
         }
 
-        public (ArgumentString args, string extraCacheKey) GetDifftasticArguments(bool isRangeDiff = false)
+        public (ArgumentString Args, string ExtraCacheKey) GetDifftasticArguments(bool isRangeDiff = false)
         {
             EnvironmentAbstraction env = new();
-            StringBuilder extraCacheKeyBuilder = new();
+            StringBuilder extraCacheKey = new();
 
             // Difftastic coloring is always used (AppSettings.UseGitColoring.Value is not used).
             // Allow user to override with difftool command line options.
@@ -455,12 +455,12 @@ namespace GitUI.Editor
                 "--tool=difftastic",
                 { TreatAllFilesAsText, "--text" },
             },
-            extraCacheKeyBuilder.ToString());
+            extraCacheKey.ToString());
 
             void SetEnvironmentVariable(string variable, string value)
             {
                 env.SetEnvironmentVariable(variable, value);
-                extraCacheKeyBuilder.AppendFormat($";{variable}={value}");
+                extraCacheKey.AppendFormat($";{variable}={value}");
             }
         }
 

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -156,14 +156,15 @@ namespace GitUI
             if (!item.Item.IsSubmodule && AppSettings.DiffDisplayAppearance.Value == GitCommands.Settings.DiffDisplayAppearance.Difftastic && fileViewer.IsDifftasticEnabled.Value)
             {
                 bool isTracked = item.Item.IsTracked || (item.Item.TreeGuid is not null && item.SecondRevision.ObjectId is not null);
-                string diffArgs = fileViewer.GetDifftasticArguments();
+                (ArgumentString diffArgs, string extraCacheKey) = fileViewer.GetDifftasticArguments();
 
                 // set file name as null to not change the restore lineno
                 await fileViewer.ViewTextAsync(fileName: null, $"git difftool {diffArgs} -- {item.Item.Name}");
 
                 ExecutionResult result = await fileViewer.Module.GetSingleDifftoolAsync(firstId, item.SecondRevision.ObjectId, item.Item.Name, item.Item.OldName,
                     diffArgs,
-                    cacheResult: false,
+                    cacheResult: true,
+                    extraCacheKey,
                     isTracked,
                     useGitColoring: true,
                     cancellationToken);

--- a/tests/CommonTestUtils/MockExecutable.cs
+++ b/tests/CommonTestUtils/MockExecutable.cs
@@ -103,6 +103,11 @@ namespace CommonTestUtils
             throw new Exception("Unexpected arguments: " + arguments);
         }
 
+        public string GetWorkingDirectory()
+        {
+            return WorkingDir;
+        }
+
         private sealed class MockProcess : IProcess
         {
             public MockProcess(string? output, int? exitCode = 0, string? error = null)

--- a/tests/app/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -51,8 +51,8 @@ namespace GitCommandsTests.Git
 
             cache.Add(
                 arguments,
-                output: GitModule.SystemEncoding.GetBytes("Hello"),
-                error: GitModule.SystemEncoding.GetBytes("World!"));
+                output: "Hello",
+                error: "World!");
 
             string output = _executable.GetOutput(arguments, cache: cache);
 
@@ -80,7 +80,7 @@ namespace GitCommandsTests.Git
 
             // Validate data stored in cache afterwards
             Assert.AreEqual(1, cache.GetCachedCommands().Count);
-            Assert.IsTrue(cache.TryGet(arguments, out byte[]? outputBytes, out byte[]? errorBytes));
+            Assert.IsTrue(cache.TryGet(arguments, out string? outputBytes, out string? errorBytes));
             Assert.AreEqual(GitModule.SystemEncoding.GetBytes(commandOutput), outputBytes);
             Assert.IsEmpty(errorBytes);
         }

--- a/tests/app/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -54,9 +54,10 @@ namespace GitCommandsTests.Git
                 output: "Hello",
                 error: "World!");
 
+            // GetOutput always ignore error output (will not add to cache).
             string output = _executable.GetOutput(arguments, cache: cache);
 
-            Assert.AreEqual($"Hello{Environment.NewLine}World!", output);
+            Assert.AreEqual($"Hello", output);
 
             // Cache should still have a single item
             Assert.AreEqual(1, cache.GetCachedCommands().Count);

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitCommandCacheTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitCommandCacheTest.cs
@@ -16,8 +16,8 @@ namespace GitCommandsTests.Git
         [Test]
         public void TestAdd()
         {
-            byte[] output = { 11, 12 };
-            byte[] error = { 13, 14 };
+            string output = "Git result";
+            string error = "No Git error!";
             string[] expectedCachedCommand = { "git command" };
 
             _cache.Add("git command", output, error);
@@ -35,12 +35,12 @@ namespace GitCommandsTests.Git
         [Test]
         public void TestTryGet()
         {
-            byte[] originalOutput = { 11, 12 };
-            byte[] originalError = { 13, 14 };
+            string originalOutput = "Another Git result";
+            string originalError = "Still no Git error.";
 
             _cache.Add("git command", originalOutput, originalError);
 
-            Assert.IsTrue(_cache.TryGet("git command", out byte[]? cachedOutput, out byte[]? cachedError));
+            Assert.IsTrue(_cache.TryGet("git command", out string? cachedOutput, out string? cachedError));
             Assert.AreEqual(cachedOutput, originalOutput);
             Assert.AreEqual(cachedError, originalError);
         }
@@ -48,7 +48,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void TestTryGetFails()
         {
-            Assert.IsFalse(_cache.TryGet(null, out byte[]? output, out byte[]? error));
+            Assert.IsFalse(_cache.TryGet(null, out string? output, out string? error));
             Assert.IsFalse(_cache.TryGet("", out output, out error));
             Assert.IsNull(output);
             Assert.IsNull(error);


### PR DESCRIPTION
Depends on #11848 

## Proposed changes

Git cache uses the command as the cache key. However a sha could
theoretically be duplicated in repos, so the path is added.
(This means that multiple clones (like worktrees) are no longer cached.)

Clean escape sequences before storing in the cache to speed up
fetching information from the cache.
Clean escape is also added to the cache key.

Cache DiffTastic commands, add environment variables as cache keys.

--

There is no strong requirement to include this PR in 5.0, but it improves DiffTastic usage in reviews. I switch the different mode several times per file and the delay to open difftastic is annoying.

## Test methodology <!-- How did you ensure quality? -->

The cache tests are updated - only the format of what is changed that is changed.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
