### PR TITLE
Fix NRE in scripts if `arguments` unset

### DIFF
--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿#nullable enable
+
+using System.Text.RegularExpressions;
 using GitCommands.Config;
 using GitCommands.UserRepositoryHistory;
 using GitExtensions.Extensibility.Git;
@@ -160,7 +162,7 @@ namespace GitUI.ScriptsEngine
 
             return (arguments, abort: false);
 
-            static IEnumerable<string> GetOptions(IReadOnlyList<string> options, IScriptOptionsProvider scriptOptionsProvider)
+            static IEnumerable<string> GetOptions(IReadOnlyList<string> options, IScriptOptionsProvider? scriptOptionsProvider)
                 => scriptOptionsProvider is null ? options : options.Union(scriptOptionsProvider.Options);
         }
 

--- a/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
+++ b/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
@@ -1,10 +1,12 @@
-﻿namespace GitUI.ScriptsEngine;
+﻿#nullable enable
+
+namespace GitUI.ScriptsEngine;
 
 internal partial class SimplePrompt : Form, IUserInputPrompt
 {
     public string UserInput { get; private set; } = "";
 
-    public SimplePrompt(string title, string label, string defaultValue)
+    public SimplePrompt(string? title, string? label, string? defaultValue)
     {
         InitializeComponent();
         txtUserInput.Text = defaultValue;
@@ -16,7 +18,7 @@ internal partial class SimplePrompt : Form, IUserInputPrompt
 
         if (!string.IsNullOrWhiteSpace(label))
         {
-            labelInput.Text = label + ":";
+            labelInput.Text = $"{label}:";
         }
     }
 

--- a/src/app/GitUI/ScriptsEngine/SimplePromptCreator.cs
+++ b/src/app/GitUI/ScriptsEngine/SimplePromptCreator.cs
@@ -1,13 +1,15 @@
-﻿namespace GitUI.ScriptsEngine;
+﻿#nullable enable
+
+namespace GitUI.ScriptsEngine;
 
 internal interface ISimplePromptCreator
 {
-    IUserInputPrompt Create(string title, string label, string defaultValue);
+    IUserInputPrompt Create(string? title, string? label, string? defaultValue);
 }
 
 internal class SimplePromptCreator : ISimplePromptCreator
 {
-    public IUserInputPrompt Create(string title, string label, string defaultValue)
+    public IUserInputPrompt Create(string? title, string? label, string? defaultValue)
     {
         return new SimplePrompt(title, label, defaultValue);
     }

--- a/tests/app/UnitTests/GitUI.Tests/Script/ScriptsManagerScriptRunnerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Script/ScriptsManagerScriptRunnerTests.cs
@@ -26,6 +26,18 @@ public class ScriptsManagerScriptRunnerTests
         _commands.Module.Returns(_module);
     }
 
+    // Regression test for https://github.com/gitextensions/gitextensions/issues/11892
+    [Test]
+    public void Parse_should_not_fail_if_arguments_null()
+    {
+        (string? arguments, bool abort, bool cancel) result = ScriptRunner.ParseUserInputs("script_name", arguments: null, _commands,
+            owner: null, scriptOptionsProvider: _scriptOptionsProvider);
+
+        result.abort.Should().Be(false);
+        result.cancel.Should().Be(false);
+        result.arguments.Should().BeNull();
+    }
+
     [Test]
     public void Parse_should_parse_distincts_userInput()
     {
@@ -34,6 +46,7 @@ public class ScriptsManagerScriptRunnerTests
             owner: null, scriptOptionsProvider: _scriptOptionsProvider);
 
         result.abort.Should().Be(false);
+        result.cancel.Should().Be(false);
         result.arguments.Should().Be(@"foo1_""bar1""_foo2_""foo2""");
     }
 
@@ -45,6 +58,7 @@ public class ScriptsManagerScriptRunnerTests
             owner: null, scriptOptionsProvider: _scriptOptionsProvider);
 
         result.abort.Should().Be(false);
+        result.cancel.Should().Be(false);
         result.arguments.Should().Be(@"foo1");
     }
 
@@ -56,6 +70,7 @@ public class ScriptsManagerScriptRunnerTests
             owner: null, scriptOptionsProvider: _scriptOptionsProvider);
 
         result.abort.Should().Be(false);
+        result.cancel.Should().Be(false);
         result.arguments.Should().Be(@"foo1_foo1_""foo1""");
     }
 
@@ -68,6 +83,7 @@ public class ScriptsManagerScriptRunnerTests
             owner: null, scriptOptionsProvider: _scriptOptionsProvider);
 
         result.abort.Should().Be(false);
+        result.cancel.Should().Be(false);
         result.arguments.Should().Be(@"file_foo.bak");
     }
 
@@ -124,6 +140,7 @@ public class ScriptsManagerScriptRunnerTests
             owner: null, scriptOptionsProvider: _scriptOptionsProvider);
 
         result.abort.Should().Be(false);
+        result.cancel.Should().Be(false);
         result.arguments.Should().Be(@"unquoted path:C:\a_file_path\file.txt - quoted path:""C:\a_file_path\file.txt""");
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11892

## Proposed changes

Handle unset script arguments which result in an NRE when a script is invoked (before the Settings dialog is opened - this sets all unset arguments to `""`).

## Screenshots <!-- Remove this section if PR does not change UI -->

## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
