### PR TITLE
Fix FileViewer's encoding bug when showing unstaged files

### DIFF
--- a/src/app/GitExtUtils/FileUtility.cs
+++ b/src/app/GitExtUtils/FileUtility.cs
@@ -9,11 +9,18 @@ namespace GitExtUtils
         /// </summary>
         /// <param name="fileName">Destination file.</param>
         /// <param name="contents">Text to write as file contents.</param>
-        public static void SafeWriteAllText(string fileName, string contents, Encoding encoding)
+        /// <param name="encoding">Encoding used for StreamWriter to convert text to bytes.</param>
+        /// <param name="filePreamble">File preamble (such as BOM) to put at the beginning of a file.</param>
+        public static void SafeWriteAllText(string fileName, string contents, Encoding encoding, byte[] filePreamble)
         {
             using FileStream fs = new(fileName, FileMode.Open);
             using (TextWriter tw = new StreamWriter(fs, encoding, bufferSize: 4096, leaveOpen: true))
             {
+                if (filePreamble.Length > 0)
+                {
+                    fs.Write(filePreamble, 0, filePreamble.Length);
+                }
+
                 tw.Write(contents);
             }
 

--- a/src/app/GitUI/CommandsDialogs/FormEditor.cs
+++ b/src/app/GitUI/CommandsDialogs/FormEditor.cs
@@ -129,18 +129,11 @@ namespace GitUI.CommandsDialogs
             {
                 if (fileViewer.FilePreamble is null || Module.FilesEncoding.GetPreamble().SequenceEqual(fileViewer.FilePreamble))
                 {
-                    FileUtility.SafeWriteAllText(_fileName, fileViewer.GetText(), Module.FilesEncoding);
+                    FileUtility.SafeWriteAllText(_fileName, fileViewer.GetText(), Module.FilesEncoding, filePreamble: []);
                 }
                 else
                 {
-                    using MemoryStream bytes = new();
-                    bytes.Write(fileViewer.FilePreamble, 0, fileViewer.FilePreamble.Length);
-                    using (StreamWriter writer = new(bytes, Module.FilesEncoding))
-                    {
-                        writer.Write(fileViewer.GetText());
-                    }
-
-                    File.WriteAllBytes(_fileName, bytes.ToArray());
+                    FileUtility.SafeWriteAllText(_fileName, fileViewer.GetText(), Module.FilesEncoding, fileViewer.FilePreamble);
                 }
 
                 // we've written the changes out to disk now, nothing to save.

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -528,7 +528,7 @@ namespace GitUI.Editor
             => ViewPrivateAsync(item, item?.Item?.Name, text, line, openWithDifftool, ViewMode.CombinedDiff, useGitColoring: AppSettings.UseGitColoring.Value);
 
         /// <summary>
-        /// Present the text as a patch in the file viewer, for GitHub.
+        /// Present the text as a patch in the file viewer.
         /// </summary>
         /// <param name="fileName">The fileName to present.</param>
         /// <param name="text">The patch text.</param>
@@ -562,7 +562,7 @@ namespace GitUI.Editor
         }
 
         /// <summary>
-        /// Present the text in the file viewer, for GitHub.
+        /// Present the text in the file viewer.
         /// </summary>
         /// <param name="fileName">The fileName to present.</param>
         /// <param name="text">The patch text.</param>
@@ -583,7 +583,7 @@ namespace GitUI.Editor
                     ResetView(ViewMode.Text, fileName, item: item);
 
                     // Check for binary file. Using gitattributes could be misleading for a changed file,
-                    // but not much other can be done
+                    // but not much else can be done
                     bool isBinary = (checkGitAttributes && FileHelper.IsBinaryFileName(Module, fileName))
                                     || FileHelper.IsBinaryFileAccordingToContent(text);
 

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -786,7 +786,7 @@ namespace GitUI.Editor
             string GetFileText()
             {
                 using FileStream stream = File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using StreamReader reader = new(stream, GitModule.LosslessEncoding);
+                using StreamReader reader = ICSharpCode.TextEditor.Util.FileReader.OpenStream(stream, GitModule.LosslessEncoding);
 #pragma warning disable VSTHRD103 // Call async methods when in an async method
                 string content = reader.ReadToEnd();
 #pragma warning restore VSTHRD103 // Call async methods when in an async method

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -19,6 +19,7 @@ using GitUI.Properties;
 using GitUI.Theming;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
+using ICSharpCode.TextEditor.Util;
 using Microsoft;
 using ResourceManager;
 
@@ -786,7 +787,7 @@ namespace GitUI.Editor
             string GetFileText()
             {
                 using FileStream stream = File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using StreamReader reader = ICSharpCode.TextEditor.Util.FileReader.OpenStream(stream, GitModule.LosslessEncoding);
+                using StreamReader reader = FileReader.OpenStream(stream, GitModule.LosslessEncoding);
 #pragma warning disable VSTHRD103 // Call async methods when in an async method
                 string content = reader.ReadToEnd();
 #pragma warning restore VSTHRD103 // Call async methods when in an async method


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11934

A bigger issue than originally mentioned in #11934 is that currently TextEditor provided/used by GitExtensions actually corrupts files 😬

## Proposed changes

- ICSharpCode.TextEditor has a helper which attempts to auto-detect the encoding, lets use it
- Depends on https://github.com/gitextensions/ICSharpCode.TextEditor/pull/42 because of this line [`FilePreamble = reader.CurrentEncoding.GetPreamble();`](https://github.com/gitextensions/gitextensions/blob/master/src/app/GitUI/Editor/FileViewer.cs#L793)
- For good measure, lets avoid creating `MemoryStream` when not necessary and we can write straight to `FileStream`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Switching between UTF8 file without BOM and with BOM

https://github.com/user-attachments/assets/b746f341-b702-427d-9514-2e83874c6d98

After save using `fileeditor` (`F4` from within commit dialog) ⚠️⚠️⚠️ notice corruption in a file without BOM

https://github.com/user-attachments/assets/6db61e34-6906-4713-a16b-fe100110bc35


### After

Both files even after saving them with `fileeditor` (`F4` from within commit dialog) are recognized as UTF8

https://github.com/user-attachments/assets/23260abd-30e1-4848-8027-323de38f1bcf


## Test methodology <!-- How did you ensure quality? -->

- Manually, checking files visually and with Hex editor

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
