### PR TITLE
feat: skip gaps in blocks for mark inline

### DIFF
--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.MarkInlineGap.verified.txt
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.MarkInlineGap.verified.txt
@@ -1,0 +1,64 @@
+﻿[
+  {
+    Item1: [
+      {
+        Offset: 388,
+        Length: 106
+      },
+      {
+        Offset: 707,
+        Length: 104
+      },
+      {
+        Offset: 812,
+        Length: 1
+      }
+    ],
+    Item2: [
+      {
+        Offset: 967,
+        Length: 106
+      },
+      {
+        Offset: 1074,
+        Length: 1
+      },
+      {
+        Offset: 1147,
+        Length: 1
+      },
+      {
+        Offset: 1149,
+        Length: 104
+      }
+    ]
+  },
+  {
+    Item1: [
+      {
+        Offset: 1580,
+        Length: 10
+      }
+    ],
+    Item2: [
+      {
+        Offset: 1591,
+        Length: 1
+      }
+    ]
+  },
+  {
+    Item1: [
+      {
+        Offset: 1621,
+        Length: 25
+      }
+    ],
+    Item2: [
+      {
+        Offset: 1647,
+        Length: 1
+      }
+    ]
+  }
+]

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/gaps.diff
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/gaps.diff
@@ -1,0 +1,37 @@
+diff --git a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+index d6191..df6ac 100644
+--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
++++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+@@ -13,16 +13,17 @@ namespace GitUI.Editor.Diff;
+ /// </summary>
+ public abstract class DiffHighlightService : TextHighlightService
+ {
+-    private static readonly Color _addedBackColor = AppColor.AnsiTerminalGreenBackNormal.GetThemeColor();
+     private static readonly Color _addedForeColor = AppColor.AnsiTerminalGreenForeBold.GetThemeColor();
+     private static readonly Color _removedBackColor = AppColor.AnsiTerminalRedBackNormal.GetThemeColor();
+-    private static readonly Color _removedForeColor = AppColor.AnsiTerminalRedForeBold.GetThemeColor();
+-
+     protected readonly bool _useGitColoring;
+     protected readonly List<TextMarker> _textMarkers = [];
+     protected DiffLinesInfo _diffLinesInfo;
+ 
++    private static readonly Color _addedBackColor = AppColor.AnsiTerminalGreenBackNormal.GetThemeColor();
++
+     public DiffHighlightService(ref string text, bool useGitColoring)
++
++    private static readonly Color _removedForeColor = AppColor.AnsiTerminalRedForeBold.GetThemeColor();
+     {
+         _useGitColoring = useGitColoring;
+         SetText(ref text);
+@@ -31,9 +32,9 @@ public DiffHighlightService(ref string text, bool useGitColoring)
+     public static IGitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring, string command)
+     {
+         if (!useGitColoring)
+-        {
++
+             // Use default
+-            return null;
++
+         }
+ 
+         GitCommandConfiguration commandConfiguration = new();


### PR DESCRIPTION
## Proposed changes

To improve inline marking of not interesting parts

Inline differences dims text that are not changed (and add markers where text were removed/added on a line)
Before only consecutive removed followed by consecutive added lines were compared.

Note: This allows gaps in the lines, but still requires removed followed by added lines, so the following is not handled
To expand on this it could be possible to match all lines within a section, but it could be confusing if matches are too far apart.

![image](https://github.com/user-attachments/assets/2dd78734-7222-4082-9678-c35511e3f7b5)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/abcd9558-07e4-473d-b9fc-75b94d1bfaa0)

### After

![image](https://github.com/user-attachments/assets/d26cd195-81f2-42ef-a976-b812efe88963)

## Test methodology <!-- How did you ensure quality? -->

Tests added

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
