### PR TITLE
fix: Reset current ansi terminal color

### DIFF
--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -131,6 +131,7 @@ public partial class AnsiEscapeUtilities
             if (currentHighlight.Length < 0 || sb.Length == currentHighlight.DocOffset)
             {
                 // Previous was a reset, just ignore.
+                currentHighlight.Length = -1;
                 return;
             }
 
@@ -184,6 +185,12 @@ public partial class AnsiEscapeUtilities
         bool bold = false;
         bool dim = false;
         bool isChange = false; // Handle only bold/dim changes to current colors
+
+        if (escapeCodes.Count == 0)
+        {
+            // Empty sequence is the same as reset to normal
+            escapeCodes = [0];
+        }
 
         for (int i = 0; i < escapeCodes.Count; ++i)
         {

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -86,9 +86,11 @@ public abstract class DiffHighlightService : TextHighlightService
         // range-diff
         if (command == "range-diff")
         {
-            SetIfUnsetInGit(key: "color.diff.contextBold", value: $"normal bold {reverse}");
+            // No override for contextBold, contextDimmed
             SetIfUnsetInGit(key: "color.diff.oldBold", value: $"brightred {reverse}");
-            SetIfUnsetInGit(key: "color.diff.newBold", value: $"brightgreen  {reverse}");
+            SetIfUnsetInGit(key: "color.diff.newBold", value: $"brightgreen {reverse}");
+            SetIfUnsetInGit(key: "color.diff.oldDimmed", value: $"red dim {reverse}");
+            SetIfUnsetInGit(key: "color.diff.newDimmed", value: $"green dim {reverse}");
         }
 
         return commandConfiguration;

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.ParseEscape.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.ParseEscape.cs
@@ -57,7 +57,7 @@ public class AnsiEscapeUtilitiesTest_ParseEscape
             Some {_escape_sequence}0;1;31mbold red{_escape_sequence}0m
             Now {_escape_sequence}101mbold reverse red{_escape_sequence}0m
             and some {_escape_sequence}2:31mdim red{_escape_sequence}0m
-            and some {_escape_sequence}mdefault{_escape_sequence}0m
+            {_escape_sequence}31m{_escape_sequence}mdefault not red{_escape_sequence}0m{_escape_sequence}31m, red no end
               
             """.ReplaceLineEndings("\n");
         string expected = """
@@ -66,7 +66,7 @@ public class AnsiEscapeUtilitiesTest_ParseEscape
             Some bold red
             Now bold reverse red
             and some dim red
-            and some default
+            default not red, red no end
               
             """.ReplaceLineEndings("\n");
         StringBuilder sb = new();
@@ -75,7 +75,7 @@ public class AnsiEscapeUtilitiesTest_ParseEscape
         AnsiEscapeUtilities.ParseEscape(in_text, sb, textMarkers);
 
         sb.ToString().Should().Be(expected);
-        textMarkers.Should().HaveCount(4);
+        textMarkers.Should().HaveCount(5);
 
         textMarkers[0].Offset.Should().Be(10);
         textMarkers[0].Length.Should().Be(3);
@@ -96,6 +96,11 @@ public class AnsiEscapeUtilitiesTest_ParseEscape
         textMarkers[3].Length.Should().Be(7);
         textMarkers[3].Color.Should().Be(SystemColors.Window);
         textMarkers[3].ForeColor.Should().Be(_redAnsiTheme[1]);
+
+        textMarkers[4].Offset.Should().Be(108);
+        textMarkers[4].Length.Should().Be(15);
+        textMarkers[4].Color.Should().Be(SystemColors.Window);
+        textMarkers[4].ForeColor.Should().Be(_redAnsiTheme[0]);
     }
 
     [Test]
@@ -204,7 +209,7 @@ public class AnsiEscapeUtilitiesTest_ParseEscape
         textMarkers[2].ForeColor.Should().Be(_redAnsiTheme[2]);
 
         textMarkers[3].Offset.Should().Be(102);
-        textMarkers[3].Length.Should().Be(14);
+        textMarkers[3].Length.Should().Be(13);
         textMarkers[3].Color.Should().Be(SystemColors.Window);
         textMarkers[3].ForeColor.Should().Be(_redAnsiTheme[1]);
 

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.TryGetColors.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.TryGetColors.cs
@@ -36,7 +36,7 @@ public class AnsiEscapeUtilitiesTest_TryGetColors
     }
 
     [Test]
-    public void TryGetColorsFromEscapeSequence_ShouldReturnFalse_WhenEscapeCodesIsEmpty()
+    public void TryGetColorsFromEscapeSequence_ShouldReset_WhenEscapeCodesIsEmpty()
     {
         // currentColorId should be preserved
         IList<int> escapeCodes = new List<int>();
@@ -47,7 +47,7 @@ public class AnsiEscapeUtilitiesTest_TryGetColors
         result.Should().BeFalse();
         backColor.Should().BeNull();
         foreColor.Should().BeNull();
-        currentColorId.Should().Be(_yellowId);
+        currentColorId.Should().Be(_blackId);
     }
 
     [Test]


### PR DESCRIPTION
Fixes #11940

## Proposed changes

An empty ansi terminal sequence must be handled as an explicit reset.
This could cause that foreground colors were applied when black was to be used.

Adjust overridden colors for range-diff.
contextBold should not be reverse bold and
newDimmed/oldDimmed should be reverse.
(There is a minimal difference bold/normal black, but this context is
not very interesting.)

## Screenshots <!-- Remove this section if PR does not change UI -->

Slightly different behavior in 5.0 and master
Use mstv's branches repro/rangediff2-a and repro/rangediff2-b

5.0
![image](https://github.com/user-attachments/assets/d89d15c7-9543-4e5d-8d74-632189015709)

master
![image](https://github.com/user-attachments/assets/c8f4c8c5-c650-4002-adef-83f54370862d)

after
![image](https://github.com/user-attachments/assets/13bfed3f-2683-4e27-a10a-d0f1c474a0a3)

## Test methodology <!-- How did you ensure quality? -->

Tests are updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
