### PR TITLE
fix(ProcessWrapper): Provide git error message instead of "External program returned non-zero exit code."

### DIFF
--- a/src/app/GitCommands/AsyncLoader.cs
+++ b/src/app/GitCommands/AsyncLoader.cs
@@ -120,7 +120,7 @@ namespace GitCommands
 
         private bool OnLoadingError(Exception exception)
         {
-            AsyncErrorEventArgs args = new(exception);
+            AsyncErrorEventArgs args = new(exception) { Handled = LoadingError is not null };
             LoadingError?.Invoke(this, args);
             return args.Handled;
         }

--- a/src/app/GitCommands/Git/ExecutableExtensions.cs
+++ b/src/app/GitCommands/Git/ExecutableExtensions.cs
@@ -12,7 +12,6 @@ namespace GitCommands
     /// </summary>
     public static partial class ExecutableExtensions
     {
-        public const string DubiousOwnershipSecurityConfigString = "config --global --add safe.directory";
         private static readonly Lazy<Encoding> _defaultOutputEncoding = new(() => GitModule.SystemEncoding, false);
 
         [GeneratedRegex(@"\u001B[\u0040-\u005F].*?[\u0040-\u007E]", RegexOptions.ExplicitCapture)]
@@ -306,9 +305,7 @@ namespace GitCommands
 
             using IProcess process = executable.Start(arguments, createWindow: false, redirectInput: writeInput is not null, redirectOutput: true, outputEncoding, throwOnErrorExit: throwOnErrorExit, cancellationToken: cancellationToken);
             using MemoryStream outputBuffer = new();
-            using MemoryStream errorBuffer = new();
             Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer, cancellationToken);
-            Task errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer, cancellationToken);
 
             if (writeInput is not null)
             {
@@ -332,35 +329,12 @@ namespace GitCommands
 #endif
 
             // Wait for the process to exit (or be cancelled) and for the output
-            int exitCode;
-            try
-            {
-                exitCode = await process.WaitForExitAsync(cancellationToken);
-                await Task.WhenAll(outputTask, errorTask);
-                cancellationToken.ThrowIfCancellationRequested();
-            }
-            catch (ExternalOperationException ex)
-            {
-                string errorTxt = null;
-                try
-                {
-                    errorTxt = outputEncoding.GetString(errorBuffer.GetBuffer(), 0, (int)errorBuffer.Length);
-                }
-                catch (Exception)
-                {
-                    // We want to ensure that this action won't crash
-                }
-
-                if (errorTxt?.Contains(DubiousOwnershipSecurityConfigString) is true)
-                {
-                    throw new ExternalOperationException(ex.Command, ex.Arguments, ex.WorkingDirectory, ex.ExitCode, new Exception(errorTxt));
-                }
-
-                throw;
-            }
+            int exitCode = await process.WaitForExitAsync(cancellationToken);
+            await outputTask;
+            cancellationToken.ThrowIfCancellationRequested();
 
             string output = CleanString(stripAnsiEscapeCodes, outputEncoding.GetString(outputBuffer.GetBuffer(), 0, (int)outputBuffer.Length));
-            string error = CleanString(stripAnsiEscapeCodes, outputEncoding.GetString(errorBuffer.GetBuffer(), 0, (int)errorBuffer.Length));
+            string error = CleanString(stripAnsiEscapeCodes, process.StandardError);
             if (cache is not null && exitCode == 0)
             {
                 cache.Add(cacheKey, output, error);

--- a/src/app/GitCommands/Git/GitCommandRunner.cs
+++ b/src/app/GitCommands/Git/GitCommandRunner.cs
@@ -22,14 +22,15 @@ namespace GitCommands
             bool createWindow = false,
             bool redirectInput = false,
             bool redirectOutput = false,
-            Encoding? outputEncoding = null)
+            Encoding? outputEncoding = null,
+            bool throwOnErrorExit = true)
         {
             if (outputEncoding is null && redirectOutput)
             {
                 outputEncoding = _defaultEncoding();
             }
 
-            return _gitExecutable.Start(arguments, createWindow, redirectInput, redirectOutput, outputEncoding, cancellationToken: cancellationToken);
+            return _gitExecutable.Start(arguments, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute: false, throwOnErrorExit, cancellationToken);
         }
 
         public void RunDetached(

--- a/src/app/GitCommands/Logging/CommandLog.cs
+++ b/src/app/GitCommands/Logging/CommandLog.cs
@@ -23,9 +23,9 @@ namespace GitCommands.Logging
             _raiseCommandsChanged = raiseCommandsChanged;
         }
 
-        public void LogProcessEnd(int exitCode) => LogProcessEnd(exitCode, ex: null);
+        public void LogProcessEnd(int exitCode, string? error = null) => LogProcessEnd(exitCode, error, ex: null);
 
