### PR TITLE
fix(in-line diff): Support non-reversed git coloring

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -18,8 +18,6 @@ public abstract class DiffHighlightService : TextHighlightService
     private static readonly Color _removedBackColor = AppColor.AnsiTerminalRedBackNormal.GetThemeColor();
     private static readonly Color _removedForeColor = AppColor.AnsiTerminalRedForeBold.GetThemeColor();
 
-    private static bool _dimBackground;
-
     protected readonly bool _useGitColoring;
     protected readonly List<TextMarker> _textMarkers = [];
     protected DiffLinesInfo _diffLinesInfo;
@@ -186,11 +184,10 @@ public abstract class DiffHighlightService : TextHighlightService
     /// </summary>
     private void AddInlineDifferenceMarkers(List<TextMarker> textMarkers, string text)
     {
-        _dimBackground = !_useGitColoring || AppSettings.ReverseGitColoring.Value;
-
         int index = 0;
         DiffLineInfo[] diffLines = [.. _diffLinesInfo.DiffLines.Values.OrderBy(l => l.LineNumInDiff)];
         const int diffContentOffset = 1; // in order to skip the prefixes '-' / '+'
+        bool dimBackground = !_useGitColoring || AppSettings.ReverseGitColoring.Value;
 
         // Process the next blocks of removed / added diffLines and mark in-line differences
         while (index < diffLines.Length)
@@ -210,7 +207,7 @@ public abstract class DiffHighlightService : TextHighlightService
 
             foreach ((ISegment lineRemoved, ISegment lineAdded) in LinesMatcher.FindLinePairs(GetText, linesRemoved, linesAdded))
             {
-                AddDifferenceMarkers(textMarkers, GetText, lineRemoved, lineAdded, diffContentOffset);
+                AddDifferenceMarkers(textMarkers, GetText, lineRemoved, lineAdded, diffContentOffset, dimBackground);
             }
         }
 
@@ -267,28 +264,29 @@ public abstract class DiffHighlightService : TextHighlightService
         return result;
     }
 
-    internal static void AddDifferenceMarkers(List<TextMarker> markers, Func<ISegment, string> getText, ISegment lineRemoved, ISegment lineAdded, int beginOffset)
+    internal static void AddDifferenceMarkers(List<TextMarker> markers, Func<ISegment, string> getText, ISegment lineRemoved, ISegment lineAdded, int beginOffset, bool dimBackground)
     {
         ReadOnlySpan<char> textRemoved = getText(lineRemoved).AsSpan();
         ReadOnlySpan<char> textAdded = getText(lineAdded).AsSpan();
         int offsetRemoved = lineRemoved.Offset + beginOffset;
         int offsetAdded = lineAdded.Offset + beginOffset;
-        (int lengthIdenticalAtStart, int lengthIdenticalAtEnd) = AddDifferenceMarkers(markers, textRemoved, textAdded, offsetRemoved, offsetAdded);
+        (int lengthIdenticalAtStart, int lengthIdenticalAtEnd) = AddDifferenceMarkers(markers, textRemoved, textAdded, offsetRemoved, offsetAdded, dimBackground);
 
         if (lengthIdenticalAtStart > 0)
         {
-            markers.Add(CreateDimmedMarker(offsetRemoved, lengthIdenticalAtStart, isRemoved: true));
-            markers.Add(CreateDimmedMarker(offsetAdded, lengthIdenticalAtStart, isRemoved: false));
+            markers.Add(CreateDimmedMarker(offsetRemoved, lengthIdenticalAtStart, isRemoved: true, dimBackground));
+            markers.Add(CreateDimmedMarker(offsetAdded, lengthIdenticalAtStart, isRemoved: false, dimBackground));
         }
 
         if (lengthIdenticalAtEnd > 0)
         {
-            markers.Add(CreateDimmedMarker(offsetRemoved + textRemoved.Length - lengthIdenticalAtEnd, lengthIdenticalAtEnd, isRemoved: true));
-            markers.Add(CreateDimmedMarker(offsetAdded + textAdded.Length - lengthIdenticalAtEnd, lengthIdenticalAtEnd, isRemoved: false));
+            markers.Add(CreateDimmedMarker(offsetRemoved + textRemoved.Length - lengthIdenticalAtEnd, lengthIdenticalAtEnd, isRemoved: true, dimBackground));
+            markers.Add(CreateDimmedMarker(offsetAdded + textAdded.Length - lengthIdenticalAtEnd, lengthIdenticalAtEnd, isRemoved: false, dimBackground));
         }
     }
 
