### PR TITLE
Diff View: Match similar lines in changed blocks

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -13,6 +13,17 @@
 
         public static ThemeSettings ThemeSettings { private get; set; } = ThemeSettings.Default;
 
+        /// <summary>
+        ///  Blends the color with the default background color, halves each value first.
+        /// </summary>
+        public static Color DimColor(Color color)
+        {
+            const uint maskWithoutLeastSignificantBits = 0xFE_FE_FE_FE;
+            uint defaultBackground = (uint)SystemColors.Window.ToArgb();
+            int dimCode = (int)((((uint)color.ToArgb() & maskWithoutLeastSignificantBits) >> 1) + ((defaultBackground & maskWithoutLeastSignificantBits) >> 1));
+            return Color.FromArgb((dimCode >> 16) & 0xff, (dimCode >> 8) & 0xff, dimCode & 0xff);
+        }
+
         public static void SetForeColorForBackColor(this Control control) =>
             control.ForeColor = GetForeColorForBackColor(control.BackColor);
 

--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -443,7 +443,7 @@ public partial class AnsiEscapeUtilities
 
         if (dim)
         {
-            color = DimColor(color);
+            color = ColorHelper.DimColor(color);
         }
 
         return color;
@@ -467,15 +467,6 @@ public partial class AnsiEscapeUtilities
             // Convert 0-23 to 0-253
             int i = (level - 232) * 11;
             return Color.FromArgb(i, i, i);
-        }
-
-        static Color DimColor(Color color)
-        {
-            // Blend the color with the background, halve each value first
-            // Note: With themes, defaultBackground must be dynamic
-            const uint defaultBackground = 0xff_ffff;
-            int dimCode = (int)(((color.ToArgb() & 0xFEFEFEFE) >> 1) + ((defaultBackground & 0xFEFEFEFE) >> 1));
-            return Color.FromArgb((dimCode >> 16) & 0xff, (dimCode >> 8) & 0xff, dimCode & 0xff);
         }
     }
 

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -346,38 +346,32 @@ public abstract class DiffHighlightService : TextHighlightService
     private void MarkInlineDifferences(IDocument document)
     {
         int line = 0;
-
         bool found = false;
-        int diffContentOffset;
-        List<ISegment> linesRemoved = GetRemovedLines(document, ref line, ref found);
-        List<ISegment> linesAdded = GetAddedLines(document, ref line, ref found);
 
-        // The first pair of removed / added lines uses to contain the filenames which could also have changed but have a different prefix length.
-        if (linesAdded.Count == 1 && linesRemoved.Count == 1)
+        // Skip the first pair of removed / added lines, which uses to contain the filenames - but without highlighting
+        _ = GetRemovedLines(document, ref line, ref found);
+        if (found)
         {
-            ISegment lineA = linesRemoved[0];
-            ISegment lineB = linesAdded[0];
-            if (lineA.Length > 4 && lineB.Length > 4 &&
-                document.GetCharAt(lineA.Offset + 4) == 'a' &&
-                document.GetCharAt(lineB.Offset + 4) == 'b')
-            {
-                diffContentOffset = 5;
-            }
-            else
-            {
-                diffContentOffset = 4;
-            }
-
-            MarkInlineDifferences(document, linesRemoved, linesAdded, diffContentOffset);
+            _ = GetAddedLines(document, ref line, ref found);
         }
 
         // Process the next blocks of removed / added lines and mark in-line differences
-        diffContentOffset = 1; // in order to skip the prefixes '-' / '+'
+        const int diffContentOffset = 1; // in order to skip the prefixes '-' / '+'
         while (line < document.TotalNumberOfLines)
         {
             found = false;
-            linesRemoved = GetRemovedLines(document, ref line, ref found);
-            linesAdded = GetAddedLines(document, ref line, ref found);
+
+            List<ISegment> linesRemoved = GetRemovedLines(document, ref line, ref found);
+            if (!found)
+            {
+                continue;
+            }
+
+            List<ISegment> linesAdded = GetAddedLines(document, ref line, ref found);
+            if (!found)
+            {
+                continue;
+            }
 
             MarkInlineDifferences(document, linesRemoved, linesAdded, diffContentOffset);
         }

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -13,6 +13,9 @@ namespace GitUI.Editor.Diff;
 /// </summary>
 public abstract class DiffHighlightService : TextHighlightService
 {
+    private static readonly Color _addedBackColor = AppColor.AnsiTerminalGreenBackNormal.GetThemeColor();
+    private static readonly Color _removedBackColor = AppColor.AnsiTerminalRedBackNormal.GetThemeColor();
+
     protected readonly bool _useGitColoring;
     protected readonly List<TextMarker> _textMarkers = [];
 
@@ -107,7 +110,7 @@ public abstract class DiffHighlightService : TextHighlightService
             // Apply GE word highlighting for Patch display (may apply to Difftastic setting, if not available for a repo)
             if (AppSettings.DiffDisplayAppearance.Value != GitCommands.Settings.DiffDisplayAppearance.GitWordDiff)
             {
-                AddExtraPatchHighlighting(document);
+                MarkInlineDifferences(document);
             }
 
             foreach (TextMarker tm in _textMarkers)
@@ -118,22 +121,15 @@ public abstract class DiffHighlightService : TextHighlightService
             return;
         }
 
-        bool forceAbort = false;
+        MarkInlineDifferences(document);
 
-        AddExtraPatchHighlighting(document);
-
-        for (int line = 0; line < document.TotalNumberOfLines && !forceAbort; line++)
+        for (int line = 0; line < document.TotalNumberOfLines; line++)
         {
             LineSegment lineSegment = document.GetLineSegment(line);
 
             if (lineSegment.TotalLength == 0)
             {
                 continue;
-            }
-
-            if (line == document.TotalNumberOfLines - 1)
-            {
-                forceAbort = true;
             }
 
             line = TryHighlightAddedAndDeletedLines(document, line, lineSegment);
@@ -228,7 +224,10 @@ public abstract class DiffHighlightService : TextHighlightService
         text = sb.ToString();
     }
 
-    private static void MarkDifference(IDocument document, IReadOnlyList<ISegment> linesRemoved, IReadOnlyList<ISegment> linesAdded, int beginOffset)
+    /// <summary>
+    ///  Matches related removed and added lines in a consecutive block and marks identical parts dimmed.
+    /// </summary>
+    private static void MarkInlineDifferences(IDocument document, IReadOnlyList<ISegment> linesRemoved, IReadOnlyList<ISegment> linesAdded, int beginOffset)
     {
         Func<ISegment, string> getText = line => document.GetText(line.Offset + beginOffset, line.Length - beginOffset);
         document.MarkerStrategy.AddMarkers(GetDifferenceMarkers(document.GetCharAt, getText, linesRemoved, linesAdded, beginOffset));
@@ -245,11 +244,12 @@ public abstract class DiffHighlightService : TextHighlightService
         }
     }
 
