### PR TITLE
feat(FileStatusList): Focus git-grep box on show

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -375,6 +375,8 @@ namespace GitUI
             cboFindInCommitFilesGitGrep.Visible = visible;
             if (visible)
             {
+                ActiveControl = cboFindInCommitFilesGitGrep;
+
                 // Adjust sizes "automatically" changed by visibility
                 cboFindInCommitFilesGitGrep.Top = 0;
             }


### PR DESCRIPTION
## Proposed changes

- Make `cboFindInCommitFilesGitGrep` the active control when it is shown

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://github.com/user-attachments/assets/c4fbf9ba-1772-4b69-a691-230f5c221616)

### Before

![image](https://github.com/user-attachments/assets/0567bd67-59ee-4f60-b125-fcd0d960921b)

### After

![image](https://github.com/user-attachments/assets/f1b3fe30-f11f-4c78-a20c-32bd1c4229e9)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).