### PR TITLE
fix(FormBrowse): Keep file context on deactivation of filter

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -33,8 +33,11 @@ namespace GitUI.CommandsDialogs
                     path = path[1..^1];
                 }
 
-                revisionDiff.FallbackFollowedFile = path;
-                fileTree.FallbackFollowedFile = path;
+                if (!string.IsNullOrWhiteSpace(path))
+                {
+                    revisionDiff.FallbackFollowedFile = path;
+                    fileTree.FallbackFollowedFile = path;
+                }
             };
 
             bool firstTimeInFileHistoryMode = isFileHistoryMode;


### PR DESCRIPTION
Fixes UX issue
mentioned in https://github.com/gitextensions/gitextensions/issues/10946#issuecomment-2483313002

## Proposed changes

- `FormBrowse`: Set `FallbackFollowedFile` of "Diff" and "File tree" only if not empty
  in order to not loose the file context ("last clicked file")

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).