### PR TITLE
Remove seconds from commit date display (#11812)

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
@@ -59,7 +59,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     return LocalizationHelpers.GetRelativeDateString(DateTime.Now, dt, displayWeeks: false);
                 }
 
-                return dt.ToString("G");
+                return dt.ToString("g");
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11812

## Proposed changes
- It changed the commit date format in commit lists from `YYYY-MM-DD HH:MM:SS` to `YYYY-MM-DD HH:MM`.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![スクリーンショット 2024-09-01 202240](https://github.com/user-attachments/assets/dec54cf0-0ecd-42ee-b8bd-d686047abecb)



### After

![スクリーンショット 2024-09-01 203256](https://github.com/user-attachments/assets/abc3a890-39f8-45cd-99d5-bd740d082123)


## Test methodology <!-- How did you ensure quality? -->
- manual


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
