### PR TITLE
fix(FormDiff): Avoid "A task was canceled."

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormDiff.cs
+++ b/src/app/GitUI/CommandsDialogs/FormDiff.cs
@@ -25,6 +25,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFileStatusListContextMenuController _revisionDiffContextMenuController;
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
+        private readonly CancellationTokenSequence _populateDiffFilesSequence = new();
         private readonly CancellationTokenSequence _viewChangesSequence = new();
 
         private readonly ToolTip _toolTipControl = new();
@@ -103,6 +104,7 @@ namespace GitUI.CommandsDialogs
         {
             if (disposing)
             {
+                _populateDiffFilesSequence.Dispose();
                 _viewChangesSequence.Dispose();
                 components?.Dispose();
             }
@@ -147,7 +149,7 @@ namespace GitUI.CommandsDialogs
                 revisions = new[] { _secondRevision, _firstRevision };
             }
 
-            DiffFiles.InvokeAndForget(() => DiffFiles.SetDiffsAsync(revisions, _currentHead.Value, _viewChangesSequence.Next()));
+            DiffFiles.InvokeAndForget(() => DiffFiles.SetDiffsAsync(revisions, _currentHead.Value, _populateDiffFilesSequence.Next()));
         }
 
         private void ShowSelectedFileDiff()


### PR DESCRIPTION
Fixes #11980

## Proposed changes

- fix(`FormDiff`): Separate `CancellationTokenSequence`s of `PopulateDiffFiles` and `ShowSelectedFileDiff`
  necessary because `ShowSelectedFileDiff` is called twice before `PopulateDiffFiles` finishes

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

exception

### After

works

## Test methodology <!-- How did you ensure quality? -->

- manual (compare commit e283787912ca8b0af82461f3d1eec50f3f680242 with working dir)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).