### PR TITLE
fix: Allow ^and .. in manual branch filters

### DIFF
--- a/src/app/GitUI/UserControls/FilterToolBar.cs
+++ b/src/app/GitUI/UserControls/FilterToolBar.cs
@@ -81,8 +81,8 @@ namespace GitUI.UserControls
                 // Ignore quoting, Git revisions do not allow spaces.
                 foreach (string branch in filter.Split((char[])null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                 {
-                    bool wildcardBranchFilter = branch.IndexOfAny(new[] { '?', '*', '[' }) >= 0;
-                    if (branch.StartsWith("--") || refs.Any(r => r.LocalName == branch))
+                    bool wildcardBranchFilter = branch.IndexOfAny(['?', '*', '[']) >= 0;
+                    if (branch.StartsWith("--") || refs.Any(r => r.LocalName == branch) || branch.Contains(".."))
                     {
                         // Added as git-log option or revision filter
                     }
@@ -92,7 +92,8 @@ namespace GitUI.UserControls
                     }
                     else
                     {
-                        ObjectId oid = GetModule().RevParse(branch);
+                        string gitref = branch.StartsWith('^') ? branch[1..] : branch;
+                        ObjectId oid = GetModule().RevParse(gitref);
                         if (oid is null)
                         {
                             TaskDialogPage page = new()

--- a/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -450,14 +450,14 @@ namespace GitUI.UserControls.RevisionGrid
                 // If BranchFilter contains wildcards, "--branches=" must be prepended.
                 // Use the simple branch filter if without wildcards (must be Git revision)
                 // in order to avoid git adding implicit /* to the "--branches=" filter.
-                // Also add apparent options.
+                // Also add apparent options and all ".." patterns.
 
                 // Split at whitespace (char[])null is default) but with split options.
                 // Ignore quouting, Git revisions do not allow spaces.
                 foreach (string branch in BranchFilter.Split((char[])null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                 {
-                    bool wildcardBranchFilter = branch.IndexOfAny(new[] { '?', '*', '[' }) >= 0;
-                    filter.Add(wildcardBranchFilter && !branch.StartsWith("--")
+                    bool wildcardBranchFilter = branch.IndexOfAny(['?', '*', '[']) >= 0;
+                    filter.Add(wildcardBranchFilter && !branch.StartsWith("--") && !branch.Contains("..")
                         ? $"--branches={branch}"
                         : branch);
                 }


### PR DESCRIPTION
Fixes #](https://github.com/gitextensions/gitextensions/issues/3165#issuecomment-2352794359)

## Proposed changes

Allow ranges in Branches quick search
With this, it possible to search branches with ^ .. ... in the search box
Previously only arguments starting with -- was excluded from git-rev-parse checks if it was not a known branch/tag so the arguments were not allowed.
The check that there is a valid reference for ^branch is there, no such check for branch2..branch1 though.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
