### PR TITLE
fix: Add missing defaults to git attributes parser

### DIFF
--- a/src/app/GitCommands/FileHelper.cs
+++ b/src/app/GitCommands/FileHelper.cs
@@ -63,7 +63,7 @@ namespace GitCommands
         /// <returns>null if no info in .gitattributes (or ambiguous). True if marked as binary, false if marked as text</returns>
         private static bool? IsBinaryAccordingToGitAttributes(IGitModule module, string fileName)
         {
-            string[] diffValues = { "set", "astextplain", "ada", "bibtext", "cpp", "csharp", "fortran", "html", "java", "matlab", "objc", "pascal", "perl", "php", "python", "ruby", "tex" };
+            string[] diffValues = { "set", "astextplain", "ada", "bibtext", "cpp", "csharp", "css", "dts", "elixir", "fortran", "html", "java", "kotlin", "markdown", "matlab", "objc", "pascal", "perl", "php", "python", "ruby", "rust", "scheme", "tex" };
             GitArgumentBuilder cmd = new("check-attr")
             {
                 "-z",


### PR DESCRIPTION
## Proposed changes

GE uses the Git built-in patterns in .gitattributes to detect if a file is binary in certain situations to prune detection. Sync the list to recent Git versions to add newer formats.

https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header

Very minor change seen together with #12007 

## Test methodology <!-- How did you ensure quality? -->

Code review

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
