### PR TITLE
chore: Update wix to v3.14.1 (security update)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
 
     <!-- Setup infra -->
     <PackageVersion Include="vswhere" Version="2.8.4" />
-    <PackageVersion Include="WiX" Version="3.14.0" />
+    <PackageVersion Include="WiX" Version="3.14.1" />
 
     <!-- Test infra -->
     <PackageVersion Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/src/app/GitExtensions/GitExtensions.csproj
+++ b/src/app/GitExtensions/GitExtensions.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="vswhere" GeneratePathProperty="true">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WiX" GeneratePathProperty="true" NoWarn="NU1903">
+    <PackageReference Include="WiX" GeneratePathProperty="true">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
No more need to ignore warning NU1903 raised by Wix package <= v3.14.0
(better fix for #11574 than ones done in #11575 and #11911 )

https://wixtoolset.org/news/2024/02/06/wix-v4.0.4-available/

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11574


## Test methodology <!-- How did you ensure quality? -->

- Build successful in AppVeyor

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
