### PR TITLE
perf(FormResetAnotherBranch): Use quicker command

### DIFF
--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -478,14 +478,16 @@ namespace GitCommands.Git
         /// <param name="targetId">The commit to move to.</param>
         /// <param name="repoDir">Directory to the current repo.</param>
         /// <param name="force">Push the reference also if commits are lost.</param>
+        /// <param name="dryRun">Just test whether Git would perform the operation.</param>
         /// <returns>The Git command to execute.</returns>
-        public static ArgumentString PushLocal(string gitRef, ObjectId targetId, string repoDir, Func<string, string?> getPathForGitExecution, bool force = false)
+        public static ArgumentString PushLocal(string gitRef, ObjectId targetId, string repoDir, Func<string, string?> getPathForGitExecution, bool force = false, bool dryRun = false)
         {
             return new GitArgumentBuilder("push")
             {
                 $@"""file://{getPathForGitExecution(repoDir)}""",
                 $"{targetId}:{gitRef}".QuoteNE(),
-                { force, "--force" }
+                { force, "--force" },
+                { dryRun, "--dry-run" }
             };
         }
 
@@ -688,6 +690,22 @@ namespace GitCommands.Git
         public static ArgumentString SubmoduleUpdate(string? name, IEnumerable<GitConfigItem>? configs = null)
         {
             return SubmoduleUpdateCommand((name ?? "").Trim().QuoteNE(), configs);
+        }
+
+        /// <summary>
+        ///  Update a local reference to a new commit.
+        ///  This is similar to "git branch --force "branch" "commit".
+        /// </summary>
+        /// <param name="gitRef">The branch to move.</param>
+        /// <param name="targetId">The commit to move to.</param>
+        /// <returns>The Git command to execute.</returns>
+        public static ArgumentString UpdateRef(string gitRef, ObjectId targetId)
+        {
+            return new GitArgumentBuilder("update-ref")
+            {
+                gitRef.QuoteNE(),
+                targetId
+            };
         }
 
         private static ArgumentString SubmoduleUpdateCommand(string name, IEnumerable<GitConfigItem>? configs)

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
@@ -102,6 +102,7 @@
             ForceReset.TabIndex = 3;
             ForceReset.Text = "&Force reset for a non-fast-forward reset";
             ForceReset.UseVisualStyleBackColor = true;
+            ForceReset.CheckedChanged += UpdateOkButton;
             // 
             // pictureBox1
             // 
@@ -135,6 +136,7 @@
             Branches.Size = new Size(499, 21);
             Branches.TabIndex = 2;
             Branches.KeyUp += Branches_KeyUp;
+            Branches.TextChanged += UpdateOkButton;
             // 
             // tableLayoutPanel1
             // 

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
@@ -102,7 +102,7 @@
             ForceReset.TabIndex = 3;
             ForceReset.Text = "&Force reset for a non-fast-forward reset";
             ForceReset.UseVisualStyleBackColor = true;
-            ForceReset.CheckedChanged += UpdateOkButton;
+            ForceReset.CheckedChanged += Validate;
             // 
             // pictureBox1
             // 
@@ -136,7 +136,9 @@
             Branches.Size = new Size(499, 21);
             Branches.TabIndex = 2;
             Branches.KeyUp += Branches_KeyUp;
-            Branches.TextChanged += UpdateOkButton;
+            Branches.Enter += Validate;
+            Branches.DropDownClosed += Validate;
+            Branches.TextChanged += Validate;
             // 
             // tableLayoutPanel1
             // 

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -134,8 +134,10 @@ namespace GitUI.HelperDialogs
         private void UpdateOkButton(object sender, EventArgs e)
         {
             Ok.Enabled = false;
+            Ok.BackColor = SystemColors.ButtonFace;
 
             IGitRef? gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
+            Branches.BackColor = gitRefToReset is null ? Color.LightCoral : SystemColors.Window;
             if (gitRefToReset is null)
             {
                 return;
@@ -149,6 +151,10 @@ namespace GitUI.HelperDialogs
                 await this.SwitchToMainThreadAsync();
 
                 Ok.Enabled = executionResult.ExitedSuccessfully;
+                if (!executionResult.ExitedSuccessfully)
+                {
+                    Ok.BackColor = Color.LightCoral;
+                }
             });
         }
     }

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -133,12 +133,17 @@ namespace GitUI.HelperDialogs
             }
         }
 