-    private static IEnumerable<TextMarker> GetDifferenceMarkers(Func<int, char> getCharAt, ISegment lineRemoved, ISegment lineAdded, int beginOffset)
+    internal static IEnumerable<TextMarker> GetDifferenceMarkers(Func<int, char> getCharAt, ISegment lineRemoved, ISegment lineAdded, int lineStartOffset)
     {
         int lineRemovedEndOffset = lineRemoved.Length;
         int lineAddedEndOffset = lineAdded.Length;
         int endOffsetMin = Math.Min(lineRemovedEndOffset, lineAddedEndOffset);
+        int beginOffset = lineStartOffset;
         int reverseOffset = 0;
 
         while (beginOffset < endOffsetMin)
@@ -292,22 +292,58 @@ public abstract class DiffHighlightService : TextHighlightService
         int addedLength = lineAdded.Length - beginOffset - reverseOffset;
         if (addedLength > 0)
         {
-            yield return CreateTextMarker(lineAdded.Offset + beginOffset, addedLength, AppColor.AnsiTerminalGreenBackBold.GetThemeColor());
+            int beforeLength = beginOffset - lineStartOffset;
+            if (beforeLength > 0)
+            {
+                yield return CreateDimmedMarker(lineAdded.Offset + lineStartOffset, beforeLength, _addedBackColor);
+            }
+
+            int afterBegin = beginOffset + addedLength;
+            int afterLength = lineAdded.Length - afterBegin;
+            if (afterLength > 0)
+            {
+                yield return CreateDimmedMarker(lineAdded.Offset + afterBegin, afterLength, _addedBackColor);
+            }
+        }
+        else
+        {
+            int length = lineAdded.Length - lineStartOffset;
+            if (length > 0)
+            {
+                yield return CreateDimmedMarker(lineAdded.Offset + lineStartOffset, length, _addedBackColor);
+            }
         }
 
         int removedLength = lineRemoved.Length - beginOffset - reverseOffset;
         if (removedLength > 0)
         {
-            yield return CreateTextMarker(lineRemoved.Offset + beginOffset, removedLength, AppColor.AnsiTerminalRedBackBold.GetThemeColor());
+            int beforeLength = beginOffset - lineStartOffset;
+            if (beforeLength > 0)
+            {
+                yield return CreateDimmedMarker(lineRemoved.Offset + lineStartOffset, beforeLength, _removedBackColor);
+            }
+
+            int afterBegin = beginOffset + removedLength;
+            int afterLength = lineRemoved.Length - afterBegin;
+            if (afterLength > 0)
+            {
+                yield return CreateDimmedMarker(lineRemoved.Offset + afterBegin, afterLength, _removedBackColor);
+            }
         }
-
-        yield break;
-
-        static TextMarker CreateTextMarker(int offset, int length, Color color)
-            => new(offset, length, TextMarkerType.SolidBlock, color, ColorHelper.GetForeColorForBackColor(color));
+        else
+        {
+            int length = lineRemoved.Length - lineStartOffset;
+            if (length > 0)
+            {
+                yield return CreateDimmedMarker(lineRemoved.Offset + lineStartOffset, length, _removedBackColor);
+            }
+        }
     }
 
