### PR TITLE
fix(File History): Do not change capitalization of filename

### DIFF
--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1723,11 +1723,8 @@ namespace GitUI
         /// <returns>false on error.</returns>
         private bool RunFileHistoryCommand(IReadOnlyList<string> args, bool showBlame)
         {
-            string fileHistoryFileName = args[2];
-
-            // The filename filter of "git log" is case-sensitive.
-            // So, just normalize the filename, but do not try to get the "exact" filename from a case-insensitive filesystem.
-            fileHistoryFileName = NormalizeFileName(fileHistoryFileName);
+            // Use the capitalization of the filename as passed because filenames in Git may differ from Windows file system.
+            string fileHistoryFileName = NormalizeFileName(args[2]);
 
             if (string.IsNullOrWhiteSpace(fileHistoryFileName))
             {

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1724,10 +1724,7 @@ namespace GitUI
         private bool RunFileHistoryCommand(IReadOnlyList<string> args, bool showBlame)
         {
             string fileHistoryFileName = args[2];
-            if (new FormFileHistoryController().TryGetExactPath(_fullPathResolver.Resolve(fileHistoryFileName), out string exactFileName))
-            {
-                fileHistoryFileName = NormalizeFileName(exactFileName);
-            }
+            fileHistoryFileName = NormalizeFileName(fileHistoryFileName);
 
             if (string.IsNullOrWhiteSpace(fileHistoryFileName))
             {

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1724,6 +1724,9 @@ namespace GitUI
         private bool RunFileHistoryCommand(IReadOnlyList<string> args, bool showBlame)
         {
             string fileHistoryFileName = args[2];
+
+            // The filename filter of "git log" is case-sensitive.
+            // So, just normalize the filename, but do not try to get the "exact" filename from a case-insensitive filesystem.
             fileHistoryFileName = NormalizeFileName(fileHistoryFileName);
 
             if (string.IsNullOrWhiteSpace(fileHistoryFileName))


### PR DESCRIPTION
 Fixes #11886

## Proposed changes

- fix(FileHistory): Do not change the capitalization of filename passed on the command line
  because the filename filter of "git log" is case-sensitive
  rather keep the existing path, which has the correct capitalization if the File History is invoked by GE

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/c74f53b0-537f-4056-87a8-614874d6f143)

### After

![image](https://github.com/user-attachments/assets/704e85a2-d53a-473f-9e0d-7cfc1af24007)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).