### PR TITLE
fix(blame previous): Remove restriction to availibility of the actual revision

### DIFF
--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -273,7 +273,7 @@ Click this info icon for more details.</source>
   <file datatype="plaintext" original="BlameControl" source-language="en">
     <body>
       <trans-unit id="_blameActualPreviousRevision.Text">
-        <source>&amp;Blame previous actual revision</source>
+        <source>&amp;Blame previous revision</source>
         <target />
       </trans-unit>
       <trans-unit id="_blameVisiblePreviousRevision.Text">

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -272,8 +272,16 @@ Click this info icon for more details.</source>
   </file>
   <file datatype="plaintext" original="BlameControl" source-language="en">
     <body>
+      <trans-unit id="_blameActualPreviousRevision.Text">
+        <source>&amp;Blame actual previous revision</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_blameVisiblePreviousRevision.Text">
+        <source>&amp;Blame visible previous revision</source>
+        <target />
+      </trans-unit>
       <trans-unit id="allCommitInfoToolStripMenuItem.Text">
-        <source>All commit info</source>
+        <source>&amp;All commit info</source>
         <target />
       </trans-unit>
       <trans-unit id="blamePreviousRevisionToolStripMenuItem.Text">
@@ -281,23 +289,23 @@ Click this info icon for more details.</source>
         <target />
       </trans-unit>
       <trans-unit id="blameRevisionToolStripMenuItem.Text">
-        <source>Blame this revision</source>
+        <source>Blame &amp;this revision</source>
         <target />
       </trans-unit>
       <trans-unit id="commitHashToolStripMenuItem.Text">
-        <source>Commit hash</source>
+        <source>Commit &amp;hash</source>
         <target />
       </trans-unit>
       <trans-unit id="commitMessageToolStripMenuItem.Text">
-        <source>Commit message</source>
+        <source>Commit &amp;message</source>
         <target />
       </trans-unit>
       <trans-unit id="copyToClipboardToolStripMenuItem.Text">
-        <source>Copy to clipboard</source>
+        <source>&amp;Copy to clipboard</source>
         <target />
       </trans-unit>
       <trans-unit id="showChangesToolStripMenuItem.Text">
-        <source>Show changes</source>
+        <source>&amp;Show changes</source>
         <target />
       </trans-unit>
     </body>

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -273,11 +273,11 @@ Click this info icon for more details.</source>
   <file datatype="plaintext" original="BlameControl" source-language="en">
     <body>
       <trans-unit id="_blameActualPreviousRevision.Text">
-        <source>&amp;Blame actual previous revision</source>
+        <source>&amp;Blame previous actual revision</source>
         <target />
       </trans-unit>
       <trans-unit id="_blameVisiblePreviousRevision.Text">
-        <source>&amp;Blame visible previous revision</source>
+        <source>&amp;Blame previous visible revision</source>
         <target />
       </trans-unit>
       <trans-unit id="allCommitInfoToolStripMenuItem.Text">

--- a/src/app/GitUI/UserControls/BlameControl.Designer.cs
+++ b/src/app/GitUI/UserControls/BlameControl.Designer.cs
@@ -121,7 +121,7 @@
             blameRevisionToolStripMenuItem.Image = Properties.Resources.Blame;
             blameRevisionToolStripMenuItem.Name = "blameRevisionToolStripMenuItem";
             blameRevisionToolStripMenuItem.Size = new Size(199, 22);
-            blameRevisionToolStripMenuItem.Text = "Blame this revision";
+            blameRevisionToolStripMenuItem.Text = "Blame &this revision";
             blameRevisionToolStripMenuItem.Click += blameRevisionToolStripMenuItem_Click;
             // 
             // blamePreviousRevisionToolStripMenuItem
@@ -137,7 +137,7 @@
             showChangesToolStripMenuItem.Image = Properties.Resources.information;
             showChangesToolStripMenuItem.Name = "showChangesToolStripMenuItem";
             showChangesToolStripMenuItem.Size = new Size(238, 22);
-            showChangesToolStripMenuItem.Text = "Show changes";
+            showChangesToolStripMenuItem.Text = "&Show changes";
             showChangesToolStripMenuItem.Click += showChangesToolStripMenuItem_Click;
             // 
             // copyToClipboardToolStripMenuItem