-        public void LogProcessEnd(Exception ex) => LogProcessEnd(exitCode: null, ex);
+        public void LogProcessEnd(Exception ex) => LogProcessEnd(exitCode: null, error: null, ex);
 
         public void SetProcessId(int processId)
         {
@@ -44,16 +44,17 @@ namespace GitCommands.Logging
         {
             if (_entry.Duration is null)
             {
-                LogProcessEnd();
+                LogProcessEnd(exitCode: null, error: ".NET object disposed", ex: null);
             }
         }
 
-        private void LogProcessEnd(int? exitCode = null, Exception? ex = null)
+        private void LogProcessEnd(int? exitCode, string? error, Exception? ex)
         {
             try
             {
                 _entry.Duration = _stopwatch.Elapsed;
                 _entry.ExitCode = exitCode;
+                _entry.Error = error;
                 _entry.Exception = ex;
                 _raiseCommandsChanged();
             }
@@ -77,6 +78,7 @@ namespace GitCommands.Logging
         public TimeSpan? Duration { get; internal set; }
         public int? ProcessId { get; set; }
         public int? ExitCode { get; set; }
+        public string? Error { get; set; }
         public Exception? Exception { get; set; }
         public StackTrace? CallStack { get; set; }
 
@@ -165,6 +167,7 @@ namespace GitCommands.Logging
                 s.Append("UI Thread?:  ").AppendLine($"{IsOnMainThread}");
                 s.Append("Duration:    ").AppendLine(Duration is not null ? $"{Duration.Value.TotalMilliseconds:0.###} ms" : "still running");
                 s.Append("Exit code:   ").AppendLine(ExitCode is not null ? $"{ExitCode}" : Exception is not null ? $"{Exception}" : "unknown");
+                s.Append("Error:       ").AppendLine(Error is not null ? Error : "not captured");
                 s.Append("Call stack:  ").Append(CallStack is not null ? $"{Environment.NewLine}{CallStack}" : "not captured");
 
                 return s.ToString();

--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -202,7 +202,7 @@ namespace GitCommands
 #if DEBUG
                 Debug.WriteLine($"git {arguments}");
 #endif
-                using IProcess process = _module.GitCommandRunner.RunDetached(cancellationToken, arguments, redirectOutput: true, outputEncoding: null);
+                using IProcess process = _module.GitCommandRunner.RunDetached(cancellationToken, arguments, redirectOutput: true, outputEncoding: null, throwOnErrorExit: false);
 
                 // StandardError.CopyToAsync - done by the IProcess instance - may become unresponsive if lengthy StandardOutput is not consumed in parallel. So, buffer the StandardOutput.
                 using MemoryStream standardOutputBuffer = new();

--- a/src/app/GitExtensions.Extensibility/Git/IGitCommandRunner.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitCommandRunner.cs
@@ -14,7 +14,8 @@ public interface IGitCommandRunner
         bool createWindow = false,
         bool redirectInput = false,
         bool redirectOutput = false,
-        Encoding? outputEncoding = null);
+        Encoding? outputEncoding = null,
+        bool throwOnErrorExit = true);
 
     /// <summary>
     /// Starts git with the given arguments in the background.

--- a/src/app/GitExtensions.Extensibility/IProcess.cs
+++ b/src/app/GitExtensions.Extensibility/IProcess.cs
@@ -31,14 +31,11 @@ public interface IProcess : IDisposable
     StreamReader StandardOutput { get; }
 
     /// <summary>
-    /// Gets an object that facilitates writing to the process's standard error stream.
+    /// Gets the redirected output from the process's standard error stream.
     /// </summary>
-    /// <remarks>
-    /// To access the underlying <see cref="Stream"/>, dereference <see cref="StreamWriter.BaseStream"/>.
-    /// </remarks>
     /// <exception cref="InvalidOperationException">This process's output was not redirected
     /// when calling <see cref="IExecutable.Start"/>.</exception>
-    StreamReader StandardError { get; }
+    string StandardError { get; }
 
     /// <summary>
     /// Kill the process at once.

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
@@ -105,7 +105,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             splitContainer2.Panel2.Controls.Add(LogOutput);
             splitContainer2.Size = new Size(657, 418);
