### PR TITLE
feat(EditboxBasedConsoleOutputControl): Improve UX and add [password] input field

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1304,6 +1304,8 @@ namespace GitCommands
             set => SetBool("closeprocessdialog", value);
         }
 
+        public static ISetting<bool> ShowProcessDialogPasswordInput => Setting.Create(DetailedSettingsPath, nameof(ShowProcessDialogPasswordInput), true);
+
         public static BoolRuntimeSetting ShowCurrentBranchOnly { get; } = new(RootSettingsPath, nameof(ShowCurrentBranchOnly), false);
 
         public static bool ShowSimplifyByDecoration

--- a/src/app/GitExtUtils/AsyncStreamReader.cs
+++ b/src/app/GitExtUtils/AsyncStreamReader.cs
@@ -1,0 +1,139 @@
+﻿using GitExtensions.Extensibility;
+using GitUI;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitExtUtils;
+
+/// <summary>
+///  Reads a stream asynchronously and provides the output split at a linefeed or at a carriage return not followed by linefeed.
+///  If no line end is received within a timeout, the already received output is provided.
+/// </summary>
+/// <remarks>
+///  Multiple lines can be provided as one block.
+///  <br/>
+///  The timeout expires for instance if an input prompt is shown in the stream.
+/// </remarks>
+public sealed class AsyncStreamReader : IDisposable
+{
+    private static readonly TimeSpan _nextCharReadTimeout = TimeSpan.FromMilliseconds(300);
+
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly TaskManager _taskManager = ThreadHelper.CreateTaskManager();
+
+    private bool _disposedValue;
+
+    /// <summary>
+    ///  Starts reading the stream and forwards its output to the <paramref name="notify"/> functor.
+    /// </summary>
+    public AsyncStreamReader(StreamReader streamReader, Action<string> notify)
+    {
+        CancellationToken cancellationToken = _cancellationTokenSource.Token;
+        _taskManager.FileAndForget(async () =>
+        {
+            // Read single chars because ReadAsync blocks until a line end is received
+            // Wait for start of new output without timeout, but read consecutive chars with timeout in order to display prompts having no line end
+            char[] buffer = new char[1];
+            Memory<char> bufferMemory = new(buffer);
+
+            string received = "";
+            while (true)
+            {
+                try
+                {
+                    CancellationTokenSource? readTimeoutCancellationTokenSource = null;
+                    CancellationToken readCancellation = GetReadCancellation(addTimeout: received.Length > 0, ref readTimeoutCancellationTokenSource);
+                    int length = await streamReader.ReadAsync(bufferMemory, readCancellation);
+                    readTimeoutCancellationTokenSource?.Dispose();
+
+                    if (length == 0)
+                    {
+                        if (streamReader.EndOfStream)
+                        {
+                            if (received.Length > 0)
+                            {
+                                notify(received);
+                            }
+
+                            return;
+                        }
+
+                        continue;
+                    }
+
+                    received += buffer[0];
+
+                    int lastLineEnd = received.LastIndexOf(Delimiters.LineFeed) + 1;
+                    if (lastLineEnd == 0)
+                    {
+                        lastLineEnd = received.LastIndexOf(Delimiters.CarriageReturn) + 1;
+                        if (lastLineEnd == 0 || lastLineEnd == received.Length)
+                        {
+                            continue;
+                        }
+                    }
+
+                    notify(received[..lastLineEnd]);
+                    received = received[lastLineEnd..];
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    if (received.Length > 0)
+                    {
+                        notify(received);
+                        received = "";
+                    }
+                }
+            }
+        });
+
+        return;
+
+        CancellationToken GetReadCancellation(bool addTimeout, ref CancellationTokenSource readTimeoutCancellationTokenSource)
+        {
+            if (!addTimeout)
+            {
+                return cancellationToken;
+            }
+
+            readTimeoutCancellationTokenSource = new CancellationTokenSource(_nextCharReadTimeout);
+            return cancellationToken.CombineWith(readTimeoutCancellationTokenSource.Token).Token;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                // Dispose managed state (managed objects)
+                _cancellationTokenSource.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    /// <summary>
+    ///  Cancels the asynchronous read.
+    /// </summary>
+    public void CancelOperation()
+    {
+        _cancellationTokenSource.Cancel();
+    }
+
+    /// <summary>
+    ///  Waits until all stream output has been read and forwarded to the notify functor.
+    /// </summary>
+    public Task WaitUntilEofAsync(CancellationToken cancellationToken)
+    {
+        return _taskManager.JoinPendingOperationsAsync(cancellationToken);
+    }
+}

--- a/src/app/GitExtUtils/AsyncStreamReader.cs
+++ b/src/app/GitExtUtils/AsyncStreamReader.cs
@@ -25,7 +25,7 @@ public sealed class AsyncStreamReader : IDisposable
     /// <summary>
     ///  Starts reading the stream and forwards its output to the <paramref name="notify"/> functor.
     /// </summary>
-    public AsyncStreamReader(StreamReader streamReader, Action<string> notify)
+    public AsyncStreamReader(IStreamReader streamReader, Action<string> notify)
     {
         CancellationToken cancellationToken = _cancellationTokenSource.Token;
         _taskManager.FileAndForget(async () =>
@@ -98,6 +98,14 @@ public sealed class AsyncStreamReader : IDisposable
             readTimeoutCancellationTokenSource = new CancellationTokenSource(_nextCharReadTimeout);
             return cancellationToken.CombineWith(readTimeoutCancellationTokenSource.Token).Token;
         }
+    }
+
+    /// <summary>
+    ///  Starts reading the stream and forwards its output to the <paramref name="notify"/> functor.
+    /// </summary>
+    public AsyncStreamReader(StreamReader streamReader, Action<string> notify)
+        : this(new StreamReaderFacade(streamReader), notify)
+    {
     }
 
     public void Dispose()

--- a/src/app/GitExtUtils/IStreamReader.cs
+++ b/src/app/GitExtUtils/IStreamReader.cs
@@ -1,0 +1,8 @@
+﻿namespace GitExtUtils;
+
+public interface IStreamReader
+{
+    bool EndOfStream { get; }
+
+    ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken);
+}

--- a/src/app/GitExtUtils/StreamReaderFacade.cs
+++ b/src/app/GitExtUtils/StreamReaderFacade.cs
@@ -1,0 +1,10 @@
+﻿namespace GitExtUtils;
+
+public sealed class StreamReaderFacade(StreamReader streamReader) : IStreamReader
+{
+    private StreamReader _streamReader = streamReader;
+
+    public bool EndOfStream => _streamReader.EndOfStream;
+
+    public ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken) => _streamReader.ReadAsync(buffer, cancellationToken);
+}

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -185,9 +185,10 @@ namespace GitUI.HelperDialogs
 
         private void DataReceivedCore(object sender, TextEventArgs e)
         {
-            if (e.Text.Contains("%") || e.Text.Contains("remote: Counting objects"))
+            // CarriageReturn has its literal meaning here, i.e. it is not a line end, but terminates transient progress information
+            if (e.Text.EndsWith(Delimiters.CarriageReturn))
             {
-                this.InvokeAndForget(() => SetProgressAsync(e.Text));
+                this.InvokeAndForget(() => SetProgressAsync(e.Text.TrimEnd()));
             }
             else
             {

--- a/src/app/GitUI/HelperDialogs/FormStatus.Designer.cs
+++ b/src/app/GitUI/HelperDialogs/FormStatus.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.HelperDialogs
+﻿using GitUI.UserControls;
+
+namespace GitUI.HelperDialogs
 {
     partial class FormStatus
     {
@@ -18,8 +20,10 @@
             Ok = new Button();
             ProgressBar = new ProgressBar();
             KeepDialogOpen = new CheckBox();
+            ShowPassword = new CheckBox();
             Abort = new Button();
             pnlOutput = new Panel();
+            PasswordInput = new PasswordInput();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
             SuspendLayout();
@@ -35,7 +39,8 @@
             ControlsPanel.Controls.Add(Abort);
             ControlsPanel.Controls.Add(Ok);
             ControlsPanel.Controls.Add(KeepDialogOpen);
-            ControlsPanel.Location = new Point(0, 249);
+            ControlsPanel.Controls.Add(ShowPassword);
+            ControlsPanel.Location = new Point(0, 288);
             ControlsPanel.Size = new Size(549, 39);
             // 
             // Ok
@@ -70,11 +75,23 @@
             KeepDialogOpen.Location = new Point(254, 8);
             KeepDialogOpen.Name = "KeepDialogOpen";
             KeepDialogOpen.Size = new Size(120, 22);
-            KeepDialogOpen.TabIndex = 2;
-            KeepDialogOpen.Text = "Keep dialog open";
+            KeepDialogOpen.TabIndex = 3;
+            KeepDialogOpen.Text = "&Keep dialog open";
             KeepDialogOpen.UseCompatibleTextRendering = true;
             KeepDialogOpen.UseVisualStyleBackColor = true;
             KeepDialogOpen.CheckedChanged += KeepDialogOpen_CheckedChanged;
+            // 
+            // ShowPassword
+            // 
+            ShowPassword.AutoSize = true;
+            ShowPassword.Location = new Point(108, 8);
+            ShowPassword.Name = "ShowPassword";
+            ShowPassword.Size = new Size(140, 22);
+            ShowPassword.TabIndex = 2;
+            ShowPassword.Text = "Show &password input";
+            ShowPassword.UseCompatibleTextRendering = true;
+            ShowPassword.UseVisualStyleBackColor = true;
+            ShowPassword.CheckedChanged += ShowPassword_CheckedChanged;
             // 
             // Abort
             // 
@@ -86,7 +103,7 @@
             Abort.Name = "Abort";
             Abort.Size = new Size(75, 23);
             Abort.TabIndex = 1;
-            Abort.Text = "Abort";
+            Abort.Text = "&Abort";
             Abort.UseCompatibleTextRendering = true;
             Abort.UseVisualStyleBackColor = true;
             Abort.Click += Abort_Click;
@@ -100,14 +117,26 @@
             pnlOutput.Size = new Size(549, 246);
             pnlOutput.TabIndex = 0;
             // 
+            // PasswordPanel
+            // 
+            PasswordInput.Dock = DockStyle.Bottom;
+            PasswordInput.Location = new Point(0, 249);
+            PasswordInput.Margin = new Padding(0);
+            PasswordInput.Name = "PasswordInput";
+            PasswordInput.Padding = new Padding(8);
+            PasswordInput.Size = new Size(549, 39);
+            PasswordInput.TabIndex = 2;
+            PasswordInput.PasswordEntered += PasswordInput_PasswordEntered;
+            // 
             // FormStatus
             // 
             AcceptButton = Ok;
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             CancelButton = Abort;
-            ClientSize = new Size(549, 288);
+            ClientSize = new Size(549, 327);
             Controls.Add(ProgressBar);
+            Controls.Add(PasswordInput);
             MaximizeBox = false;
             MinimizeBox = false;
             MinimumSize = new Size(500, 200);
@@ -115,6 +144,7 @@
             StartPosition = FormStartPosition.CenterParent;
             Text = "Process";
             Controls.SetChildIndex(ControlsPanel, 0);
+            Controls.SetChildIndex(PasswordInput, 0);
             Controls.SetChildIndex(ProgressBar, 0);
             Controls.SetChildIndex(MainPanel, 0);
             MainPanel.ResumeLayout(false);
@@ -122,14 +152,15 @@
             ControlsPanel.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
-
         }
 
         #endregion
 
         private ProgressBar ProgressBar;
+        protected PasswordInput PasswordInput;
         protected Button Ok;
         protected CheckBox KeepDialogOpen;
+        protected CheckBox ShowPassword;
         protected Button Abort;
         protected Panel pnlOutput;
     }

--- a/src/app/GitUI/HelperDialogs/FormStatus.cs
+++ b/src/app/GitUI/HelperDialogs/FormStatus.cs
@@ -39,6 +39,8 @@ namespace GitUI.HelperDialogs
             pnlOutput.Controls.Add(ConsoleOutput);
             ConsoleOutput.Dock = DockStyle.Fill;
 
+            ShowPassword.Checked = AppSettings.ShowProcessDialogPasswordInput.Value;
+
             if (_useDialogSettings)
             {
                 KeepDialogOpen.Checked = !AppSettings.CloseProcessDialog;
@@ -122,6 +124,8 @@ namespace GitUI.HelperDialogs
 
             form.ProgressBar.Visible = false;
             form.KeepDialogOpen.Visible = false;
+            form.ShowPassword.Visible = false;
+            form.PasswordInput.Visible = false;
             form.Abort.Visible = false;
 
             form.StartPosition = FormStartPosition.CenterParent;
@@ -175,6 +179,8 @@ namespace GitUI.HelperDialogs
                 }
 
                 AppendMessage("Done");
+                ShowPassword.Visible = false;
+                PasswordInput.Visible = false;
                 ProgressBar.Visible = false;
                 Ok.Enabled = true;
                 Ok.Focus();
@@ -202,9 +208,11 @@ namespace GitUI.HelperDialogs
             SetIcon(Images.StatusBadgeWaiting);
             ConsoleOutput.Reset();
             OutputLog.Clear();
+            ShowPassword.Visible = true;
+            PasswordInput.Visible = ShowPassword.CheckState != CheckState.Unchecked;
             ProgressBar.Visible = true;
             Ok.Enabled = false;
-            ActiveControl = null;
+            ActiveControl = PasswordInput.Visible ? PasswordInput : null;
         }
 
         private void SetIcon(Bitmap image)
@@ -277,6 +285,17 @@ namespace GitUI.HelperDialogs
             {
                 Close();
             }
+        }
+
+        private void ShowPassword_CheckedChanged(object sender, EventArgs e)
+        {
+            AppSettings.ShowProcessDialogPasswordInput.Value = ShowPassword.CheckState == CheckState.Checked;
+            PasswordInput.Visible = ShowPassword.CheckState != CheckState.Unchecked;
+        }
+
+        private void PasswordInput_PasswordEntered(object sender, TextEventArgs e)
+        {
+            ConsoleOutput.AppendInput($"{e.Text}\n");
         }
 
         private void Ok_Click(object sender, EventArgs e)

