### PR TITLE
fix: Restrict settings to "global" when not in a repository

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
@@ -21,7 +21,7 @@
     {
         private readonly SettingsPageWithHeader? _page;
 
-        public SettingsPageHeader(SettingsPageWithHeader? page)
+        public SettingsPageHeader(SettingsPageWithHeader? page, bool canSaveInsideRepo)
         {
             InitializeComponent();
             InitializeComplete();
@@ -33,13 +33,13 @@
                 settingsPagePanel.Controls.Add(page);
                 page.Dock = DockStyle.Fill;
                 _page = page;
-                ConfigureHeader();
+                ConfigureHeader(canSaveInsideRepo);
             }
         }
 
-        private void ConfigureHeader()
+        private void ConfigureHeader(bool canSaveInsideRepo)
         {
-            if (!(_page is ILocalSettingsPage localSettingsPage))
+            if (!(_page is ILocalSettingsPage localSettingsPage) || !canSaveInsideRepo)
             {
                 GlobalRB.Checked = true;
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
@@ -1,18 +1,25 @@
 ﻿using GitCommands;
+using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Settings;
+using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public partial class SettingsPageWithHeader : SettingsPageBase, IGlobalSettingsPage
     {
         private SettingsPageHeader? _header;
+        private bool _canSaveInsideRepo;
 
         public SettingsPageWithHeader(IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
+            if (serviceProvider is IGitUICommands uiCommands)
+            {
+                _canSaveInsideRepo = uiCommands.Module.IsValidGitWorkingDir();
+            }
         }
 
-        public override Control GuiControl => _header ??= new SettingsPageHeader(this);
+        public override Control GuiControl => _header ??= new SettingsPageHeader(this, _canSaveInsideRepo);
 
         public virtual void SetGlobalSettings()
         {


### PR DESCRIPTION
and so that settings file can't be saved in a "not existing" local repository.

Check that repo is valid and provide the information when creating pages

Fixes #11907 (at least prevent one way to reproduce it)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/f367efa8-1506-415e-ac17-f8cbc727d8f0)

### After

![image](https://github.com/user-attachments/assets/51b27e99-252c-412d-8244-7aba513fc481)

## Test methodology <!-- How did you ensure quality? -->

- Manual (Opening settings from dashboard i.e. while no repo opened)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).
(Will be squashed before merging)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
