### PR TITLE
chore: Convert remaining post-fix `FileAndForget`

### DIFF
--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1322,14 +1322,14 @@ namespace GitUI
             WrapRepoHostingCall(TranslatedStrings.AddUpstreamRemote, gitHoster,
                                 gh =>
                                 {
-                                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                    ThreadHelper.FileAndForget(async () =>
                                     {
                                         string remoteName = await gh.AddUpstreamRemoteAsync();
                                         if (!string.IsNullOrEmpty(remoteName))
                                         {
                                             StartPullDialogAndPullImmediately(owner, remoteBranch: null, remoteName, GitPullAction.Fetch);
                                         }
-                                    }).FileAndForget();
+                                    });
                                 });
         }
 

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabSettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabSettingsUserControl.cs
@@ -64,14 +64,14 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
             {
                 if (host is not null)
                 {
-                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                    ThreadHelper.FileAndForget(async () =>
                     {
                         projectId = await UpdateProjectIdAsync(host, apiToken);
                         if (projectId is > 0)
                         {
                             ProjectIdTextBox.Text = projectId.ToString();
                         }
-                    }).FileAndForget();
+                    });
                 }
             }
         }
@@ -124,7 +124,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
 
             GetProjectIdStatusText.Visible = false;
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
                 int? projectId = await UpdateProjectIdAsync(InstanceUrlTextBox.Text, ApiTokenTextBox.Text);
                 if (projectId is > 0)
@@ -135,7 +135,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
                 {
                     GetProjectIdStatusText.Visible = true;
                 }
-            }).FileAndForget();
+            });
         }
 
         private void TokenManagementLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
## Proposed changes

- Replace `ThreadHelper.JoinableTaskFactory.RunAsync(...).FileAndForget()` with `ThreadHelper.FileAndForget(...)` 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).