### PR TITLE
feat: Support saving LFS files

### DIFF
--- a/src/app/GitCommands/Git/GitFileStreamGetter.cs
+++ b/src/app/GitCommands/Git/GitFileStreamGetter.cs
@@ -14,6 +14,7 @@ internal static class GitFileStreamGetter
     /// </summary>
     /// <param name="blob">The Git file identifier.</param>
     /// <param name="gitCommandRunner">The wrapper for the Git executable, which handles file encoding.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns>A <see cref="MemoryStream"/> with the file contents or <see langword="null"/> on error.</returns>
     public static async Task<MemoryStream?> GetFileStreamAsync(string blob, IGitCommandRunner gitCommandRunner, CancellationToken cancellationToken)
     {

--- a/src/app/GitCommands/Git/GitFileStreamGetter.cs
+++ b/src/app/GitCommands/Git/GitFileStreamGetter.cs
@@ -93,14 +93,7 @@ internal static class GitFileStreamGetter
             return false;
         }
 
-        char[] buffer = new char[lfsVersionPrefix.Length];
-        using (StreamReader reader = new(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, buffer.Length, leaveOpen: true))
-        {
-            reader.Read(buffer);
-        }
-
-        stream.Position = 0;
-
-        return lfsVersionPrefix.AsSpan().Equals(buffer, StringComparison.Ordinal);
+        string prefix = Encoding.UTF8.GetString(stream.GetBuffer(), 0, lfsVersionPrefix.Length);
+        return prefix == lfsVersionPrefix;
     }
 }

--- a/src/app/GitCommands/Git/GitFileStreamGetter.cs
+++ b/src/app/GitCommands/Git/GitFileStreamGetter.cs
@@ -61,14 +61,16 @@ internal static class GitFileStreamGetter
             await process.StandardOutput.BaseStream.CopyToAsync(smudgedStream, cancellationToken);
             smudgedStream.Position = 0;
 
-            string errorOutput = await process.StandardError.ReadToEndAsync();
+            int exitCode = await process.WaitForExitAsync(cancellationToken);
+
+            string errorOutput = process.StandardError;
             if (!string.IsNullOrWhiteSpace(errorOutput))
             {
                 Trace.WriteLine(errorOutput);
                 return lfsPointerStream;
             }
 
-            if (await process.WaitForExitAsync(cancellationToken) != ExecutionResult.Success)
+            if (exitCode != ExecutionResult.Success)
             {
                 return lfsPointerStream;
             }

--- a/src/app/GitCommands/Git/GitFileStreamGetter.cs
+++ b/src/app/GitCommands/Git/GitFileStreamGetter.cs
@@ -1,0 +1,106 @@
+﻿using System.Diagnostics;
+using System.Text;
+using GitExtensions.Extensibility;
+using GitExtensions.Extensibility.Git;
+using GitExtUtils;
+
+namespace GitCommands.Git;
+
+internal static class GitFileStreamGetter
+{
+    /// <summary>
+    ///  Gets the plain file contents from Git.
+    ///  If the file starts with the version string of a LFS pointer, the LFS Smudge filter is applied.
+    /// </summary>
+    /// <param name="blob">The Git file identifier.</param>
+    /// <param name="gitCommandRunner">The wrapper for the Git executable, which handles file encoding.</param>
+    /// <returns>A <see cref="MemoryStream"/> with the file contents or <see langword="null"/> on error.</returns>
+    public static MemoryStream? GetFileStream(string blob, IGitCommandRunner gitCommandRunner)
+    {
+        try
+        {
+            MemoryStream stream = CatFile(blob, gitCommandRunner);
+            return MightBeLfsPointer(stream)
+                ? ApplyLfsSmudge(stream, gitCommandRunner)
+                : stream;
+        }
+        catch (Exception ex)
+        {
+            Trace.WriteLine(ex);
+            return null;
+        }
+    }
+
+    private static MemoryStream CatFile(string blob, IGitCommandRunner gitCommandRunner)
+    {
+        GitArgumentBuilder args = new("cat-file")
+        {
+                "blob",
+                blob
+        };
+        using IProcess process = gitCommandRunner.RunDetached(CancellationToken.None, args, redirectOutput: true);
+
+        MemoryStream stream = new();
+        process.StandardOutput.BaseStream.CopyTo(stream);
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static MemoryStream ApplyLfsSmudge(MemoryStream lfsPointerStream, IGitCommandRunner gitCommandRunner)
+    {
+        try
+        {
+            GitArgumentBuilder args = new("lfs") { "smudge" };
+            using IProcess process = gitCommandRunner.RunDetached(CancellationToken.None, args, redirectInput: true, redirectOutput: true, throwOnErrorExit: false);
+
+            lfsPointerStream.CopyTo(process.StandardInput.BaseStream);
+            process.StandardInput.Close();
+            lfsPointerStream.Position = 0;
+
+            MemoryStream smudgedStream = new();
+            process.StandardOutput.BaseStream.CopyTo(smudgedStream);
+            smudgedStream.Position = 0;
+
+            string errorOutput = process.StandardError.ReadToEnd();
+            if (!string.IsNullOrWhiteSpace(errorOutput))
+            {
+                Trace.WriteLine(errorOutput);
+                return lfsPointerStream;
+            }
+
+            if (process.WaitForExit() != ExecutionResult.Success)
+            {
+                return lfsPointerStream;
+            }
+
+            lfsPointerStream.Dispose();
+
+            return smudgedStream;
+        }
+        catch (Exception ex)
+        {
+            Trace.WriteLine(ex);
+            return lfsPointerStream;
+        }
+    }
+
+    private static bool MightBeLfsPointer(MemoryStream stream)
+    {
+        const string lfsVersionPrefix = "version https://git-lfs.github.com/spec/v";
+
+        if (stream.Length < lfsVersionPrefix.Length)
+        {
+            return false;
+        }
+
+        char[] buffer = new char[lfsVersionPrefix.Length];
+        using (StreamReader reader = new(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, buffer.Length, leaveOpen: true))
+        {
+            reader.Read(buffer);
+        }
+
+        stream.Position = 0;
+
+        return lfsVersionPrefix.AsSpan().Equals(buffer, StringComparison.Ordinal);
+    }
+}

--- a/src/app/GitCommands/Git/GitFileStreamGetter.cs
+++ b/src/app/GitCommands/Git/GitFileStreamGetter.cs
@@ -15,13 +15,13 @@ internal static class GitFileStreamGetter
     /// <param name="blob">The Git file identifier.</param>
     /// <param name="gitCommandRunner">The wrapper for the Git executable, which handles file encoding.</param>
     /// <returns>A <see cref="MemoryStream"/> with the file contents or <see langword="null"/> on error.</returns>
-    public static MemoryStream? GetFileStream(string blob, IGitCommandRunner gitCommandRunner)
+    public static async Task<MemoryStream?> GetFileStreamAsync(string blob, IGitCommandRunner gitCommandRunner, CancellationToken cancellationToken)
     {
         try
         {
-            MemoryStream stream = CatFile(blob, gitCommandRunner);
+            MemoryStream stream = await CatFileAsync(blob, gitCommandRunner, cancellationToken);
             return MightBeLfsPointer(stream)
-                ? ApplyLfsSmudge(stream, gitCommandRunner)
+                ? await ApplyLfsSmudgeAsync(stream, gitCommandRunner, cancellationToken)
                 : stream;
         }
         catch (Exception ex)
@@ -31,7 +31,7 @@ internal static class GitFileStreamGetter
         }
     }
 