-    private static (int LengthIdenticalAtStart, int LengthIdenticalAtEnd) AddDifferenceMarkers(List<TextMarker> markers, ReadOnlySpan<char> textRemoved, ReadOnlySpan<char> textAdded, int offsetRemoved, int offsetAdded)
+    private static (int LengthIdenticalAtStart, int LengthIdenticalAtEnd) AddDifferenceMarkers(
+        List<TextMarker> markers, ReadOnlySpan<char> textRemoved, ReadOnlySpan<char> textAdded, int offsetRemoved, int offsetAdded, bool dimBackground)
     {
         // removed:             added:              "d" stands for "deleted" / "i" for "inserted" -> anchor marker in added / removed
         // "d b R a "           " b A a i"          split at "b" (stands for "before")
@@ -322,7 +320,7 @@ public abstract class DiffHighlightService : TextHighlightService
             int startIndexRightPartAdded = startIndexIdenticalAdded + lengthIdentical;
             (int lengthIdenticalAtStartRightPart, lengthIdenticalAtEnd) = AddDifferenceMarkers(markers,
                 textRemoved[startIndexRightPartRemoved..], textAdded[startIndexRightPartAdded..],
-                offsetRemoved + startIndexRightPartRemoved, offsetAdded + startIndexRightPartAdded);
+                offsetRemoved + startIndexRightPartRemoved, offsetAdded + startIndexRightPartAdded, dimBackground);
             lengthIdentical += lengthIdenticalAtStartRightPart;
 
             ////                                                             "LeftPart|CommonWord+identical"
@@ -330,7 +328,7 @@ public abstract class DiffHighlightService : TextHighlightService
             //// lengthIdenticalAtStart (final value) <- ^^^^^^^^^  ignored "identical+CommonWord+identical"
             (lengthIdenticalAtStart, int lengthIdenticalAtLeftPartEnd) = AddDifferenceMarkers(markers,
                 textRemoved[..startIndexIdenticalRemoved], textAdded[..startIndexIdenticalAdded],
-                offsetRemoved, offsetAdded);
+                offsetRemoved, offsetAdded, dimBackground);
             lengthIdentical += lengthIdenticalAtLeftPartEnd;
             startIndexIdenticalRemoved -= lengthIdenticalAtLeftPartEnd;
             startIndexIdenticalAdded -= lengthIdenticalAtLeftPartEnd;
@@ -347,8 +345,8 @@ public abstract class DiffHighlightService : TextHighlightService
             }
             else
             {
-                markers.Add(CreateDimmedMarker(offsetRemoved + startIndexIdenticalRemoved, lengthIdentical, isRemoved: true));
-                markers.Add(CreateDimmedMarker(offsetAdded + startIndexIdenticalAdded, lengthIdentical, isRemoved: false));
+                markers.Add(CreateDimmedMarker(offsetRemoved + startIndexIdenticalRemoved, lengthIdentical, isRemoved: true, dimBackground));
+                markers.Add(CreateDimmedMarker(offsetAdded + startIndexIdenticalAdded, lengthIdentical, isRemoved: false, dimBackground));
             }
         }
         else
@@ -390,16 +388,11 @@ public abstract class DiffHighlightService : TextHighlightService
     private static TextMarker CreateAnchorMarker(int offset, Color color)
         => new(offset, length: 0, TextMarkerType.InterChar, color);
 
-    private static TextMarker CreateDimmedMarker(int offset, int length, bool isRemoved)
-        => _dimBackground
+    private static TextMarker CreateDimmedMarker(int offset, int length, bool isRemoved, bool dimBackground)
+        => dimBackground
             ? CreateTextMarker(offset, length, ColorHelper.DimColor(ColorHelper.DimColor(isRemoved ? _removedBackColor : _addedBackColor)))
             : new(offset, length, TextMarkerType.SolidBlock, SystemColors.Window, ColorHelper.DimColor(isRemoved ? _removedForeColor : _addedForeColor));
 
     private static TextMarker CreateTextMarker(int offset, int length, Color color)
         => new(offset, length, TextMarkerType.SolidBlock, color, ColorHelper.GetForeColorForBackColor(color));