-            splitContainer2.SplitterDistance = 279;
+            splitContainer2.SplitterDistance = 264;
             splitContainer2.TabIndex = 1;
             // 
             // LogItems

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -516,7 +516,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                         }
                         catch (Exception exception)
                         {
-                            if (exception.Message?.Contains(ExecutableExtensions.DubiousOwnershipSecurityConfigString) is true)
+                            if (exception.Message?.Contains(BugReportInvoker.DubiousOwnershipSecurityConfigString) is true)
                             {
                                 BugReportInvoker.Report(exception, isTerminating: false);
                             }

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -14,6 +14,8 @@ namespace GitUI.NBugReports
 {
     public static class BugReportInvoker
     {
+        public const string DubiousOwnershipSecurityConfigString = "config --global --add safe.directory";
+
         private static Form? OwnerForm
             => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
 
@@ -126,7 +128,7 @@ namespace GitUI.NBugReports
 
             ExternalOperationException externalOperationException = exception as ExternalOperationException;
 
-            if (externalOperationException?.InnerException?.Message?.Contains(ExecutableExtensions.DubiousOwnershipSecurityConfigString) is true)
+            if (externalOperationException?.InnerException?.Message?.Contains(DubiousOwnershipSecurityConfigString) is true)
             {
                 ReportDubiousOwnership(externalOperationException.InnerException);
                 return;
@@ -275,9 +277,9 @@ namespace GitUI.NBugReports
                 AllowCancel = true,
                 SizeToContent = true,
             };
-            int startIndex = error.IndexOf(ExecutableExtensions.DubiousOwnershipSecurityConfigString);
+            int startIndex = error.IndexOf(DubiousOwnershipSecurityConfigString);
             string gitConfigTrustRepoCommand = ReplaceRepoPathQuotes(error[startIndex..].Trim());
-            string folderPath = error[(startIndex + ExecutableExtensions.DubiousOwnershipSecurityConfigString.Length + 1)..];
+            string folderPath = error[(startIndex + DubiousOwnershipSecurityConfigString.Length + 1)..];
 
             TaskDialogCommandLinkButton openExplorerButton = new(TranslatedStrings.GitDubiousOwnershipOpenRepositoryFolder, allowCloseDialog: false);
             openExplorerButton.Click += (_, _) => OsShellUtil.OpenWithFileExplorer(PathUtil.ToNativePath(folderPath));

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -131,8 +131,16 @@ namespace GitUI.Blame
             await BlameAuthor.ClearAsync();
             await BlameFile.ClearAsync();
 
-            await _blameLoader.LoadAsync(cancellationToken => _blame = Module.Blame(fileName, objectId.ToString(), encoding, lines: null, cancellationToken: cancellationToken),
-                () => ProcessBlame(fileName, revision, children, controlToMask, line, cancellationToken));
+            try
+            {
+                await _blameLoader.LoadAsync(cancellationToken => _blame = Module.Blame(fileName, objectId.ToString(), encoding, lines: null, cancellationToken: cancellationToken),
+                    () => ProcessBlame(fileName, revision, children, controlToMask, line, cancellationToken));
+            }
+            catch (ExternalOperationException ex)
+            {
+                _blame = null;
+                await BlameFile.ViewTextAsync(fileName, ex.Message);
+            }
         }
 
         private void commitInfo_CommandClicked(object sender, CommandEventArgs e)

--- a/tests/CommonTestUtils/MockExecutable.cs
+++ b/tests/CommonTestUtils/MockExecutable.cs
@@ -113,7 +113,7 @@ namespace CommonTestUtils
             public MockProcess(string? output, int? exitCode = 0, string? error = null)
             {
                 StandardOutput = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(output ?? "")));
-                StandardError = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(error ?? "")));
+                StandardError = error ?? "";
                 StandardInput = new StreamWriter(new MemoryStream());
                 _exitCode = exitCode;
             }
@@ -121,7 +121,7 @@ namespace CommonTestUtils
             public MockProcess()
             {
                 StandardOutput = new StreamReader(new MemoryStream());
-                StandardError = new StreamReader(new MemoryStream());
+                StandardError = "";
                 StandardInput = new StreamWriter(new MemoryStream());
                 _exitCode = 0;
             }
@@ -129,7 +129,7 @@ namespace CommonTestUtils
             private int? _exitCode;
             public StreamWriter StandardInput { get; }
             public StreamReader StandardOutput { get; }
-            public StreamReader StandardError { get; }
+            public string StandardError { get; }
 
             public void Kill(bool entireProcessTree)
             {
@@ -176,7 +176,6 @@ namespace CommonTestUtils
             {
                 // all output should have been read
                 Assert.AreEqual(StandardOutput.BaseStream.Length, StandardOutput.BaseStream.Position);
-                Assert.AreEqual(StandardError.BaseStream.Length, StandardError.BaseStream.Position);
 
                 // Only verify if std input is not closed.
                 // ExecutableExtensions.ExecuteAsync will close std input when writeInput action is specified

--- a/tests/app/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
@@ -224,16 +224,17 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void Error_raised_via_event_when_no_error_handler_installed_does_not_fault_task()
+        public void Error_raised_via_event_when_no_error_handler_installed_faults_task()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                Exception ex = new();
+            Exception ex = new();
 
-                await _loader.LoadAsync(
-                    () => throw ex,
-                    Assert.Fail);
-            });
+            JoinableTask loadTask = ThreadHelper.JoinableTaskFactory.RunAsync(() =>
+                _loader.LoadAsync(
+                    loadContent: () => throw ex,
+                    onLoaded: Assert.Fail));
+
+            Exception oe = Assert.Throws<Exception>(() => loadTask.Join());
+            Assert.AreSame(oe, ex);
         }
 
         [Test]

