### PR TITLE
fix: Align difftastic colors

### DIFF
--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -311,13 +311,16 @@ public partial class AnsiEscapeUtilities
             }
         }
 
-        if (themeColors && !reverse
+        if (themeColors && !reverse && !dim
             && (currentBack < 0 || backColor is null)
             && foreColor is null
-            && currentFore is 1 or 2 && !dim)
+            && currentFore is 1 or 2)
         {
             // Assume this is a fit for the theme colors with reverse color (e.g. difftastic)
-            reverse = true;
+            // Change bold -> normal, normal -> dim to match GE theme better
+            // difftastic 'normal' is not only unchanged why GE unchanged dim-dim is not used
+            backColor = Get8bitColor(currentFore, fore: false, bold: false, dim: !bold);
+            currentFore = -1;
         }
 
         if (isChange && (foreColor is null && backColor is null && currentFore < 0 && currentBack < 0))


### PR DESCRIPTION
## Proposed changes

Align with updated GE colors in #11851 and use normal/dim instead of bold/normal.
GE uses dim-dim for unchanged, but the difftastic default normal is not exactly the same and need better visibility.

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://github.com/user-attachments/assets/cb17bfd6-b04c-4d1f-bb88-e869d7230ec4)
![image](https://github.com/user-attachments/assets/2bdd9317-257a-46aa-94b4-48cf890f499b)

![image](https://github.com/user-attachments/assets/dce8d59e-34f1-4725-a863-9623abded1ef)
the "bleeding of green" is due to incorrect vwesion used to take screenshot...
![image](https://github.com/user-attachments/assets/68f7248d-3dc2-42ea-83b4-d9f0aee3da0d)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
