### PR TITLE
fix: Always present git inserted as Header

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/src/app/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -123,8 +123,10 @@ public partial class DiffLineNumAnalyzer
                 leftLineNum++;
                 rightLineNum++;
             }
-            else if (i == lines.Length - 1 && line.StartsWith(GitModule.NoNewLineAtTheEnd))
+            else if (!isGitWordDiff && line.StartsWith('\\'))
             {
+                // git-diff has inserted this line, present it as a header
+                // The only known string is GitModule.NoNewLineAtTheEnd
                 DiffLineInfo meta = new()
                 {
                     LineNumInDiff = lineNumInDiff,


### PR DESCRIPTION
Part of #11831, that PR reports on the Git behavior to insert the information rather than the GE presentation.
I do not want to manipulate the git-diff output here, which is what is requested in #11831.

## Proposed changes

Git may insert "\ No newline at end of file" in the end lines of a diff, this was not presented as Header unless last line.
(This printout may appear before last line in addition to the last line.)
Incorrect line numbers and not extra gray background.
Note that all printouts with '\' as first chars could be handled this way, the first position is special (+/-/@ after the header).

## Screenshots <!-- Remove this section if PR does not change UI -->

See 1e1b946b65669c232db8eef55efb378d41a44b82

### Before

![image](https://github.com/user-attachments/assets/4861337f-6cff-4c04-a69f-affa2d20ace0)

### After

![image](https://github.com/user-attachments/assets/601b281b-2f58-4d95-b358-f6624fdd5a9a)

## Test methodology <!-- How did you ensure quality? -->

A test is added in an upcoming PR, some restructuring is done to tests and I prefer to wait on that. 
(PR awaits #11851 and #11862).

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
