### PR TITLE
fix: commit gpgSign Git defaults

### DIFF
--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -190,7 +190,7 @@ namespace GitCommands.Git
             };
         }
 
-        public static ArgumentString Commit(bool amend, bool signOff, string author, bool useExplicitCommitMessage, string? commitMessageFile, Func<string, string?> getPathForGitExecution, bool noVerify = false, bool gpgSign = false, string gpgKeyId = "", bool allowEmpty = false, bool resetAuthor = false)
+        public static ArgumentString Commit(bool amend, bool signOff, string author, bool useExplicitCommitMessage, string? commitMessageFile, Func<string, string?> getPathForGitExecution, bool noVerify = false, bool? gpgSign = null, string gpgKeyId = "", bool allowEmpty = false, bool resetAuthor = false)
         {
             if (useExplicitCommitMessage && string.IsNullOrEmpty(commitMessageFile))
             {
@@ -203,8 +203,9 @@ namespace GitCommands.Git
                 { noVerify, "--no-verify" },
                 { signOff, "--signoff" },
                 { !string.IsNullOrEmpty(author), $"--author=\"{author?.Trim().Trim('"')}\"" },
-                { gpgSign && string.IsNullOrWhiteSpace(gpgKeyId), "-S" },
-                { gpgSign && !string.IsNullOrWhiteSpace(gpgKeyId), $"-S{gpgKeyId}" },
+                { gpgSign is false, "--no-gpg-sign" },
+                { gpgSign is true && string.IsNullOrWhiteSpace(gpgKeyId), "--gpg-sign" },
+                { gpgSign is true && !string.IsNullOrWhiteSpace(gpgKeyId), $"--gpg-sign={gpgKeyId}" },
                 { useExplicitCommitMessage, $"-F {getPathForGitExecution(commitMessageFile).Quote()}" },
                 { allowEmpty, "--allow-empty" },
                 { resetAuthor && amend, "--reset-author" }

--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1379,7 +1379,7 @@ namespace GitUI.CommandsDialogs
             gpgSignCommitToolStripComboBox.BackColor = SystemColors.Control;
             gpgSignCommitToolStripComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
             gpgSignCommitToolStripComboBox.Items.AddRange(new object[] {
-            "Git default",
+            "Git default GPG signing",
             "Do not sign commit",
             "Sign with default GPG",
             "Sign with specific GPG"});

--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1379,6 +1379,7 @@ namespace GitUI.CommandsDialogs
             gpgSignCommitToolStripComboBox.BackColor = SystemColors.Control;
             gpgSignCommitToolStripComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
             gpgSignCommitToolStripComboBox.Items.AddRange(new object[] {
+            "Git default",
             "Do not sign commit",
             "Sign with default GPG",
             "Sign with specific GPG"});

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1408,7 +1408,7 @@ namespace GitUI.CommandsDialogs
                         _commitMessageManager.CommitMessagePath,
                         Module.GetPathForGitExecution,
                         noVerifyToolStripMenuItem.Checked,
-                        gpgSignCommitToolStripComboBox.SelectedIndex == 0 ? null : gpgSignCommitToolStripComboBox.SelectedIndex > 0,
+                        gpgSignCommitToolStripComboBox.SelectedIndex == 0 ? null : gpgSignCommitToolStripComboBox.SelectedIndex > 1,
                         toolStripGpgKeyTextBox.Text,
                         Staged.IsEmpty,
                         resetAuthor);

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1408,7 +1408,7 @@ namespace GitUI.CommandsDialogs
                         _commitMessageManager.CommitMessagePath,
                         Module.GetPathForGitExecution,
                         noVerifyToolStripMenuItem.Checked,
-                        gpgSignCommitToolStripComboBox.SelectedIndex > 0,
+                        gpgSignCommitToolStripComboBox.SelectedIndex == 0 ? null : gpgSignCommitToolStripComboBox.SelectedIndex > 0,
                         toolStripGpgKeyTextBox.Text,
                         Staged.IsEmpty,
                         resetAuthor);

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -172,30 +172,33 @@ namespace GitCommandsTests_Git
         {
             Assert.AreEqual(
                 "commit -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: null).Arguments);
             Assert.AreEqual(
                 "commit -F \"adapted_commit_message_path\"",
-                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", path => "adapted_commit_message_path").Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", path => "adapted_commit_message_path", gpgSign: null).Arguments);
             Assert.AreEqual(
                 "commit --amend -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: true, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
+                Commands.Commit(amend: true, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: null).Arguments);
             Assert.AreEqual(
                 "commit --signoff -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, signOff: true, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
+                Commands.Commit(amend: false, signOff: true, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: null).Arguments);
             Assert.AreEqual(
                 "commit --author=\"foo\" -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, signOff: false, author: "foo", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "foo", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: null).Arguments);
             Assert.AreEqual(
                 "commit",
-                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: false, commitMessageFile: null, PathUtil.ToPosixPath).Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: false, commitMessageFile: null, PathUtil.ToPosixPath, gpgSign: null).Arguments);
             Assert.AreEqual(
                 "commit --no-verify -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, noVerify: true).Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, noVerify: true, gpgSign: null).Arguments);
             Assert.AreEqual(
-                "commit -S -F \"COMMITMESSAGE\"",
+                "commit --no-gpg-sign -F \"COMMITMESSAGE\"",
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: false).Arguments);
+            Assert.AreEqual(
+                "commit --gpg-sign -F \"COMMITMESSAGE\"",
                 Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: true).Arguments);
             Assert.AreEqual(
-                "commit -Skey -F \"COMMITMESSAGE\"",
+                "commit --gpg-sign=key -F \"COMMITMESSAGE\"",
                 Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: true, gpgKeyId: "key").Arguments);
         }
 
