### PR TITLE
fix(inline-diff): Limit highlight length

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -276,8 +276,8 @@ public abstract class DiffHighlightService : TextHighlightService
 
     internal static void AddDifferenceMarkers(List<TextMarker> markers, Func<ISegment, string> getText, ISegment lineRemoved, ISegment lineAdded, int beginOffset, bool dimBackground)
     {
-        ReadOnlySpan<char> textRemoved = getText(lineRemoved).AsSpan();
-        ReadOnlySpan<char> textAdded = getText(lineAdded).AsSpan();
+        ReadOnlySpan<char> textRemoved = LimitLength(getText(lineRemoved).AsSpan());
+        ReadOnlySpan<char> textAdded = LimitLength(getText(lineAdded).AsSpan());
         int offsetRemoved = lineRemoved.Offset + beginOffset;
         int offsetAdded = lineAdded.Offset + beginOffset;
         (int lengthIdenticalAtStart, int lengthIdenticalAtEnd) = AddDifferenceMarkers(markers, textRemoved, textAdded, offsetRemoved, offsetAdded, dimBackground);
@@ -292,6 +292,14 @@ public abstract class DiffHighlightService : TextHighlightService
         {
             markers.Add(CreateDimmedMarker(offsetRemoved + textRemoved.Length - lengthIdenticalAtEnd, lengthIdenticalAtEnd, isRemoved: true, dimBackground));
             markers.Add(CreateDimmedMarker(offsetAdded + textAdded.Length - lengthIdenticalAtEnd, lengthIdenticalAtEnd, isRemoved: false, dimBackground));
+        }
+
+        return;
+
+        static ReadOnlySpan<char> LimitLength(ReadOnlySpan<char> text)
+        {
+            const int maxLength = 2000;
+            return text.Length <= maxLength ? text : text[..maxLength];
         }
     }
 


### PR DESCRIPTION
Fixes #12038

## Proposed changes

- DiffHighlightService: Apply highlighting to the first 2000 characters only

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

stack overflow

### After

![image](https://github.com/user-attachments/assets/4e259f97-183b-4d3c-82f2-969b7c80c71c)

![image](https://github.com/user-attachments/assets/8a98266b-53aa-4b3c-ab8e-ed25e1b894b2)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).