### PR TITLE
fix(Scripts): Do not display mnemonic ampersand

### DIFF
--- a/src/app/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
+++ b/src/app/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
@@ -42,9 +42,9 @@ namespace GitUI.CommandsDialogs
                 ToolStripMenuItem item = new()
                 {
                     Text = script.Name,
-                    Name = $"{script.Name}{ScriptNameSuffix}",
+                    Name = $"{script.GetDisplayName()}{ScriptNameSuffix}",
                     Image = script.GetIcon(),
-                    ShortcutKeyDisplayString = hotkeys.FirstOrDefault(h => h.Name == script.Name)?.KeyData.ToShortcutKeyDisplayString()
+                    ShortcutKeyDisplayString = hotkeys.FirstOrDefault(h => h.Name == script.GetDisplayName())?.KeyData.ToShortcutKeyDisplayString()
                 };
 
                 item.Click += (s, e) =>

--- a/src/app/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/src/app/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -406,7 +406,7 @@ namespace GitUI.Hotkey
                 return _scriptsManager
                     .GetScripts()
                     .Where(s => !string.IsNullOrEmpty(s.Name))
-                    .Select(s => new HotkeyCommand(s.HotkeyCommandIdentifier, s.Name!) { KeyData = Keys.None })
+                    .Select(s => new HotkeyCommand(s.HotkeyCommandIdentifier, s.GetDisplayName()) { KeyData = Keys.None })
                     .ToArray();
             }
         }

--- a/src/app/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -1,8 +1,14 @@
-﻿namespace GitUI.ScriptsEngine
+﻿using System.Text.RegularExpressions;
+
+namespace GitUI.ScriptsEngine
 {
     // WARNING: This class is serialized to XML!
-    public class ScriptInfo
+    public partial class ScriptInfo
     {
+        // Match a single '&' (lookahead to not be followed by a second '&')
+        [GeneratedRegex("&(?!&)")]
+        private static partial Regex MnemonicAmpersandRegex();
+
         public ScriptInfo()
         {
             Icon = "bug";
@@ -38,6 +44,11 @@
         /// Gets or sets the path to the file containing the icon.
         /// </summary>
         public string? IconFilePath { get; set; }
+
+        /// <summary>
+        ///  Returns the name with mnemonic ampersands removed.
+        /// </summary>
+        public string GetDisplayName() => MnemonicAmpersandRegex().Replace(Name, "");
 
         /// <summary>
         /// Gets the associated bitmap.

--- a/src/app/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -35,7 +35,7 @@ namespace GitUI.ScriptsEngine
                 }
                 catch (ExternalOperationException ex) when (ex is not UserExternalOperationException)
                 {
-                    throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorFailedToExecute}: '{script.Name}'", ex);
+                    throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorFailedToExecute}: '{script.GetDisplayName()}'", ex);
                 }
             }
 
