### PR TITLE
feat(Git Command Log): Improve display of command cache

### DIFF
--- a/src/app/GitCommands/Git/CommandCache.cs
+++ b/src/app/GitCommands/Git/CommandCache.cs
@@ -102,5 +102,13 @@ namespace GitCommands
 
             Changed?.Invoke(this, EventArgs.Empty);
         }
+
+        /// <summary>
+        ///  Clears the cache.
+        /// </summary>
+        public void Clear()
+        {
+            _cache.Clear();
+        }
     }
 }

--- a/src/app/GitCommands/Logging/CommandLog.cs
+++ b/src/app/GitCommands/Logging/CommandLog.cs
@@ -102,12 +102,12 @@ namespace GitCommands.Logging
                 if (FileName.StartsWith("wsl "))
                 {
                     fileName = "wsl";
-                    arguments = GitArgumentsWithoutConfigurationRegex().Replace(Arguments, "").TrimEnd();
+                    arguments = GetGitArgumentsWithoutConfiguration(Arguments);
                 }
                 else if (FileName.EndsWith("git.exe"))
                 {
                     fileName = "git";
-                    arguments = GitArgumentsWithoutConfigurationRegex().Replace(Arguments, "").TrimEnd();
+                    arguments = GetGitArgumentsWithoutConfiguration(Arguments);
                 }
                 else
                 {
@@ -170,6 +170,9 @@ namespace GitCommands.Logging
                 return s.ToString();
             }
         }
+
+        public static string GetGitArgumentsWithoutConfiguration(string arguments)
+            => GitArgumentsWithoutConfigurationRegex().Replace(arguments, "").TrimEnd();
     }
 
     public static class CommandLog

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
@@ -43,6 +43,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             tabPageCommandCache = new TabPage();
             splitContainer1 = new SplitContainer();
             CommandCacheItems = new ListBox();
+            cmsCache = new ContextMenuStrip(components);
+            tsmiClearCache = new ToolStripMenuItem();
             commandCacheOutput = new RichTextBox();
             chkAlwaysOnTop = new CheckBox();
             chkWordWrap = new CheckBox();
@@ -59,6 +61,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             splitContainer1.Panel1.SuspendLayout();
             splitContainer1.Panel2.SuspendLayout();
             splitContainer1.SuspendLayout();
+            cmsCache.SuspendLayout();
             SuspendLayout();
             // 
             // TabControl
@@ -76,6 +79,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // tabPageCommandLog
             // 
             tabPageCommandLog.BackColor = SystemColors.ControlLight;
+            tabPageCommandLog.ContextMenuStrip = contextMenu;
             tabPageCommandLog.Controls.Add(splitContainer2);
             tabPageCommandLog.Location = new Point(1, 23);
             tabPageCommandLog.Margin = new Padding(0);
@@ -122,14 +126,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             contextMenu.Items.AddRange(new ToolStripItem[] { mnuSaveToFile, mnuCopyCommandLine, mnuClear });
             contextMenu.Name = "logContextMenuStrip";
-            contextMenu.Size = new Size(225, 92);
+            contextMenu.Size = new Size(247, 70);
             // 
             // mnuSaveToFile
             // 
             mnuSaveToFile.Image = Properties.Images.SaveAs;
             mnuSaveToFile.Name = "mnuSaveToFile";
             mnuSaveToFile.ShortcutKeys = Keys.Control | Keys.S;
-            mnuSaveToFile.Size = new Size(224, 22);
+            mnuSaveToFile.Size = new Size(246, 22);
             mnuSaveToFile.Text = "&Save to file";
             mnuSaveToFile.Click += mnuSaveToFile_Click;
             // 
@@ -138,7 +142,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             mnuCopyCommandLine.Image = Properties.Images.CopyToClipboard;
             mnuCopyCommandLine.Name = "mnuCopyCommandLine";
             mnuCopyCommandLine.ShortcutKeys = Keys.Control | Keys.C;
-            mnuCopyCommandLine.Size = new Size(224, 22);
+            mnuCopyCommandLine.Size = new Size(246, 22);
             mnuCopyCommandLine.Text = "&Copy full command line";
             mnuCopyCommandLine.Click += mnuCopyCommandLine_Click;
             // 
@@ -147,7 +151,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             mnuClear.Image = Properties.Images.ClearLog;
             mnuClear.Name = "mnuClear";
             mnuClear.ShortcutKeys = Keys.Control | Keys.L;
-            mnuClear.Size = new Size(224, 22);
+            mnuClear.Size = new Size(246, 22);
             mnuClear.Text = "C&lear";
             mnuClear.Click += mnuClear_Click;
             // 
