### PR TITLE
fix: support Git < 2.26 with bright colors

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -57,10 +57,21 @@ public abstract class DiffHighlightService : TextHighlightService
         if (AppSettings.ReverseGitColoring.Value)
         {
             // Fix: Force black foreground to avoid that foreground is calculated to white
-            SetIfUnsetInGit(key: "color.diff.oldMoved", value: "black brightmagenta");
-            SetIfUnsetInGit(key: "color.diff.newMoved", value: "black brightblue");
-            SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: "black brightcyan");
-            SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: "black brightyellow");
+            GitVersion supportsBrightColors = new("2.26.0.0");
+            if (module.GitVersion >= supportsBrightColors)
+            {
+                SetIfUnsetInGit(key: "color.diff.oldMoved", value: "black brightmagenta");
+                SetIfUnsetInGit(key: "color.diff.newMoved", value: "black brightblue");
+                SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: "black brightcyan");
+                SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: "black brightyellow");
+            }
+            else
+            {
+                SetIfUnsetInGit(key: "color.diff.oldMoved", value: "reverse bold magenta");
+                SetIfUnsetInGit(key: "color.diff.newMoved", value: "reverse bold blue");
+                SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: "reverse bold cyan");
+                SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: "reverse bold yellow");
+            }
         }
 
         // Set dimmed colors, default is gray dimmed/italic


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/pull/11847#issuecomment-2346101789

## Proposed changes

Git before 2.26 do not support the bright attribute for colors. As a workaround reverse bold is set, which has occasionally derived white foreground colors.
This doeos not change the appearance, except for the situations that #11847 addressed. The workaround for #11847 would have to be done for all Git users with < 2.26

Note: Adding the version to IGitVersion would require a change of all plugins to change this. Even if this is done for 5.0.1 I rather change this at this single usage.

An alternative is to raise LastVersionWithoutKnownLimitations from 2.15 to 2.26, which is a little steep.
I have whish to support 2.25 as that is the version in Ubuntu 20.04, not very important though.

## Test methodology <!-- How did you ensure quality? -->

Manual, faking version

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
