### PR TITLE
fix: Handle dubious repo ownership, too, if detected by GitStatusMonitor

### DIFF
--- a/src/app/GitExtensions/Program.cs
+++ b/src/app/GitExtensions/Program.cs
@@ -28,6 +28,13 @@ namespace GitExtensions
         [STAThread]
         private static void Main()
         {
+            // If you want to suppress the BugReportInvoker when debugging and exit quickly, uncomment the condition:
+            ////if (!Debugger.IsAttached)
+            {
+                AppDomain.CurrentDomain.UnhandledException += (s, e) => BugReportInvoker.Report((Exception)e.ExceptionObject, e.IsTerminating);
+                Application.ThreadException += (s, e) => BugReportInvoker.Report(e.Exception, isTerminating: false);
+            }
+
             if (Environment.OSVersion.Version.Major >= 6)
             {
                 SetProcessDPIAware();
@@ -83,13 +90,6 @@ namespace GitExtensions
             try
             {
                 DiagnosticsClient.Initialize(ThisAssembly.Git.IsDirty);
-
-                // If you want to suppress the BugReportInvoker when debugging and exit quickly, uncomment the condition:
-                ////if (!Debugger.IsAttached)
-                {
-                    AppDomain.CurrentDomain.UnhandledException += (s, e) => BugReportInvoker.Report((Exception)e.ExceptionObject, e.IsTerminating);
-                    Application.ThreadException += (s, e) => BugReportInvoker.Report(e.Exception, isTerminating: false);
-                }
             }
             catch (TypeInitializationException tie)
             {

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitUI.NBugReports;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
@@ -512,8 +514,17 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                         {
                             // No action
                         }
-                        catch
+                        catch (Exception exception)
                         {
+                            if (exception.Message?.Contains(ExecutableExtensions.DubiousOwnershipSecurityConfigString) is true)
+                            {
+                                BugReportInvoker.Report(exception, isTerminating: false);
+                            }
+                            else
+                            {
+                                Trace.WriteLine(exception.Message);
+                            }
+
                             try
                             {
                                 if (++_consecutiveErrorCount < _maxConsecutiveErrors)


### PR DESCRIPTION
Fixes #11964

## Proposed changes

- `GitStatusMonitor`: Let the `BugReportInvoker` handle dubious repo ownership, and trace other exceptions
- `Main`: Register exception handlers as early as possible

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

empty FormBrowse

### After

dubious ownership popup

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).