### PR TITLE
chore(MemoryStream): Add missing `using` statement

### DIFF
--- a/src/app/GitCommands/Git/ExecutableExtensions.cs
+++ b/src/app/GitCommands/Git/ExecutableExtensions.cs
@@ -124,7 +124,7 @@ namespace GitCommands
             }
 #endif
 
-            MemoryStream outputBuffer = new();
+            using MemoryStream outputBuffer = new();
             Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer);
             Task<int> exitTask = process.WaitForExitAsync();
 
@@ -305,8 +305,8 @@ namespace GitCommands
             cancellationToken.ThrowIfCancellationRequested();
 
             using IProcess process = executable.Start(arguments, createWindow: false, redirectInput: writeInput is not null, redirectOutput: true, outputEncoding, throwOnErrorExit: throwOnErrorExit, cancellationToken: cancellationToken);
-            MemoryStream outputBuffer = new();
-            MemoryStream errorBuffer = new();
+            using MemoryStream outputBuffer = new();
+            using MemoryStream errorBuffer = new();
             Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer, cancellationToken);
             Task errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer, cancellationToken);
 

--- a/src/app/GitCommands/Utils/JsonSerializer.cs
+++ b/src/app/GitCommands/Utils/JsonSerializer.cs
@@ -8,7 +8,7 @@ namespace GitCommands.Utils
         public static string Serialize<T>(T? myObject) where T : class
         {
             DataContractJsonSerializer json = new(typeof(T));
-            MemoryStream stream = new();
+            using MemoryStream stream = new();
             json.WriteObject(stream, myObject);
             return Encoding.UTF8.GetString(stream.ToArray());
         }
@@ -16,7 +16,7 @@ namespace GitCommands.Utils
         public static T? Deserialize<T>(string myString) where T : class
         {
             DataContractJsonSerializer json = new(typeof(T));
-            MemoryStream stream = new(Encoding.UTF8.GetBytes(myString));
+            using MemoryStream stream = new(Encoding.UTF8.GetBytes(myString));
             return (T?)json.ReadObject(stream);
         }
     }

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -1058,18 +1058,11 @@ namespace GitUI.Editor
                 return icon.ToBitmap();
             }
 
-            return new Bitmap(CopyStream());
+            return new Bitmap(stream);
 
             bool IsIcon()
             {
                 return fileName.EndsWith(".ico", StringComparison.CurrentCultureIgnoreCase);
-            }
-
-            MemoryStream CopyStream()
-            {
-                MemoryStream copy = new();
-                stream.CopyTo(copy);
-                return copy;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/12072#discussion_r1861390651 in all other occurrences

## Proposed changes

- `MemoryStream`: Add missing `using` statement 
- Remove unnecessary stream copy from `FileViewer.CreateImage`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests
- manually (view `.ico` and `.png` file of GE repo in diff and as new file)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).