--- a/src/app/GitUI/HelperDialogs/FormStatus.cs
+++ b/src/app/GitUI/HelperDialogs/FormStatus.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using GitCommands;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 using GitUI.Models;
@@ -160,6 +161,18 @@ namespace GitUI.HelperDialogs
         private protected void AppendMessage(string text)
         {
             ConsoleOutput.AppendMessageFreeThreaded(text);
+
+            if (!text.EndsWith(Delimiters.LineFeed))
+            {
+                this.InvokeAndForget(() =>
+                {
+                    if (ShowPassword.CheckState == CheckState.Unchecked)
+                    {
+                        ShowPassword.CheckState = CheckState.Indeterminate;
+                        PasswordInput.Focus();
+                    }
+                });
+            }
         }
 
         private protected void Done(bool isSuccess)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6452,15 +6452,19 @@ Stash them before if you don't want to lose them.</source>
         <target />
       </trans-unit>
       <trans-unit id="Abort.Text">
-        <source>Abort</source>
+        <source>&amp;Abort</source>
         <target />
       </trans-unit>
       <trans-unit id="KeepDialogOpen.Text">
-        <source>Keep dialog open</source>
+        <source>&amp;Keep dialog open</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">
         <source>OK</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ShowPassword.Text">
+        <source>Show &amp;password input</source>
         <target />
       </trans-unit>
       <trans-unit id="_fingerprintNotRegistredText.Text">