-
-    internal class TestAccessor
-    {
-        internal static void SetDimBackground(bool value) => _dimBackground = value;
-    }
 }

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
@@ -13,8 +13,7 @@ public class DiffHighlightServiceTests
     [Test]
     public void GetDifferenceMarkers_should_dim_identical_parts_at_begin_and_end()
     {
-        // LineSegment is hard to create. Use TextMarker as implementation type of ISegment for this test.
-        const TextMarkerType dontCare = TextMarkerType.SolidBlock;
+        DiffHighlightService.TestAccessor.SetDimBackground(true);
 
         const string identicalPartBefore = "identical_part_before_";
         const string identicalPartAfter = "_identical_part_after";
@@ -23,8 +22,8 @@ public class DiffHighlightServiceTests
         const string removedLineText = $"-{identicalPartBefore}{differentRemoved}{identicalPartAfter}";
         const string addedLineText = $"+{identicalPartBefore}{differentAdded}{identicalPartAfter}";
         const string text = $"{removedLineText}\n{addedLineText}";
-        TextMarker removedLine = new(offset: text.IndexOf(removedLineText), removedLineText.Length, textMarkerType: dontCare);
-        TextMarker addedLine = new(offset: text.IndexOf(addedLineText), addedLineText.Length, textMarkerType: dontCare);
+        ISegment removedLine = new Segment() { Offset = text.IndexOf(removedLineText), Length = removedLineText.Length };
+        ISegment addedLine = new Segment() { Offset = text.IndexOf(addedLineText), Length = addedLineText.Length };
         const int beginOffset = 1;
 
         List<TextMarker> markers = [];
@@ -51,8 +50,7 @@ public class DiffHighlightServiceTests
     [Test]
     public void GetDifferenceMarkers_should_add_anchor_markers()
     {
-        // LineSegment is hard to create. Use TextMarker as implementation type of ISegment for this test.
-        const TextMarkerType dontCare = TextMarkerType.SolidBlock;
+        DiffHighlightService.TestAccessor.SetDimBackground(true);
 
         const string deletion = nameof(deletion);
         const string insertion = nameof(insertion);
@@ -63,8 +61,8 @@ public class DiffHighlightServiceTests
         const string removedLineText = $"-{deletion}{identicalPartBefore}{differentRemoved}{identicalPartAfter}";
         const string addedLineText = $"+{identicalPartBefore}{differentAdded}{identicalPartAfter}{insertion}";
         const string text = $"{removedLineText}\n{addedLineText}";
-        TextMarker removedLine = new(offset: text.IndexOf(removedLineText), removedLineText.Length, textMarkerType: dontCare);
-        TextMarker addedLine = new(offset: text.IndexOf(addedLineText), addedLineText.Length, textMarkerType: dontCare);
+        ISegment removedLine = new Segment() { Offset = text.IndexOf(removedLineText), Length = removedLineText.Length };
+        ISegment addedLine = new Segment() { Offset = text.IndexOf(addedLineText), Length = addedLineText.Length };
         const int beginOffset = 1;
 
         List<TextMarker> markers = [];

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
@@ -13,8 +13,6 @@ public class DiffHighlightServiceTests
     [Test]
     public void GetDifferenceMarkers_should_dim_identical_parts_at_begin_and_end()
     {
-        DiffHighlightService.TestAccessor.SetDimBackground(true);
-
         const string identicalPartBefore = "identical_part_before_";
         const string identicalPartAfter = "_identical_part_after";
         const string differentRemoved = "RemovedX";
@@ -27,7 +25,7 @@ public class DiffHighlightServiceTests
         const int beginOffset = 1;
 
         List<TextMarker> markers = [];
-        DiffHighlightService.AddDifferenceMarkers(markers, GetText, removedLine, addedLine, beginOffset);
+        DiffHighlightService.AddDifferenceMarkers(markers, GetText, removedLine, addedLine, beginOffset, dimBackground: true);
         IReadOnlyList<TextMarker> sortedMarkers = markers.ToImmutableSortedSet(new MarkerComparer());
 
         TextMarker[] expectedMarkers =
@@ -50,8 +48,6 @@ public class DiffHighlightServiceTests
     [Test]
     public void GetDifferenceMarkers_should_add_anchor_markers()
     {
-        DiffHighlightService.TestAccessor.SetDimBackground(true);
-
         const string deletion = nameof(deletion);
         const string insertion = nameof(insertion);
         const string identicalPartBefore = " identical_part_before ";
@@ -66,7 +62,7 @@ public class DiffHighlightServiceTests
         const int beginOffset = 1;
 
         List<TextMarker> markers = [];
-        DiffHighlightService.AddDifferenceMarkers(markers, GetText, removedLine, addedLine, beginOffset);
+        DiffHighlightService.AddDifferenceMarkers(markers, GetText, removedLine, addedLine, beginOffset, dimBackground: true);
         IReadOnlyList<TextMarker> sortedMarkers = markers.ToImmutableSortedSet(new MarkerComparer());
 
         TextMarker[] expectedMarkers =


### PR DESCRIPTION
## Proposed changes

- in case of `AppSettings.ReverseGitColoring` set to `false`, dim the text and keep the window background

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/0c1496c2-42e9-4566-90a9-29665774b06e)

### After

![image](https://github.com/user-attachments/assets/58f74933-c9f3-41ab-b5c9-424f8d69de54)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).