### PR TITLE
Correctly escape paths

### DIFF
--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32104.313
@@ -247,6 +248,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{
 		tests\plugins\UnitTests\Directory.Build.props = tests\plugins\UnitTests\Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FindLargeFiles.Tests", "tests\plugins\UnitTests\FindLargeFiles.Tests\FindLargeFiles.Tests.csproj", "{85006436-9332-4ADA-89BF-A9541F90F761}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -447,6 +450,10 @@ Global
 		{790D97FD-8C38-46B2-8469-C3755CD55E9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{790D97FD-8C38-46B2-8469-C3755CD55E9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{790D97FD-8C38-46B2-8469-C3755CD55E9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85006436-9332-4ADA-89BF-A9541F90F761}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85006436-9332-4ADA-89BF-A9541F90F761}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85006436-9332-4ADA-89BF-A9541F90F761}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85006436-9332-4ADA-89BF-A9541F90F761}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -516,6 +523,7 @@ Global
 		{8D26B963-EC2E-4D08-A5B4-2177BAC602AE} = {449DD87E-63E9-4C61-B797-A94F8CBE8837}
 		{1110DC9C-5A1E-43E8-A91C-819B3B5207A1} = {449DD87E-63E9-4C61-B797-A94F8CBE8837}
 		{0C71ED08-A7BC-42CC-B690-81F53C62A731} = {1110DC9C-5A1E-43E8-A91C-819B3B5207A1}
+		{85006436-9332-4ADA-89BF-A9541F90F761} = {0C71ED08-A7BC-42CC-B690-81F53C62A731}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ECECB7EA-BCCF-44AD-B63E-C2FA45589FB0}

--- a/src/plugins/FindLargeFiles/FindLargeFilesPlugin.cs
+++ b/src/plugins/FindLargeFiles/FindLargeFilesPlugin.cs
@@ -28,7 +28,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
 
         public override bool Execute(GitUIEventArgs args)
         {
-            using FindLargeFilesForm frm = new(_sizeLargeFile.ValueOrDefault(Settings), args);
+            using FindLargeFilesForm frm = new(_sizeLargeFile.ValueOrDefault(Settings), args.GitUICommands);
             frm.ShowDialog(args.OwnerForm);
 
             return true;

--- a/src/plugins/FindLargeFiles/Properties/AssemblyInfo.cs
+++ b/src/plugins/FindLargeFiles/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyDescription("GitExtensions plugin for finding large files")]
+
+[assembly:InternalsVisibleTo("FindLargeFiles.Tests")]

--- a/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFiles.Tests.csproj
+++ b/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFiles.Tests.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\app\GitUI\GitUI.csproj" />
+    <ProjectReference Include="..\..\..\..\src\app\ResourceManager\ResourceManager.csproj" />
+    <ProjectReference Include="..\..\..\..\src\plugins\FindLargeFiles\GitExtensions.Plugins.FindLargeFiles.csproj" />
+    <ProjectReference Include="..\..\..\CommonTestUtils\CommonTestUtils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFilesFormTests.GenerateCommand_with_deletions_should_return_expected.verified.txt
+++ b/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFilesFormTests.GenerateCommand_with_deletions_should_return_expected.verified.txt
@@ -1,0 +1,7 @@
+﻿SET gitexe="C:\Program Files\Git\bin\git.exe"
+%gitexe% filter-branch --index-filter "git rm -r -f --cached --ignore-unmatch 'intune/packages/file.intunewin'" --prune-empty -- --all
+%gitexe% filter-branch --index-filter "git rm -r -f --cached --ignore-unmatch 'intune/packages/file with spaces.intunewin'" --prune-empty -- --all
+%gitexe% filter-branch --index-filter "git rm -r -f --cached --ignore-unmatch 'intune/packages/XL Upload/xl-upload.intunewin'" --prune-empty -- --all
+for /f "usebackq" %%a IN (`"%gitexe% for-each-ref --format="%%^(refname^)" refs/original/"`) DO %gitexe% update-ref -d %%a
+%gitexe% reflog expire --expire=now --all
+%gitexe% gc --aggressive --prune=now

--- a/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFilesFormTests.GenerateCommand_without_deletions_should_return_expected.verified.txt
+++ b/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFilesFormTests.GenerateCommand_without_deletions_should_return_expected.verified.txt
@@ -1,0 +1,4 @@
+﻿SET gitexe="C:\Program Files\Git\bin\git.exe"
+for /f "usebackq" %%a IN (`"%gitexe% for-each-ref --format="%%^(refname^)" refs/original/"`) DO %gitexe% update-ref -d %%a
+%gitexe% reflog expire --expire=now --all
+%gitexe% gc --aggressive --prune=now

--- a/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFilesFormTests.cs
+++ b/tests/plugins/UnitTests/FindLargeFiles.Tests/FindLargeFilesFormTests.cs
@@ -1,0 +1,47 @@
+﻿using GitCommands;
+using GitExtensions.Plugins.FindLargeFiles;
+
+namespace DeleteUnusedBranchesTests
+{
+    [TestFixture]
+    public class FindLargeFilesFormTests
+    {
+        [Test]
+        public async Task GenerateCommand_without_deletions_should_return_expected()
+        {
+            string original = AppSettings.GitCommandValue;
+            try
+            {
+                AppSettings.GitCommandValue = @"C:\Program Files\Git\bin\git.exe";
+                await Verifier.Verify(FindLargeFilesForm.GetTestAccessor().GenerateCommand([]));
+            }
+            finally
+            {
+                AppSettings.GitCommandValue = original;
+            }
+        }
+
+        [Test]
+        public async Task GenerateCommand_with_deletions_should_return_expected()
+        {
+            string original = AppSettings.GitCommandValue;
+            try
+            {
+                AppSettings.GitCommandValue = @"C:\Program Files\Git\bin\git.exe";
+                SortableObjectsList gitObjects =
+                    [
+                        new GitObject("sha1", "intune/packages/file.intunewin", 1, "commit") { Delete = true },
+                        new GitObject("sha1", "intune/packages/file with spaces.intunewin", 1, "commit") { Delete = true },
+                        new GitObject("sha1", "intune/packages/XL Upload/xl-upload.intunewin", 1, "commit") { Delete = true },
+                        new GitObject("sha1", "readme.md", 1, "commit"),
+                    ];
+
+                await Verifier.Verify(FindLargeFilesForm.GetTestAccessor().GenerateCommand(gitObjects));
+            }
+            finally
+            {
+                AppSettings.GitCommandValue = original;
+            }
+        }
+    }
+}

--- a/tests/plugins/UnitTests/FindLargeFiles.Tests/Properties/AssemblyInfo.cs
+++ b/tests/plugins/UnitTests/FindLargeFiles.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using CommonTestUtils;
+
+[assembly: TestAppSettings]
+[assembly: Category("UnitTests")]


### PR DESCRIPTION
Fixes #11896
Fixes #11897

![image](https://github.com/user-attachments/assets/4e241541-76b3-4c0d-b2f5-9970a04f3dee)


## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
