### PR TITLE
fix(FormCommit): Restore file selection

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1156,7 +1156,7 @@ namespace GitUI.CommandsDialogs
 
         private void RestoreSelectedFiles(IReadOnlyList<GitItemStatus> unstagedFiles, IReadOnlyList<GitItemStatus> stagedFiles, IReadOnlyList<GitItemStatus>? lastSelection)
         {
-            if (!_currentFilesList.IsEmpty)
+            if (_currentFilesList.IsEmpty)
             {
                 SelectStoredNextIndex();
                 return;


### PR DESCRIPTION
Fixes #11903

## Proposed changes

- fix(FormCommit): Restore correct condition in `RestoreSelectedFiles`, which was stupidly broken in #11363

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

first file selected

### After

selected file restored

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).