### PR TITLE
fix: LineNumber presentation for Git word-diff

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/src/app/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -16,6 +16,7 @@ public partial class DiffLineNumAnalyzer
     public static DiffLinesInfo Analyze(TextEditorControl textEditor, bool isCombinedDiff, bool isGitWordDiff = false)
     {
         DiffLinesInfo ret = new();
+        bool reverseGitColoring = AppSettings.ReverseGitColoring.Value;
         int lineNumInDiff = 0;
         int leftLineNum = DiffLineInfo.NotApplicableLineNum;
         int rightLineNum = DiffLineInfo.NotApplicableLineNum;
@@ -153,7 +154,7 @@ public partial class DiffLineNumAnalyzer
 
         return ret;
 
-        static bool IsGitWordMatch(DiffLineType lineType, string line, int textOffset, int textLength, List<TextMarker> textMarkers)
+        bool IsGitWordMatch(DiffLineType lineType, string line, int textOffset, int textLength, List<TextMarker> textMarkers)
         {
             // Heuristics (or wild guessing): For GitWordDiff find if the line is exclusive (otherwise DiffLineType.MinusPlus).
             // If the marker covers the line this should be true.
@@ -165,7 +166,7 @@ public partial class DiffLineNumAnalyzer
 
             return textMarkers.Count == 1
 
-                    // start may be intended, if a new block of changes starts with white spaces
+                    // start may be indented, if a new block of changes starts with white spaces
                     && (textMarkers[0].Offset <= textOffset || (firstNonWhiteSpace > 0 && textMarkers[0].Offset <= textOffset + firstNonWhiteSpace))
 
                     // Compensate length->ending and remove the trailing newline chars (no check for \r\n vs \n)
@@ -175,15 +176,15 @@ public partial class DiffLineNumAnalyzer
                     && MarkerColorMatch(textMarkers[0], lineType);
         }
 
-        static bool MarkerColorMatch(TextMarker textMarker, DiffLineType lineType)
+        bool MarkerColorMatch(TextMarker textMarker, DiffLineType lineType)
         {
             // The expected marker color for a line type, for heuristics.
 
             return lineType is (DiffLineType.Minus or DiffLineType.MinusLeft)
-                ? (AppSettings.ReverseGitColoring.Value
+                ? (reverseGitColoring
                     ? textMarker.Color == AppColor.AnsiTerminalRedBackNormal.GetThemeColor()
                     : textMarker.ForeColor == AppColor.AnsiTerminalRedForeNormal.GetThemeColor())
-                : (AppSettings.ReverseGitColoring.Value
+                : (reverseGitColoring
                     ? textMarker.Color == AppColor.AnsiTerminalGreenBackNormal.GetThemeColor()
                     : textMarker.ForeColor == AppColor.AnsiTerminalGreenForeNormal.GetThemeColor());
         }

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -154,6 +154,9 @@ public class DiffLineNumAnalyzerTests
     [Test]
     public void CanGetGitWordDiffInfo()
     {
+        GitCommands.Settings.DiffDisplayAppearance theme = AppSettings.DiffDisplayAppearance.Value;
+        AppSettings.DiffDisplayAppearance.Value = GitCommands.Settings.DiffDisplayAppearance.GitWordDiff;
+
         string text = _sampleGitWordDiff;
         DiffHighlightService diffHighlightService = new PatchHighlightService(ref text, useGitColoring: true);
         _textEditor.Text = text;
@@ -164,21 +167,42 @@ public class DiffLineNumAnalyzerTests
         result.DiffLines[5].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[5].LineType.Should().Be(DiffLineType.Header);
 
-        result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-        result.DiffLines[6].RightLineNumber.Should().Be(1);
-        result.DiffLines[6].LineType.Should().Be(DiffLineType.PlusRight);
+        result.DiffLines[9].LeftLineNumber.Should().Be(8);
+        result.DiffLines[9].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[9].LineType.Should().Be(DiffLineType.MinusLeft);
 
-        result.DiffLines[8].LeftLineNumber.Should().Be(1);
-        result.DiffLines[8].RightLineNumber.Should().Be(3);
-        result.DiffLines[8].LineType.Should().Be(DiffLineType.Context);
+        result.DiffLines[17].LeftLineNumber.Should().Be(16);
+        result.DiffLines[17].RightLineNumber.Should().Be(14);
+        result.DiffLines[17].LineType.Should().Be(DiffLineType.Context);
 
-        result.DiffLines[15].LeftLineNumber.Should().Be(19);
-        result.DiffLines[15].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-        result.DiffLines[15].LineType.Should().Be(DiffLineType.MinusLeft);
+        result.DiffLines[18].LeftLineNumber.Should().Be(17);
+        result.DiffLines[18].RightLineNumber.Should().Be(15);
+        result.DiffLines[18].LineType.Should().Be(DiffLineType.MinusPlus);
 
-        result.DiffLines[23].LeftLineNumber.Should().Be(28);
-        result.DiffLines[23].RightLineNumber.Should().Be(28);
+        result.DiffLines[23].LeftLineNumber.Should().Be(22);
+        result.DiffLines[23].RightLineNumber.Should().Be(20);
         result.DiffLines[23].LineType.Should().Be(DiffLineType.MinusPlus);
+
+        // Git output dubious: Bad presentation
+        result.DiffLines[25].LeftLineNumber.Should().Be(24);
+        result.DiffLines[25].RightLineNumber.Should().Be(22);
+        result.DiffLines[25].LineType.Should().Be(DiffLineType.Context);
+
+        // Git output dubious: PlusRight that start intended
+        result.DiffLines[26].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[26].RightLineNumber.Should().Be(23);
+        result.DiffLines[26].LineType.Should().Be(DiffLineType.PlusRight);
+
+        result.DiffLines[27].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[27].RightLineNumber.Should().Be(24);
+        result.DiffLines[27].LineType.Should().Be(DiffLineType.PlusRight);
+
+        // Git output dubious: Context that should be MinusLeft
+        result.DiffLines[34].LeftLineNumber.Should().Be(31);
+        result.DiffLines[34].RightLineNumber.Should().Be(29);
+        result.DiffLines[34].LineType.Should().Be(DiffLineType.Context);
+
+        AppSettings.DiffDisplayAppearance.Value = theme;
     }
 
     [Test]

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/SampleGitWord.diff
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/SampleGitWord.diff
@@ -1,37 +1,37 @@
-[1mdiff --git a/GitUI/Editor/Diff/PatchHighlightService.cs b/GitUI/Editor/Diff/PatchHighlightService.cs[m
-[1mindex 6e386..cad79 100644[m
-[1m--- a/GitUI/Editor/Diff/PatchHighlightService.cs[m
-[1m+++ b/GitUI/Editor/Diff/PatchHighlightService.cs[m
-[36m@@ -1,4 +1,5 @@[m
-﻿using [38;2;0;0;0;48;2;200;255;200mGitCommands;[m
-[38;2;0;0;0;48;2;200;255;200musing[m GitExtUtils;
-using GitExtUtils.GitUI.Theming;[m
-using GitUI.Theming;[m
-using GitUIPluginInterfaces;[m
-[36m@@ -16,7 +17,6 @@[m [mpublic class PatchHighlightService : DiffHighlightService[m
-    private const string _addedLinePrefix = "+";[m
-    private const string _removedLinePrefix = "-";[m
-    private static readonly string[] _diffFullPrefixes = [" ", _addedLinePrefix, _removedLinePrefix];[m
-[38;2;0;0;0;48;2;255;200;200m    private static readonly string[] _diffSearchPrefixes = [_addedLinePrefix, _removedLinePrefix];[m
+[1mdiff --git a/src/app/GitUI/Editor/Diff/GrepHighlightService.cs b/src/app/GitUI/Editor/Diff/GrepHighlightService.cs[m
+[1mindex 5a619..bdfe1 100644[m
+[1m--- a/src/app/GitUI/Editor/Diff/GrepHighlightService.cs[m
+[1m+++ b/src/app/GitUI/Editor/Diff/GrepHighlightService.cs[m
+[36m@@ -5,8 +5,6 @@[m
+using GitExtensions.Extensibility;[m
+using GitExtensions.Extensibility.Git;[m
+using GitExtUtils;[m
+[7;31musing GitExtUtils.GitUI.Theming;[m
+[7;31musing ICSharpCode.TextEditor;[m
+using ICSharpCode.TextEditor.Document;[m
 
-    public PatchHighlightService(ref string text, bool useGitColoring)[m
-        : base(ref text, useGitColoring)[m
-[36m@@ -25,9 +25,9 @@[m [mpublic PatchHighlightService(ref string text, bool useGitColoring)[m
+namespace GitUI.Editor.Diff;[m
+[36m@@ -14,20 +12,20 @@[m [mnamespace GitUI.Editor.Diff;[m
+public partial class GrepHighlightService : TextHighlightService[m
+{[m
+    private readonly List<TextMarker> _textMarkers = [];[m
+    private DiffLinesInfo [7;31m_matchInfos[m[7;32m_diffLinesInfo[m = new();
 
-    public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)[m
-    {[m
-        [38;2;0;0;0;48;2;255;200;200m// Note: This is the fourth time the text is parsed...[m[38;2;0;0;0;48;2;200;255;200mbool isGitWordDiff = _useGitColoring && AppSettings.ShowGitWordColoring.Value;[m
-        DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor[38;2;0;0;0;48;2;255;200;200m.Text[m, isCombinedDiff: false[38;2;0;0;0;48;2;200;255;200m, isGitWordDiff[m);
-        lineNumbersControl.DisplayLineNum(result, showLeftColumn: [38;2;0;0;0;48;2;255;200;200mtrue[m[38;2;0;0;0;48;2;200;255;200m!isGitWordDiff[m);
-    }[m
+    [GeneratedRegex(@"^(?<line>\d+)(?<kind>:|.)(?<text>.*)$", RegexOptions.ExplicitCapture)][m
+    private static partial Regex GrepLineRegex();[m
 
-    public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)[m
-[36m@@ -35,8 +35,6 @@[m [mpublic static GitCommandConfiguration GetGitCommandConfiguration(IGitModule modu[m
+    public GrepHighlightService(ref string text[7;32m, DiffViewerLineNumberControl lineNumbersControl[m)
+    [7;31m=>[m[7;32m{[m
+        SetText(ref text);
+        [7;32mlineNumbersControl.DisplayLineNum(_diffLinesInfo, showLeftColumn: false);[m
+[7;32m    }[m
 
-    public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;[m
+    public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)[m
+        => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.MinusPlus or DiffLineType.Grep);[m
 
-[38;2;0;0;0;48;2;255;200;200m    public override bool IsSearchMatch(string line) => line.StartsWithAny(_diffSearchPrefixes);[m
+[7;31m    public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)[m
+[7;31m        => lineNumbersControl.DisplayLineNum(_matchInfos, showLeftColumn: false);[m
 
-    protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)[m
-        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _addedLinePrefix, ref found);[m
-
+    /// <summary>[m
+    /// Get the next/previous line for the grep match.[m
+    /// </summary>[m


### PR DESCRIPTION

## Proposed changes

Tune the heuristics to get word-diff line numbers. If the diff only had added or removed chars, only added/removed line numbers were presented.

There are still many situations where the Git output is incomplete, the line numbers will be incorrect still.
Comments added to the code, trying to explain the issues.

## Screenshots <!-- Remove this section if PR does not change UI -->

File to compare is in a private branch, did not find a good example in recent commits

![image](https://github.com/user-attachments/assets/092fc7bc-8399-4cb7-b88d-3eb1a615eb58)

with #11868 

![image](https://github.com/user-attachments/assets/2a33873b-2990-45b3-801e-63799ac87e49)

### Before

see line 20

![image](https://github.com/user-attachments/assets/10fb12eb-091f-4f3e-b33d-dd3c3c905922)

### After

![image](https://github.com/user-attachments/assets/baaf9c5a-50c8-4ce0-9635-405b14d65d83)

## Test methodology <!-- How did you ensure quality? -->

tests updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
