### PR TITLE
Use "-D" instead of "-d" when deleting unmerged branches

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -211,3 +211,4 @@ YYYY/MM/DD, github id, Full name, email
 2024/05/27, redcatH, Yi Liu, i.hao.lin[at}outlook.com
 2024/06/17, astos-marcb, Marc Becker, marc.becker@astos.de
 2024/09/12, ericstj, Eric StJohn, ericstj(at)microsoft.com
+2024/09/26, georg138, Georg Siebke, github(at)georgsiebke.de

--- a/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -197,7 +197,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                     {
                         GitArgumentBuilder args = new("branch")
                         {
-                            "-d",
+                            includeUnmergedBranches.Checked ? "-D" : "-d",
                             localBranch.Name
                         };
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3871

## Proposed changes

Use `git branch -D` instead of `git branch -d` when explicitly deleting unmerged branches.

## Screenshots <!-- Remove this section if PR does not change UI -->

## Test methodology <!-- How did you ensure quality? -->

- Manual test to check if deleting unmerged branches works instead of return an error message from git.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.46.0
- Windows 10 Enterprise 22H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
