### PR TITLE
fix(FormGoToCommit): Improve performance

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.Designer.cs
@@ -112,7 +112,6 @@
             comboBoxTags.Size = new Size(287, 23);
             comboBoxTags.TabIndex = 1;
             comboBoxTags.SelectionChangeCommitted += comboBoxTags_SelectionChangeCommitted;
-            comboBoxTags.TextChanged += comboBoxTags_TextChanged;
             comboBoxTags.Enter += comboBoxTags_Enter;
             comboBoxTags.KeyUp += comboBoxTags_KeyUp;
             // 
@@ -136,7 +135,6 @@
             comboBoxBranches.Size = new Size(287, 23);
             comboBoxBranches.TabIndex = 2;
             comboBoxBranches.SelectionChangeCommitted += comboBoxBranches_SelectionChangeCommitted;
-            comboBoxBranches.TextChanged += comboBoxBranches_TextChanged;
             comboBoxBranches.Enter += comboBoxBranches_Enter;
             comboBoxBranches.KeyUp += comboBoxBranches_KeyUp;
             // 
@@ -161,6 +159,7 @@
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;
             Text = "Go to commit";
+            FormClosed += FormGoToCommit_Closed;
             Load += FormGoToCommit_Load;
             groupBox1.ResumeLayout(false);
             groupBox1.PerformLayout();

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -6,6 +6,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 {
     public sealed partial class FormGoToCommit : GitModuleForm
     {
+        private const int _maxDropDownCount = 20_000;
+
         /// <summary>
         /// this will be used when Go() is called.
         /// </summary>
@@ -23,6 +25,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             InitializeComponent();
             InitializeComplete();
+        }
+
+        private void FormGoToCommit_Closed(object sender, FormClosedEventArgs e)
+        {
+            _branchesLoader.Cancel();
+            _tagsLoader.Cancel();
         }
 
         private void FormGoToCommit_Load(object sender, EventArgs e)
@@ -65,12 +73,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             comboBoxTags.Text = TranslatedStrings.LoadingData;
             return _tagsLoader.LoadAsync(
-                () => Module.GetRefs(RefsFilter.Tags).ToList(),
+                () => Module.GetRefs(RefsFilter.Tags).Take(_maxDropDownCount).ToList(),
                 list =>
                 {
                     comboBoxTags.Text = string.Empty;
-                    comboBoxTags.DataSource = list;
                     comboBoxTags.DisplayMember = nameof(IGitRef.LocalName);
+                    comboBoxTags.DataSource = list;
+                    comboBoxTags.TextChanged += comboBoxTags_TextChanged;
                     SetSelectedRevisionByFocusedControl();
                 });
         }
@@ -79,12 +88,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             comboBoxBranches.Text = TranslatedStrings.LoadingData;
             return _branchesLoader.LoadAsync(
-                () => Module.GetRefs(RefsFilter.Heads).ToList(),
+                () => Module.GetRefs(RefsFilter.Heads).Take(_maxDropDownCount).ToList(),
                 list =>
                 {
                     comboBoxBranches.Text = string.Empty;
-                    comboBoxBranches.DataSource = list;
                     comboBoxBranches.DisplayMember = nameof(IGitRef.LocalName);
+                    comboBoxBranches.DataSource = list;
+                    comboBoxBranches.TextChanged += comboBoxBranches_TextChanged;
                     SetSelectedRevisionByFocusedControl();
                 });
         }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -6,7 +6,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 {
     public sealed partial class FormGoToCommit : GitModuleForm
     {
-        private const int _maxDropDownCount = 20_000;
+        private const int _maxDropDownCount = 1_000;
 
         /// <summary>
         /// this will be used when Go() is called.


### PR DESCRIPTION
Fixes #11683

## Proposed changes

`FormGoToCommit`:
- limit number of loaded branches and tags to 20.000 entries each
- assign `DisplayMember` first!
- activate `TextChanged` last
- cancel loading on `FormClosed`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- simulate lots of tags

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).