### PR TITLE
fix(FormRenameBranch): Run git interactively

### DIFF
--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -575,6 +575,16 @@ namespace GitCommands.Git
             };
         }
 
+        public static ArgumentString RenameBranch(string name, string newName)
+        {
+            return new GitArgumentBuilder("branch")
+            {
+                "-m",
+                name.QuoteNE(),
+                newName.QuoteNE()
+            };
+        }
+
         /// <summary>
         /// The Git command line for reset.
         /// </summary>

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1975,17 +1975,6 @@ namespace GitCommands
             return _gitExecutable.GetOutput(args);
         }
 
-        public string RenameBranch(string name, string newName)
-        {
-            GitArgumentBuilder args = new("branch")
-            {
-                "-m",
-                name.QuoteNE(),
-                newName.QuoteNE()
-            };
-            return _gitExecutable.GetOutput(args);
-        }
-
         public string AddRemote(string? name, string? path)
         {
             if (string.IsNullOrEmpty(name))

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -501,7 +501,6 @@ public interface IGitModule
     /// </returns>
     string GetRemoteBranch(string branch);
 
-    string RenameBranch(string name, string newName);
     IReadOnlyList<GitItemStatus> GetGrepFilesStatus(ObjectId objectId, string grepString, CancellationToken cancellationToken);
     Task<ExecutionResult> GetGrepFileAsync(
         ObjectId objectId,

--- a/src/app/GitUI/CommandsDialogs/FormRenameBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRenameBranch.cs
@@ -1,14 +1,14 @@
-﻿using System.Diagnostics;
-using GitCommands;
+﻿using GitCommands;
 using GitCommands.Git;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitUI.HelperDialogs;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormRenameBranch : GitModuleForm
     {
-        private readonly TranslationString _branchRenameFailed = new("Rename failed.");
         private readonly IGitBranchNameNormaliser _branchNameNormaliser;
         private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
         private readonly string _oldName;
@@ -51,22 +51,10 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            try
-            {
-                string renameBranchResult = Module.RenameBranch(_oldName, newName);
+            ArgumentString command = Commands.RenameBranch(_oldName, newName);
+            bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
 
-                if (!string.IsNullOrEmpty(renameBranchResult))
-                {
-                    MessageBox.Show(this, _branchRenameFailed.Text + Environment.NewLine + renameBranchResult, Text,
-                        MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine(ex.Message);
-            }
-
-            DialogResult = DialogResult.OK;
+            DialogResult = success ? DialogResult.OK : DialogResult.None;
         }
     }
 }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6643,10 +6643,6 @@ Value has been reset to empty value.</source>
         <source>Rename</source>
         <target />
       </trans-unit>
-      <trans-unit id="_branchRenameFailed.Text">
-        <source>Rename failed.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="label1.Text">
         <source>New name</source>
         <target />

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -568,6 +568,17 @@ namespace GitCommandsTests_Git
                 Commands.Remove(files: new[] { "a", "b", "c" }).Arguments);
         }
 
+        [Test]
+        public void RenameBranch()
+        {
+            const string oldName = "foo";
+            const string newName = "far";
+
+            Assert.AreEqual(
+                $"branch -m \"{oldName}\" \"{newName}\"",
+                Commands.RenameBranch(oldName, newName).Arguments);
+        }
+
         [TestCase(null)]
         [TestCase("")]
         [TestCase("\t")]

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -486,19 +486,6 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void RenameBranch()
-        {
-            const string oldName = "foo";
-            const string newName = "far";
-            const string output = "bar";
-
-            using (_executable.StageOutput($"branch -m \"{oldName}\" \"{newName}\"", output))
-            {
-                Assert.AreEqual(output, _gitModule.RenameBranch(oldName, newName));
-            }
-        }
-
-        [Test]
         public void AddRemote()
         {
             const string name = "foo";


### PR DESCRIPTION
Fixes #10375

## Proposed changes

- FormRenameBranch: Run git interactively instead of manually dealing with git output and silent tracing of exceptions
- dialog remains open on error in order to be able to fixup the entered name

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

nothing but an entry in the Git Command Log:

![image](https://github.com/user-attachments/assets/77b1a307-2b4b-4629-a576-bb1747991dca)

### After

![image](https://github.com/user-attachments/assets/5e846766-89be-4ac0-a5c1-4e51bdc3ea1a)

## Test methodology <!-- How did you ensure quality? -->

- manual
- adapt testcase

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).