@@ -7492,15 +7496,19 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <target />
       </trans-unit>
       <trans-unit id="Abort.Text">
-        <source>Abort</source>
+        <source>&amp;Abort</source>
         <target />
       </trans-unit>
       <trans-unit id="KeepDialogOpen.Text">
-        <source>Keep dialog open</source>
+        <source>&amp;Keep dialog open</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">
         <source>OK</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ShowPassword.Text">
+        <source>Show &amp;password input</source>
         <target />
       </trans-unit>
     </body>
@@ -8562,6 +8570,14 @@ This will just checkout on the submodule the commit determined by the superproje
       </trans-unit>
       <trans-unit id="tsmiCopy.Text">
         <source>&amp;Copy</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="plaintext" original="PasswordInput" source-language="en">
+    <body>
+      <trans-unit id="SendInput.Text">
+        <source>Send input</source>
         <target />
       </trans-unit>
     </body>

--- a/src/app/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/src/app/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -43,6 +43,12 @@ namespace GitUI.UserControls
             _terminal.RunningSession?.WriteOutputTextAsync(text);
         }
 
+        public override void AppendInput(string text)
+        {
+            Validates.NotNull(_terminal);
+            this.InvokeAndForget(() => _terminal.RunningSession?.WriteInputTextAsync(text));
+        }
+
         public override void KillProcess()
         {
             Validates.NotNull(_terminal);

--- a/src/app/GitUI/UserControls/ConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/ConsoleOutputControl.cs
@@ -18,6 +18,8 @@ namespace GitUI.UserControls
 
         public abstract void AppendMessageFreeThreaded(string text);
 
+        public abstract void AppendInput(string text);
+
         /// <summary>
         /// Creates the instance best fitting the current environment.
         /// </summary>

--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -143,11 +143,11 @@ namespace GitUI.UserControls
                 process.ErrorDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));
                 process.Exited += delegate
                 {
-                    this.InvokeAndForget(
-                        () =>
+                    ThreadHelper.FileAndForget(async () =>
                         {
                             if (_process is null)
                             {
+                                await this.SwitchToMainThreadAsync();
                                 operation.LogProcessEnd(new Exception("Process instance is null in Exited event"));
                                 return;
                             }
@@ -162,10 +162,12 @@ namespace GitUI.UserControls
                             }
                             catch (Exception ex)
                             {
+                                await this.SwitchToMainThreadAsync();
                                 operation.LogProcessEnd(ex);
                             }
 
                             _exitcode = _process.ExitCode;
+                            await this.SwitchToMainThreadAsync();
                             operation.LogProcessEnd(_exitcode);
                             _process = null;
                             _input = null;

--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -31,6 +31,7 @@ namespace GitUI.UserControls
                 BackColor = SystemColors.Window,
                 BorderStyle = BorderStyle.FixedSingle,
                 Dock = DockStyle.Fill,
+                Font = AppSettings.MonospaceFont,
                 ReadOnly = true
             };
             Controls.Add(_editbox);

--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -4,6 +4,7 @@ using GitCommands;
 using GitCommands.Git.Extensions;
 using GitCommands.Logging;
 using GitExtensions.Extensibility;
+using Microsoft;
 using Timer = System.Windows.Forms.Timer;
 
 namespace GitUI.UserControls
@@ -20,6 +21,8 @@ namespace GitUI.UserControls
         private Process? _process;
 
         private ProcessOutputThrottle? _outputThrottle;
+
+        private StreamWriter? _input;
 
         public EditboxBasedConsoleOutputControl()
         {
@@ -60,6 +63,12 @@ namespace GitUI.UserControls
             _outputThrottle?.Append(text);
         }
 
+        public override void AppendInput(string text)
+        {
+            Validates.NotNull(_input);
+            _input.Write(text);
+        }
+
         public override void KillProcess()
         {
             if (InvokeRequired)
@@ -82,6 +91,7 @@ namespace GitUI.UserControls
             }
 
             _process = null;
+            _input = null;
             FireProcessExited();
         }
 
@@ -157,6 +167,7 @@ namespace GitUI.UserControls
                             _exitcode = _process.ExitCode;
                             operation.LogProcessEnd(_exitcode);
                             _process = null;
+                            _input = null;
                             _outputThrottle?.FlushOutput();
                             FireProcessExited();
                             _outputThrottle?.Stop(flush: true);
@@ -166,6 +177,7 @@ namespace GitUI.UserControls
                 process.Start();
                 operation.SetProcessId(process.Id);
                 _process = process;
+                _input = process.StandardInput;
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
             }

