### PR TITLE
feat(settings): deeper checks for GitExtensions install directory

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -530,7 +530,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return false;
             }
 
-            if (installDir.EndsWith(".exe"))
+            if (installDir.EndsWith(".exe") || !Directory.Exists(installDir))
+            {
+                RenderSettingUnset(GitExtensionsInstall, GitExtensionsInstall_Fix, _registryKeyGitExtensionsFaulty.Text);
+                return false;
+            }
+
+            if (!System.Diagnostics.Debugger.IsAttached && installDir != AppSettings.GetGitExtensionsDirectory())
             {
                 RenderSettingUnset(GitExtensionsInstall, GitExtensionsInstall_Fix, _registryKeyGitExtensionsFaulty.Text);
                 return false;


### PR DESCRIPTION
* Check that the folder exists
* Check that it is set to the currently running instance GE install path

Make GE config more reliable. Related to https://github.com/gitextensions/gitextensions.vsix/issues/33#issuecomment-2348488930

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build 5ac26f6ed7cd0d8da2f8fe1f629f4de3b77948fb (Dirty)
- Git 2.45.0.windows.1 (recommended: 2.46.0 or later)
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.8
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.31 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.33 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.20 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.7 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.8 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
