### PR TITLE
fix(Diff View): Avoid exception on open

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -378,7 +378,7 @@ namespace GitUI
                 // Adjust sizes "automatically" changed by visibility
                 cboFindInCommitFilesGitGrep.Top = 0;
             }
-            else if (_formFindInCommitFilesGitGrep?.Visible is false or null && cboFindInCommitFilesGitGrep.Text.Length > 0)
+            else if (_formFindInCommitFilesGitGrep?.Visible is not true && cboFindInCommitFilesGitGrep.Text.Length > 0)
             {
                 cboFindInCommitFilesGitGrep.Text = "";
                 FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 0);

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -381,7 +381,7 @@ namespace GitUI
             else if (_formFindInCommitFilesGitGrep?.Visible is false or null && cboFindInCommitFilesGitGrep.Text.Length > 0)
             {
                 cboFindInCommitFilesGitGrep.Text = "";
-                FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, 0);
+                FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 0);
             }
 
             // Adjust locations
@@ -2106,7 +2106,7 @@ namespace GitUI
 
         private void cboFindInCommitFilesGitGrep_SelectedIndexChanged(object sender, EventArgs e)
         {
-            FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, 0);
+            FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 0);
         }
 
         private void cboFindInCommitFilesGitGrep_GotFocus(object sender, EventArgs e)
@@ -2132,7 +2132,7 @@ namespace GitUI
         private void DeleteSearchButton_Click(object sender, EventArgs e)
         {
             cboFindInCommitFilesGitGrep.Text = "";
-            FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, 0);
+            FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 0);
         }
 
         private void SortByFilePath()

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -263,7 +263,10 @@ namespace GitUI
             // Show/hide the search box if settings are changed
             void UICommands_PostSettings(object sender, GitUIPostActionEventArgs? e)
             {
-                BeginInvoke(() => SetFindInCommitFilesGitGrepVisibility(AppSettings.ShowFindInCommitFilesGitGrep.Value));
+                if (CanUseFindInCommitFilesGitGrep && Visible)
+                {
+                    BeginInvoke(() => SetFindInCommitFilesGitGrepVisibility(AppSettings.ShowFindInCommitFilesGitGrep.Value));
+                }
             }
         }
 
@@ -375,6 +378,11 @@ namespace GitUI
                 // Adjust sizes "automatically" changed by visibility
                 cboFindInCommitFilesGitGrep.Top = 0;
             }
+            else if (_formFindInCommitFilesGitGrep?.Visible is false or null && cboFindInCommitFilesGitGrep.Text.Length > 0)
+            {
+                cboFindInCommitFilesGitGrep.Text = "";
+                FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, 0);
+            }
 
             // Adjust locations
             // Note that 'LoadingFiles' location depends on visibility of Filter box, must be set each time made visible
@@ -385,7 +393,7 @@ namespace GitUI
             DeleteFilterButton.Top = FilterComboBox.Top;
 
             SetFindInCommitFilesGitGrepWatermarkVisibility();
-            SetFileStatusListVisibility(!NoFiles.Visible);
+            SetFileStatusListVisibility(filesPresent: !NoFiles.Visible);
         }
 
         private void SetFileStatusListVisibility(bool filesPresent)


### PR DESCRIPTION
Fixes #12026

## Proposed changes

Fixup FileStatusList:
- Skip unnecessary git-grep box visibility handling (which called `BeginInvoke` too early)
- Clear search string on hide of git-grep box

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).