### PR TITLE
chore(dubious ownership): Remove "Trust all repositories" button

### DIFF
--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -284,7 +284,6 @@ namespace GitUI.NBugReports
             pageSecurity.Buttons.Add(openExplorerButton);
 
             AddTrustRepoButton(TranslatedStrings.GitDubiousOwnershipTrustRepository, gitConfigTrustRepoCommand);
-            AddTrustAllReposButton(TranslatedStrings.GitDubiousOwnershipTrustAllRepositories);
 
             TaskDialogButton helpButton = TaskDialogButton.Help;
             helpButton.Click += (_, _) =>
@@ -322,35 +321,6 @@ namespace GitUI.NBugReports
                 {
                     new GitModule(".").GitExecutable.Start(command);
                     ShowGitRepo(OwnerForm, folderPath);
-                };
-
-                pageSecurity.Buttons.Add(button);
-            }
-
-            void AddTrustAllReposButton(string buttonText)
-            {
-                TaskDialogCommandLinkButton button = new(buttonText, allowCloseDialog: false)
-                {
-                    DescriptionText = $"git {ExecutableExtensions.DubiousOwnershipSecurityConfigString} *",
-                };
-
-                button.Click += (_, _) =>
-                {
-                    string tempFile = Path.GetTempFileName();
-                    File.WriteAllText(tempFile, $"{TranslatedStrings.GitDubiousOwnershipTrustAllInstruction}\r\n\r\ngit {ExecutableExtensions.DubiousOwnershipSecurityConfigString} \"*\"");
-
-                    // TODO: if FormEditor ever changed to use the DI, we'll need to configure the container
-                    using FormEditor formEditor = new(new GitUICommands(GitUICommands.EmptyServiceProvider, new GitModule(null)), tempFile, showWarning: false, readOnly: true);
-                    formEditor.ShowDialog();
-
-                    try
-                    {
-                        File.Delete(tempFile);
-                    }
-                    catch
-                    {
-                        // no-op
-                    }
                 };
 
                 pageSecurity.Buttons.Add(button);

--- a/src/app/GitUI/TranslatedStrings.cs
+++ b/src/app/GitUI/TranslatedStrings.cs
@@ -154,19 +154,9 @@ To be able to open this repository, you need to either:
 - add a security exception for the repository to make git trust it, or
 - correct the ownership of the repository.");
         private readonly TranslationString _gitDubiousOwnershipTrustRepository = new("Trust this repository");
-        private readonly TranslationString _gitDubiousOwnershipTrustAllRepositories = new("Trust all repositories");
         private readonly TranslationString _gitDubiousOwnershipOpenRepositoryFolder = new("Open repository in Explorer");
         private readonly TranslationString _gitDubiousOwnershipSeeGitCommandOutput = new("See git command output...");
         private readonly TranslationString _gitDubiousOwnershipHideGitCommandOutput = new("Hide git command output...");
-        private readonly TranslationString _gitDubiousOwnershipTrustAllInstruction = new(@"Git-tracked directories are considered unsafe if they are owned by someone other than the current user.
-By default, Git will refuse to even parse a Git config of a repository owned by someone else, let alone
-run its hooks, and this config setting allows users to specify exceptions, e.g. for intentionally shared
-repositories.
-
-If you wish to trust all git repositories on your system even if they are owned by someone else, run the
-following command.
-
-!!! THIS CAN BE DANGEROUS !!!");
 
         private readonly TranslationString _seeErrorMessage = new("See error message...");
         private readonly TranslationString _hideErrorMessage = new("Hide error message...");
@@ -358,11 +348,9 @@ Copy error details to clipboard?");
         public static string GitDubiousOwnershipHeader => _instance.Value._gitDubiousOwnershipHeader.Text;
         public static string GitDubiousOwnershipText => _instance.Value._gitDubiousOwnershipText.Text;
         public static string GitDubiousOwnershipTrustRepository => _instance.Value._gitDubiousOwnershipTrustRepository.Text;
-        public static string GitDubiousOwnershipTrustAllRepositories => _instance.Value._gitDubiousOwnershipTrustAllRepositories.Text;
         public static string GitDubiousOwnershipOpenRepositoryFolder => _instance.Value._gitDubiousOwnershipOpenRepositoryFolder.Text;
         public static string GitDubiousOwnershipSeeGitCommandOutput => _instance.Value._gitDubiousOwnershipSeeGitCommandOutput.Text;
         public static string GitDubiousOwnershipHideGitCommandOutput => _instance.Value._gitDubiousOwnershipHideGitCommandOutput.Text;
-        public static string GitDubiousOwnershipTrustAllInstruction => _instance.Value._gitDubiousOwnershipTrustAllInstruction.Text;
 
         public static string SeeErrorMessage => _instance.Value._seeErrorMessage.Text;
         public static string HideErrorMessage => _instance.Value._hideErrorMessage.Text;

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -10473,22 +10473,6 @@ To be able to open this repository, you need to either:
 - correct the ownership of the repository.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_gitDubiousOwnershipTrustAllInstruction.Text">
-        <source>Git-tracked directories are considered unsafe if they are owned by someone other than the current user.
-By default, Git will refuse to even parse a Git config of a repository owned by someone else, let alone
-run its hooks, and this config setting allows users to specify exceptions, e.g. for intentionally shared
-repositories.
-
-If you wish to trust all git repositories on your system even if they are owned by someone else, run the
-following command.
-
-!!! THIS CAN BE DANGEROUS !!!</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_gitDubiousOwnershipTrustAllRepositories.Text">
-        <source>Trust all repositories</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_gitDubiousOwnershipTrustRepository.Text">
         <source>Trust this repository</source>
         <target />


### PR DESCRIPTION
Closes #12053

## Proposed changes

- Remove "Trust all repositories" button from `BugReportInvoker.ReportDubiousOwnership`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/9026b47d-9b5d-4139-a150-99ba918b4dfd)

### After

![image](https://github.com/user-attachments/assets/e83963ec-3c86-4961-8f73-dfad95397bf9)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).