--- a/tests/app/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
@@ -12,7 +12,7 @@ namespace GitCommandsTests.Git
         private MemoryStream _standardOutputStream;
         private MemoryStream _standardErrorStream;
         private StreamReader _outputStreamReader;
-        private StreamReader _errorStreamReader;
+        private string _errorOutput = "";
         private IProcess _process;
         private IExecutable _executable;
         private AheadBehindDataProvider _provider;
@@ -23,11 +23,10 @@ namespace GitCommandsTests.Git
             _standardOutputStream = new MemoryStream();
             _standardErrorStream = new MemoryStream();
             _outputStreamReader = new StreamReader(_standardOutputStream);
-            _errorStreamReader = new StreamReader(_standardErrorStream);
 
             _process = Substitute.For<IProcess>();
             _process.StandardOutput.Returns(x => _outputStreamReader);
-            _process.StandardError.Returns(x => _errorStreamReader);
+            _process.StandardError.Returns(x => _errorOutput);
 
             _executable = Substitute.For<IExecutable>();
             _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(x => _process);
@@ -41,7 +40,7 @@ namespace GitCommandsTests.Git
             _standardOutputStream?.Dispose();
             _standardErrorStream?.Dispose();
             _outputStreamReader?.Dispose();
-            _errorStreamReader?.Dispose();
+            _process?.Dispose();
         }
 
         [TestCase(null)]

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -282,6 +282,9 @@ namespace GitUITests.UserControls
             GitRevision rev3 = new(ObjectId.Parse(_commit3));
             GitRevision rev2 = new(ObjectId.Parse(_commit2));
 
+            // Avoid InvalidOperationException "The UI Command Source is not available for this control. Are you calling methods before adding it to the parent control?"
+            _blameControl.HideCommitInfo();
+
             await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
@@ -312,6 +315,9 @@ namespace GitUITests.UserControls
             GitRevision rev3 = new(ObjectId.Parse(_commit3));
             GitRevision rev2 = new(ObjectId.Parse(_commit2));
 
+            // Avoid InvalidOperationException "The UI Command Source is not available for this control. Are you calling methods before adding it to the parent control?"
+            _blameControl.HideCommitInfo();
+
             await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
@@ -341,6 +347,9 @@ namespace GitUITests.UserControls
         {
             GitRevision rev1 = new(ObjectId.Parse(_referenceRepository.CommitHash));
 
+            // Avoid InvalidOperationException "The UI Command Source is not available for this control. Are you calling methods before adding it to the parent control?"
+            _blameControl.HideCommitInfo();
+
             await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
@@ -354,6 +363,9 @@ namespace GitUITests.UserControls
         public async Task BlameControlShouldGotoRequestedLineAtStartAndIfReloaded()
         {
             GitRevision rev1 = new(ObjectId.Parse(_referenceRepository.CommitHash));
+
+            // Avoid InvalidOperationException "The UI Command Source is not available for this control. Are you calling methods before adding it to the parent control?"
+            _blameControl.HideCommitInfo();
 
             await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, null, initialLine: 4);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(4);


### PR DESCRIPTION
## Proposed changes

- feat(Git Command Log): Log `StandardError`, too, unless not redirected (initial draft by @gerhardol)
- fix(`ProcessWrapper`): Provide git error message (if any) instead of "External program returned non-zero exit code."
- fix(`ExecutableExtensions.ExecuteAsync`): Remove check for `DubiousOwnershipSecurityConfigString` because that error message is provided by `ProcessWrapper` now 
- fix(`AsyncLoader`): Do not swallow unhandled exceptions
- fix(`BlameControl`): Show git error message and avoid outdated tooltips

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/160d1087-69bf-4318-af05-cb3aad228401)

![image](https://github.com/user-attachments/assets/e0f1e81c-817b-4c78-98b4-14a9e5ee3ffb)   ![image](https://github.com/user-attachments/assets/0b6488b1-99a3-4206-91c0-062f017b030c)

### After

![image](https://github.com/user-attachments/assets/5a910961-bc1f-491a-9b0b-3e408023fcdf)

![image](https://github.com/user-attachments/assets/c0a4a093-dfce-47c0-99ec-1677a76f3ca7)  ![image](https://github.com/user-attachments/assets/8c1d6be4-d926-4fda-8e64-fbb92970dc61)

## Test methodology <!-- How did you ensure quality? -->

- manual
- adapt existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).