### PR TITLE
fix: Merge git-diff textmarkers separated by newlines

### DIFF
--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -47,12 +47,12 @@ public partial class AnsiEscapeUtilities
                         sb.Append("@!");
                         TryGetColorsFromEscapeSequence(new List<int>() { 0, dim, i + 30 + (fore ? 0 : 10) + (bold ? 60 : 0) }, out Color? backColor, out Color? foreColor, ref currentColorId, themeColors: false);
                         if (TryGetTextMarker(new()
-                        {
-                            DocOffset = sb.Length - 2,
-                            Length = 2,
-                            BackColor = backColor,
-                            ForeColor = foreColor
-                        },
+                                {
+                                    DocOffset = sb.Length - 2,
+                                    Length = 2,
+                                    BackColor = backColor,
+                                    ForeColor = foreColor
+                                },
                                 prevMarker: null,
                                 sb,
                                 out TextMarker tm))
@@ -508,10 +508,10 @@ public partial class AnsiEscapeUtilities
             int gapLen = hl.DocOffset - prevMarker.EndOffset - 1;
             if (gapLen == 0)
             {
-                // zero gap, Git often have consequtive sections (like '+' in separate)
+                // zero gap, Git often have consecutive sections (like '+' in separate)
             }
             else if (gapLen == 1
-                && sb[hl.DocOffset - 1] == '\n')
+                && sb[hl.DocOffset - 1] is ('\n' or '\r'))
             {
                 // Only \n, gap is a newline, not colored in the viewer
             }


### PR DESCRIPTION
Follow up to #11887 
Adds tests, refactor a little, slightly more performant and merges some more text markers.
This was discussed with #11843 but is not strictly needed (but simplifies that PR too).

## Proposed changes

Number of text markers affect performance, merge with previous text marker if the new is directly following or only separated by newline.

* do not color empty \r

git-diff tries to color \r also if diff.colorMovedWS=no This has no visible effect and is just polluting the markers.

## Screenshots <!-- Remove this section if PR does not change UI -->

No change, \r\n are never colored.

## Test methodology <!-- How did you ensure quality? -->

Tests are added.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