@@ -123,13 +123,13 @@ namespace GitUI.ScriptsEngine
                                                                             && ScriptOptionsParser.Contains(arguments, option));
                     if (optionDependingOnSelectedRevision is not null)
                     {
-                        throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.Name}'{Environment.NewLine}'{optionDependingOnSelectedRevision}' {TranslatedStrings.ScriptErrorOptionWithoutRevisionGridText}",
+                        throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.GetDisplayName()}'{Environment.NewLine}'{optionDependingOnSelectedRevision}' {TranslatedStrings.ScriptErrorOptionWithoutRevisionGridText}",
                             new ExternalOperationException(script.Command, arguments, uiCommands.Module.WorkingDir));
                     }
                 }
 
                 if (script.AskConfirmation &&
-                    MessageBox.Show(owner, $"{TranslatedStrings.ScriptConfirmExecute}: '{script.Name}'?", TranslatedStrings.ScriptText,
+                    MessageBox.Show(owner, $"{TranslatedStrings.ScriptConfirmExecute}: '{script.GetDisplayName()}'?", TranslatedStrings.ScriptText,
                                     MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
                 {
                     return false;
@@ -137,11 +137,11 @@ namespace GitUI.ScriptsEngine
 
                 string? originalCommand = script.Command;
 
-                (arguments, bool abort, bool cancelled) = ParseUserInputs(script.Name ?? "<_nameless_script_>", script.Arguments, uiCommands, owner, scriptOptionsProvider);
+                (arguments, bool abort, bool cancelled) = ParseUserInputs(script.GetDisplayName() ?? "<_nameless_script_>", script.Arguments, uiCommands, owner, scriptOptionsProvider);
 
                 if (cancelled)
                 {
-                    MessageBox.Show(owner, TranslatedStrings.ScriptUserCanceledRun, script.Name, MessageBoxButtons.OK);
+                    MessageBox.Show(owner, TranslatedStrings.ScriptUserCanceledRun, script.GetDisplayName(), MessageBoxButtons.OK);
                     return false;
                 }
 
@@ -150,7 +150,7 @@ namespace GitUI.ScriptsEngine
                     : ScriptOptionsParser.Parse(arguments, uiCommands, owner, scriptOptionsProvider);
                 if (abort)
                 {
-                    throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.Name}'{Environment.NewLine}{TranslatedStrings.ScriptErrorOptionWithoutRevisionText}",
+                    throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.GetDisplayName()}'{Environment.NewLine}{TranslatedStrings.ScriptErrorOptionWithoutRevisionText}",
                         new ExternalOperationException(script.Command, arguments, uiCommands.Module.WorkingDir));
                 }
 

--- a/src/app/GitUI/ScriptsEngine/ScriptsManager.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptsManager.cs
@@ -140,7 +140,7 @@ namespace GitUI.ScriptsEngine
                 new ScriptInfo
                 {
                     HotkeyCommandIdentifier = 9002,
-                    Name = "Example",
+                    Name = "&Example",
                     Command = @"c:\windows\system32\calc.exe",
                     Arguments = "",
                     RunInBackground = false,

--- a/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
@@ -135,7 +135,7 @@ namespace GitExtensions.UITests.ScriptEngine
 
             ExceptionAssertions<UserExternalOperationException> ex = ((Action)(() => ExecuteRunScript(_exampleScript, _mockForm, _commands))).Should()
                 .Throw<UserExternalOperationException>();
-            ex.And.Context.Should().Be($"Script: '{_exampleScript.Name}'\r\nA valid revision is required to substitute the argument options");
+            ex.And.Context.Should().Be($"Script: '{_exampleScript.GetDisplayName()}'\r\nA valid revision is required to substitute the argument options");
             ex.And.Command.Should().Be(_exampleScript.Command);
             ex.And.Arguments.Should().Be(_exampleScript.Arguments);
             ex.And.WorkingDirectory.Should().Be(_module.WorkingDir);
@@ -151,7 +151,7 @@ namespace GitExtensions.UITests.ScriptEngine
 
             ExceptionAssertions<UserExternalOperationException> ex = ((Action)(() => ExecuteRunScript(_exampleScript, _mockForm, _mockForm.UICommands))).Should()
                 .Throw<UserExternalOperationException>();
-            ex.And.Context.Should().Be($"Script: '{_exampleScript.Name}'\r\n'sHash' option is only supported when invoked from the revision grid");
+            ex.And.Context.Should().Be($"Script: '{_exampleScript.GetDisplayName()}'\r\n'sHash' option is only supported when invoked from the revision grid");
             ex.And.Command.Should().Be(_exampleScript.Command);
             ex.And.Arguments.Should().Be(_exampleScript.Arguments);
             ex.And.WorkingDirectory.Should().Be(_module.WorkingDir);
@@ -175,7 +175,7 @@ namespace GitExtensions.UITests.ScriptEngine
 
                 ExceptionAssertions<UserExternalOperationException> ex = ((Action)(() => ExecuteRunScript(_exampleScript, formBrowse, formBrowse.UICommands))).Should()
                         .Throw<UserExternalOperationException>();
-                ex.And.Context.Should().Be($"Script: '{_exampleScript.Name}'\r\nA valid revision is required to substitute the argument options");
+                ex.And.Context.Should().Be($"Script: '{_exampleScript.GetDisplayName()}'\r\nA valid revision is required to substitute the argument options");
                 ex.And.Command.Should().Be(_exampleScript.Command);
                 ex.And.Arguments.Should().Be(_exampleScript.Arguments);
                 ex.And.WorkingDirectory.Should().Be(_referenceRepository.Module.WorkingDir);


### PR DESCRIPTION
## Proposed changes

- Remove mnemonic ampersand in script name except for tool bar and menus 

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://github.com/user-attachments/assets/101acf22-908e-415a-8c96-951128be04cd)

Before | After
-|-
![image](https://github.com/user-attachments/assets/c75f5f08-4284-44f3-a24a-2e9e1f7e9893) | ![image](https://github.com/user-attachments/assets/de057d5b-2792-44bd-a717-475af3b616e4)
![image](https://github.com/user-attachments/assets/db58e09a-1bb1-4e85-a20f-8165f4522e9d) | ![image](https://github.com/user-attachments/assets/2a33f32f-7b7c-4f35-9e09-d30774303cba)
![image](https://github.com/user-attachments/assets/bafe24e6-31b9-451d-add2-89740aff4377) | ![image](https://github.com/user-attachments/assets/c62464e2-6097-4ad6-9fc1-123448507a58)

## Test methodology <!-- How did you ensure quality? -->

- adapt tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).