### PR TITLE
feat(CI/ADO): Add support for pull requests

### DIFF
--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -47,7 +47,7 @@ namespace AzureDevOpsIntegration
             string apiTokenHeaderValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{apiToken}"));
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", apiTokenHeaderValue);
 
-            _httpClient.BaseAddress = new Uri(projectUrl.EndsWith("/") ? projectUrl + "_apis/" : projectUrl + "/_apis/");
+            _httpClient.BaseAddress = new Uri(projectUrl.EndsWith('/') ? projectUrl + "_apis/" : projectUrl + "/_apis/");
         }
 
         private async Task<T> HttpGetAsync<T>(string url)
@@ -113,18 +113,21 @@ namespace AzureDevOpsIntegration
                 ? $"&minTime={sinceDate.Value.ToUniversalTime():s}&api-version=4.1"
                 : "&api-version=2.0";
 
-            IList<Build> finishedBuilds = (await HttpGetAsync<ListWrapper<Build>>(queryUrl)).Value;
-            Validates.NotNull(finishedBuilds);
-            return finishedBuilds;
+            return await QueryBuildsAsync(queryUrl);
+        }
+
+        private async Task<IList<Build>> QueryBuildsAsync(string queryUrl)
+        {
+            IList<Build> builds = (await HttpGetAsync<ListWrapper<Build>>(queryUrl)).Value;
+            Validates.NotNull(builds);
+            return builds;
         }
 
         public async Task<IList<Build>> QueryRunningBuildsAsync(string buildDefinitionsToQuery)
         {
             string queryUrl = QueryForBuildStatus(buildDefinitionsToQuery, "cancelling,inProgress,none,notStarted,postponed") + "&api-version=2.0";
 
-            IList<Build> runningBuilds = (await HttpGetAsync<ListWrapper<Build>>(queryUrl)).Value;
-            Validates.NotNull(runningBuilds);
-            return runningBuilds;
+            return await QueryBuildsAsync(queryUrl);
         }
 
         // Api doc: https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-4.1
@@ -133,8 +136,13 @@ namespace AzureDevOpsIntegration
 
         public void Dispose()
         {
-            _httpClient?.Dispose();
+            Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            _httpClient?.Dispose();
         }
     }
 

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -179,16 +179,27 @@ namespace AzureDevOpsIntegration
         public const string StatusNotStarted = "notStarted"; // The build has not yet started.
         public const string StatusPostponed = "postponed"; // The build is inactive in the queue.
 
+        public const string ReasonPullRequest = "validateShelveset"; // The build is triggered from a Pull Request.
+
         public string? SourceVersion { get; set; }
         public string? Status { get; set; }
         public string? BuildNumber { get; set; }
         public string? Result { get; set; }
+        public string? Reason { get; set; }
+        public Repository? Repository { get; set; }
+        public string? Parameters { get; set; }
         public BuildDefinition? Definition { get; set; }
         public BuildLinks? _links { get; set; }
         public DateTime? StartTime { get; set; }
         public DateTime? FinishTime { get; set; }
 
         public bool IsInProgress => Status != StatusCompleted;
+        public bool IsPullRequest => Reason == ReasonPullRequest;
+    }
+
+    public class Repository
+    {
+        public string? Url { get; set; }
     }
 
     public class BuildLinks

--- a/src/plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildDurationFormatter.cs
+++ b/src/plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildDurationFormatter.cs
@@ -8,14 +8,6 @@
     public class BuildDurationFormatter : IBuildDurationFormatter
     {
         public string Format(long? durationMilliseconds)
-        {
-            if (durationMilliseconds.HasValue)
-            {
-                string timeText = TimeSpan.FromMilliseconds(durationMilliseconds.Value).ToString(@"mm\:ss");
-                return $"({timeText})";
-            }
-
-            return string.Empty;
-        }
+            => durationMilliseconds.HasValue ? TimeSpan.FromMilliseconds(durationMilliseconds.Value).ToString(@"mm\:ss") : string.Empty;
     }
 }


### PR DESCRIPTION
## Proposed changes

- Display Azure DevOps PRs builds result in commit built (pipeline is building a merge commit
and so it is a little more tricky to get the original hash of the commit built)
- Add support to open Pull Request page from contextual menu
- improve a little the tooltip (to have all the information on one line --and prepare display of multiple build result in the tooltip--)
   - display also PR id and build name

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

* The result for the PR is not available
![image](https://github.com/user-attachments/assets/55ea5bb7-a38a-450c-91ad-a8cc0e67c768)


### After

* Build result on the commit & Tooltip (with PR information)
![image](https://github.com/user-attachments/assets/6f0abb63-5e21-423a-ba70-65cf5d190439)


* Open the PR
![image](https://github.com/user-attachments/assets/60827d12-973a-42ce-933c-8fb8e8587d36)


## Test methodology <!-- How did you ensure quality? -->

- Manual 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5a7e3d88ee69ac359c3dcba8160c607959f85c97 (Dirty)
- Git 2.45.0.windows.1 (recommended: 2.46.0 or later)
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.8
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.31 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.33 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.20 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.7 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.8 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer do what they want with this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