-    private void AddExtraPatchHighlighting(IDocument document)
+    /// <summary>
+    ///  Matches related removed and added lines in a consecutive block of a patch document and marks identical parts dimmed.
+    /// </summary>
+    private void MarkInlineDifferences(IDocument document)
     {
         int line = 0;
 
@@ -315,6 +351,8 @@ public abstract class DiffHighlightService : TextHighlightService
         int diffContentOffset;
         List<ISegment> linesRemoved = GetRemovedLines(document, ref line, ref found);
         List<ISegment> linesAdded = GetAddedLines(document, ref line, ref found);
+
+        // The first pair of removed / added lines uses to contain the filenames which could also have changed but have a different prefix length.
         if (linesAdded.Count == 1 && linesRemoved.Count == 1)
         {
             ISegment lineA = linesRemoved[0];
@@ -330,18 +368,24 @@ public abstract class DiffHighlightService : TextHighlightService
                 diffContentOffset = 4;
             }
 
-            MarkDifference(document, linesRemoved, linesAdded, diffContentOffset);
+            MarkInlineDifferences(document, linesRemoved, linesAdded, diffContentOffset);
         }
 
-        // overlap when marking
-        diffContentOffset = 1;
+        // Process the next blocks of removed / added lines and mark in-line differences
+        diffContentOffset = 1; // in order to skip the prefixes '-' / '+'
         while (line < document.TotalNumberOfLines)
         {
             found = false;
             linesRemoved = GetRemovedLines(document, ref line, ref found);
             linesAdded = GetAddedLines(document, ref line, ref found);
 
-            MarkDifference(document, linesRemoved, linesAdded, diffContentOffset);
+            MarkInlineDifferences(document, linesRemoved, linesAdded, diffContentOffset);
         }
     }
