### PR TITLE
fix(show git-grep): Sync and use actual visibility

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -779,6 +779,8 @@ namespace GitUI.CommandsDialogs
             }
 
             toolStripSeparatorScript.Visible = DiffContextMenu.AddUserScripts(runScriptToolStripMenuItem, ExecuteCommand, script => script.OnEvent == ScriptEvent.ShowInFileList, UICommands);
+
+            showFindInCommitFilesGitGrepToolStripMenuItem.Checked = DiffFiles.FindInCommitFilesGitGrepVisible;
         }
 
         private void DiffContextMenu_Opening(object sender, CancelEventArgs e)

--- a/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
+++ b/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
@@ -66,6 +66,11 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
         cboFindInCommitFilesGitGrep.EndUpdate();
     }
 
+    internal void SetShowFindInCommitFilesGitGrep(bool visible)
+    {
+        chkShowSearchBox.Checked = visible;
+    }
+
     protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
     {
         if (keyData == Keys.Escape)
@@ -94,7 +99,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
     private void FormFindInCommitFilesGitGrep_FormClosing(object sender, FormClosingEventArgs e)
     {
         // Close the search if search is not visible (or user has cleared input)
-        if (string.IsNullOrEmpty(GitGrepExpressionText) || !AppSettings.ShowFindInCommitFilesGitGrep.Value)
+        if (string.IsNullOrEmpty(GitGrepExpressionText) || !chkShowSearchBox.Checked)
         {
             FilesGitGrepLocator?.Invoke("", 0);
         }
@@ -107,7 +112,6 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
         txtOptions.Text = AppSettings.GitGrepUserArguments.Value;
         chkMatchCase.Checked = !AppSettings.GitGrepIgnoreCase.Value;
         chkMatchWholeWord.Checked = AppSettings.GitGrepMatchWholeWord.Value;
-        chkShowSearchBox.Checked = AppSettings.ShowFindInCommitFilesGitGrep.Value;
         cboFindInCommitFilesGitGrep.Focus();
         _hasLoaded = true;
     }

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -347,6 +347,7 @@ namespace GitUI
 
         public bool FilterFilesByNameRegexFocused => FilterComboBox.Focused;
         public bool FindInCommitFilesGitGrepFocused => cboFindInCommitFilesGitGrep.Focused;
+        public bool FindInCommitFilesGitGrepVisible => cboFindInCommitFilesGitGrep.Visible;
 
         /// <summary>
         ///  Indicates whether the git-grep search functionality is enabled for this control.
@@ -366,6 +367,8 @@ namespace GitUI
 
         private void SetFindInCommitFilesGitGrepVisibilityImpl(bool visible)
         {
+            _formFindInCommitFilesGitGrep?.SetShowFindInCommitFilesGitGrep(visible);
+
             cboFindInCommitFilesGitGrep.Visible = visible;
             if (visible)
             {
@@ -1605,6 +1608,7 @@ namespace GitUI
 
             _formFindInCommitFilesGitGrep.GitGrepExpressionText = !string.IsNullOrEmpty(text) ? text : (cboFindInCommitFilesGitGrep.Visible && !string.IsNullOrWhiteSpace(cboFindInCommitFilesGitGrep.Text) ? cboFindInCommitFilesGitGrep.Text : null);
             _formFindInCommitFilesGitGrep.SetSearchItems(cboFindInCommitFilesGitGrep.Items);
+            _formFindInCommitFilesGitGrep.SetShowFindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Visible);
             _formFindInCommitFilesGitGrep.Show();
             _formFindInCommitFilesGitGrep.Focus();
         }


### PR DESCRIPTION
## Proposed changes

`AppSettings` can be changed by another instance.
`AppSettings` are automatically updated in all other instance but are not applied to most of the UI.
Thus, the visibility of the `cboFindInCommitFilesGitGrep` can become out of sync with the checked state of `Show 'Find in commit files using git-grep'` - both in the git-grep form and in the context menu.

So, set the checked state of `Show 'Find in commit files using git-grep'` to the actual visibility of `cboFindInCommitFilesGitGrep` instead of `AppSettings.ShowFindInCommitFilesGitGrep`.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/dea975aa-e824-4846-bfc1-43288ee37e09)

### After

![image](https://github.com/user-attachments/assets/2969f859-f5de-4421-99a4-20b6a4501bb2)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).