--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -28,7 +28,7 @@ namespace GitUI.UserControls
         {
             _editbox = new RichTextBox
             {
-                BackColor = SystemColors.Window,
+                BackColor = SystemColors.Info,
                 BorderStyle = BorderStyle.FixedSingle,
                 Dock = DockStyle.Fill,
                 Font = AppSettings.MonospaceFont,

--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -118,8 +118,6 @@ namespace GitUI.UserControls
             {
                 EnvironmentConfiguration.SetEnvironmentVariables();
 
-                bool ssh = UseSsh(arguments);
-
                 KillProcess();
 
                 _logProcessKilled = () => operation.LogProcessEnd(new Exception("Process killed"));
@@ -130,7 +128,7 @@ namespace GitUI.UserControls
                 {
                     UseShellExecute = false,
                     ErrorDialog = false,
-                    CreateNoWindow = !ssh && !AppSettings.ShowGitCommandLine,
+                    CreateNoWindow = !AppSettings.ShowGitCommandLine,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
@@ -263,25 +261,6 @@ namespace GitUI.UserControls
             }
 
             base.Dispose(disposing);
-        }
-
-        private static bool UseSsh(string arguments)
-        {
-            return arguments.Contains("plink")
-                || (!GitSshHelpers.IsPlink && DoArgumentsRequireSsh());
-
-            bool DoArgumentsRequireSsh()
-            {
-                return (arguments.Contains('@') && arguments.Contains("://")) ||
-                       (arguments.Contains('@') && arguments.Contains(':')) ||
-                       arguments.Contains("ssh://") ||
-                       arguments.Contains("http://") ||
-                       arguments.Contains("git://") ||
-                       arguments.Contains("push") ||
-                       arguments.Contains("remote") ||
-                       arguments.Contains("fetch") ||
-                       arguments.Contains("pull");
-            }
         }
 
         #region ProcessOutputThrottle

--- a/src/app/GitUI/UserControls/PasswordInput.Designer.cs
+++ b/src/app/GitUI/UserControls/PasswordInput.Designer.cs
@@ -1,0 +1,117 @@
+﻿namespace GitUI.UserControls
+{
+    partial class PasswordInput
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            TableLayoutPanel = new TableLayoutPanel();
+            SendInput = new Button();
+            ShowPassword = new Button();
+            Password = new TextBox();
+            TableLayoutPanel.SuspendLayout();
+            SuspendLayout();
+            // 
+            // TableLayoutPanel
+            // 
+            TableLayoutPanel.AutoSize = true;
+            TableLayoutPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            TableLayoutPanel.ColumnCount = 3;
+            TableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            TableLayoutPanel.ColumnStyles.Add(new ColumnStyle());
+            TableLayoutPanel.ColumnStyles.Add(new ColumnStyle());
+            TableLayoutPanel.Controls.Add(SendInput, 2, 0);
+            TableLayoutPanel.Controls.Add(ShowPassword, 1, 0);
+            TableLayoutPanel.Controls.Add(Password, 0, 0);
+            TableLayoutPanel.Dock = DockStyle.Top;
+            TableLayoutPanel.Location = new Point(0, 0);
+            TableLayoutPanel.Name = "TableLayoutPanel";
+            TableLayoutPanel.RowCount = 1;
+            TableLayoutPanel.RowStyles.Add(new RowStyle());
+            TableLayoutPanel.Size = new Size(349, 31);
+            TableLayoutPanel.TabIndex = 1;
+            // 
+            // SendInput
+            // 
+            SendInput.AutoSize = true;
+            SendInput.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            SendInput.Location = new Point(272, 3);
+            SendInput.Name = "SendInput";
+            SendInput.Size = new Size(74, 25);
+            SendInput.TabIndex = 3;
+            SendInput.Text = "Send input";
+            SendInput.UseVisualStyleBackColor = true;
+            SendInput.Click += SendInput_Click;
+            // 
+            // ShowPassword
+            // 
+            ShowPassword.Image = Properties.Images.EyeClosed;
+            ShowPassword.Location = new Point(241, 3);
+            ShowPassword.Name = "ShowPassword";
+            ShowPassword.Size = new Size(25, 25);
+            ShowPassword.TabIndex = 2;
+            ShowPassword.UseVisualStyleBackColor = true;
+            ShowPassword.Click += ShowPassword_Click;
+            // 
+            // Password
+            // 
+            Password.AllowDrop = true;
+            Password.Dock = DockStyle.Fill;
+            Password.Location = new Point(4, 4);
+            Password.Margin = new Padding(4);
+            Password.MinimumSize = new Size(100, 23);
+            Password.Name = "Password";
+            Password.Size = new Size(230, 23);
+            Password.TabIndex = 1;
+            Password.UseSystemPasswordChar = true;
+            Password.DragDrop += Text_DragDrop;
+            Password.DragEnter += Text_DragEnter;
+            Password.DragOver += Text_DragEnter;
+            Password.Enter += Text_Enter;
+            Password.Leave += Text_Leave;
+            // 
+            // PasswordInput
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            Controls.Add(TableLayoutPanel);
+            Name = "PasswordInput";
+            Size = new Size(349, 31);
+            TableLayoutPanel.ResumeLayout(false);
+            TableLayoutPanel.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private TableLayoutPanel TableLayoutPanel;
+        private Button SendInput;
+        private Button ShowPassword;
+        private TextBox Password;
+    }
+}

--- a/src/app/GitUI/UserControls/PasswordInput.cs
+++ b/src/app/GitUI/UserControls/PasswordInput.cs
@@ -1,0 +1,70 @@
+﻿using ResourceManager;
+
+namespace GitUI.UserControls;
+
+public partial class PasswordInput : TranslatedControl
+{
+    private IButtonControl? _originalAcceptButton;
+
+    public PasswordInput()
+    {
+        InitializeComponent();
+        InitializeComplete();
+    }
+
+    public event EventHandler<TextEventArgs>? PasswordEntered;
+
+    private void SendInput_Click(object sender, EventArgs e)
+    {
+        PasswordEntered?.Invoke(this, new TextEventArgs(Password.Text));
+        Password.Text = "";
+    }
+
+    private void ShowPassword_Click(object sender, EventArgs e)
+    {
+        Password.UseSystemPasswordChar = !Password.UseSystemPasswordChar;
+        ShowPassword.Image = Password.UseSystemPasswordChar ? Properties.Images.EyeClosed : Properties.Images.EyeOpened;
+        Password.Focus();
+    }
+
+    private void Text_DragDrop(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(DataFormats.Text))
+        {
+            Password.Paste(e.Data.GetData(DataFormats.Text).ToString());
+        }
+    }
+
+    private void Text_DragEnter(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(DataFormats.Text))
+        {
+            e.Effect = DragDropEffects.Copy;
+            Password.Focus();
+
+            // Workaround for a bug in GetCharIndexFromPosition: It cannot return the position after the last character
+            string original = Password.Text;
+            Password.Text = $"{original} ";
+            int pos = Password.GetCharIndexFromPosition(Password.PointToClient(new Point(e.X, e.Y)));
+            Password.Text = original;
+            Password.Select(pos, length: 0);
+        }
+    }
+
+    private void Text_Enter(object sender, EventArgs e)
+    {
+        if (FindForm() is Form parentForm)
+        {
+            _originalAcceptButton = parentForm.AcceptButton;
+            parentForm.AcceptButton = SendInput;
+        }
+    }
+
+    private void Text_Leave(object sender, EventArgs e)
+    {
+        if (FindForm() is Form parentForm && parentForm.AcceptButton == SendInput)
+        {
+            parentForm.AcceptButton = _originalAcceptButton;
+        }
+    }
+}