+
+    private static TextMarker CreateDimmedMarker(int offset, int length, Color color)
+        => CreateTextMarker(offset, length, ColorHelper.DimColor(ColorHelper.DimColor(color)));
+
+    private static TextMarker CreateTextMarker(int offset, int length, Color color)
+        => new(offset, length, TextMarkerType.SolidBlock, color, ColorHelper.GetForeColorForBackColor(color));
 }

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -235,11 +235,9 @@ public abstract class DiffHighlightService : TextHighlightService
 
     private static IEnumerable<TextMarker> GetDifferenceMarkers(Func<int, char> getCharAt, IReadOnlyList<ISegment> linesRemoved, IReadOnlyList<ISegment> linesAdded, int beginOffset)
     {
-        int count = Math.Min(linesRemoved.Count, linesAdded.Count);
-
-        for (int i = 0; i < count; i++)
+        foreach ((ISegment lineRemoved, ISegment lineAdded) in LinesMatcher.FindLinePairs(linesRemoved, linesAdded))
         {
-            foreach (TextMarker marker in GetDifferenceMarkers(getCharAt, linesRemoved[i], linesAdded[i], beginOffset))
+            foreach (TextMarker marker in GetDifferenceMarkers(getCharAt, lineRemoved, lineAdded, beginOffset))
             {
                 yield return marker;
             }

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -230,12 +230,13 @@ public abstract class DiffHighlightService : TextHighlightService
 
     private static void MarkDifference(IDocument document, IReadOnlyList<ISegment> linesRemoved, IReadOnlyList<ISegment> linesAdded, int beginOffset)
     {
-        document.MarkerStrategy.AddMarkers(GetDifferenceMarkers(document.GetCharAt, linesRemoved, linesAdded, beginOffset));
+        Func<ISegment, string> getText = line => document.GetText(line.Offset + beginOffset, line.Length - beginOffset);
+        document.MarkerStrategy.AddMarkers(GetDifferenceMarkers(document.GetCharAt, getText, linesRemoved, linesAdded, beginOffset));
     }
 
-    private static IEnumerable<TextMarker> GetDifferenceMarkers(Func<int, char> getCharAt, IReadOnlyList<ISegment> linesRemoved, IReadOnlyList<ISegment> linesAdded, int beginOffset)
+    private static IEnumerable<TextMarker> GetDifferenceMarkers(Func<int, char> getCharAt, Func<ISegment, string> getText, IReadOnlyList<ISegment> linesRemoved, IReadOnlyList<ISegment> linesAdded, int beginOffset)
     {
-        foreach ((ISegment lineRemoved, ISegment lineAdded) in LinesMatcher.FindLinePairs(linesRemoved, linesAdded))
+        foreach ((ISegment lineRemoved, ISegment lineAdded) in LinesMatcher.FindLinePairs(getText, linesRemoved, linesAdded))
         {
             foreach (TextMarker marker in GetDifferenceMarkers(getCharAt, lineRemoved, lineAdded, beginOffset))
             {

--- a/src/app/GitUI/Editor/Diff/LinesMatcher.cs
+++ b/src/app/GitUI/Editor/Diff/LinesMatcher.cs
@@ -64,6 +64,15 @@ internal static class LinesMatcher
 
     private static (int RemovedIndex, int AddedIndex) FindBestMatch(LineData[] removed, LineData[] added)
     {
+        // first, search longest match of trimmed lines, i.e. detect indented lines
+        (LineData longestMatchingRemoved, int matchingAddedIndex)
+            = removed.Select(r => (r, addedIndex: added.IndexOf(a => a.Trimmed == r.Trimmed)))
+                     .MaxBy(pair => pair.addedIndex < 0 ? -1 : pair.r.Trimmed.Length);
+        if (matchingAddedIndex >= 0)
+        {
+            return (Array.IndexOf(removed, longestMatchingRemoved), matchingAddedIndex);
+        }
+
         return (0, 0);
     }
 

--- a/src/app/GitUI/Editor/Diff/LinesMatcher.cs
+++ b/src/app/GitUI/Editor/Diff/LinesMatcher.cs
@@ -1,0 +1,16 @@
+﻿using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor.Diff;
+
+internal static class LinesMatcher
+{
+    internal static IEnumerable<(ISegment RemovedLine, ISegment AddedLine)> FindLinePairs(
+        IReadOnlyList<ISegment> removedLines, IReadOnlyList<ISegment> addedLines)
+    {
+        int minCount = Math.Min(removedLines.Count, addedLines.Count);
+        for (int i = 0; i < minCount; ++i)
+        {
+            yield return (removedLines[i], addedLines[i]);
+        }
+    }
+}

--- a/src/app/GitUI/Editor/Diff/LinesMatcher.cs
+++ b/src/app/GitUI/Editor/Diff/LinesMatcher.cs
@@ -1,16 +1,121 @@
-﻿using ICSharpCode.TextEditor.Document;
+﻿using System.Diagnostics;
+using GitExtensions.Extensibility;
+using ICSharpCode.TextEditor.Document;
 
 namespace GitUI.Editor.Diff;
 
 internal static class LinesMatcher
 {
     internal static IEnumerable<(ISegment RemovedLine, ISegment AddedLine)> FindLinePairs(
-        IReadOnlyList<ISegment> removedLines, IReadOnlyList<ISegment> addedLines)
+        Func<ISegment, string> getText, IReadOnlyList<ISegment> removedLines, IReadOnlyList<ISegment> addedLines)
     {
-        int minCount = Math.Min(removedLines.Count, addedLines.Count);
-        for (int i = 0; i < minCount; ++i)
+        int numberOfCombinations = removedLines.Count * addedLines.Count;
+        if (numberOfCombinations < 1)
         {
-            yield return (removedLines[i], addedLines[i]);
+            yield break;
+        }
+
+        // Do not try to match more lines than usually visible at the same time, because it costs O(n^2) operations
+        const int maxCombinations = 100 * 100;
+        if (numberOfCombinations == 1 || numberOfCombinations > maxCombinations)
+        {
+            int minCount = Math.Min(removedLines.Count, addedLines.Count);
+            for (int i = 0; i < minCount; ++i)
+            {
+                yield return (removedLines[i], addedLines[i]);
+            }
+
+            yield break;
+        }
+
+        LineData[] removed = removedLines.Select(line => new LineData(line, getText(line))).ToArray();
+        LineData[] added = addedLines.Select(line => new LineData(line, getText(line))).ToArray();
+
+        foreach ((ISegment, ISegment) linePair in FindLinePairs(removed, added))
+        {
+            yield return linePair;
+        }
+    }
+
+    private static IEnumerable<(ISegment RemovedLine, ISegment AddedLine)> FindLinePairs(LineData[] removed, LineData[] added)
+    {
+        (int removedIndex, int addedIndex) = FindBestMatch(removed, added);
+
+        if (removedIndex > 0 && addedIndex > 0)
+        {
+            foreach ((ISegment, ISegment) linePair in FindLinePairs(removed[0..removedIndex], added[0..addedIndex]))
+            {
+                yield return linePair;
+            }
+        }
+
+        yield return (removed[removedIndex].Line, added[addedIndex].Line);
+
+        ++removedIndex;
+        ++addedIndex;
+        if (removedIndex < removed.Length && addedIndex < added.Length)
+        {
+            foreach ((ISegment, ISegment) linePair in FindLinePairs(removed[removedIndex..], added[addedIndex..]))
+            {
+                yield return linePair;
+            }
+        }
+    }
+
+    private static (int RemovedIndex, int AddedIndex) FindBestMatch(LineData[] removed, LineData[] added)
+    {
+        return (0, 0);
+    }
+
+    internal static IEnumerable<string> GetWords(string text, Func<char, bool> isWordChar)
+    {
+        int length = text.Length;
+        int start = 0;
+        while (true)
+        {
+            for (; ; ++start)
+            {
+                if (start >= length)
+                {
+                    // no (more) word found, exit function
+                    yield break;
+                }
+
+                if (isWordChar(text[start]))
+                {
+                    break;
+                }
+            }
+
+            // start of word found
+
+            for (int end = start + 1; ; ++end)
+            {
+                if (end >= length || !isWordChar(text[end]))
+                {
+                    // word end found, yield and find next word
+                    yield return text[start..end];
+                    start = end + 1;
+                    break;
+                }
+            }
+        }
+    }
+
+    [DebuggerDisplay("{Line.Offset}: {Trimmed}")]
+    private readonly struct LineData
+    {
+        internal ISegment Line { get; }
+        internal string Full { get; }
+        internal string Trimmed { get; }
+        internal IReadOnlySet<string> Words { get; }
+
+        internal LineData(ISegment line, string text)
+        {
+            Line = line;
+            Full = text;
+            Trimmed = text.Trim();
+            Words = GetWords(Trimmed, TextUtilities.IsLetterDigitOrUnderscore).ToHashSet();
         }
     }
 }

--- a/src/app/GitUI/Editor/Diff/LinesMatcher.cs
+++ b/src/app/GitUI/Editor/Diff/LinesMatcher.cs
@@ -73,7 +73,64 @@ internal static class LinesMatcher
             return (Array.IndexOf(removed, longestMatchingRemoved), matchingAddedIndex);
         }
 
-        return (0, 0);
+        // then match lines whose common words have the maximum summed-up length
+        int removedMaxScoreIndex = 0;
+        int addedMaxScoreIndex = 0;
+        float maxScore = -1;
+        foreach ((int removedIndex, int addedIndex) in GetAllCombinations(removed.Length, added.Length))
+        {
+            float score = GetWordMatchScore(removed[removedIndex], added[addedIndex]);
+            if (maxScore < score)
+            {
+                maxScore = score;
+                removedMaxScoreIndex = removedIndex;
+                addedMaxScoreIndex = addedIndex;
+                if (maxScore == 1)
+                {
+                    return (removedMaxScoreIndex, addedMaxScoreIndex);
+                }
+            }
+        }
+
+        const float insignificantWordMatchScore = 0.1f;
+        return maxScore <= insignificantWordMatchScore ? (0, 0) : (removedMaxScoreIndex, addedMaxScoreIndex);
+
+        static float GetWordMatchScore(LineData r, LineData a)
+        {
+            if (r.Words.Count == 0 || a.Words.Count == 0)
+            {
+                return -1;
+            }
+
+            return (float)r.Words.Intersect(a.Words).Sum(w => w.Length) / Math.Max(r.WordsTotalLength, a.WordsTotalLength);
+        }
+    }
+
+    /// <summary>
+    ///  Iterates all combinations of indices - starting with (0,0), (1,0), (0,1), (2,0), (1,1), ...
+    /// </summary>
+    /// <returns>an enumeration of the index pairs</returns>
+    internal static IEnumerable<(int FirstIndex, int SecondIndex)> GetAllCombinations(int firstEnd, int secondEnd)
+    {
+        // upper left half including prinicipal diagonal
+        for (int diagonalIndex = 0; diagonalIndex < firstEnd; ++diagonalIndex)
+        {
+            int diagonalEnd = Math.Min(diagonalIndex + 1, secondEnd);
+            for (int secondIndex = 0; secondIndex < diagonalEnd; ++secondIndex)
+            {
+                yield return (FirstIndex: diagonalIndex - secondIndex, secondIndex);
+            }
+        }
+
+        // lower right half
+        for (int diagonalIndex = 1; diagonalIndex < secondEnd; ++diagonalIndex)
+        {
+            int diagonalEnd = Math.Min(firstEnd + diagonalIndex, secondEnd);
+            for (int secondIndex = diagonalIndex; secondIndex < diagonalEnd; ++secondIndex)
+            {
+                yield return (FirstIndex: firstEnd - 1 + diagonalIndex - secondIndex, secondIndex);
+            }
+        }
     }
 
     internal static IEnumerable<string> GetWords(string text, Func<char, bool> isWordChar)
@@ -118,6 +175,7 @@ internal static class LinesMatcher
         internal string Full { get; }
         internal string Trimmed { get; }
         internal IReadOnlySet<string> Words { get; }
+        internal int WordsTotalLength { get; }
 
         internal LineData(ISegment line, string text)
         {
@@ -125,6 +183,7 @@ internal static class LinesMatcher
             Full = text;
             Trimmed = text.Trim();
             Words = GetWords(Trimmed, TextUtilities.IsLetterDigitOrUnderscore).ToHashSet();
+            WordsTotalLength = Words.Sum(w => w.Length);
         }
     }
 }

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Immutable;
+using FluentAssertions;
+using GitExtUtils.GitUI.Theming;
+using GitUI.Editor.Diff;
+using GitUI.Theming;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUITests.Editor.Diff;
+
+[TestFixture]
+public class DiffHighlightServiceTests
+{
+    [Test]
+    public void GetDifferenceMarkers_should_dim_identical_parts_at_begin_and_end()
+    {
+        // LineSegment is hard to create. Use TextMarker as implementation type of ISegment for this test.
+        const TextMarkerType dontCare = TextMarkerType.SolidBlock;
+
+        const string identicalPartBefore = "identical_part_before_";
+        const string identicalPartAfter = "_identical_part_after";
+        const string differentRemoved = "RemovedX";
+        const string differentAdded = "AddedY";
+        const string removedLineText = $"-{identicalPartBefore}{differentRemoved}{identicalPartAfter}";
+        const string addedLineText = $"+{identicalPartBefore}{differentAdded}{identicalPartAfter}";
+        const string text = $"{removedLineText}\n{addedLineText}";
+        TextMarker removedLine = new(offset: text.IndexOf(removedLineText), removedLineText.Length, textMarkerType: dontCare);
+        TextMarker addedLine = new(offset: text.IndexOf(addedLineText), addedLineText.Length, textMarkerType: dontCare);
+        const int beginOffset = 1;
+
+        IEnumerable<TextMarker> markers = DiffHighlightService.GetDifferenceMarkers(GetCharAt, removedLine, addedLine, beginOffset);
+        IReadOnlyList<TextMarker> sortedMarkers = markers.ToImmutableSortedSet(new MarkerComparer());
+
+        TextMarker[] expectedMarkers =
+        [
+            CreateDimmedMarker(removedLine, offset: 0, length: identicalPartBefore.Length),
+            CreateDimmedMarker(removedLine, offset: identicalPartBefore.Length + differentRemoved.Length, length: identicalPartAfter.Length),
+            CreateDimmedMarker(addedLine, offset: 0, length: identicalPartBefore.Length),
+            CreateDimmedMarker(addedLine, offset: identicalPartBefore.Length + differentAdded.Length, length: identicalPartAfter.Length),
+        ];
+        sortedMarkers.Should().BeEquivalentTo(expectedMarkers);
+
+        return;
+
+        TextMarker CreateDimmedMarker(ISegment line, int offset, int length)
+            => DiffHighlightServiceTests.CreateDimmedMarker(line.Offset + beginOffset + offset, length, isAdded: line == addedLine);
+
+        char GetCharAt(int offset) => text[offset];
+    }
+
+    private static TextMarker CreateDimmedMarker(int offset, int length, bool isAdded)
+    {
+        Color color = (isAdded ? AppColor.AnsiTerminalGreenBackNormal : AppColor.AnsiTerminalRedBackNormal).GetThemeColor();
+        Color dimmedColor = ColorHelper.DimColor(ColorHelper.DimColor(color));
+        return new TextMarker(offset, length, TextMarkerType.SolidBlock, dimmedColor, ColorHelper.GetForeColorForBackColor(dimmedColor));
+    }
+
+    private sealed class MarkerComparer : IComparer<TextMarker>
+    {
+        public int Compare(TextMarker? left, TextMarker? right)
+            => left.Offset < right.Offset ? -1
+                : left.Offset > right.Offset ? 1
+                : left.TextMarkerType == TextMarkerType.InterChar ? -1
+                : right.TextMarkerType == TextMarkerType.InterChar ? 1
+                : throw new InvalidOperationException("markers should not overlap");
+    }
+}

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/LinesMatcherTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/LinesMatcherTests.cs
@@ -1,0 +1,152 @@
+﻿using FluentAssertions;
+using GitUI.Editor.Diff;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUITests.Editor.Diff;
+
+[TestFixture]
+public class LinesMatcherTests
+{
+    [Test]
+    public void GetAllCombinations([Range(1, 4)] int firstEnd, [Range(1, 4)] int secondEnd)
+    {
+        bool[,] visited = new bool[firstEnd, secondEnd];
+        foreach ((int firstIndex, int secondIndex) in LinesMatcher.GetAllCombinations(firstEnd, secondEnd))
+        {
+            firstIndex.Should().BeLessThan(firstEnd);
+            secondIndex.Should().BeLessThan(secondEnd);
+            visited[firstIndex, secondIndex].Should().BeFalse();
+            visited[firstIndex, secondIndex] = true;
+        }
+
+        for (int i = 0; i < firstEnd; ++i)
+        {
+            for (int j = 0; j < secondEnd; ++j)
+            {
+                visited[i, j].Should().BeTrue($"everywhere including at {i}, {j}");
+            }
+        }
+    }
+
+    [Test]
+    [TestCase("", new string[] { })]
+    [TestCase("a", new string[] { "a" })]
+    [TestCase("a-", new string[] { "a" })]
+    [TestCase("-a", new string[] { "a" })]
+    [TestCase("a bc", new string[] { "a", "bc" })]
+    [TestCase("-a bc", new string[] { "a", "bc" })]
+    [TestCase("a bc-", new string[] { "a", "bc" })]
+    [TestCase("---abc---123---def_7---", new string[] { "abc", "123", "def_7" })]
+    public void GetWords(string text, string[] words)
+    {
+        LinesMatcher.GetWords(text, TextUtilities.IsLetterDigitOrUnderscore)
+            .Should().BeEquivalentTo(words);
+    }
+
+    [Test]
+    public void FindLinePairs_shall_not_search_in_too_large_blocks()
+    {
+        const int removedCount = 10;
+        const int maxCombinations = 100 * 100;
+        LineSegment[] removedLines = CreateLines(removedCount);
+        LineSegment[] addedLines = CreateLines((maxCombinations / removedCount) + 1);
+        Dictionary<ISegment, string> lineTexts = new();
+        for (int index = 0; index < removedCount; ++index)
+        {
+            string lineText = $"line{index}";
+            lineTexts[removedLines[index]] = lineText;
+            lineTexts[addedLines[index + removedCount]] = lineText;
+        }
+
+        IEnumerable<(ISegment RemovedLine, ISegment AddedLine)> pairs = LinesMatcher.FindLinePairs(GetText, removedLines, addedLines);
+
+        int pairIndex = 0;
+        foreach ((ISegment removedLine, ISegment addedLine) in pairs)
+        {
+            removedLine.Should().Be(removedLines[pairIndex]);
+            addedLine.Should().Be(addedLines[pairIndex]);
+            ++pairIndex;
+        }
+
+        return;
+
+        string GetText(ISegment line) => lineTexts.GetValueOrDefault(line, "other line");
+    }
+
+    [Test]
+    public void FindLinePairs_shall_match_trimmed_lines()
+    {
+        LineSegment[] removedLines = CreateLines(3);
+        LineSegment[] addedLines = CreateLines(5);
+        Dictionary<ISegment, string> lineTexts = new()
+        {
+            { removedLines[0], "r0" },
+            { removedLines[1], " trimmed line\t" },
+            { removedLines[2], "r2" },
+            { addedLines[0], "a0" },
+            { addedLines[1], "a1" },
+            { addedLines[2], "a2" },
+            { addedLines[3], "trimmed line" },
+            { addedLines[4], "a4" },
+        };
+
+        IEnumerable<(ISegment RemovedLine, ISegment AddedLine)> pairs = LinesMatcher.FindLinePairs(GetText, removedLines, addedLines);
+
+        (ISegment RemovedLine, ISegment AddedLine)[] expectedPairs =
+        [
+            (removedLines[0], addedLines[0]),
+            (removedLines[1], addedLines[3]),
+            (removedLines[2], addedLines[4]),
+        ];
+        pairs.Should().BeEquivalentTo(expectedPairs);
+
+        return;
+
+        string GetText(ISegment line) => lineTexts.GetValueOrDefault(line, "other line");
+    }
+
+    [Test]
+    public void FindLinePairs_shall_match_lines_whose_common_words_have_maximum_summedup_length()
+    {
+        LineSegment[] removedLines = CreateLines(4);
+        LineSegment[] addedLines = CreateLines(5);
+        Dictionary<ISegment, string> lineTexts = new()
+        {
+            { removedLines[0], "line 0 had some words" },
+            { removedLines[1], "line 1 had some more common words" },
+            { removedLines[2], " trimmed line\t" },
+            { removedLines[3], "r2" },
+            { addedLines[0], "some words" },
+            { addedLines[1], "line 1 has some words" },
+            { addedLines[2], "line 2 has some common words" },
+            { addedLines[3], "trimmed line" },
+            { addedLines[4], "a4" },
+        };
+
+        IEnumerable<(ISegment RemovedLine, ISegment AddedLine)> pairs = LinesMatcher.FindLinePairs(GetText, removedLines, addedLines);
+
+        (ISegment RemovedLine, ISegment AddedLine)[] expectedPairs =
+        [
+            (removedLines[0], addedLines[1]), // longer common words
+            (removedLines[1], addedLines[2]), // most long common words
+            (removedLines[2], addedLines[3]), // trimmed
+            (removedLines[3], addedLines[4]), // single remaining lines after best match
+        ];
+        pairs.Should().BeEquivalentTo(expectedPairs);
+
+        return;
+
+        string GetText(ISegment line) => lineTexts.GetValueOrDefault(line, "other line");
+    }
+
+    private static LineSegment[] CreateLines(int count)
+    {
+        LineSegment[] lines = new LineSegment[count];
+        for (int index = 0; index < count; ++index)
+        {
+            lines[index] = new LineSegment();
+        }
+
+        return lines;
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Detect indented lines
- Then match by common words
- Reduce the highlight (from git) for identical parts of the line - instead of marking the different part
- Remove highlighting of filenames in the diff header because their background highlighting was removed in f201220e8b77f5ab218277f60fd3e008c1ee5041
- Some refactoring into functions

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

`FormRevertCommit.cs` in 6a9f3c01b1c988d5a01369a5f54020115022a5cf

![image](https://github.com/user-attachments/assets/d0ff86e4-ffce-41f8-ad03-10c954e7215d)

### After (final variant)

![grafik](https://github.com/user-attachments/assets/2e096864-b8cd-4657-81a0-f67319471e89)

### After (intermediate variant with bold highlight)

![image](https://github.com/user-attachments/assets/678630e4-6053-4040-b4db-296ab8dc1946)

## Test methodology <!-- How did you ensure quality? -->

- some additional tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).