### PR TITLE
feat: Cache the diff highlighting

### DIFF
--- a/src/app/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
@@ -11,6 +11,7 @@ public class CombinedDiffHighlightService : DiffHighlightService
     {
         _diffLinesInfo = DiffLineNumAnalyzer.Analyze(text, _textMarkers, isCombinedDiff: true);
         lineNumbersControl.DisplayLineNum(_diffLinesInfo, showLeftColumn: true);
+        SetHighlighting(text);
     }
 
     public static IGitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)

--- a/src/app/GitUI/Editor/Diff/DifftasticHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DifftasticHighlightService.cs
@@ -282,14 +282,9 @@ public partial class DifftasticHighlightService : TextHighlightService
         }
     }
 
+    public override void AddTextHighlighting(IDocument document)
+        => document.MarkerStrategy.AddMarkers(_textMarkers);
+
     public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
         => lineNumbersControl.GetLineInfo(indexInText)?.LineType is DiffLineType.Plus or DiffLineType.Minus or DiffLineType.MinusPlus or DiffLineType.MinusLeft or DiffLineType.PlusRight;
-
-    public override void AddTextHighlighting(IDocument document)
-    {
-        foreach (TextMarker tm in _textMarkers)
-        {
-            document.MarkerStrategy.AddMarker(tm);
-        }
-    }
 }

--- a/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
@@ -23,6 +23,9 @@ public partial class GrepHighlightService : TextHighlightService
         lineNumbersControl.DisplayLineNum(_diffLinesInfo, showLeftColumn: false);
     }
 
+    public override void AddTextHighlighting(IDocument document)
+        => document.MarkerStrategy.AddMarkers(_textMarkers);
+
     public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
         => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.MinusPlus or DiffLineType.Grep);
 
@@ -77,14 +80,6 @@ public partial class GrepHighlightService : TextHighlightService
             {
                 commandConfiguration.Add(new GitConfigItem(key, value), "grep");
             }
-        }
-    }
-
-    public override void AddTextHighlighting(IDocument document)
-    {
-        foreach (TextMarker tm in _textMarkers)
-        {
-            document.MarkerStrategy.AddMarker(tm);
         }
     }
 

--- a/src/app/GitUI/Editor/Diff/PatchHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/PatchHighlightService.cs
@@ -17,6 +17,7 @@ public class PatchHighlightService : DiffHighlightService
         bool isGitWordDiff = _useGitColoring && AppSettings.DiffDisplayAppearance.Value == GitCommands.Settings.DiffDisplayAppearance.GitWordDiff;
         _diffLinesInfo = DiffLineNumAnalyzer.Analyze(text, _textMarkers, isCombinedDiff: false, isGitWordDiff);
         lineNumbersControl.DisplayLineNum(_diffLinesInfo, showLeftColumn: true);
+        SetHighlighting(text);
     }
 
     public static IGitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)

--- a/src/app/GitUI/Editor/Diff/RangeDiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/RangeDiffHighlightService.cs
@@ -45,12 +45,4 @@ public partial class RangeDiffHighlightService : DiffHighlightService
         => lineNumbersControl.GetLineInfo(indexInText)?.LineType is DiffLineType.Header;
 
     public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
-
-    public override void AddTextHighlighting(IDocument document)
-    {
-        foreach (TextMarker tm in _textMarkers)
-        {
-            document.MarkerStrategy.AddMarker(tm);
-        }
-    }
 }

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -98,11 +98,7 @@ namespace GitUI.Editor
             TextEditor.Document.MarkerStrategy.RemoveAll(m => true);
 
             IList<TextMarker> selectionMarkers = GetTextMarkersMatchingWord(text);
-
-            foreach (TextMarker selectionMarker in selectionMarkers)
-            {
-                TextEditor.Document.MarkerStrategy.AddMarker(selectionMarker);
-            }
+            TextEditor.Document.MarkerStrategy.AddMarkers(selectionMarkers);
 
             _textHighlightService.AddTextHighlighting(TextEditor.Document);
             TextEditor.ActiveTextAreaControl.TextArea.Invalidate();


### PR DESCRIPTION
Depends on #11947

## Proposed changes

Split in two commits for review:

- GE diff highlighting, if Git coloring is not used (Git colors were cached already) 
- Inline processing to find common parts

Before this processing was done every time a marker was changed in the diff viewer.
(before #11947 the complete text was parsed every time too)

## Test methodology <!-- How did you ensure quality? -->

Refactoring only, tests exists

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
