### PR TITLE
fix: ReadExactly from stream

### DIFF
--- a/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -151,7 +151,7 @@ namespace GitUI.BuildServerIntegration
                     {
                         byte[] protectedData = new byte[stream.Length];
 
-                        stream.Read(protectedData, 0, (int)stream.Length);
+                        stream.ReadExactly(protectedData, 0, (int)stream.Length);
                         try
                         {
                             byte[] unprotectedData = ProtectedData.Unprotect(protectedData, null,


### PR DESCRIPTION

## Proposed changes

Read() from a stream could obtain fewer characters than requested, the number of chars read was never checked.

This is a warning with .net9 and a potential issue in current master.
With this change all bytes reported to be in the stream are read, which should be the case anyway.

ReadExactly () was added in .net7. (I considered using that when optimizing the read of revisions for 4.x (that was for .net6, just testing an update.) If Git reported number of bytes for a commit the handling was slower than the current handling that searches for \0 in the stream).

Alternatives to this change:
- Suppress the warning in .net9 
- Assign Read() to _ to ack that the value is not used (there will likely be an exception below instead)
- Return with error if no of bytes are not read.

## Test methodology <!-- How did you ensure quality? -->

code review - cannot provoke the error

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
