### PR TITLE
FileStatusList: Reuse context menu separators

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1675,7 +1675,7 @@ namespace GitUI.CommandsDialogs
             deleteFileToolStripMenuItem.Enabled = !isAnyDeleted;
             openContainingFolderToolStripMenuItem.Enabled = !isAnyDeleted;
 
-            UnstagedFileContext.AddUserScripts(runScriptToolStripMenuItem, ExecuteCommand, script => script.OnEvent == ScriptEvent.ShowInFileList, UICommands);
+            toolStripSeparatorScript.Visible = UnstagedFileContext.AddUserScripts(runScriptToolStripMenuItem, ExecuteCommand, script => script.OnEvent == ScriptEvent.ShowInFileList, UICommands);
         }
 
         private void StagedFileContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
@@ -1696,7 +1696,7 @@ namespace GitUI.CommandsDialogs
             stagedOpenWithToolStripMenuItem8.Enabled = !isAnyDeleted;
             stagedOpenFolderToolStripMenuItem10.Enabled = !isAnyDeleted;
 
-            StagedFileContext.AddUserScripts(stagedRunScriptToolStripMenuItem, ExecuteCommand, script => script.OnEvent == ScriptEvent.ShowInFileList, UICommands);
+            toolStripSeparatorScript.Visible = StagedFileContext.AddUserScripts(stagedRunScriptToolStripMenuItem, ExecuteCommand, script => script.OnEvent == ScriptEvent.ShowInFileList, UICommands);
         }
 
         private void UnstagedSubmoduleContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -33,7 +33,7 @@ namespace GitUI
         private readonly ToolStripItem _openInVisualStudioSeparator = new ToolStripSeparator();
         private readonly ToolStripItem _NO_TRANSLATE_openInVisualStudioMenuItem;
         private readonly CancellationTokenSequence _reloadSequence = new();
