### PR TITLE
fix(FileStatusList): Set `Text` for accessibility

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1207,7 +1207,10 @@ namespace GitUI
                         listItem.Selected = true;
                     }
 
+                    // Also set .Text in order to provide accessibility information
+                    listItem.Text = item.ToString();
                     listItem.Tag = new FileStatusItem(i.FirstRev, i.SecondRev, item, i.BaseA, i.BaseB);
+
                     list.Add(listItem);
                 }
             }


### PR DESCRIPTION
Fixes #10976

## Proposed changes

- Also set `listItem.Text` in addition to the `FileStatusItem` instance in order to provide accessibility information

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).