### PR TITLE
fix(ReportDubiousOwnership): Support normal paths, too

### DIFF
--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -371,6 +371,9 @@ namespace GitUI.NBugReports
             // Turns single quotes to double quotes on Windows if there are any at all around the repo path.
             // in : git config --global -add safe.directory '%(prefix)///unc_machine/folder/to/repo'
             // out: git config --global -add safe.directory "%(prefix)///unc_machine/folder/to/repo"
+            // as well as:
+            // in : git config --global -add safe.directory 'd:/folder/to/repo with space in name'
+            // out: git config --global -add safe.directory "d:/folder/to/repo with space in name"
             static string ReplaceRepoPathQuotes(string command)
             {
                 if (!EnvUtils.RunningOnWindows() || !command.EndsWith('\''))
@@ -378,7 +381,7 @@ namespace GitUI.NBugReports
                     return command;
                 }
 
-                int quoteIndex = command.IndexOf("'%(prefix)");
+                int quoteIndex = command.IndexOf('\'');
                 return quoteIndex < 0 ? command : @$"{command[..quoteIndex]}""{command[(quoteIndex + 1)..^1]}""";
             }
         }


### PR DESCRIPTION
Fixes #11958

## Proposed changes

- `ReportDubiousOwnership`: Support normal paths (containing spaces), too, by replacing the first single quote instead of searching for `"'%(prefix)"`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/f58f34b4-44c5-4502-acf5-8d2eaece5314)

### After

![image](https://github.com/user-attachments/assets/de02cb39-ea0c-4201-aa2e-0ff9e825d14b)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).