### PR TITLE
fix(FilterToolBar): Correctly resize branch dropdown

### DIFF
--- a/src/app/GitUI/UserControls/FilterToolBar.cs
+++ b/src/app/GitUI/UserControls/FilterToolBar.cs
@@ -335,10 +335,14 @@ namespace GitUI.UserControls
                 }
 
                 int index = tscboBranchFilter.SelectionStart;
+                tscboBranchFilter.BeginUpdate();
                 tscboBranchFilter.Items.Clear();
                 tscboBranchFilter.Items.AddRange(matches);
-                tscboBranchFilter.SelectionStart = index;
                 tscboBranchFilter.ComboBox.ResizeDropDownWidth();
+                tscboBranchFilter.ComboBox.DroppedDown = true;
+                tscboBranchFilter.Text = filter;
+                tscboBranchFilter.SelectionStart = index;
+                tscboBranchFilter.EndUpdate();
             }
         }
 


### PR DESCRIPTION
Fixes #11942

## Proposed changes

- fix(FilterToolBar): Correctly resize branch dropdown and restore filter text

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/fd2778ee-627d-4751-be9f-516dbfc081a7)

### After

![image](https://github.com/user-attachments/assets/0ef89f16-c298-4021-bed8-f8fd842bc692)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).