### PR TITLE
fix(git diff): Suppress `diff.external`

### DIFF
--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -279,6 +279,7 @@ namespace GitCommands.Git
         {
             return new GitArgumentBuilder("diff", gitOptions: noLocks ? (ArgumentString)"--no-optional-locks" : default)
                 {
+                    "--no-ext-diff",
                     "--find-renames",
                     "--find-copies",
                     { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2222,6 +2222,7 @@ namespace GitCommands
 
             GitArgumentBuilder args = new("diff", commandConfiguration)
             {
+                "--no-ext-diff",
                 "--find-renames",
                 "--find-copies",
                 { useGitColoring, "--color=always" },
@@ -2418,6 +2419,7 @@ namespace GitCommands
             return _gitExecutable.Execute(
                 new GitArgumentBuilder("diff")
                 {
+                    "--no-ext-diff",
                     "--find-renames",
                     "--find-copies",
                     "--name-status",
@@ -2686,6 +2688,7 @@ namespace GitCommands
         {
             GitArgumentBuilder args = new("diff")
             {
+                "--no-ext-diff",
                 "--find-renames",
                 "--find-copies",
                 "-z",

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -2403,6 +2403,7 @@ namespace GitUI.CommandsDialogs
             {
                 GitArgumentBuilder args = new("diff")
                 {
+                    "--no-ext-diff",
                     "--cached",
                     "-z",
                     "--",

--- a/src/app/GitUI/UserControls/GitBlameParser.cs
+++ b/src/app/GitUI/UserControls/GitBlameParser.cs
@@ -40,7 +40,8 @@ internal partial class GitBlameParser : IGitBlameParser
             // git-config diff algorithm option must be overridden for user preferences and tests
             GitArgumentBuilder args = new("diff")
             {
-                $"-U0",
+                "--no-ext-diff",
+                "-U0",
                 $"--diff-algorithm={(AppSettings.UseHistogramDiffAlgorithm ? "histogram" : "default")}",
                 { AppSettings.DetectCopyInFileOnBlame, "--find-renames" }, // git-blame only has -M
                 { AppSettings.DetectCopyInAllOnBlame, "--find-copies" }, // git-blame only has -C

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -293,9 +293,9 @@ namespace GitCommandsTests_Git
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default, noLocks: true).Arguments);
         }
 
-        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", false)]
-        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --find-renames --find-copies extra -- ""new""", "new", "old", false, "extra", false)]
-        [TestCase(@"--no-optional-locks -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", true)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, string oldFileName, bool staged, string extraDiffArguments, bool noLocks)
         {
             Assert.AreEqual(expected, Commands.GetCurrentChanges(fileName, oldFileName, staged,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12006

## Proposed changes

- Add argument `--no-ext-diff` to all 6 found `git diff` commands in order to suppress a possibly configured `diff.external` tool

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapt existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).