-    private static MemoryStream CatFile(string blob, IGitCommandRunner gitCommandRunner)
+    private static async Task<MemoryStream> CatFileAsync(string blob, IGitCommandRunner gitCommandRunner, CancellationToken cancellationToken)
     {
         GitArgumentBuilder args = new("cat-file")
         {
@@ -41,39 +41,39 @@ internal static class GitFileStreamGetter
         using IProcess process = gitCommandRunner.RunDetached(CancellationToken.None, args, redirectOutput: true);
 
         MemoryStream stream = new();
-        process.StandardOutput.BaseStream.CopyTo(stream);
+        await process.StandardOutput.BaseStream.CopyToAsync(stream, cancellationToken);
         stream.Position = 0;
         return stream;
     }
 
-    private static MemoryStream ApplyLfsSmudge(MemoryStream lfsPointerStream, IGitCommandRunner gitCommandRunner)
+    private static async Task<MemoryStream> ApplyLfsSmudgeAsync(MemoryStream lfsPointerStream, IGitCommandRunner gitCommandRunner, CancellationToken cancellationToken)
     {
         try
         {
             GitArgumentBuilder args = new("lfs") { "smudge" };
             using IProcess process = gitCommandRunner.RunDetached(CancellationToken.None, args, redirectInput: true, redirectOutput: true, throwOnErrorExit: false);
 
-            lfsPointerStream.CopyTo(process.StandardInput.BaseStream);
+            await lfsPointerStream.CopyToAsync(process.StandardInput.BaseStream, cancellationToken);
             process.StandardInput.Close();
             lfsPointerStream.Position = 0;
 
             MemoryStream smudgedStream = new();
-            process.StandardOutput.BaseStream.CopyTo(smudgedStream);
+            await process.StandardOutput.BaseStream.CopyToAsync(smudgedStream, cancellationToken);
             smudgedStream.Position = 0;
 
-            string errorOutput = process.StandardError.ReadToEnd();
+            string errorOutput = await process.StandardError.ReadToEndAsync();
             if (!string.IsNullOrWhiteSpace(errorOutput))
             {
                 Trace.WriteLine(errorOutput);
                 return lfsPointerStream;
             }
 
-            if (process.WaitForExit() != ExecutionResult.Success)
+            if (await process.WaitForExitAsync(cancellationToken) != ExecutionResult.Success)
             {
                 return lfsPointerStream;
             }
 
-            lfsPointerStream.Dispose();
+            await lfsPointerStream.DisposeAsync();
 
             return smudgedStream;
         }

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -3515,28 +3515,7 @@ namespace GitCommands
         }
 
         public MemoryStream? GetFileStream(string blob)
-        {
-            // TODO why return a stream here? should just return a byte[]
-
-            try
-            {
-                GitArgumentBuilder args = new("cat-file")
-                {
-                    "blob",
-                    blob
-                };
-                using IProcess process = _gitCommandRunner.RunDetached(CancellationToken.None, args, redirectOutput: true);
-                MemoryStream stream = new();
-                process.StandardOutput.BaseStream.CopyTo(stream);
-                stream.Position = 0;
-                return stream;
-            }
-            catch (Win32Exception ex)
-            {
-                Trace.WriteLine(ex);
-                return null;
-            }
-        }
+            => GitFileStreamGetter.GetFileStream(blob, _gitCommandRunner);
 
         public IEnumerable<string?> GetPreviousCommitMessages(int count, string revision, string authorPattern)
         {

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -229,7 +229,8 @@ public interface IGitModule
 
     (int TotalCount, Dictionary<string, int> CountByName) GetCommitsByContributor(DateTime? since = null, DateTime? until = null);
 
-    void SaveBlobAs(string saveAs, string blob);
+    void SaveBlobAs(string saveAs, string blob, CancellationToken cancellationToken = default);
+    Task SaveBlobAsAsync(string saveAs, string blob, CancellationToken cancellationToken = default);
     Task<(char Code, ObjectId CommitId)> GetSuperprojectCurrentCheckoutAsync();
     Task<Patch?> GetCurrentChangesAsync(string? fileName, string? oldFileName, bool staged, string extraDiffArguments, Encoding? encoding = null, bool noLocks = false);
     Task<string?> GetFileContentsAsync(GitItemStatus file);
@@ -436,7 +437,7 @@ public interface IGitModule
 
     string GetFileText(ObjectId id, Encoding encoding, bool stripAnsiEscapeCodes);
 
-    MemoryStream? GetFileStream(string blob);
+    Task<MemoryStream?> GetFileStreamAsync(string blob, CancellationToken cancellationToken);
 
     IReadOnlyList<GitItemStatus> GitStatus(UntrackedFilesMode untrackedFilesMode, IgnoreSubmodulesMode ignoreSubmodulesMode = IgnoreSubmodulesMode.None);
 

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1072,7 +1072,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ThreadHelper.FileAndForget(() =>
+            ThreadHelper.FileAndForget(async () =>
             {
                 ObjectId blob = Module.GetFileBlobHash(item.Item.Name, item.SecondRevision.ObjectId);
 
@@ -1083,7 +1083,7 @@ namespace GitUI.CommandsDialogs
 
                 string fileName = PathUtil.GetFileName(item.Item.Name);
                 fileName = (Path.GetTempPath() + fileName).ToNativePath();
-                Module.SaveBlobAs(fileName, blob.ToString());
+                await Module.SaveBlobAsAsync(fileName, blob.ToString());
 
                 onSaved(fileName);
             });

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -404,7 +404,7 @@ See the changes in the commit form.");
                 string fileName = gitItem.FileName.SubstringAfterLast('/').SubstringAfterLast('\\');
 
                 fileName = (Path.GetTempPath() + fileName).ToNativePath();
-                Module.SaveBlobAs(fileName, gitItem.Guid);
+                ThreadHelper.JoinableTaskFactory.Run(() => Module.SaveBlobAsAsync(fileName, gitItem.Guid));
                 return fileName;
             }
 

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -687,7 +687,7 @@ namespace GitUI.Editor
             return ViewItemAsync(
                 file.Name,
                 isSubmodule,
-                getImage: GetImage,
+                getImage: () => ThreadHelper.JoinableTaskFactory.Run(GetImageAsync),
                 getFileText: GetFileTextIfBlobExists,
                 getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha, cache: true),
                 item: item,
@@ -705,11 +705,11 @@ namespace GitUI.Editor
                 return file.TreeGuid is not null ? Module.GetFileText(file.TreeGuid, Encoding, stripAnsiEscapeCodes) : string.Empty;
             }
 
-            Image? GetImage()
+            async Task<Image?> GetImageAsync()
             {
                 try
                 {
-                    using MemoryStream stream = Module.GetFileStream(sha);
+                    using MemoryStream stream = await Module.GetFileStreamAsync(sha, cancellationToken: default);
                     if (stream is not null)
                     {
                         return CreateImage(file.Name, stream);


### PR DESCRIPTION
Fixes #6146
Finishes #6189

## Proposed changes

- Detect LFS pointer files and apply the LFS smudge filter in this case - in order to always get the plain file contents 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/e20a95e3-f6e2-45c6-a724-718f9249aaa8)

### After

![image](https://github.com/user-attachments/assets/9cc781e7-3aa5-40e8-b8b5-cd15511a6030)

## Test methodology <!-- How did you ensure quality? -->

- test repo: https://github.com/mstv/test_lfs
  with LFS-pointer-like files

![image](https://github.com/user-attachments/assets/49d3e7ec-a924-41cf-b62c-a36852f76109)

- created an invalid pointer file, which cannot be pushed to GH

![image](https://github.com/user-attachments/assets/8e7790cd-958e-4f16-805a-875b7ff226fc)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).