### PR TITLE
fix: try-catch for FileSystemWatcher

### DIFF
--- a/src/app/GitCommands/Settings/FileSettingsCache.cs
+++ b/src/app/GitCommands/Settings/FileSettingsCache.cs
@@ -54,6 +54,7 @@ namespace GitCommands.Settings
             }
             catch
             {
+                _fileWatcher.EnableRaisingEvents = false;
             }
 
             FileChanged();

--- a/src/app/GitCommands/Settings/FileSettingsCache.cs
+++ b/src/app/GitCommands/Settings/FileSettingsCache.cs
@@ -44,12 +44,12 @@ namespace GitCommands.Settings
                 string? dir = Path.GetDirectoryName(SettingsFilePath);
                 if (Directory.Exists(dir))
                 {
+                    // Notifications may not fire
+                    _forceFileChangeChecks = PathUtil.IsWslPath(SettingsFilePath);
+
                     _fileWatcher.Path = dir;
                     _fileWatcher.Filter = Path.GetFileName(SettingsFilePath);
                     _fileWatcher.EnableRaisingEvents = true;
-
-                    // Notifications may not fire
-                    _forceFileChangeChecks = PathUtil.IsWslPath(SettingsFilePath);
                 }
             }
             catch

--- a/src/app/GitCommands/Settings/FileSettingsCache.cs
+++ b/src/app/GitCommands/Settings/FileSettingsCache.cs
@@ -39,15 +39,21 @@ namespace GitCommands.Settings
             _fileWatcher.Deleted += _fileWatcher_Changed;
             _fileWatcher.Renamed += _fileWatcher_Changed;
 
-            string? dir = Path.GetDirectoryName(SettingsFilePath);
-            if (Directory.Exists(dir))
+            try
             {
-                _fileWatcher.Path = dir;
-                _fileWatcher.Filter = Path.GetFileName(SettingsFilePath);
-                _fileWatcher.EnableRaisingEvents = true;
+                string? dir = Path.GetDirectoryName(SettingsFilePath);
+                if (Directory.Exists(dir))
+                {
+                    _fileWatcher.Path = dir;
+                    _fileWatcher.Filter = Path.GetFileName(SettingsFilePath);
+                    _fileWatcher.EnableRaisingEvents = true;
 
-                // Notifications may not fire
-                _forceFileChangeChecks = PathUtil.IsWslPath(SettingsFilePath);
+                    // Notifications may not fire
+                    _forceFileChangeChecks = PathUtil.IsWslPath(SettingsFilePath);
+                }
+            }
+            catch
+            {
             }
 
             FileChanged();

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -221,9 +221,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 return;
             }
 
-            _workTreeWatcher.EnableRaisingEvents = Directory.Exists(_workTreeWatcher.Path);
-            _gitDirWatcher.EnableRaisingEvents = Directory.Exists(_gitDirWatcher.Path)
-                    && !_gitDirWatcher.Path.StartsWith(_workTreeWatcher.Path);
+            try
+            {
+                _workTreeWatcher.EnableRaisingEvents = Directory.Exists(_workTreeWatcher.Path);
+                _gitDirWatcher.EnableRaisingEvents = Directory.Exists(_gitDirWatcher.Path)
+                        && !_gitDirWatcher.Path.StartsWith(_workTreeWatcher.Path);
+            }
+            catch
+            {
+            }
         }
 
         private GitStatusMonitorState CurrentStatus

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -229,6 +229,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
             catch
             {
+                _workTreeWatcher.EnableRaisingEvents = false;
+                _gitDirWatcher.EnableRaisingEvents = false;
             }
         }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
@@ -89,8 +89,14 @@ namespace GitUI.UserControls.RevisionGrid
             set
             {
                 _indexChanged = value;
-                GitIndexWatcher.EnableRaisingEvents = !IndexChanged
-                    && Directory.Exists(GitIndexWatcher.Path);
+                try
+                {
+                    GitIndexWatcher.EnableRaisingEvents = !IndexChanged
+                        && Directory.Exists(GitIndexWatcher.Path);
+                }
+                catch
+                {
+                }
 
                 Changed?.Invoke(this, new IndexChangedEventArgs(IndexChanged));
             }

--- a/src/app/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
@@ -96,6 +96,7 @@ namespace GitUI.UserControls.RevisionGrid
                 }
                 catch
                 {
+                    GitIndexWatcher.EnableRaisingEvents = false;
                 }
 
                 Changed?.Invoke(this, new IndexChangedEventArgs(IndexChanged));


### PR DESCRIPTION
Fixes #11854

## Proposed changes

Add try-catch for FileSystemWatcher, as this can raise FileNotFoundException. This addresses exceptions with interactive rebase editor for the FileSettingsCache in WSL.

## Test methodology <!-- How did you ensure quality? -->

Manual use

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