@@ -208,18 +211,19 @@ namespace GitCommandsTests_Git
             StringAssert.AreEqualIgnoringCase(expected, actual);
         }
 
-        [TestCase(false, false, @"", false, false, false, @"", @"commit")]
-        [TestCase(true, false, @"", false, false, false, @"", @"commit --amend")]
-        [TestCase(false, true, @"", false, false, false, @"", @"commit --signoff")]
-        [TestCase(false, false, @"", true, false, false, @"", @"commit -F ""COMMITMESSAGE""")]
-        [TestCase(false, false, @"", false, true, false, @"", @"commit --no-verify")]
-        [TestCase(false, false, @"", false, false, false, @"12345678", @"commit")]
-        [TestCase(false, false, @"", false, false, true, @"", @"commit -S")]
-        [TestCase(false, false, @"", false, false, true, @"      ", @"commit -S")]
-        [TestCase(false, false, @"", false, false, true, null, @"commit -S")]
-        [TestCase(false, false, @"", false, false, true, @"12345678", @"commit -S12345678")]
-        [TestCase(true, true, @"", true, true, true, @"12345678", @"commit --amend --no-verify --signoff -S12345678 -F ""COMMITMESSAGE""")]
-        public void CommitCmdTests(bool amend, bool signOff, string author, bool useExplicitCommitMessage, bool noVerify, bool gpgSign, string gpgKeyId, string expected)
+        [TestCase(false, false, @"", false, false, null, @"", @"commit")]
+        [TestCase(false, false, @"", false, false, false, @"", @"commit --no-gpg-sign")]
+        [TestCase(true, false, @"", false, false, false, @"", @"commit --amend --no-gpg-sign")]
+        [TestCase(false, true, @"", false, false, false, @"", @"commit --signoff --no-gpg-sign")]
+        [TestCase(false, false, @"", true, false, false, @"", @"commit --no-gpg-sign -F ""COMMITMESSAGE""")]
+        [TestCase(false, false, @"", false, true, false, @"", @"commit --no-verify --no-gpg-sign")]
+        [TestCase(false, false, @"", false, false, false, @"12345678", @"commit --no-gpg-sign")]
+        [TestCase(false, false, @"", false, false, true, @"", @"commit --gpg-sign")]
+        [TestCase(false, false, @"", false, false, true, @"      ", @"commit --gpg-sign")]
+        [TestCase(false, false, @"", false, false, true, null, @"commit --gpg-sign")]
+        [TestCase(false, false, @"", false, false, true, @"12345678", @"commit --gpg-sign=12345678")]
+        [TestCase(true, true, @"", true, true, true, @"12345678", @"commit --amend --no-verify --signoff --gpg-sign=12345678 -F ""COMMITMESSAGE""")]
+        public void CommitCmdTests(bool amend, bool signOff, string author, bool useExplicitCommitMessage, bool noVerify, bool? gpgSign, string gpgKeyId, string expected)
         {
             ArgumentString actual = Commands.Commit(amend, signOff, author, useExplicitCommitMessage, "COMMITMESSAGE", PathUtil.ToPosixPath, noVerify, gpgSign, gpgKeyId);
             StringAssert.AreEqualIgnoringCase(expected, actual);


### PR DESCRIPTION
Fixes #11931

## Proposed changes

Commit dialogue "Do not sign commit" should explicitly not set GPG key.
The default is set to "Git default", using the git-config settings.

## Screenshots <!-- Remove this section if PR does not change UI -->

Adding the first option in the dropdown
![image](https://github.com/user-attachments/assets/5338277f-f5b8-4c8d-892f-aaad6c105593)

## Test methodology <!-- How did you ensure quality? -->

tests updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