--- a/src/app/GitUI/UserControls/PasswordInput.resx
+++ b/src/app/GitUI/UserControls/PasswordInput.resx
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/tests/app/UnitTests/GitExtUtils.Tests/ArrayExtensionsTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/ArrayExtensionsTests.cs
@@ -1,47 +1,46 @@
 ﻿using GitExtUtils;
 
-namespace GitCommandsTests
+namespace GitExtUtilsTests;
+
+[TestFixture]
+public sealed class ArrayExtensionsTests
 {
-    [TestFixture]
-    public sealed class ArrayExtensionsTests
+    [Test]
+    public void Subsequence()
     {
-        [Test]
-        public void Subsequence()
-        {
-            int[] nums = Enumerable.Range(0, 10).ToArray();
+        int[] nums = Enumerable.Range(0, 10).ToArray();
 
-            Assert.AreEqual(
-                new[] { 0, 1, 2, 3 },
-                nums.Subsequence(0, 4));
-            Assert.AreEqual(
-                new[] { 1, 2, 3, 4 },
-                nums.Subsequence(1, 4));
+        Assert.AreEqual(
+            new[] { 0, 1, 2, 3 },
+            nums.Subsequence(0, 4));
+        Assert.AreEqual(
+            new[] { 1, 2, 3, 4 },
+            nums.Subsequence(1, 4));
 
-            Assert.AreEqual(
-                nums,
-                nums.Subsequence(0, 10));
+        Assert.AreEqual(
+            nums,
+            nums.Subsequence(0, 10));
 
-            Assert.AreEqual(
-                Array.Empty<int>(),
-                nums.Subsequence(0, 0));
+        Assert.AreEqual(
+            Array.Empty<int>(),
+            nums.Subsequence(0, 0));
 
-            Assert.AreEqual(
-                Array.Empty<int>(),
-                nums.Subsequence(9, 0));
-        }
+        Assert.AreEqual(
+            Array.Empty<int>(),
+            nums.Subsequence(9, 0));
+    }
 
-        [Test]
-        public void Append()
-        {
-            Assert.AreEqual(
-                new[] { 0, 1 },
-                new[] { 0 }.Append(1));
-            Assert.AreEqual(
-                new[] { 0 },
-                Array.Empty<int>().Append(0));
-            Assert.AreEqual(
-                new[] { 0, 1, 2 },
-                Array.Empty<int>().Append(0).Append(1).Append(2));
-        }
+    [Test]
+    public void Append()
+    {
+        Assert.AreEqual(
+            new[] { 0, 1 },
+            new[] { 0 }.Append(1));
+        Assert.AreEqual(
+            new[] { 0 },
+            Array.Empty<int>().Append(0));
+        Assert.AreEqual(
+            new[] { 0, 1, 2 },
+            Array.Empty<int>().Append(0).Append(1).Append(2));
     }
 }

