### PR TITLE
FormCommit: Disable ResetSoft if command not applicable

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -31,6 +31,8 @@ namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormCommit : GitModuleForm
     {
+        private const string _resetSoftRevision = "HEAD~1";
+
         #region Translation
 
         private readonly TranslationString _amendCommit
@@ -2174,7 +2176,7 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                ArgumentString cmd = Commands.Reset(ResetMode.Soft, "HEAD~1");
+                ArgumentString cmd = Commands.Reset(ResetMode.Soft, _resetSoftRevision);
                 Module.GitExecutable.RunCommand(cmd);
                 Amend.Enabled = false;
                 Amend.Checked = false;
@@ -3400,6 +3402,8 @@ namespace GitUI.CommandsDialogs
             {
                 ReplaceMessage(Module.GetPreviousCommitMessages(count: 1, revision: "HEAD", authorPattern: string.Empty).FirstOrDefault()?.Trim());
             }
+
+            ResetSoft.Enabled = ResetSoft.Visible && Amend.Checked && Module.RevParse(_resetSoftRevision) is not null;
 
             if (AppSettings.CommitAndPushForcedWhenAmend)
             {


### PR DESCRIPTION
Fixes #11894

## Proposed changes

- FormCommit: Disable ResetSoft if the git command will not be applicable, i.e. if "HEAD~1" does not exist

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

exception (refer to issue)

### After

![image](https://github.com/user-attachments/assets/bb08bfda-f2da-460e-98d5-fee9ce1132ca)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).