### PR TITLE
Move NoWarn=NU1903 to the Wix PackageReference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <LangVersion>12</LangVersion>
-    <NoWarn>$(NoWarn);1573;1591;1712;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);1573;1591;1712</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -210,3 +210,4 @@ YYYY/MM/DD, github id, Full name, email
 2024/03/24, berrs, Per-Erik Stendahl, pererik.stendahl@gmail.com
 2024/05/27, redcatH, Yi Liu, i.hao.lin[at}outlook.com
 2024/06/17, astos-marcb, Marc Becker, marc.becker@astos.de
+2024/09/12, ericstj, Eric StJohn, ericstj(at)microsoft.com

--- a/src/app/GitExtensions/GitExtensions.csproj
+++ b/src/app/GitExtensions/GitExtensions.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="vswhere" GeneratePathProperty="true">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WiX" GeneratePathProperty="true">
+    <PackageReference Include="WiX" GeneratePathProperty="true" NoWarn="NU1903">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION

https://github.com/gitextensions/gitextensions/issues/11574 @RussKie 

## Proposed changes
- Instead of suppressing warning globally for the repo, suppress it on the single package reference where its needed.  This lets GitExtensions still see warnings for other vulnerable packages.

## Test methodology <!-- How did you ensure quality? -->

- Restore before change - works
- Remove NoWarn - fails with NU1903
- Add NoWarn to package reference - works again

## Test environment(s) <!-- Remove any that don't apply -->

Windows, dotnet 9.0 preview 7 SDK

## Merge strategy
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).

I agree that the maintainer squash merge this PR (if the commit message is clear).

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