@@ -149,14 +149,14 @@
             copyToClipboardToolStripMenuItem.Image = Properties.Resources.CopyToClipboard;
             copyToClipboardToolStripMenuItem.Name = "copyToClipboardToolStripMenuItem";
             copyToClipboardToolStripMenuItem.Size = new Size(199, 22);
-            copyToClipboardToolStripMenuItem.Text = "Copy to clipboard";
+            copyToClipboardToolStripMenuItem.Text = "&Copy to clipboard";
             // 
             // commitHashToolStripMenuItem
             // 
             commitHashToolStripMenuItem.Image = Properties.Resources.CommitId;
             commitHashToolStripMenuItem.Name = "commitHashToolStripMenuItem";
             commitHashToolStripMenuItem.Size = new Size(180, 22);
-            commitHashToolStripMenuItem.Text = "Commit hash";
+            commitHashToolStripMenuItem.Text = "Commit &hash";
             commitHashToolStripMenuItem.Click += copyCommitHashToClipboardToolStripMenuItem_Click;
             // 
             // commitMessageToolStripMenuItem
@@ -164,7 +164,7 @@
             commitMessageToolStripMenuItem.Image = Properties.Resources.Message;
             commitMessageToolStripMenuItem.Name = "commitMessageToolStripMenuItem";
             commitMessageToolStripMenuItem.Size = new Size(180, 22);
-            commitMessageToolStripMenuItem.Text = "Commit message";
+            commitMessageToolStripMenuItem.Text = "Commit &message";
             commitMessageToolStripMenuItem.Click += copyLogMessageToolStripMenuItem_Click;
             // 
             // allCommitInfoToolStripMenuItem
@@ -172,7 +172,7 @@
             allCommitInfoToolStripMenuItem.Image = Properties.Resources.CommitSummary;
             allCommitInfoToolStripMenuItem.Name = "allCommitInfoToolStripMenuItem";
             allCommitInfoToolStripMenuItem.Size = new Size(180, 22);
-            allCommitInfoToolStripMenuItem.Text = "All commit info";
+            allCommitInfoToolStripMenuItem.Text = "&All commit info";
             allCommitInfoToolStripMenuItem.Click += copyAllCommitInfoToClipboardToolStripMenuItem_Click;
             // 
             // BlameFile

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -47,8 +47,8 @@ namespace GitUI.Blame
         private bool _changingScrollPosition;
         private IRepositoryHostPlugin? _gitHoster;
         private static readonly IList<Color> AgeBucketGradientColors = GetAgeBucketGradientColors();
-        private static readonly TranslationString _blameActualPreviousRevision = new("&Blame actual previous revision");
-        private static readonly TranslationString _blameVisiblePreviousRevision = new("&Blame visible previous revision");
+        private static readonly TranslationString _blameActualPreviousRevision = new("&Blame previous actual revision");
+        private static readonly TranslationString _blameVisiblePreviousRevision = new("&Blame previous visible revision");
         private readonly IGitRevisionSummaryBuilder _gitRevisionSummaryBuilder;
         private readonly IGitBlameParser _gitBlameParser;
 

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -47,7 +47,7 @@ namespace GitUI.Blame
         private bool _changingScrollPosition;
         private IRepositoryHostPlugin? _gitHoster;
         private static readonly IList<Color> AgeBucketGradientColors = GetAgeBucketGradientColors();
-        private static readonly TranslationString _blameActualPreviousRevision = new("&Blame previous actual revision");
+        private static readonly TranslationString _blameActualPreviousRevision = new("&Blame previous revision");
         private static readonly TranslationString _blameVisiblePreviousRevision = new("&Blame previous visible revision");
         private readonly IGitRevisionSummaryBuilder _gitRevisionSummaryBuilder;
         private readonly IGitBlameParser _gitBlameParser;


### PR DESCRIPTION
Fixes #10946

## Proposed changes

`BlameControl`
- Remove restriction to availibility of the actual revision
- Use visible previous revision instead

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

context menu item disabled

### After

context menu item enabled if there is shown a (virtual) parent

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).