### PR TITLE
feat(difftastic): use VRulerPos for right hand diff

### DIFF
--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -254,16 +254,28 @@ namespace GitUI.Editor
 
             // Get the highlight service, possibly clean escape sequences in the text and create highlight.
             _lineNumbersControl.Clear();
+            int vrulerpos = -1;
             _textHighlightService = viewMode switch
             {
                 ViewMode.Text => TextHighlightService.Instance,
                 ViewMode.Diff or ViewMode.FixedDiff => new PatchHighlightService(ref text, useGitColoring, _lineNumbersControl),
                 ViewMode.CombinedDiff => new CombinedDiffHighlightService(ref text, useGitColoring, _lineNumbersControl),
-                ViewMode.Difftastic => new DifftasticHighlightService(ref text, _lineNumbersControl),
+                ViewMode.Difftastic => new DifftasticHighlightService(ref text, _lineNumbersControl, out vrulerpos),
                 ViewMode.RangeDiff => new RangeDiffHighlightService(ref text, _lineNumbersControl),
                 ViewMode.Grep => new GrepHighlightService(ref text, _lineNumbersControl),
                 _ => throw new ArgumentException($"Unexpected viewMode: {viewMode}", nameof(viewMode))
             };
+
+            if (vrulerpos >= 0)
+            {
+                // Difftastic set the position (0 to hide)
+                VRulerPosition = vrulerpos;
+            }
+            else if (VRulerPosition != AppSettings.DiffVerticalRulerPosition)
+            {
+                // Reset if Difftastic changed the position
+                VRulerPosition = AppSettings.DiffVerticalRulerPosition;
+            }
 
             TextEditor.Text = text;
             bool hasLineNumberControl = viewMode.IsPartialTextView();

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -432,11 +432,13 @@ public class DiffLineNumAnalyzerTests
         bool theme = AppSettings.ReverseGitColoring.Value;
         AppSettings.ReverseGitColoring.Value = false;
 
-        _ = new DifftasticHighlightService(ref text, _diffViewerLineNumber);
+        _ = new DifftasticHighlightService(ref text, _diffViewerLineNumber, out int vrulerpos);
         _textEditor.Text = text;
         DiffLinesInfo result = _diffViewerLineNumber.GetTestAccessor().Result;
 
         GenericResultCheck(result, allowNotApplicable: false);
+
+        vrulerpos.Should().Be(97);
 
         result.DiffLines[5].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[5].RightLineNumber.Should().Be(16);


### PR DESCRIPTION
## Proposed changes

instead of inserting '|' to the text

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
5.0.0 
Highlight colors is here normal/bold, changed to dim/bold in master

![image](https://github.com/user-attachments/assets/c6b11bd2-b9d2-4a7c-a9d5-3eb1a19975af)

### After

![image](https://github.com/user-attachments/assets/74dd30e9-1d2c-4843-ad6a-640aff8ce91b)

## Test methodology <!-- How did you ensure quality? -->

test for the divider added

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
