### PR TITLE
fix(GPG): Ignore exit code from verify-tag

### DIFF
--- a/src/app/GitCommands/Git/GitGpgController.cs
+++ b/src/app/GitCommands/Git/GitGpgController.cs
@@ -244,7 +244,7 @@ namespace GitCommands.Gpg
             };
 
             // 'verify-tag' returns info in stderr
-            return GetModule().GitExecutable.Execute(args).StandardError;
+            return GetModule().GitExecutable.Execute(args, throwOnErrorExit: false).StandardError;
         }
 
         private string? EvaluateTagVerifyMessage(IReadOnlyList<IGitRef> usefulTagRefs)


### PR DESCRIPTION
Fixes #12048

## Proposed changes

- `GitGpgController`: Ignore exit code from "git verify-tag"
   (Git does not document exit codes of this command. And the output is handled to a certain degree. If it fails for other reasons, users need to consult the Git Command Log.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![EOE](https://github.com/user-attachments/assets/a5062bdf-8624-4965-996d-f6d5ed428bed)

### After

![image](https://github.com/user-attachments/assets/91d7c8b6-4d1c-46e4-bfbb-d221a68da800)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).