--- a/tests/app/UnitTests/GitExtUtils.Tests/AsyncStreamReaderTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/AsyncStreamReaderTests.cs
@@ -1,0 +1,149 @@
+﻿using System.Threading.Channels;
+using FluentAssertions;
+using GitExtUtils;
+using GitUI;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitCommandsTests;
+
+[TestFixture]
+public sealed class AsyncStreamReaderTests
+{
+    [SetUp]
+    public void Setup()
+    {
+        ThreadHelper.JoinableTaskContext = new JoinableTaskContext();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        ThreadHelper.JoinableTaskContext = null;
+    }
+
+    [Test]
+    [Repeat(3)]
+    public async Task AsyncStreamReader()
+    {
+        const int millisecondsDelayForAsyncNotification = 50;
+        const int millisecondsDelayForPartialLine = 300;
+
+        const string line1 = "line with LF\n";
+        const string line2 = "line with CRLF\r\n";
+        const string prompt = "prompt>";
+        const string input = "input\n";
+        const string progress1 = "33%\r";
+        const string progress2 = "66%\r";
+        const string progress3 = "100%\r";
+        const string partialLine = "partial";
+        const string blockOfEndedLines = $"{line1}{line2}";
+        const string blockOfLinesWithoutEnd = $"{blockOfEndedLines}{prompt}";
+
+        StreamReaderMock streamReaderMock = new();
+
+        List<string> notifiedTexts = [];
+        List<string> expectedTexts = [];
+
+        AsyncStreamReader asyncStreamReader = new(streamReaderMock, notify: text => notifiedTexts.Add(text));
+
+        streamReaderMock.Inject(blockOfEndedLines);
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([line1, line2]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+
+        streamReaderMock.Inject(blockOfLinesWithoutEnd);
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([line1, line2]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+        await Task.Delay(millisecondsDelayForPartialLine);
+        expectedTexts.AddRange([prompt]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+
+        streamReaderMock.Inject(input);
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([input]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+
+        streamReaderMock.Inject("");
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+        await Task.Delay(millisecondsDelayForPartialLine);
+        expectedTexts.AddRange([]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+
+        streamReaderMock.Inject(progress1);
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+        await Task.Delay(millisecondsDelayForPartialLine);
+        expectedTexts.AddRange([progress1]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+
+        streamReaderMock.Inject(progress2);
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+        streamReaderMock.Inject(progress3);
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([progress2]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+        streamReaderMock.Inject(partialLine);
+        await Task.Delay(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([progress3]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+
+        streamReaderMock.EndOfStream = true;
+        int start = Environment.TickCount;
+        await asyncStreamReader.WaitUntilEofAsync(cancellationToken: default);
+        int delay = Environment.TickCount - start;
+        delay.Should().BeLessThan(millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([partialLine]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+
+        streamReaderMock.Inject(blockOfEndedLines);
+        await Task.Delay(millisecondsDelayForPartialLine + millisecondsDelayForAsyncNotification);
+        expectedTexts.AddRange([]);
+        notifiedTexts.Should().BeEquivalentTo(expectedTexts);
+    }
+
+    private class StreamReaderMock : IStreamReader
+    {
+        private readonly Channel<string> _channel = Channel.CreateUnbounded<string>();
+        private bool _endOfStream = false;
+        private string _buffer = "";
+
+        public bool EndOfStream
+        {
+            get => _endOfStream;
+            set
+            {
+                _endOfStream = value;
+                Inject("");
+            }
+        }
+
+        public async ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken)
+        {
+            if (_buffer.Length == 0)
+            {
+                _buffer = await _channel.Reader.ReadAsync(cancellationToken);
+            }
+
+            int length = Math.Min(_buffer.Length, buffer.Length);
+            for (int index = 0; index < length; ++index)
+            {
+                buffer.Span[index] = _buffer[index];
+            }
+
+            _buffer = _buffer[length..];
+
+            return length;
+        }
+
+        internal void Inject(string text)
+        {
+            _channel.Writer.TryWrite(text);
+        }
+    }
+}


### PR DESCRIPTION
Extends and supersedes #11182

## Proposed changes

- feat(FormStatus): Add password text box
  - as `UserControl`
  - Automatically show input field
  - Show in all `FormStatus`, not only in `FormRemoteProcess`
  - Focus the new control
  - Cleanup unnecessary `FreeThreaded`
- fix(EditboxBasedConsoleOutputControl):
  - Use `MonospaceFont` and `SystemColors.Info`
  - Less delays
  - Unblock UI
  - Workaround for hang in `WaitForExit`
  - Fixup dispose
  - Log "Process killed"
- feat(EditboxBasedConsoleOutputControl): Add `AsyncStreamReader` in order to display prompts, i.e. output which has not been terminated with a line end (yet)
  Thus, there is no need for console window for SSH any longer.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![process_before](https://github.com/user-attachments/assets/805b0759-a6e0-4958-bb2f-dae5f4ca8636)

### After

![process_after](https://github.com/user-attachments/assets/c3045547-d3ef-46e7-b4af-b65eae147b53)

![input](https://github.com/user-attachments/assets/64eaf92d-fbcf-48cc-ae74-2dc0b21ae6f7)

## Test methodology <!-- How did you ensure quality? -->

- add unit test for `AsyncStreamReader` (would have been easier if `System.IO.StreamReader` implemented an `interface`)
- manual

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).