### PR TITLE
fix(RevisionDataGridView): Always select a revision

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -484,16 +484,8 @@ namespace GitUI.UserControls.RevisionGrid
 
                 if (_toBeSelectedGraphIndexesCache.Value.Count == 0)
                 {
-                    // Nothing to select or interrupted, select the first shown real commit or the first row (which exists here)
-                    if (SelectedRows.Count == 0)
-                    {
-                        int index = GetFallbackRowIndexToSelect();
-                        Rows[index].Selected = true;
-                        CurrentCell = Rows[index].Cells[1];
-                        EnsureRowVisible(index);
-                    }
-
-                    MarkAsDataLoadingComplete();
+                    // Nothing to select or interrupted
+                    LoadingFinishedWithRevisions();
                     return;
                 }
 
@@ -524,10 +516,24 @@ namespace GitUI.UserControls.RevisionGrid
                     EnsureRowVisible(firstGraphIndex);
                 }
 
-                MarkAsDataLoadingComplete();
+                LoadingFinishedWithRevisions();
             });
 
             return;
+
+            void LoadingFinishedWithRevisions()
+            {
+                // As fallback, select the first shown real commit or the first row (which exists here)
+                if (SelectedRows.Count == 0)
+                {
+                    int index = GetFallbackRowIndexToSelect();
+                    Rows[index].Selected = true;
+                    CurrentCell = Rows[index].Cells[1];
+                    EnsureRowVisible(index);
+                }
+
+                MarkAsDataLoadingComplete();
+            }
 
             int GetFallbackRowIndexToSelect()
             {

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -485,10 +485,13 @@ namespace GitUI.UserControls.RevisionGrid
                 if (_toBeSelectedGraphIndexesCache.Value.Count == 0)
                 {
                     // Nothing to select or interrupted, select the first shown real commit or the first row (which exists here)
-                    int index = GetFallbackRowIndexToSelect();
-                    Rows[index].Selected = true;
-                    CurrentCell = Rows[index].Cells[1];
-                    EnsureRowVisible(index);
+                    if (SelectedRows.Count == 0)
+                    {
+                        int index = GetFallbackRowIndexToSelect();
+                        Rows[index].Selected = true;
+                        CurrentCell = Rows[index].Cells[1];
+                        EnsureRowVisible(index);
+                    }
 
                     MarkAsDataLoadingComplete();
                     return;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -484,7 +484,12 @@ namespace GitUI.UserControls.RevisionGrid
 
                 if (_toBeSelectedGraphIndexesCache.Value.Count == 0)
                 {
-                    // Nothing to select or interrupted
+                    // Nothing to select or interrupted, select the first shown real commit or the first row (which exists here)
+                    int index = GetFallbackRowIndexToSelect();
+                    Rows[index].Selected = true;
+                    CurrentCell = Rows[index].Cells[1];
+                    EnsureRowVisible(index);
+
                     MarkAsDataLoadingComplete();
                     return;
                 }
@@ -518,6 +523,21 @@ namespace GitUI.UserControls.RevisionGrid
 
                 MarkAsDataLoadingComplete();
             });
+
+            return;
+
+            int GetFallbackRowIndexToSelect()
+            {
+                for (int index = 0; index < _revisionGraph.Count; ++index)
+                {
+                    if (_revisionGraph.GetNodeForRow(index)?.GitRevision?.IsArtificial is false)
+                    {
+                        return index;
+                    }
+                }
+
+                return 0;
+            }
         }
 
         public void MarkAsDataLoadingComplete()


### PR DESCRIPTION
Fixes #11782

## Proposed changes

- If no selection can be restored, select the first shown real commit or the first row
- Set `CurrentCell` accordingly, which works wonders!

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(after scrolling down and up again)

![image](https://github.com/user-attachments/assets/e160150f-9d70-404e-8ac6-b6ed99a99334)

### After

![image](https://github.com/user-attachments/assets/eac0c8f4-7ed9-4d8d-8cda-92d89ef62698)

## Test methodology <!-- How did you ensure quality? -->

- manual 

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).