### PR TITLE
fix(settings): Ignore non-boolean advanced git config settings

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -41,7 +41,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Validates.NotNull(CurrentSettings);
             foreach (GitSettingUiMapping gitSetting in _gitSettings)
             {
-                gitSetting.MappedCheckbox.Checked = CurrentSettings.GetValue<bool>(gitSetting.GitSettingKey) is true;
+                gitSetting.MappedCheckbox.CheckState = CurrentSettings.GetValue(gitSetting.GitSettingKey) switch
+                    {
+                        "true" => CheckState.Checked,
+                        "false" => CheckState.Unchecked,
+                        _ => CheckState.Indeterminate
+                    };
             }
 
             base.SettingsToPage();
@@ -50,7 +55,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             Validates.NotNull(CurrentSettings);
-            foreach (GitSettingUiMapping gitSetting in _gitSettings)
+            foreach (GitSettingUiMapping gitSetting in _gitSettings.Where(s => s.MappedCheckbox.CheckState != CheckState.Indeterminate))
             {
                 CurrentSettings.SetValue(gitSetting.GitSettingKey, gitSetting.MappedCheckbox.Checked ? "true" : "false");
             }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -43,8 +43,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 gitSetting.MappedCheckbox.CheckState = CurrentSettings.GetValue(gitSetting.GitSettingKey) switch
                     {
-                        "true" => CheckState.Checked,
-                        "false" => CheckState.Unchecked,
+                        "true" or "yes" or "on" or "1" => CheckState.Checked,
+                        "false" or "no" or "off" or "0" or "" => CheckState.Unchecked,
                         _ => CheckState.Indeterminate
                     };
             }


### PR DESCRIPTION
Fixes #11939

## Proposed changes

GitConfigAdvancedSettingsPage:
- display git config without value or with non-boolean value as indeterminate 
- do not overwrite such settings

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/3da63fa5-0186-428e-87f4-49407a8b6856)

### After

![image](https://github.com/user-attachments/assets/4ee39b47-585f-4b7e-acd9-e37a0664114b)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).