### PR TITLE
Fix(git-grep)

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2394,7 +2394,7 @@ namespace GitCommands
                 grepString,
                 !objectId.IsArtificial ? objectId.ToString() : objectId == ObjectId.IndexId ? "--cached" : "",
                 "--",
-                fileName
+                fileName.Quote()
             };
 
             return await _gitExecutable.ExecuteAsync(

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -893,6 +893,10 @@ namespace GitUI.Editor
                     {
                         GoToLine(line.Value);
                     }
+                    else if (viewMode == ViewMode.Grep && ShowEntireFile)
+                    {
+                        internalFileViewer.GoToNextChange(NumberOfContextLines);
+                    }
 
                     TextLoaded?.Invoke(this, null);
                     return Task.CompletedTask;

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -420,7 +420,7 @@ namespace GitUI
             SetDeleteSearchButtonVisibility();
             SetFindInCommitFilesGitGrepWatermarkVisibility();
 
-            int top = _NO_TRANSLATE_FilterComboBox.Visible ? _NO_TRANSLATE_FilterComboBox.Bottom + _NO_TRANSLATE_FilterComboBox.Margin.Top + _NO_TRANSLATE_FilterComboBox.Margin.Bottom : 0;
+            int top = GetFileStatusListTop();
             int height = ClientRectangle.Height - top - FileStatusListView.Margin.Top - FileStatusListView.Margin.Bottom;
             FileStatusListView.SetBounds(0, top, 0, height, BoundsSpecified.Y | BoundsSpecified.Height);
         }
@@ -1111,7 +1111,7 @@ namespace GitUI
         {
             // Show "Files loading" below the filterbox
             NoFiles.Visible = false;
-            int top = _NO_TRANSLATE_FilterComboBox.Visible ? _NO_TRANSLATE_FilterComboBox.Bottom + _NO_TRANSLATE_FilterComboBox.Margin.Top + _NO_TRANSLATE_FilterComboBox.Margin.Bottom : 0;
+            int top = GetFileStatusListTop();
             LoadingFiles.Top = top;
             LoadingFiles.Visible = true;
             LoadingFiles.BringToFront();
@@ -1121,6 +1121,11 @@ namespace GitUI
             FileStatusListView.Items.Clear();
             FileStatusListView.EndUpdate();
         }
+
+        private int GetFileStatusListTop()
+            => _NO_TRANSLATE_FilterComboBox.Visible ? _NO_TRANSLATE_FilterComboBox.Bottom + _NO_TRANSLATE_FilterComboBox.Margin.Top + _NO_TRANSLATE_FilterComboBox.Margin.Bottom
+                : cboFindInCommitFilesGitGrep.Visible ? cboFindInCommitFilesGitGrep.Bottom + cboFindInCommitFilesGitGrep.Margin.Top + cboFindInCommitFilesGitGrep.Margin.Bottom
+                : 0;
 
         private void UpdateFileStatusListView(IReadOnlyList<FileStatusWithDescription> items, bool updateCausedByFilter = false)
         {

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1061,6 +1061,12 @@ namespace GitUI
                     firstSelectedItem.Focused = true;
                     firstSelectedItem.Selected = true;
                     firstSelectedItem.EnsureVisible();
+
+                    ListViewGroup? group = firstSelectedItem?.Group;
+                    if (group?.CollapsedState is ListViewGroupCollapsedState.Collapsed)
+                    {
+                        group.CollapsedState = ListViewGroupCollapsedState.Expanded;
+                    }
                 }
             }
             finally


### PR DESCRIPTION
## Proposed changes

- fix(FileStatusList): Extract function `GetFileStatusListTop` and consider all additional boxes
  in order to fixup the position of "Loading data..." - particularly on empty (artificial) commits, the just shown empty ComBox could be covered by the ListView
- fix(FileStatusList): Expand group of selected item
  otherwise the selection of a diff file is not visible because all diff groups are collapsed for git-grep
- fix(GetGrepFileAsync): Quote filename
  in order to support files with spaces in their name
- fix(git-grep): Go to first match if showing the entire file

## Screenshots <!-- Remove this section if PR does not change UI -->

Not really applicable

## Test methodology <!-- How did you ensure quality? -->

- manual

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).