-        private void UpdateOkButton(object sender, EventArgs e)
+        private void Validate(object sender, EventArgs e)
         {
+            if (_localGitRefs is null)
+            {
+                return;
+            }
+
             CancellationToken cancellationToken = _cancellationTokenSequence.Next();
 
             IGitRef? gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
-            Branches.BackColor = gitRefToReset is null ? Color.LightCoral : SystemColors.Window;
+            Branches.BackColor = gitRefToReset is null && ActiveControl != Branches ? Color.LightCoral : SystemColors.Window;
 
             Ok.Enabled = gitRefToReset is not null && ForceReset.Checked;
             Ok.BackColor = SystemColors.ButtonFace;

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -137,11 +137,12 @@ namespace GitUI.HelperDialogs
         {
             CancellationToken cancellationToken = _cancellationTokenSequence.Next();
 
-            Ok.Enabled = ForceReset.Checked;
-            Ok.BackColor = SystemColors.ButtonFace;
-
             IGitRef? gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
             Branches.BackColor = gitRefToReset is null ? Color.LightCoral : SystemColors.Window;
+
+            Ok.Enabled = gitRefToReset is not null && ForceReset.Checked;
+            Ok.BackColor = SystemColors.ButtonFace;
+
             if (gitRefToReset is null || ForceReset.Checked)
             {
                 return;

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -445,12 +445,12 @@ namespace GitCommandsTests_Git
                 Commands.Push("remote", "from-branch", "to-branch", ForcePushOptions.DoNotForce, track: false, recursiveSubmodules: 2).Arguments);
         }
 
-        [TestCase("mybranch", ".", false, ExpectedResult = @"push ""file://."" ""1111111111111111111111111111111111111111:mybranch""")]
-        [TestCase("branch2", "/my/path", true, ExpectedResult = @"push ""file:///my/path"" ""1111111111111111111111111111111111111111:branch2"" --force")]
-        [TestCase("branchx", @"c:/my/path", true, ExpectedResult = @"push ""file://c:/my/path"" ""1111111111111111111111111111111111111111:branchx"" --force")]
-        public string PushLocalCmd(string gitRef, string repoDir, bool force)
+        [TestCase("mybranch", ".", false, false, ExpectedResult = @"push ""file://."" ""1111111111111111111111111111111111111111:mybranch""")]
+        [TestCase("branch2", "/my/path", true, false, ExpectedResult = @"push ""file:///my/path"" ""1111111111111111111111111111111111111111:branch2"" --force")]
+        [TestCase("branchx", @"c:/my/path", true, true, ExpectedResult = @"push ""file://c:/my/path"" ""1111111111111111111111111111111111111111:branchx"" --force --dry-run")]
+        public string PushLocalCmd(string gitRef, string repoDir, bool force, bool dryRun)
         {
-            return Commands.PushLocal(gitRef, ObjectId.WorkTreeId, repoDir, PathUtil.ToPosixPath, force).Arguments;
+            return Commands.PushLocal(gitRef, ObjectId.WorkTreeId, repoDir, PathUtil.ToPosixPath, force, dryRun).Arguments;
         }
 
         [Test]
@@ -722,6 +722,12 @@ namespace GitCommandsTests_Git
             Assert.AreEqual($"{config}submodule sync \"foo\"", Commands.SubmoduleSync("foo").Arguments);
             Assert.AreEqual($"{config}submodule sync", Commands.SubmoduleSync("").Arguments);
             Assert.AreEqual($"{config}submodule sync", Commands.SubmoduleSync(null).Arguments);
+        }
+
+        [TestCase("mybranch", "2111111111111111111111111111111111111111", ExpectedResult = @"update-ref ""mybranch"" 2111111111111111111111111111111111111111")]
+        public string UpdateRef(string gitRef, string hash)
+        {
+            return Commands.UpdateRef(gitRef, ObjectId.Parse(hash)).Arguments;
         }
     }
 }


### PR DESCRIPTION
Fixes #12035

## Proposed changes

- FormResetAnotherBranch: Use quicker command "update-ref"
- Enable the `OK` button using a dry-run of the previous command "push" 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- add testcase

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).