### PR TITLE
fix: RunCommand() should not throw when exit is checked

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -3761,10 +3761,7 @@ namespace GitCommands
 
         public bool CheckBranchFormat(string branchName)
         {
-            if (branchName is null)
-            {
-                throw new ArgumentNullException(nameof(branchName));
-            }
+            ArgumentNullException.ThrowIfNull(branchName);
 
             if (string.IsNullOrWhiteSpace(branchName))
             {
@@ -3776,7 +3773,7 @@ namespace GitCommands
                 "--branch",
                 branchName.QuoteNE()
             };
-            return _gitExecutable.RunCommand(args, throwOnErrorExit: false);
+            return _gitExecutable.Execute(args, throwOnErrorExit: false).ExitedSuccessfully;
         }
 
         public string FormatBranchName(string branchName)

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -535,7 +535,7 @@ namespace GitCommands
             string editor = GetEffectiveSetting("core.editor").ToLower();
             bool createWindow = !editor.Contains("gitextensions") && !editor.Contains("notepad");
 
-            return _gitExecutable.RunCommand(arguments, createWindow: createWindow);
+            return _gitExecutable.RunCommand(arguments, createWindow: createWindow, throwOnErrorExit: false);
         }
 
         public bool InTheMiddleOfConflictedMerge(bool throwOnErrorExit = true)
@@ -1779,7 +1779,8 @@ namespace GitCommands
                 {
                     "--add",
                     file.ToPosixPath().Quote()
-                });
+                },
+                throwOnErrorExit: false);
         }
 
         /// <summary>
@@ -1889,7 +1890,8 @@ namespace GitCommands
                 {
                     "--intent-to-add",
                     file.Name.Quote()
-                });
+                },
+                throwOnErrorExit: false);
         }
 
         public async Task<bool> AddInteractiveAsync(GitItemStatus file)
@@ -3769,13 +3771,12 @@ namespace GitCommands
                 return false;
             }
 
-            branchName = branchName.Replace("\"", "\\\"");
             GitArgumentBuilder args = new("check-ref-format")
             {
                 "--branch",
                 branchName.QuoteNE()
             };
-            return _gitExecutable.RunCommand(args);
+            return _gitExecutable.RunCommand(args, throwOnErrorExit: false);
         }
 
         public string FormatBranchName(string branchName)

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1772,15 +1772,14 @@ namespace GitCommands
             return !wereErrors;
         }
 
-        public bool StageFile(string file)
+        public void StageFile(string file)
         {
-            return _gitExecutable.RunCommand(
+            _gitExecutable.RunCommand(
                 new GitArgumentBuilder("update-index")
                 {
                     "--add",
                     file.ToPosixPath().Quote()
-                },
-                throwOnErrorExit: false);
+                });
         }
 
         /// <summary>
@@ -1883,28 +1882,8 @@ namespace GitCommands
             return shouldRescanChanges;
         }
 
-        private async Task<bool> ExpressIntentToAddAsync(GitItemStatus file)
-        {
-            return await _gitExecutable.RunCommandAsync(
-                new GitArgumentBuilder("add")
-                {
-                    "--intent-to-add",
-                    file.Name.Quote()
-                },
-                throwOnErrorExit: false);
-        }
-
         public async Task<bool> AddInteractiveAsync(GitItemStatus file)
         {
-            if (file.IsNew)
-            {
-                bool result = await ExpressIntentToAddAsync(file);
-                if (!result)
-                {
-                    return result;
-                }
-            }
-
             GitArgumentBuilder args = new("add")
             {
                 "--patch",

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -370,7 +370,7 @@ public interface IGitModule
     string? GetTagMessage(string? tag, CancellationToken cancellationToken);
     void UnstageFile(string file);
     bool UnstageFiles(IReadOnlyList<GitItemStatus> files, out string allOutput);
-    bool StageFile(string file);
+    void StageFile(string file);
     bool StageFiles(IReadOnlyList<GitItemStatus> files, out string allOutput);
     IEnumerable<IGitRef> GetRemoteBranches();
     IEnumerable<string?> GetPreviousCommitMessages(int count, string revision, string authorPattern);

--- a/src/app/GitUI/Infrastructure/PuttyHelpers.cs
+++ b/src/app/GitUI/Infrastructure/PuttyHelpers.cs
@@ -85,7 +85,7 @@ namespace GitUI.Infrastructure
 
             ThrowIfFileNotFound(sshKeyFile, $"'{sshKeyFile}'", TranslatedStrings.ErrorSshKeyNotFound);
 
-            return pageantExecutable.RunCommand(sshKeyFile.Quote());
+            return pageantExecutable.RunCommand(sshKeyFile.Quote(), throwOnErrorExit: false);
 
             static bool IsPageantRunning()
             {


### PR DESCRIPTION
Fixes #11869 

## Proposed changes

Some methods intend to check the Git output, but the command always throws at exit.
throwOnErrorExit need to be configurable for these methods.
Quotes were additionally quouted too (done in QuoteNE())

This occurs for instance when checking the characters in a branch name and staging files.
Note that the command still echoes the branchname to the console.

While Git allows quotes in branch names, Windows does not (this is a file) allow quotes in the name.

Note: There are a few calls of RunCommand() that could be supressed in addition to those thatactually check the output, but I left it at the checked calls.
This cannot be be too commonly occurring as the throwOnErrorExit checks were added in 4.1 or 4.0.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

NBug

### After

![image](https://github.com/user-attachments/assets/492dfadf-3214-4c7d-a275-7f00c9569902)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