@@ -166,6 +170,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // tabPageCommandCache
             // 
             tabPageCommandCache.BackColor = SystemColors.ControlLight;
+            tabPageCommandCache.ContextMenuStrip = cmsCache;
             tabPageCommandCache.Controls.Add(splitContainer1);
             tabPageCommandCache.Location = new Point(1, 23);
             tabPageCommandCache.Margin = new Padding(0);
@@ -195,6 +200,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // CommandCacheItems
             // 
             CommandCacheItems.BorderStyle = BorderStyle.None;
+            CommandCacheItems.ContextMenuStrip = cmsCache;
             CommandCacheItems.Dock = DockStyle.Fill;
             CommandCacheItems.FormattingEnabled = true;
             CommandCacheItems.ItemHeight = 15;
@@ -204,6 +210,21 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             CommandCacheItems.Size = new Size(657, 183);
             CommandCacheItems.TabIndex = 0;
             CommandCacheItems.SelectedIndexChanged += CommandCacheItems_SelectedIndexChanged;
+            // 
+            // cmsCache
+            // 
+            cmsCache.Items.AddRange(new ToolStripItem[] { tsmiClearCache });
+            cmsCache.Name = "logContextMenuStrip";
+            cmsCache.Size = new Size(144, 26);
+            // 
+            // tsmiClearCache
+            // 
+            tsmiClearCache.Image = Properties.Images.ClearLog;
+            tsmiClearCache.Name = "tsmiClearCache";
+            tsmiClearCache.ShortcutKeys = Keys.Control | Keys.L;
+            tsmiClearCache.Size = new Size(143, 22);
+            tsmiClearCache.Text = "C&lear";
+            tsmiClearCache.Click += tsmiClearCache_Click;
             // 
             // commandCacheOutput
             // 
@@ -276,6 +297,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
             splitContainer1.ResumeLayout(false);
+            cmsCache.ResumeLayout(false);
             ResumeLayout(false);
             PerformLayout();
         }
@@ -298,5 +320,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private ToolStripMenuItem mnuClear;
         private CheckBox chkCaptureCallStacks;
         private ToolStripMenuItem mnuCopyCommandLine;
+        private ContextMenuStrip cmsCache;
+        private ToolStripMenuItem tsmiClearCache;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -197,6 +197,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
         }
 
+        private void tsmiClearCache_Click(object sender, EventArgs e)
+        {
+            GitModule.GitCommandCache.Clear();
+            RefreshCommandCacheItems();
+        }
+
         #region Single instance static members
 
         private static FormGitCommandLog? instance;

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -72,7 +72,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             if (TabControl.SelectedTab == tabPageCommandCache)
             {
-                RefreshListBox(CommandCacheItems, GitModule.GitCommandCache.GetCachedCommands());
+                CommandCacheItems.ValueMember = nameof(CacheItem.DisplayString);
+                RefreshListBox(CommandCacheItems, GitModule.GitCommandCache.GetCachedCommands().Select(key => new CacheItem(key)).ToArray());
             }
         }
 
@@ -114,7 +115,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void CommandCacheItems_SelectedIndexChanged(object sender, EventArgs e)
         {
-            string command = (string)CommandCacheItems.SelectedItem;
+            string command = ((CacheItem)CommandCacheItems.SelectedItem).Key;
 
             if (GitModule.GitCommandCache.TryGet(command, out string? cmdOut, out string? cmdErr))
             {
@@ -217,5 +218,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         }
 
         #endregion
+
+        private sealed class CacheItem(string key)
+        {
+            public string Key { get; } = key;
+            public string DisplayString { get; } = CommandLogEntry.GetGitArgumentsWithoutConfiguration(key);
+        }
     }
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.resx
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.resx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
@@ -119,5 +119,8 @@
   </resheader>
   <metadata name="contextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="cmsCache.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>142, 17</value>
   </metadata>
 </root>

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -5111,6 +5111,10 @@ command "git help gitattributes"
         <source>Command log</source>
         <target />
       </trans-unit>
+      <trans-unit id="tsmiClearCache.Text">
+        <source>C&amp;lear</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="FormGitIgnore" source-language="en">


### PR DESCRIPTION
## Proposed changes

- Hide git configuration arguments in cache tab, too
- Add context menu item for clearing the cache

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/898b269c-caad-4dee-9109-3003cff6c6a1)

### After

![image](https://github.com/user-attachments/assets/80af9355-12ed-46aa-bd75-24776a0d5acc)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Please do not squash merge
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).