-        private readonly ToolStripItem _showDiffForAllParentsSeparator = new ToolStripSeparator() { Name = _showDiffForAllParentsItemName + "Separator" };
+        private readonly ToolStripItem _showDiffForAllParentsSeparator = new ToolStripSeparator() { Name = $"{_showDiffForAllParentsItemName}Separator" };
         private readonly ToolStripItem _sortBySeparator = new ToolStripSeparator();
 
         private int _nextIndexToSelect = -1;

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -22,7 +22,7 @@ namespace GitUI
 {
     public sealed partial class FileStatusList : GitModuleControl
     {
-        private const string _showAllDifferencesItemName = "ShowDiffForAllParentsText";
+        private const string _showDiffForAllParentsItemName = nameof(TranslatedStrings.ShowDiffForAllParentsText);
 
         private static readonly TimeSpan SelectedIndexChangeThrottleDuration = TimeSpan.FromMilliseconds(50);
         private readonly IFullPathResolver _fullPathResolver;
@@ -33,7 +33,7 @@ namespace GitUI
         private readonly ToolStripItem _openInVisualStudioSeparator = new ToolStripSeparator();
         private readonly ToolStripItem _NO_TRANSLATE_openInVisualStudioMenuItem;
         private readonly CancellationTokenSequence _reloadSequence = new();
-        private readonly ToolStripItem _showAllDifferencesSeparator = new ToolStripSeparator() { Name = _showAllDifferencesItemName + "Separator" };
+        private readonly ToolStripItem _showDiffForAllParentsSeparator = new ToolStripSeparator() { Name = _showDiffForAllParentsItemName + "Separator" };
         private readonly ToolStripItem _sortBySeparator = new ToolStripSeparator();
 
         private int _nextIndexToSelect = -1;
@@ -1507,17 +1507,17 @@ namespace GitUI
             // Show 'Show file differences for all parents' menu item if it is possible that there are multiple first revisions
             bool mayBeMultipleRevs = _enableDisablingShowDiffForAllParents && GitItemStatusesWithDescription.Count > 1;
 
-            ToolStripItem[] diffItem = cm.Items.Find(_showAllDifferencesItemName, true);
+            ToolStripItem[] diffItem = cm.Items.Find(_showDiffForAllParentsItemName, true);
             if (diffItem.Length == 0)
             {
-                cm.Items.Add(_showAllDifferencesSeparator);
-                _showAllDifferencesSeparator.Visible = mayBeMultipleRevs;
+                cm.Items.Add(_showDiffForAllParentsSeparator);
+                _showDiffForAllParentsSeparator.Visible = mayBeMultipleRevs;
 
                 ToolStripMenuItem showAllDifferencesItem = new(TranslatedStrings.ShowDiffForAllParentsText)
                 {
                     Checked = AppSettings.ShowDiffForAllParents,
                     ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip,
-                    Name = _showAllDifferencesItemName,
+                    Name = _showDiffForAllParentsItemName,
                     CheckOnClick = true,
                     Visible = mayBeMultipleRevs
                 };
@@ -1540,7 +1540,7 @@ namespace GitUI
             {
                 diffItem[0].Visible = mayBeMultipleRevs;
 
-                ToolStripItem[] sepItem = cm.Items.Find(_showAllDifferencesSeparator.Name, true);
+                ToolStripItem[] sepItem = cm.Items.Find(_showDiffForAllParentsSeparator.Name, true);
                 if (sepItem.Length > 0)
                 {
                     sepItem[0].Visible = mayBeMultipleRevs;

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -22,6 +22,8 @@ namespace GitUI
 {
     public sealed partial class FileStatusList : GitModuleControl
     {
+        private const string _showAllDifferencesItemName = "ShowDiffForAllParentsText";
+
         private static readonly TimeSpan SelectedIndexChangeThrottleDuration = TimeSpan.FromMilliseconds(50);
         private readonly IFullPathResolver _fullPathResolver;
         private readonly FileStatusDiffCalculator _diffCalculator;
@@ -31,6 +33,8 @@ namespace GitUI
         private readonly ToolStripItem _openInVisualStudioSeparator = new ToolStripSeparator();
         private readonly ToolStripItem _NO_TRANSLATE_openInVisualStudioMenuItem;
         private readonly CancellationTokenSequence _reloadSequence = new();
+        private readonly ToolStripItem _showAllDifferencesSeparator = new ToolStripSeparator() { Name = _showAllDifferencesItemName + "Separator" };
+        private readonly ToolStripItem _sortBySeparator = new ToolStripSeparator();
 
         private int _nextIndexToSelect = -1;
         private bool _enableSelectedIndexChangeEvent = true;
@@ -1496,28 +1500,24 @@ namespace GitUI
 
             if (!cm.Items.Find(_sortByContextMenu.Name, true).Any())
             {
-                cm.Items.Add(new ToolStripSeparator());
+                cm.Items.Add(_sortBySeparator);
                 cm.Items.Add(_sortByContextMenu);
             }
 
             // Show 'Show file differences for all parents' menu item if it is possible that there are multiple first revisions
             bool mayBeMultipleRevs = _enableDisablingShowDiffForAllParents && GitItemStatusesWithDescription.Count > 1;
 
-            const string showAllDifferencesItemName = "ShowDiffForAllParentsText";
-            ToolStripItem[] diffItem = cm.Items.Find(showAllDifferencesItemName, true);
-            const string separatorKey = showAllDifferencesItemName + "Separator";
+            ToolStripItem[] diffItem = cm.Items.Find(_showAllDifferencesItemName, true);
             if (diffItem.Length == 0)
             {
-                cm.Items.Add(new ToolStripSeparator
-                {
-                    Name = separatorKey,
-                    Visible = mayBeMultipleRevs
-                });
+                cm.Items.Add(_showAllDifferencesSeparator);
+                _showAllDifferencesSeparator.Visible = mayBeMultipleRevs;
+
                 ToolStripMenuItem showAllDifferencesItem = new(TranslatedStrings.ShowDiffForAllParentsText)
                 {
                     Checked = AppSettings.ShowDiffForAllParents,
                     ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip,
-                    Name = showAllDifferencesItemName,
+                    Name = _showAllDifferencesItemName,
                     CheckOnClick = true,
                     Visible = mayBeMultipleRevs
                 };
@@ -1534,14 +1534,13 @@ namespace GitUI
                         UpdateFileStatusListView(gitItemStatusesWithDescription);
                     });
                 };
-
                 cm.Items.Add(showAllDifferencesItem);
             }
             else
             {
                 diffItem[0].Visible = mayBeMultipleRevs;
 
-                ToolStripItem[] sepItem = cm.Items.Find(separatorKey, true);
+                ToolStripItem[] sepItem = cm.Items.Find(_showAllDifferencesSeparator.Name, true);
                 if (sepItem.Length > 0)
                 {
                     sepItem[0].Visible = mayBeMultipleRevs;


### PR DESCRIPTION
Fixes #11909

## Proposed changes

1. There are used different ContextMenuStrips for files and for submodules.
The menu items are added on menu open - and automatically removed from the other menu.
When re-adding them, the separators must not be created anew (as it is done for `_openInVisualStudioSeparator`).

2. Set the visibility of `FormCommit.toolStripSeparatorScript` as in https://github.com/gitextensions/gitextensions/commit/844050a9fd4a5d3a93a4888a2f6e5d424d7e1ac0 (done for all usages of `AddUserScripts`).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

see issue

### After

no multiple separators

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).