### PR TITLE
fix: WFO1000 Property does not configure the code serialization for i…

### DIFF
--- a/externals/NetSpell.SpellChecker/Spelling.cs
+++ b/externals/NetSpell.SpellChecker/Spelling.cs
@@ -1204,6 +1204,7 @@ namespace NetSpell.SpellChecker
         [Browsable(true)]
         [Category("Dictionary")]
         [Description("The WordDictionary object to use when spell checking")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public WordDictionary Dictionary
         {
             get

--- a/src/app/BugReporter/ExceptionDetails.cs
+++ b/src/app/BugReporter/ExceptionDetails.cs
@@ -18,6 +18,7 @@ namespace BugReporter
             InitializeComponent();
         }
 
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int InformationColumnWidth
         {
@@ -32,6 +33,7 @@ namespace BugReporter
             }
         }
 
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int PropertyColumnWidth
         {

--- a/src/app/BugReporter/ExceptionDetails.cs
+++ b/src/app/BugReporter/ExceptionDetails.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.ComponentModel;
 using BugReporter.Serialization;
 
 namespace BugReporter
@@ -17,6 +18,7 @@ namespace BugReporter
             InitializeComponent();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int InformationColumnWidth
         {
             get
@@ -30,6 +32,7 @@ namespace BugReporter
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int PropertyColumnWidth
         {
             get

--- a/src/app/GitExtensions.Extensibility/Settings/UserControls/CredentialsControl.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/UserControls/CredentialsControl.cs
@@ -11,6 +11,7 @@ public partial class CredentialsControl : UserControl
         ChangeLabelText(userNameLabelText, passwordLabelText);
     }
 
+    [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string UserName
     {
@@ -19,6 +20,7 @@ public partial class CredentialsControl : UserControl
         set => userNameTextBox.Text = value;
     }
 
+    [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Password
     {

--- a/src/app/GitExtensions.Extensibility/Settings/UserControls/CredentialsControl.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/UserControls/CredentialsControl.cs
@@ -1,4 +1,6 @@
-﻿namespace GitExtensions.Extensibility.Settings.UserControls;
+﻿using System.ComponentModel;
+
+namespace GitExtensions.Extensibility.Settings.UserControls;
 
 public partial class CredentialsControl : UserControl
 {
@@ -9,6 +11,7 @@ public partial class CredentialsControl : UserControl
         ChangeLabelText(userNameLabelText, passwordLabelText);
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string UserName
     {
         get => userNameTextBox.Text;
@@ -16,6 +19,7 @@ public partial class CredentialsControl : UserControl
         set => userNameTextBox.Text = value;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Password
     {
         get => passwordTextBox.Text;

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
@@ -1,4 +1,5 @@
-﻿using ResourceManager;
+﻿using System.ComponentModel;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 {
@@ -35,6 +36,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         /// <summary>
         /// Gets the new category.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? Category { get; private set; }
 
         private void OkButton_Click(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
@@ -36,6 +36,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         /// <summary>
         /// Gets the new category.
         /// </summary>
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? Category { get; private set; }
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -134,6 +134,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get { return base.ForeColor; }
@@ -153,6 +154,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color HeaderColor
         {
             get { return _headerColor; }
@@ -170,6 +172,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color HeaderBackColor
         {
             get { return _headerBackColor; }
@@ -199,6 +202,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color HoverColor
         {
             get { return _hoverColor; }
@@ -217,6 +221,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color MainBackColor
         {
             get { return _mainBackColor; }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -134,6 +134,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
@@ -154,6 +155,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color HeaderColor
         {
@@ -172,6 +174,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color HeaderBackColor
         {
@@ -202,6 +205,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color HoverColor
         {
@@ -221,6 +225,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color MainBackColor
         {

--- a/src/app/GitUI/CommandsDialogs/EnvironmentInfo.cs
+++ b/src/app/GitUI/CommandsDialogs/EnvironmentInfo.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommandsDialogs
             environmentIssueInfo.Text = UserEnvironmentInformation.GetInformation().Replace("- ", "");
         }
 
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public ToolTip? ToolTip { get; set; }
 

--- a/src/app/GitUI/CommandsDialogs/EnvironmentInfo.cs
+++ b/src/app/GitUI/CommandsDialogs/EnvironmentInfo.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommandsDialogs
             environmentIssueInfo.Text = UserEnvironmentInformation.GetInformation().Replace("- ", "");
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public ToolTip? ToolTip { get; set; }
 
         public void SetCopyButtonTooltip(string tooltip)

--- a/src/app/GitUI/CommandsDialogs/FormArchive.cs
+++ b/src/app/GitUI/CommandsDialogs/FormArchive.cs
@@ -1,4 +1,5 @@
-﻿using GitExtensions.Extensibility.Git;
+﻿using System.ComponentModel;
+using GitExtensions.Extensibility.Git;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -20,6 +21,7 @@ namespace GitUI.CommandsDialogs
             new("You need to choose a target revision.");
 
         private GitRevision? _selectedRevision;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public GitRevision? SelectedRevision
         {
             get { return _selectedRevision; }

--- a/src/app/GitUI/CommandsDialogs/FormArchive.cs
+++ b/src/app/GitUI/CommandsDialogs/FormArchive.cs
@@ -21,6 +21,7 @@ namespace GitUI.CommandsDialogs
             new("You need to choose a target revision.");
 
         private GitRevision? _selectedRevision;
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public GitRevision? SelectedRevision
         {

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -22,6 +23,7 @@ namespace GitUI.CommandsDialogs
 
         private const int _parentsListItemHeight = 18;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public GitRevision? Revision { get; set; }
 
         public FormCherryPick(IGitUICommands commands, GitRevision? revision)

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -23,6 +23,7 @@ namespace GitUI.CommandsDialogs
 
         private const int _parentsListItemHeight = 18;
 
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public GitRevision? Revision { get; set; }
 

--- a/src/app/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -25,6 +25,7 @@ namespace GitUI.CommandsDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? BranchName { get; private set; }
 
         private void btnCompare_Click(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -1,4 +1,5 @@
-﻿using GitExtensions.Extensibility.Git;
+﻿using System.ComponentModel;
+using GitExtensions.Extensibility.Git;
 
 namespace GitUI.CommandsDialogs
 {
@@ -23,6 +24,7 @@ namespace GitUI.CommandsDialogs
             branchSelector.Focus();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? BranchName { get; private set; }
 
         private void btnCompare_Click(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -19,10 +19,13 @@ namespace GitUI.CommandsDialogs
         private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool CheckoutAfterCreation { get; set; } = true;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool UserAbleToChangeRevision { get; set; } = true;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool CouldBeOrphan { get; set; } = true;
 
         public FormCreateBranch(IGitUICommands commands, ObjectId? objectId, string? newBranchNamePrefix = null)

--- a/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.ComponentModel;
+using System.Diagnostics;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
@@ -17,8 +18,11 @@ namespace GitUI.CommandsDialogs
         private readonly IGitBranchNameNormaliser _branchNameNormaliser = new GitBranchNameNormaliser();
         private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool CheckoutAfterCreation { get; set; } = true;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool UserAbleToChangeRevision { get; set; } = true;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool CouldBeOrphan { get; set; } = true;
 
         public FormCreateBranch(IGitUICommands commands, ObjectId? objectId, string? newBranchNamePrefix = null)

--- a/src/app/GitUI/CommandsDialogs/FormPull.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPull.cs
@@ -127,6 +127,7 @@ namespace GitUI.CommandsDialogs
         private static partial Regex IsRefRemoved();
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ErrorOccurred { get; private set; }
 
         public FormPull(GitUICommands commands, string? defaultRemoteBranch, string? defaultRemote, GitPullAction pullAction)

--- a/src/app/GitUI/CommandsDialogs/FormPull.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPull.cs
@@ -126,6 +126,7 @@ namespace GitUI.CommandsDialogs
         [GeneratedRegex(@"Your configuration specifies to .* the ref '.*'[\r]?\nfrom the remote, but no such ref was fetched.", RegexOptions.ExplicitCapture)]
         private static partial Regex IsRefRemoved();
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ErrorOccurred { get; private set; }
 
         public FormPull(GitUICommands commands, string? defaultRemoteBranch, string? defaultRemote, GitPullAction pullAction)

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -41,6 +41,7 @@ namespace GitUI.CommandsDialogs
         private readonly IConfigFileRemoteSettingsManager _remotesManager;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ErrorOccurred { get; private set; }
         private int _pushColumnIndex;
 

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.ComponentModel;
+using System.Data;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Config;
@@ -39,6 +40,7 @@ namespace GitUI.CommandsDialogs
         private IReadOnlyList<IGitRef>? _gitRefs;
         private readonly IConfigFileRemoteSettingsManager _remotesManager;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ErrorOccurred { get; private set; }
         private int _pushColumnIndex;
 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remotes;
 using GitCommands.UserRepositoryHistory;
@@ -129,6 +130,7 @@ Inactive remote is completely invisible to git.");
         /// remote name will be preselected in the listbox.
         /// </summary>
         /// <remarks>exclusive of <see cref="PreselectLocalOnLoad"/>.</remarks>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? PreselectRemoteOnLoad { get; set; }
 
         /// <summary>
@@ -136,6 +138,7 @@ Inactive remote is completely invisible to git.");
         /// and the given local name will be preselected in the listbox.
         /// </summary>
         /// <remarks>exclusive of <see cref="PreselectRemoteOnLoad"/>.</remarks>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? PreselectLocalOnLoad { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -131,6 +131,7 @@ Inactive remote is completely invisible to git.");
         /// </summary>
         /// <remarks>exclusive of <see cref="PreselectLocalOnLoad"/>.</remarks>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? PreselectRemoteOnLoad { get; set; }
 
         /// <summary>
@@ -139,6 +140,7 @@ Inactive remote is completely invisible to git.");
         /// </summary>
         /// <remarks>exclusive of <see cref="PreselectRemoteOnLoad"/>.</remarks>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? PreselectLocalOnLoad { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/CommandsDialogs/FormResetChanges.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResetChanges.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommandsDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public ActionEnum SelectedAction { get; private set; }
 
         public FormResetChanges(bool hasExistingFiles, bool hasNewFiles, string? confirmationMessage = null)

--- a/src/app/GitUI/CommandsDialogs/FormResetChanges.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResetChanges.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs
+﻿using System.ComponentModel;
+
+namespace GitUI.CommandsDialogs
 {
     /// <summary>
     /// Shows a form asking if the user wants to reset their changes.
@@ -14,6 +16,7 @@
             ResetAndDelete
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public ActionEnum SelectedAction { get; private set; }
 
         public FormResetChanges(bool hasExistingFiles, bool hasNewFiles, string? confirmationMessage = null)

--- a/src/app/GitUI/CommandsDialogs/FormStash.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
@@ -16,6 +17,7 @@ namespace GitUI.CommandsDialogs
         private readonly AsyncLoader _asyncLoader = new();
         private int _lastSelectedStashIndex = -1;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ManageStashes { get; set; }
         private GitStash? _currentWorkingDirStashItem;
 

--- a/src/app/GitUI/CommandsDialogs/FormStash.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.cs
@@ -18,6 +18,7 @@ namespace GitUI.CommandsDialogs
         private int _lastSelectedStashIndex = -1;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ManageStashes { get; set; }
         private GitStash? _currentWorkingDirStashItem;
 

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -282,6 +282,7 @@ namespace GitUI.CommandsDialogs
         /// When switching commits, the last selected file is "followed" if available in the new commit,
         /// this file is used as a fallback.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? FallbackFollowedFile
         {
             get => _fallbackFollowedFile;

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -283,6 +283,7 @@ namespace GitUI.CommandsDialogs
         /// this file is used as a fallback.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? FallbackFollowedFile
         {
             get => _fallbackFollowedFile;

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -178,6 +178,7 @@ See the changes in the commit form.");
         /// this file is used as a fallback.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? FallbackFollowedFile { get; set; } = null;
 
         public void LoadRevision(GitRevision? revision)

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using GitCommands;
 using GitCommands.Git;
@@ -176,6 +177,7 @@ See the changes in the commit form.");
         /// When switching commits, the last selected file is "followed" if available in the new commit,
         /// this file is used as a fallback.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? FallbackFollowedFile { get; set; } = null;
 
         public void LoadRevision(GitRevision? revision)

--- a/src/app/GitUI/CommandsDialogs/SearchControl.cs
+++ b/src/app/GitUI/CommandsDialogs/SearchControl.cs
@@ -13,6 +13,7 @@ namespace GitUI.CommandsDialogs
         public event Action? OnCancelled;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public override string Text
         {
             get => txtSearchBox.Text;
@@ -47,6 +48,7 @@ namespace GitUI.CommandsDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public BorderStyle SearchBoxBorderStyle
         {
             get => txtSearchBox.BorderStyle;
@@ -54,6 +56,7 @@ namespace GitUI.CommandsDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Color SearchBoxBorderDefaultColor
         {
             get => txtSearchBox.BorderDefaultColor;
@@ -61,6 +64,7 @@ namespace GitUI.CommandsDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Color SearchBoxBorderHoveredColor
         {
             get => txtSearchBox.BorderHoveredColor;
@@ -68,6 +72,7 @@ namespace GitUI.CommandsDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Color SearchBoxBorderFocusedColor
         {
             get => txtSearchBox.BorderFocusedColor;
@@ -75,6 +80,7 @@ namespace GitUI.CommandsDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         private void SearchForCandidates(IEnumerable<T> candidates)
         {
             int selectionStart = txtSearchBox.SelectionStart;

--- a/src/app/GitUI/CommandsDialogs/SearchControl.cs
+++ b/src/app/GitUI/CommandsDialogs/SearchControl.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 
 namespace GitUI.CommandsDialogs
 {
@@ -11,6 +12,7 @@ namespace GitUI.CommandsDialogs
         public event Action? OnTextEntered;
         public event Action? OnCancelled;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string Text
         {
             get => txtSearchBox.Text;
@@ -44,30 +46,35 @@ namespace GitUI.CommandsDialogs
             listBoxSearchResult.Visible = false;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public BorderStyle SearchBoxBorderStyle
         {
             get => txtSearchBox.BorderStyle;
             set => txtSearchBox.BorderStyle = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color SearchBoxBorderDefaultColor
         {
             get => txtSearchBox.BorderDefaultColor;
             set => txtSearchBox.BorderDefaultColor = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color SearchBoxBorderHoveredColor
         {
             get => txtSearchBox.BorderHoveredColor;
             set => txtSearchBox.BorderHoveredColor = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color SearchBoxBorderFocusedColor
         {
             get => txtSearchBox.BorderFocusedColor;
             set => txtSearchBox.BorderFocusedColor = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         private void SearchForCandidates(IEnumerable<T> candidates)
         {
             int selectionStart = txtSearchBox.SelectionStart;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Utils;
@@ -132,6 +133,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// <summary>
         /// TODO: remove this direct dependency to another SettingsPage later when possible.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public SshSettingsPage? SshSettingsPage { get; set; }
 
         public ChecklistSettingsPage(IServiceProvider serviceProvider)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -134,6 +134,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// TODO: remove this direct dependency to another SettingsPage later when possible.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public SshSettingsPage? SshSettingsPage { get; set; }
 
         public ChecklistSettingsPage(IServiceProvider serviceProvider)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
@@ -33,6 +33,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public ThemeId SelectedThemeId
         {
             get
@@ -65,6 +66,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string[] SelectedThemeVariations
         {
             get => chkColorblind.Checked
@@ -75,6 +77,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool UseSystemVisualStyle
         {
             get => chkUseSystemVisualStyle.Checked;
@@ -82,6 +85,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool LabelRestartIsNeededVisible
         {
             get => lblRestartNeeded.Visible;
@@ -89,6 +93,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsChoosingVisualStyleEnabled
         {
             get => chkUseSystemVisualStyle.Enabled;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using GitCommands;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
@@ -31,6 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComplete();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public ThemeId SelectedThemeId
         {
             get
@@ -62,6 +64,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string[] SelectedThemeVariations
         {
             get => chkColorblind.Checked
@@ -71,18 +74,21 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             set => chkColorblind.Checked = value.Contains(ThemeVariations.Colorblind);
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool UseSystemVisualStyle
         {
             get => chkUseSystemVisualStyle.Checked;
             set => chkUseSystemVisualStyle.Checked = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool LabelRestartIsNeededVisible
         {
             get => lblRestartNeeded.Visible;
             set => lblRestartNeeded.Visible = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsChoosingVisualStyleEnabled
         {
             get => chkUseSystemVisualStyle.Enabled;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
@@ -24,6 +24,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         /// <summary>Gets or sets the KeyData.</summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Keys KeyData
         {
             get => _keyData;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
@@ -1,4 +1,5 @@
-﻿using GitExtUtils;
+﻿using System.ComponentModel;
+using GitExtUtils;
 using GitUI.Hotkey;
 using ResourceManager.Hotkey;
 
@@ -22,6 +23,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         }
 
         /// <summary>Gets or sets the KeyData.</summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Keys KeyData
         {
             get => _keyData;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SimpleHelpDisplayDialog.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SimpleHelpDisplayDialog.cs
@@ -10,9 +10,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? DialogTitle { get; set; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? ContentText { get; set; }
 
         protected override void OnLoad(EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SimpleHelpDisplayDialog.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SimpleHelpDisplayDialog.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs.SettingsDialog
+﻿using System.ComponentModel;
+
+namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public partial class SimpleHelpDisplayDialog : Form
     {
@@ -7,8 +9,10 @@
             InitializeComponent();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? DialogTitle { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? ContentText { get; set; }
 
         protected override void OnLoad(EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         public bool OpenWorktree => openWorktreeCheckBox.Checked;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public IReadOnlyList<IGitRef>? ExistingBranches { get; set; }
 
         public FormCreateWorktree(IGitUICommands commands, string? path)

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -15,6 +16,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         public string WorktreeDirectory => newWorktreeDirectory.Text;
         public bool OpenWorktree => openWorktreeCheckBox.Checked;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IReadOnlyList<IGitRef>? ExistingBranches { get; set; }
 
         public FormCreateWorktree(IGitUICommands commands, string? path)

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -18,6 +19,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private List<WorkTree>? _worktrees;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ShouldRefreshRevisionGrid { get; private set; }
 
         public FormManageWorktree(IGitUICommands commands)
@@ -43,6 +45,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         /// If this is not null before showing the dialog the given
         /// remote name will be preselected in the listbox.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? PreselectRemoteOnLoad { get; set; }
 
         protected override void OnRuntimeLoad(EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -20,6 +20,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         private List<WorkTree>? _worktrees;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ShouldRefreshRevisionGrid { get; private set; }
 
         public FormManageWorktree(IGitUICommands commands)
@@ -46,6 +47,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         /// remote name will be preselected in the listbox.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? PreselectRemoteOnLoad { get; set; }
 
         protected override void OnRuntimeLoad(EventArgs e)

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -199,6 +199,7 @@ namespace GitUI.Editor
         // Public properties
 
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public byte[]? FilePreamble { get; private set; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -806,6 +807,7 @@ namespace GitUI.Editor
         /// <summary>
         /// If the file viewer contents support line patches.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool SupportLinePatching { get; private set; }
 
         /// <summary>
@@ -813,6 +815,7 @@ namespace GitUI.Editor
         /// by clearing <see cref="AllowLinePatching" />
         /// Used for index/worktree where line patches modifies the diff.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool LinePatchingBlocksUntilReload { private get; set; }
 
         /// <summary>

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -808,6 +808,7 @@ namespace GitUI.Editor
         /// If the file viewer contents support line patches.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool SupportLinePatching { get; private set; }
 
         /// <summary>
@@ -816,6 +817,7 @@ namespace GitUI.Editor
         /// Used for index/worktree where line patches modifies the diff.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool LinePatchingBlocksUntilReload { private get; set; }
 
         /// <summary>

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -140,6 +140,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public new Font Font
         {
             get => TextEditor.Font;
@@ -147,6 +148,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Action? OpenWithDifftool { get; private set; }
 
         /// <summary>
@@ -226,6 +228,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool? ShowLineNumbers { get; set; }
 
         /// <summary>
@@ -545,6 +548,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public int HScrollPosition
         {
             get { return TextEditor.ActiveTextAreaControl.HScrollBar?.Value ?? 0; }
@@ -563,6 +567,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public int VScrollPosition
         {
             get { return TextEditor.ActiveTextAreaControl.VScrollBar?.Value ?? 0; }
@@ -581,6 +586,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public EolMarkerStyle EolMarkerStyle
         {
             get => TextEditor.EolMarkerStyle;
@@ -588,6 +594,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ShowSpaces
         {
             get => TextEditor.ShowSpaces;
@@ -595,6 +602,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ShowTabs
         {
             get => TextEditor.ShowTabs;
@@ -602,6 +610,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public int VRulerPosition
         {
             get => TextEditor.VRulerRow;
@@ -707,6 +716,7 @@ namespace GitUI.Editor
         public int TotalNumberOfLines => TextEditor.Document.TotalNumberOfLines;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsReadOnly
         {
             get => TextEditor.IsReadOnly;
@@ -756,6 +766,7 @@ namespace GitUI.Editor
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ShowGutterAvatars
         {
             get => _showGutterAvatars;

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitCommands.Settings;
 using GitExtensions.Extensibility;
 using GitExtUtils;
@@ -138,12 +139,14 @@ namespace GitUI.Editor
             return selectionMarkers;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new Font Font
         {
             get => TextEditor.Font;
             set => TextEditor.Font = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Action? OpenWithDifftool { get; private set; }
 
         /// <summary>
@@ -222,6 +225,7 @@ namespace GitUI.Editor
             return TextEditor.Text;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool? ShowLineNumbers { get; set; }
 
         /// <summary>
@@ -540,6 +544,7 @@ namespace GitUI.Editor
             ClipboardUtil.TrySetText(text.AdjustLineEndings(Module.GetEffectiveSettingsByPath("core").GetNullableEnum<AutoCRLFType>("autocrlf")));
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int HScrollPosition
         {
             get { return TextEditor.ActiveTextAreaControl.HScrollBar?.Value ?? 0; }
@@ -557,6 +562,7 @@ namespace GitUI.Editor
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int VScrollPosition
         {
             get { return TextEditor.ActiveTextAreaControl.VScrollBar?.Value ?? 0; }
@@ -574,24 +580,28 @@ namespace GitUI.Editor
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public EolMarkerStyle EolMarkerStyle
         {
             get => TextEditor.EolMarkerStyle;
             set => TextEditor.EolMarkerStyle = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ShowSpaces
         {
             get => TextEditor.ShowSpaces;
             set => TextEditor.ShowSpaces = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ShowTabs
         {
             get => TextEditor.ShowTabs;
             set => TextEditor.ShowTabs = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int VRulerPosition
         {
             get => TextEditor.VRulerRow;
@@ -696,6 +706,7 @@ namespace GitUI.Editor
 
         public int TotalNumberOfLines => TextEditor.Document.TotalNumberOfLines;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsReadOnly
         {
             get => TextEditor.IsReadOnly;
@@ -744,6 +755,7 @@ namespace GitUI.Editor
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ShowGutterAvatars
         {
             get => _showGutterAvatars;

--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -50,6 +50,7 @@ namespace GitUI
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool ReplaceMode
         {
             get { return txtReplaceWith.Visible; }

--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -1,4 +1,5 @@
-﻿using GitExtensions.Extensibility;
+﻿using System.ComponentModel;
+using GitExtensions.Extensibility;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 using Microsoft;
@@ -48,6 +49,7 @@ namespace GitUI
             ShowInTaskbar = false;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ReplaceMode
         {
             get { return txtReplaceWith.Visible; }

--- a/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
+++ b/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
@@ -30,6 +30,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
     }
 
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Browsable(false)]
     public string? GitGrepExpressionText
     {
         get => cboFindInCommitFilesGitGrep.Text;

--- a/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
+++ b/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitExtensions.Extensibility.Git;
 
 namespace GitUI;
@@ -28,6 +29,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
         ShowInTaskbar = false;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string? GitGrepExpressionText
     {
         get => cboFindInCommitFilesGitGrep.Text;

--- a/src/app/GitUI/FormPuttyError.cs
+++ b/src/app/GitUI/FormPuttyError.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GitUI
 {
@@ -16,6 +17,7 @@ namespace GitUI
             return result == DialogResult.Retry;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? KeyPath { get; private set; }
 
         public FormPuttyError()

--- a/src/app/GitUI/FormPuttyError.cs
+++ b/src/app/GitUI/FormPuttyError.cs
@@ -18,6 +18,7 @@ namespace GitUI
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? KeyPath { get; private set; }
 
         public FormPuttyError()

--- a/src/app/GitUI/GitExtensionsDialog.cs
+++ b/src/app/GitUI/GitExtensionsDialog.cs
@@ -36,6 +36,7 @@ namespace GitUI
         /// The URL structure:
         /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? ManualSectionAnchorName { get; set; }
 
         /// <summary>
@@ -45,6 +46,7 @@ namespace GitUI
         /// The URL structure:
         /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? ManualSectionSubfolder { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/GitExtensionsDialog.cs
+++ b/src/app/GitUI/GitExtensionsDialog.cs
@@ -37,6 +37,7 @@ namespace GitUI
         /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? ManualSectionAnchorName { get; set; }
 
         /// <summary>
@@ -47,6 +48,7 @@ namespace GitUI
         /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? ManualSectionSubfolder { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/GitModuleForm.cs
+++ b/src/app/GitUI/GitModuleForm.cs
@@ -25,9 +25,11 @@ namespace GitUI
         /// Indicates that the process is run by unit tests runner.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal static bool IsUnitTestActive { get; set; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public IHotkeySettingsLoader HotkeySettingsReader
         {
             get => _hotkeySettingsLoader ?? throw new InvalidOperationException($"{GetType().FullName} was constructed incorrectly.");
@@ -35,6 +37,7 @@ namespace GitUI
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public IScriptsRunner ScriptsRunner
         {
             get => _scriptsRunner ?? throw new InvalidOperationException($"{GetType().FullName} was constructed incorrectly.");

--- a/src/app/GitUI/GitModuleForm.cs
+++ b/src/app/GitUI/GitModuleForm.cs
@@ -24,14 +24,17 @@ namespace GitUI
         /// <summary>
         /// Indicates that the process is run by unit tests runner.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal static bool IsUnitTestActive { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IHotkeySettingsLoader HotkeySettingsReader
         {
             get => _hotkeySettingsLoader ?? throw new InvalidOperationException($"{GetType().FullName} was constructed incorrectly.");
             private set => _hotkeySettingsLoader = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IScriptsRunner ScriptsRunner
         {
             get => _scriptsRunner ?? throw new InvalidOperationException($"{GetType().FullName} was constructed incorrectly.");
@@ -40,6 +43,7 @@ namespace GitUI
 
         /// <inheritdoc />
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IGitUICommands UICommands
         {
             get

--- a/src/app/GitUI/HelperDialogs/FormBuildServerCredentials.cs
+++ b/src/app/GitUI/HelperDialogs/FormBuildServerCredentials.cs
@@ -1,4 +1,5 @@
-﻿using GitUIPluginInterfaces.BuildServerIntegration;
+﻿using System.ComponentModel;
+using GitUIPluginInterfaces.BuildServerIntegration;
 
 namespace GitUI.HelperDialogs
 {
@@ -11,6 +12,7 @@ namespace GitUI.HelperDialogs
             labelHeader.Text = string.Format(labelHeader.Text, buildServerUniqueKey);
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IBuildServerCredentials? BuildServerCredentials { get; set; }
 
         private void buttonOK_Click(object sender, EventArgs e)

--- a/src/app/GitUI/HelperDialogs/FormBuildServerCredentials.cs
+++ b/src/app/GitUI/HelperDialogs/FormBuildServerCredentials.cs
@@ -13,6 +13,7 @@ namespace GitUI.HelperDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public IBuildServerCredentials? BuildServerCredentials { get; set; }
 
         private void buttonOK_Click(object sender, EventArgs e)

--- a/src/app/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/src/app/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -40,6 +40,7 @@ namespace GitUI.HelperDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public GitRevision? SelectedRevision { get; private set; }
 
         protected override void OnLoad(EventArgs e)

--- a/src/app/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/src/app/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -1,4 +1,5 @@
-﻿using GitExtensions.Extensibility.Git;
+﻿using System.ComponentModel;
+using GitExtensions.Extensibility.Git;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
 
@@ -38,6 +39,7 @@ namespace GitUI.HelperDialogs
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public GitRevision? SelectedRevision { get; private set; }
 
         protected override void OnLoad(EventArgs e)

--- a/src/app/GitUI/HelperDialogs/FormEdit.cs
+++ b/src/app/GitUI/HelperDialogs/FormEdit.cs
@@ -1,4 +1,5 @@
-﻿using GitExtensions.Extensibility.Git;
+﻿using System.ComponentModel;
+using GitExtensions.Extensibility.Git;
 
 namespace GitUI.HelperDialogs
 {
@@ -13,6 +14,7 @@ namespace GitUI.HelperDialogs
             Viewer.IsReadOnly = false;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsReadOnly
         {
             get => Viewer.IsReadOnly;

--- a/src/app/GitUI/HelperDialogs/FormEdit.cs
+++ b/src/app/GitUI/HelperDialogs/FormEdit.cs
@@ -15,6 +15,7 @@ namespace GitUI.HelperDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsReadOnly
         {
             get => Viewer.IsReadOnly;

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -12,9 +13,11 @@ namespace GitUI.HelperDialogs
 
     public partial class FormProcess : FormStatus
     {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string Remote { get; set; }
         public string? ProcessInput { get; }
         public readonly string WorkingDirectory;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public HandleOnExit? HandleOnExitCallback { get; set; }
         public readonly Dictionary<string, string> ProcessEnvVariables = [];
 

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -14,10 +14,12 @@ namespace GitUI.HelperDialogs
     public partial class FormProcess : FormStatus
     {
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string Remote { get; set; }
         public string? ProcessInput { get; }
         public readonly string WorkingDirectory;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public HandleOnExit? HandleOnExitCallback { get; set; }
         public readonly Dictionary<string, string> ProcessEnvVariables = [];
 

--- a/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using GitCommands;
 using GitCommands.Config;
 using GitExtensions.Extensibility;
@@ -42,6 +43,7 @@ Do you want to register the host's fingerprint and restart the process?");
             return !formRemoteProcess.ErrorOccurred();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool Plink { get; set; }
 
         private IGitUICommands Commands { get; }

--- a/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -44,6 +44,7 @@ Do you want to register the host's fingerprint and restart the process?");
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool Plink { get; set; }
 
         private IGitUICommands Commands { get; }

--- a/src/app/GitUI/HelperDialogs/FormStatus.cs
+++ b/src/app/GitUI/HelperDialogs/FormStatus.cs
@@ -56,8 +56,10 @@ namespace GitUI.HelperDialogs
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? ProcessString { get; protected init; }
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? ProcessArguments { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/HelperDialogs/FormStatus.cs
+++ b/src/app/GitUI/HelperDialogs/FormStatus.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
@@ -54,7 +55,9 @@ namespace GitUI.HelperDialogs
             InitializeComplete();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? ProcessString { get; protected init; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? ProcessArguments { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/ScriptsEngine/FormFilePrompt.cs
+++ b/src/app/GitUI/ScriptsEngine/FormFilePrompt.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitExtensions.Extensibility.Translations;
 using GitExtUtils.GitUI;
 
@@ -6,6 +7,7 @@ namespace GitUI.ScriptsEngine
 {
     internal partial class FormFilePrompt : GitExtensionsForm, IUserInputPrompt
     {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string UserInput { get; private set; } = string.Empty;
 
         public FormFilePrompt()

--- a/src/app/GitUI/ScriptsEngine/FormFilePrompt.cs
+++ b/src/app/GitUI/ScriptsEngine/FormFilePrompt.cs
@@ -8,6 +8,7 @@ namespace GitUI.ScriptsEngine
     internal partial class FormFilePrompt : GitExtensionsForm, IUserInputPrompt
     {
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string UserInput { get; private set; } = string.Empty;
 
         public FormFilePrompt()

--- a/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
+++ b/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
@@ -1,9 +1,12 @@
 ﻿#nullable enable
 
+using System.ComponentModel;
+
 namespace GitUI.ScriptsEngine;
 
 internal partial class SimplePrompt : Form, IUserInputPrompt
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string UserInput { get; private set; } = "";
 
     public SimplePrompt(string? title, string? label, string? defaultValue)

--- a/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
+++ b/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
@@ -7,6 +7,7 @@ namespace GitUI.ScriptsEngine;
 internal partial class SimplePrompt : Form, IUserInputPrompt
 {
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Browsable(false)]
     public string UserInput { get; private set; } = "";
 
     public SimplePrompt(string? title, string? label, string? defaultValue)

--- a/src/app/GitUI/ScriptsEngine/SplitButton.cs
+++ b/src/app/GitUI/ScriptsEngine/SplitButton.cs
@@ -54,6 +54,7 @@ namespace GitUI.ScriptsEngine
         #region Properties
 
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => SplitMenuStrip;

--- a/src/app/GitUI/SpellChecker/EditNetSpell.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.cs
@@ -52,6 +52,7 @@ namespace GitUI.SpellChecker
 
         private readonly IWordAtCursorExtractor _wordAtCursorExtractor;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Font TextBoxFont { get; set; }
 
         public bool IsUndoInProgress;
@@ -71,6 +72,7 @@ namespace GitUI.SpellChecker
             _ = new TextBoxSilencer(TextBox);
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string Text
         {
             get

--- a/src/app/GitUI/SpellChecker/EditNetSpell.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.cs
@@ -53,6 +53,7 @@ namespace GitUI.SpellChecker
         private readonly IWordAtCursorExtractor _wordAtCursorExtractor;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Font TextBoxFont { get; set; }
 
         public bool IsUndoInProgress;
@@ -73,6 +74,7 @@ namespace GitUI.SpellChecker
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public override string Text
         {
             get

--- a/src/app/GitUI/UserControls/AvatarControl.cs
+++ b/src/app/GitUI/UserControls/AvatarControl.cs
@@ -83,9 +83,11 @@ namespace GitUI
         }
 
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? Email { get; private set; }
 
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? AuthorName { get; private set; }
 
         public void LoadImage(string? email, string? name)

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -53,6 +53,7 @@ namespace GitUI.Blame
 
         // Relative path of the file to blame when blaming a new revision
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? PathToBlame { get; private set; }
 
         public BlameControl()

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using GitCommands;
@@ -51,6 +52,7 @@ namespace GitUI.Blame
         private readonly IGitBlameParser _gitBlameParser;
 
         // Relative path of the file to blame when blaming a new revision
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? PathToBlame { get; private set; }
 
         public BlameControl()

--- a/src/app/GitUI/UserControls/BranchComboBox.cs
+++ b/src/app/GitUI/UserControls/BranchComboBox.cs
@@ -30,6 +30,7 @@ namespace GitUI
 
         private IReadOnlyList<IGitRef>? _branchesToSelect;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public IReadOnlyList<IGitRef>? BranchesToSelect
         {
             get

--- a/src/app/GitUI/UserControls/BranchComboBox.cs
+++ b/src/app/GitUI/UserControls/BranchComboBox.cs
@@ -29,6 +29,7 @@ namespace GitUI
         public event EventHandler SelectedValueChanged;
 
         private IReadOnlyList<IGitRef>? _branchesToSelect;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IReadOnlyList<IGitRef>? BranchesToSelect
         {
             get

--- a/src/app/GitUI/UserControls/CommitSummaryUserControl.cs
+++ b/src/app/GitUI/UserControls/CommitSummaryUserControl.cs
@@ -45,6 +45,7 @@ namespace GitUI.UserControls
         /// Gets or sets a revision for which to show a summary.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public GitRevision? Revision
         {
             get => _revision;

--- a/src/app/GitUI/UserControls/CommitSummaryUserControl.cs
+++ b/src/app/GitUI/UserControls/CommitSummaryUserControl.cs
@@ -1,4 +1,5 @@
-﻿using GitExtensions.Extensibility.Git;
+﻿using System.ComponentModel;
+using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -43,6 +44,7 @@ namespace GitUI.UserControls
         /// <summary>
         /// Gets or sets a revision for which to show a summary.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public GitRevision? Revision
         {
             get => _revision;

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -323,6 +323,7 @@ namespace GitUI
         public int AllItemsCount => FileStatusListView.Items.Count;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public override ContextMenuStrip ContextMenuStrip
         {
             get { return FileStatusListView.ContextMenuStrip; }
@@ -446,6 +447,7 @@ namespace GitUI
         private IReadOnlyList<FileStatusWithDescription> GitItemStatusesWithDescription { get; set; } = Array.Empty<FileStatusWithDescription>();
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool GroupByRevision { get; set; } = false;
 
         [Browsable(false)]

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -322,6 +322,7 @@ namespace GitUI
 
         public int AllItemsCount => FileStatusListView.Items.Count;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ContextMenuStrip ContextMenuStrip
         {
             get { return FileStatusListView.ContextMenuStrip; }
@@ -444,6 +445,7 @@ namespace GitUI
 
         private IReadOnlyList<FileStatusWithDescription> GitItemStatusesWithDescription { get; set; } = Array.Empty<FileStatusWithDescription>();
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool GroupByRevision { get; set; } = false;
 
         [Browsable(false)]

--- a/src/app/GitUI/UserControls/FolderBrowserButton.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using Microsoft;
 using ResourceManager;
 
@@ -16,6 +17,7 @@ namespace GitUI.UserControls
         /// The Text property of this control will be filled with the selected path
         /// and the Text property is used as path to initialize the folder browser's default selection.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Control? PathShowingControl { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/UserControls/FolderBrowserButton.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.cs
@@ -18,6 +18,7 @@ namespace GitUI.UserControls
         /// and the Text property is used as path to initialize the folder browser's default selection.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Control? PathShowingControl { get; set; }
 
         /// <summary>

--- a/src/app/GitUI/UserControls/GotoUserManualControl.cs
+++ b/src/app/GitUI/UserControls/GotoUserManualControl.cs
@@ -27,6 +27,7 @@ namespace GitUI.UserControls
 
         private string _manualSectionAnchorName;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string ManualSectionAnchorName
         {
             get { return _manualSectionAnchorName; }
@@ -42,6 +43,7 @@ namespace GitUI.UserControls
 
         private string _manualSectionSubfolder;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string ManualSectionSubfolder
         {
             get { return _manualSectionSubfolder; }

--- a/src/app/GitUI/UserControls/GotoUserManualControl.cs
+++ b/src/app/GitUI/UserControls/GotoUserManualControl.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using ResourceManager;
 
 namespace GitUI.UserControls
@@ -25,6 +26,7 @@ namespace GitUI.UserControls
         }
 
         private string _manualSectionAnchorName;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string ManualSectionAnchorName
         {
             get { return _manualSectionAnchorName; }
@@ -39,6 +41,7 @@ namespace GitUI.UserControls
         }
 
         private string _manualSectionSubfolder;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string ManualSectionSubfolder
         {
             get { return _manualSectionSubfolder; }

--- a/src/app/GitUI/UserControls/HelpImageDisplayUserControl.cs
+++ b/src/app/GitUI/UserControls/HelpImageDisplayUserControl.cs
@@ -35,6 +35,7 @@ namespace GitUI.Help
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsExpanded
         {
             get { return _isExpanded; }
@@ -62,6 +63,7 @@ namespace GitUI.Help
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? UniqueIsExpandedSettingsId { get; set; }
 
         private void UpdateIsExpandedState()
@@ -91,6 +93,7 @@ namespace GitUI.Help
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Image? Image1
         {
             get { return _image1; }
@@ -106,6 +109,7 @@ namespace GitUI.Help
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Image? Image2
         {
             get { return _image2; }
@@ -124,6 +128,7 @@ namespace GitUI.Help
         /// see also IsOnHoverShowImage2NoticeText.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsOnHoverShowImage2
         {
             get { return _showImage2OnHover; }
@@ -142,6 +147,7 @@ namespace GitUI.Help
         /// only shown when IsOnHoverShowImage2 is true.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string IsOnHoverShowImage2NoticeText
         {
             get => labelHoverText.Text;

--- a/src/app/GitUI/UserControls/HelpImageDisplayUserControl.cs
+++ b/src/app/GitUI/UserControls/HelpImageDisplayUserControl.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitExtUtils.GitUI;
 using ResourceManager;
 
@@ -33,6 +34,7 @@ namespace GitUI.Help
             _isLoaded = true;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsExpanded
         {
             get { return _isExpanded; }
@@ -59,6 +61,7 @@ namespace GitUI.Help
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? UniqueIsExpandedSettingsId { get; set; }
 
         private void UpdateIsExpandedState()
@@ -87,6 +90,7 @@ namespace GitUI.Help
             UpdateControlSize();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Image? Image1
         {
             get { return _image1; }
@@ -101,6 +105,7 @@ namespace GitUI.Help
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Image? Image2
         {
             get { return _image2; }
@@ -118,6 +123,7 @@ namespace GitUI.Help
         /// <summary>
         /// see also IsOnHoverShowImage2NoticeText.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsOnHoverShowImage2
         {
             get { return _showImage2OnHover; }
@@ -135,6 +141,7 @@ namespace GitUI.Help
         /// <summary>
         /// only shown when IsOnHoverShowImage2 is true.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string IsOnHoverShowImage2NoticeText
         {
             get => labelHoverText.Text;

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -59,6 +59,7 @@ namespace GitUI
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IReadOnlyList<PatchFile>? PatchFiles { get; private set; }
 
         private void DisplayPatches(IReadOnlyList<PatchFile> patchFiles)

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -60,6 +60,7 @@ namespace GitUI
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public IReadOnlyList<PatchFile>? PatchFiles { get; private set; }
 
         private void DisplayPatches(IReadOnlyList<PatchFile> patchFiles)

--- a/src/app/GitUI/UserControls/RemotesComboboxControl.cs
+++ b/src/app/GitUI/UserControls/RemotesComboboxControl.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands.Remotes;
+﻿using System.ComponentModel;
+using GitCommands.Remotes;
 
 namespace GitUI.UserControls
 {
@@ -11,6 +12,7 @@ namespace GitUI.UserControls
             AllowMultiselect = false;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string SelectedRemote
         {
             get => comboBoxRemotes.Text;
@@ -18,6 +20,7 @@ namespace GitUI.UserControls
         }
 
         private bool _allowMultiselect;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool AllowMultiselect
         {
             get { return _allowMultiselect; }

--- a/src/app/GitUI/UserControls/RemotesComboboxControl.cs
+++ b/src/app/GitUI/UserControls/RemotesComboboxControl.cs
@@ -13,6 +13,7 @@ namespace GitUI.UserControls
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string SelectedRemote
         {
             get => comboBoxRemotes.Text;
@@ -21,6 +22,7 @@ namespace GitUI.UserControls
 
         private bool _allowMultiselect;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool AllowMultiselect
         {
             get { return _allowMultiselect; }

--- a/src/app/GitUI/UserControls/RevisionGrid/LoadingControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/LoadingControl.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.UserControls.RevisionGrid
+﻿using System.ComponentModel;
+
+namespace GitUI.UserControls.RevisionGrid
 {
     public sealed class LoadingControl : UserControl
     {
@@ -26,6 +28,7 @@
             this.AdjustForDpiScaling();
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsAnimating
         {
             get => _waitSpinner.IsAnimating;

--- a/src/app/GitUI/UserControls/RevisionGrid/LoadingControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/LoadingControl.cs
@@ -29,6 +29,7 @@ namespace GitUI.UserControls.RevisionGrid
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsAnimating
         {
             get => _waitSpinner.IsAnimating;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -82,9 +82,11 @@ namespace GitUI.UserControls.RevisionGrid
         /// This property is intended to be used by tests.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsDataLoadComplete { get; private set; } = true;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool UpdatingVisibleRows { get; private set; }
 
         // _toBeSelectedGraphIndexesCache is init in Clear()
@@ -193,11 +195,13 @@ namespace GitUI.UserControls.RevisionGrid
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal AuthorRevisionHighlighting? AuthorHighlighting { get; set; }
 
         // Contains the object Id's that will be selected as soon as all of them have been loaded.
         // The object Id's are in the order in which they were originally selected.
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public IReadOnlyList<ObjectId> ToBeSelectedObjectIds { get; set; } = Array.Empty<ObjectId>();
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -81,8 +81,10 @@ namespace GitUI.UserControls.RevisionGrid
         ///
         /// This property is intended to be used by tests.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsDataLoadComplete { get; private set; } = true;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool UpdatingVisibleRows { get; private set; }
 
         // _toBeSelectedGraphIndexesCache is init in Clear()
@@ -190,10 +192,12 @@ namespace GitUI.UserControls.RevisionGrid
             base.Dispose(disposing);
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal AuthorRevisionHighlighting? AuthorHighlighting { get; set; }
 
         // Contains the object Id's that will be selected as soon as all of them have been loaded.
         // The object Id's are in the order in which they were originally selected.
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IReadOnlyList<ObjectId> ToBeSelectedObjectIds { get; set; } = Array.Empty<ObjectId>();
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -134,28 +134,35 @@ namespace GitUI
         // NOTE internal properties aren't serialised by the WinForms designer
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
 
         internal ObjectId? CurrentCheckout { get; private set; }
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal Lazy<string> CurrentBranch { get; private set; } = new(() => "");
         internal FilterInfo CurrentFilter => _filterInfo;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal bool ShowUncommittedChangesIfPossible { get; set; } = true;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal bool ShowBuildServerInfo { get; set; }
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal bool DoubleClickDoesNotOpenCommitInfo { get; set; }
 
         /// <summary>
         /// The last selected commit in the grid (with related CommitInfo in Browse).
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal ObjectId? SelectedId { private get; set; }
 
         /// <summary>
         /// The first selected, the first commit in a diff.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal ObjectId? FirstId { private get; set; }
 
         internal RevisionGridMenuCommands MenuCommands { get; }
@@ -166,6 +173,7 @@ namespace GitUI
         /// The property is explicitly initialized by FileHistory.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal Dictionary<ObjectId, string>? FilePathByObjectId { get; set; } = null;
 
         public RevisionGridControl()
@@ -368,6 +376,7 @@ namespace GitUI
         internal GitRevision? LatestSelectedRevision => IsValidRevisionIndex(_latestSelectedRowIndex) ? GetRevision(_latestSelectedRowIndex) : null;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         internal bool MultiSelect
         {
             get => _gridView.MultiSelect;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -133,21 +133,29 @@ namespace GitUI
 
         // NOTE internal properties aren't serialised by the WinForms designer
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+
         internal ObjectId? CurrentCheckout { get; private set; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal Lazy<string> CurrentBranch { get; private set; } = new(() => "");
         internal FilterInfo CurrentFilter => _filterInfo;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal bool ShowUncommittedChangesIfPossible { get; set; } = true;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal bool ShowBuildServerInfo { get; set; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal bool DoubleClickDoesNotOpenCommitInfo { get; set; }
 
         /// <summary>
         /// The last selected commit in the grid (with related CommitInfo in Browse).
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ObjectId? SelectedId { private get; set; }
 
         /// <summary>
         /// The first selected, the first commit in a diff.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ObjectId? FirstId { private get; set; }
 
         internal RevisionGridMenuCommands MenuCommands { get; }
@@ -157,6 +165,7 @@ namespace GitUI
         /// See BuildFilter() for limitations of commits included.
         /// The property is explicitly initialized by FileHistory.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal Dictionary<ObjectId, string>? FilePathByObjectId { get; set; } = null;
 
         public RevisionGridControl()
@@ -358,6 +367,7 @@ namespace GitUI
 
         internal GitRevision? LatestSelectedRevision => IsValidRevisionIndex(_latestSelectedRowIndex) ? GetRevision(_latestSelectedRowIndex) : null;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal bool MultiSelect
         {
             get => _gridView.MultiSelect;

--- a/src/app/GitUI/UserControls/Settings/SettingsCheckBox.cs
+++ b/src/app/GitUI/UserControls/Settings/SettingsCheckBox.cs
@@ -31,6 +31,7 @@ namespace GitUI.UserControls.Settings
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool Checked
         {
             get => checkBox.Checked;
@@ -45,6 +46,7 @@ namespace GitUI.UserControls.Settings
         /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? ManualSectionAnchorName { get; set; }
 
         /// <summary>
@@ -69,6 +71,7 @@ namespace GitUI.UserControls.Settings
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? ToolTipText
         {
             get => _toolTipText;
@@ -83,6 +86,7 @@ namespace GitUI.UserControls.Settings
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public ToolTipIcon ToolTipIcon
         {
             get => _toolTipIcon;

--- a/src/app/GitUI/UserControls/Settings/SettingsCheckBox.cs
+++ b/src/app/GitUI/UserControls/Settings/SettingsCheckBox.cs
@@ -30,6 +30,7 @@ namespace GitUI.UserControls.Settings
             };
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool Checked
         {
             get => checkBox.Checked;
@@ -43,6 +44,7 @@ namespace GitUI.UserControls.Settings
         /// The URL structure:
         /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? ManualSectionAnchorName { get; set; }
 
         /// <summary>
@@ -66,6 +68,7 @@ namespace GitUI.UserControls.Settings
             set => checkBox.Text = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? ToolTipText
         {
             get => _toolTipText;
@@ -79,6 +82,7 @@ namespace GitUI.UserControls.Settings
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public ToolTipIcon ToolTipIcon
         {
             get => _toolTipIcon;

--- a/src/app/GitUI/UserControls/TextBoxEx.cs
+++ b/src/app/GitUI/UserControls/TextBoxEx.cs
@@ -16,6 +16,7 @@ namespace GitUI.UserControls
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Color BorderDefaultColor
         {
             get => _borderDefaultColor;
@@ -27,6 +28,7 @@ namespace GitUI.UserControls
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Color BorderHoveredColor
         {
             get => _borderHoveredColor;
@@ -38,6 +40,7 @@ namespace GitUI.UserControls
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public Color BorderFocusedColor
         {
             get => _borderFocusedColor;

--- a/src/app/GitUI/UserControls/TextBoxEx.cs
+++ b/src/app/GitUI/UserControls/TextBoxEx.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.UserControls
+﻿using System.ComponentModel;
+
+namespace GitUI.UserControls
 {
     internal sealed class TextBoxEx : TextBox
     {
@@ -13,6 +15,7 @@
             SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color BorderDefaultColor
         {
             get => _borderDefaultColor;
@@ -23,6 +26,7 @@
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color BorderHoveredColor
         {
             get => _borderHoveredColor;
@@ -33,6 +37,7 @@
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color BorderFocusedColor
         {
             get => _borderFocusedColor;

--- a/src/app/GitUI/UserControls/WaitSpinner.cs
+++ b/src/app/GitUI/UserControls/WaitSpinner.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing.Drawing2D;
+﻿using System.ComponentModel;
+using System.Drawing.Drawing2D;
 using GitExtUtils.GitUI;
 using Timer = System.Windows.Forms.Timer;
 
@@ -19,6 +20,7 @@ namespace GitUI.UserControls
         private PointF _centre;
         private int _progress;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsAnimating
         {
             get => _isAnimating;

--- a/src/app/GitUI/UserControls/WaitSpinner.cs
+++ b/src/app/GitUI/UserControls/WaitSpinner.cs
@@ -21,6 +21,7 @@ namespace GitUI.UserControls
         private int _progress;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsAnimating
         {
             get => _isAnimating;

--- a/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
+++ b/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft;
+﻿using System.ComponentModel;
+using Microsoft;
 
 namespace TeamCityIntegration.Settings
 {
@@ -6,7 +7,9 @@ namespace TeamCityIntegration.Settings
     {
         private readonly TeamCityAdapter _teamCityAdapter = new();
         private TreeNode? _previouslySelectedProject;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string TeamCityProjectName { get; private set; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string TeamCityBuildIdFilter { get; private set; }
 
         public TeamCityBuildChooser(string teamCityServerUrl, string teamCityProjectName, string teamCityBuildIdFilter)

--- a/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
+++ b/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
@@ -8,8 +8,10 @@ namespace TeamCityIntegration.Settings
         private readonly TeamCityAdapter _teamCityAdapter = new();
         private TreeNode? _previouslySelectedProject;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string TeamCityProjectName { get; private set; }
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string TeamCityBuildIdFilter { get; private set; }
 
         public TeamCityBuildChooser(string teamCityServerUrl, string teamCityProjectName, string teamCityBuildIdFilter)

--- a/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.ComponentModel;
+using System.Text.RegularExpressions;
 using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -36,6 +37,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
         private readonly IGitPlugin _gitPlugin;
         private readonly GitBranchOutputCommandParser _commandOutputParser;
         private CancellationTokenSource? _refreshCancellation;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool HasDeletedBranch { get; internal set; }
 
         public DeleteUnusedBranchesForm(DeleteUnusedBranchesFormSettings settings, IGitModule gitCommands, IGitUICommands? gitUiCommands, IGitPlugin gitPlugin)

--- a/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -38,6 +38,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
         private readonly GitBranchOutputCommandParser _commandOutputParser;
         private CancellationTokenSource? _refreshCancellation;
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool HasDeletedBranch { get; internal set; }
 
         public DeleteUnusedBranchesForm(DeleteUnusedBranchesFormSettings settings, IGitModule gitCommands, IGitUICommands? gitUiCommands, IGitPlugin gitPlugin)

--- a/src/plugins/GitFlow/GitFlowForm.cs
+++ b/src/plugins/GitFlow/GitFlowForm.cs
@@ -24,6 +24,7 @@ namespace GitExtensions.Plugins.GitFlow
         private readonly AsyncLoader _task = new();
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public bool IsRefreshNeeded { get; set; }
 
         private string? CurrentBranch { get; set; }

--- a/src/plugins/GitFlow/GitFlowForm.cs
+++ b/src/plugins/GitFlow/GitFlowForm.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitExtensions.Extensibility;
@@ -22,6 +23,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private readonly AsyncLoader _task = new();
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsRefreshNeeded { get; set; }
 
         private string? CurrentBranch { get; set; }

--- a/src/plugins/Gource/GourceStart.cs
+++ b/src/plugins/Gource/GourceStart.cs
@@ -35,12 +35,15 @@ namespace GitExtensions.Plugins.Gource
         private GitUIEventArgs GitUIArgs { get; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string PathToGource { get; set; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string? GitWorkingDir { get; set; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string GourceArguments { get; set; }
 
         private void RunRealCmdDetached(string cmd, string arguments)

--- a/src/plugins/Gource/GourceStart.cs
+++ b/src/plugins/Gource/GourceStart.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing.Imaging;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
@@ -33,10 +34,13 @@ namespace GitExtensions.Plugins.Gource
 
         private GitUIEventArgs GitUIArgs { get; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string PathToGource { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string? GitWorkingDir { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string GourceArguments { get; set; }
 
         private void RunRealCmdDetached(string cmd, string arguments)

--- a/src/plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/src/plugins/Statistics/GitImpact/ImpactControl.cs
@@ -47,6 +47,7 @@ namespace GitExtensions.Plugins.GitImpact
         private readonly Pen _selectedAuthorPen = new(SystemColors.WindowText, 2);
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string SelectedAuthor { get; private set; } = string.Empty;
 
         public ImpactControl()

--- a/src/plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/src/plugins/Statistics/GitImpact/ImpactControl.cs
@@ -46,6 +46,7 @@ namespace GitExtensions.Plugins.GitImpact
         private readonly Brush _linesBrush = Brushes.White;
         private readonly Pen _selectedAuthorPen = new(SystemColors.WindowText, 2);
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string SelectedAuthor { get; private set; } = string.Empty;
 
         public ImpactControl()

--- a/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Text;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
@@ -47,6 +48,7 @@ namespace GitExtensions.Plugins.GitStatistics
                     Color.Purple
                 };
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string DirectoriesToIgnore { get; set; } = "";
 
         public FormGitStatistics(IGitModule module, string codeFilePattern, bool countSubmodules)

--- a/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -49,6 +49,7 @@ namespace GitExtensions.Plugins.GitStatistics
                 };
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string DirectoriesToIgnore { get; set; } = "";
 
         public FormGitStatistics(IGitModule module, string codeFilePattern, bool countSubmodules)

--- a/src/plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
+++ b/src/plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Drawing.Drawing2D;
 using GitExtensions.Extensibility;
 
@@ -42,11 +43,13 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
         ///   Gets or sets the tool tips.
         /// </summary>
         /// <value>The tool tips.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string[]? ToolTips { get; set; }
 
         /// <summary>
         ///   Sets the initial angle from which pies are drawn.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public float InitialAngle
         {
             get => _initialAngle;

--- a/src/plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
+++ b/src/plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
@@ -44,12 +44,14 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
         /// </summary>
         /// <value>The tool tips.</value>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public string[]? ToolTips { get; set; }
 
         /// <summary>
         ///   Sets the initial angle from which pies are drawn.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
         public float InitialAngle
         {
             get => _initialAngle;


### PR DESCRIPTION
…ts property content

## Proposed changes

Content serialization must be declared with .NET9, error WFO1000 
Similar change is needed for conemu, icsharp submodules
An alternative is to supress the warning for .net9

I took .net9 for a quick spin, this was the biggest required change. A few other suppression needed due to deprecations.
The app starts. With the favorite in left panel the app hanged after a fetch though

## Test methodology <!-- How did you ensure quality? -->

Manual use, just annotations

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
