### PR TITLE
fix(PatchProcessor): Fixup encoding for diff text

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -68,7 +68,7 @@ namespace GitCommands
         [GeneratedRegex(@"(\\(?<octal>[0-7]{3}))+", RegexOptions.ExplicitCapture)]
         private static partial Regex EscapedOctalCodePointRegex();
 
-        [GeneratedRegex(@"^(?<code>[ -+U])(?<sha>[0-9a-f]{40}) (?<path>.+) \((?<branch>.+)\)$", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"^(?<code>[\-+U ])(?<sha>[0-9a-f]{40}) (?<path>.+) \((?<branch>.+)\)$", RegexOptions.ExplicitCapture)]
         private static partial Regex ShaRegex();
 
         [GeneratedRegex(@"^\s*(?<count>\d+)\s+(?<name>.*)$", RegexOptions.ExplicitCapture)]

--- a/src/app/GitCommands/Patches/PatchProcessor.cs
+++ b/src/app/GitCommands/Patches/PatchProcessor.cs
@@ -39,7 +39,7 @@ namespace GitCommands.Patches
         [GeneratedRegex(@$"(---|\+\+\+) [""]?[^/\s]+/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)]
         private static partial Regex FileNameRegex();
 
-        [GeneratedRegex(@$"^({_escapeSequenceRegex})?[-+@ ]", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@$"^({_escapeSequenceRegex})?[\-+@ ]", RegexOptions.ExplicitCapture)]
         private static partial Regex StartOfContentsRegex();
 
         /// <summary>

--- a/src/app/GitCommands/Patches/PatchProcessor.cs
+++ b/src/app/GitCommands/Patches/PatchProcessor.cs
@@ -39,7 +39,7 @@ namespace GitCommands.Patches
         [GeneratedRegex(@$"(---|\+\+\+) [""]?[^/\s]+/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)]
         private static partial Regex FileNameRegex();
 
-        [GeneratedRegex(@$"^({_escapeSequenceRegex})?[ -+@]", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@$"^({_escapeSequenceRegex})?[-+@ ]", RegexOptions.ExplicitCapture)]
         private static partial Regex StartOfContentsRegex();
 
         /// <summary>

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_Text_ChangeFile_filesContentEncoding=System.Text.ASCIIEncoding+ASCIIEncodingSealed.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_Text_ChangeFile_filesContentEncoding=System.Text.ASCIIEncoding+ASCIIEncodingSealed.verified.json
@@ -1,0 +1,11 @@
+﻿[
+  {
+    "Header": "diff --git a/old.txt b/new.txt",
+    "Index": "index cb36533..5550a88 100644",
+    "FileType": "Text",
+    "FileNameA": "old.txt",
+    "FileNameB": "new.txt",
+    "ChangeType": "ChangeFile",
+    "Text": "diff --git a/old.txt b/new.txt\nindex cb36533..5550a88 100644\n--- a/old.txt\n+++ b/new.txt\n\u001b[7;37m@@ -1 +1 @@\u001b[m\n\u001b[7;31m-?? ????????\u001b[m\n\u001b[7;32m+\u001b[m\u001b[7;32mA ????????\u001b[m"
+  }
+]

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_Text_ChangeFile_filesContentEncoding=System.Text.Latin1Encoding+Latin1EncodingSealed.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_Text_ChangeFile_filesContentEncoding=System.Text.Latin1Encoding+Latin1EncodingSealed.verified.json
@@ -1,0 +1,11 @@
+﻿[
+  {
+    "Header": "diff --git a/old.txt b/new.txt",
+    "Index": "index cb36533..5550a88 100644",
+    "FileType": "Text",
+    "FileNameA": "old.txt",
+    "FileNameB": "new.txt",
+    "ChangeType": "ChangeFile",
+    "Text": "diff --git a/old.txt b/new.txt\nindex cb36533..5550a88 100644\n--- a/old.txt\n+++ b/new.txt\n\u001b[7;37m@@ -1 +1 @@\u001b[m\n\u001b[7;31m-Ð ÐÐÐÐ\u001b[m\n\u001b[7;32m+\u001b[m\u001b[7;32mA ÐÐÐÐ\u001b[m"
+  }
+]

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_Text_ChangeFile_filesContentEncoding=System.Text.UTF8Encoding+UTF8EncodingSealed.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_Text_ChangeFile_filesContentEncoding=System.Text.UTF8Encoding+UTF8EncodingSealed.verified.json
@@ -1,0 +1,11 @@
+﻿[
+  {
+    "Header": "diff --git a/old.txt b/new.txt",
+    "Index": "index cb36533..5550a88 100644",
+    "FileType": "Text",
+    "FileNameA": "old.txt",
+    "FileNameB": "new.txt",
+    "ChangeType": "ChangeFile",
+    "Text": "diff --git a/old.txt b/new.txt\nindex cb36533..5550a88 100644\n--- a/old.txt\n+++ b/new.txt\n\u001b[7;37m@@ -1 +1 @@\u001b[m\n\u001b[7;31m-И ПОКА\u001b[m\n\u001b[7;32m+\u001b[m\u001b[7;32mA ПОКА\u001b[m"
+  }
+]

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.cs
@@ -1,3 +1,4 @@
+﻿using System.Collections;
 using System.Text;
 using GitCommands;
 using GitCommands.Patches;
@@ -240,6 +241,41 @@ index cdf8bebba,55ff37bb9..000000000
                 patchText.Append(line).Append("\n");
                 patchOutput.Append(GitModule.ReEncodeString(line, Encoding.UTF8, GitModule.LosslessEncoding));
                 patchOutput.Append("\n");
+            }
+        }
+
+        [TestCaseSource(typeof(CreatePatchFromStringTestData), nameof(CreatePatchFromStringTestData.TestCases))]
+        public async Task CreatePatchFromString_Text_ChangeFile(Encoding filesContentEncoding)
+        {
+            const char escape = '\u001b';
+            string patchText = $"""
+                From 42a3043eafe08409c55b48c36661cf6cf3055c68 Mon Sep 17 00:00:00 2001
+                From: Some One <else@mail.net>
+                Date: Mon, 2 Sep 2024 17:42:00 +0200
+                Subject: Patch for test
+
+                ---
+                {escape}[1mdiff --git a/old.txt b/new.txt{escape}[m
+                {escape}[1mindex cb36533..5550a88 100644{escape}[m
+                {escape}[1m--- a/old.txt{escape}[m
+                {escape}[1m+++ b/new.txt{escape}[m
+                {escape}[7;37m@@ -1 +1 @@{escape}[m
+                {escape}[7;31m-Ð ÐÐÐÐ{escape}[m
+                {escape}[7;32m+{escape}[m{escape}[7;32mA ÐÐÐÐ{escape}[m
+                """.Replace("\r\n", "\n");
+            await Verifier.Verify(PatchProcessor.CreatePatchesFromString(patchText, new Lazy<Encoding>(filesContentEncoding)));
+        }
+
+        public class CreatePatchFromStringTestData
+        {
+            public static IEnumerable TestCases
+            {
+                get
+                {
+                    yield return new TestCaseData(Encoding.UTF8);
+                    yield return new TestCaseData(Encoding.ASCII);
+                    yield return new TestCaseData(Encoding.Latin1);
+                }
             }
         }
 

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/testdata/color-prefix.diff
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/testdata/color-prefix.diff
@@ -17,7 +17,7 @@
 [31m-        private static partial Regex DiffCommandRegex();[m
 [31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}diff --(cc|combined) [""]?(?<filenamea>.*?)[""]?{_escapeSequenceRegex}$", RegexOptions.ExplicitCapture)][m
 [31m-        private static partial Regex CombinedDiffCommandRegex();[m
-[31m-        [GeneratedRegex(@$"{_escapeSequenceRegex}[-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?{_escapeSequenceRegex}", RegexOptions.ExplicitCapture)][m
+[31m-        [GeneratedRegex(@$"{_escapeSequenceRegex}[\-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?{_escapeSequenceRegex}", RegexOptions.ExplicitCapture)][m
 [32m+[m
 [32m+[m[32m        // diff --git a/GitCommands/CommitInformationTest.cs b/GitCommands/CommitInformationTest.cs[m
 [32m+[m[32m        // diff --git b/Benchmarks/App.config a/Benchmarks/App.config[m
@@ -28,13 +28,13 @@
 [32m+[m[32m        ////private static partial Regex DiffCommandRegex();[m
 [32m+[m[32m        ////[GeneratedRegex(@$"^diff --(cc|combined) [""]?(?<filenamea>.*?)[""]?$", RegexOptions.ExplicitCapture)][m
 [32m+[m[32m        ////private static partial Regex CombinedDiffCommandRegex();[m
-[32m+[m[32m        [GeneratedRegex(@$"[-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        [GeneratedRegex(@$"[\-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)][m
          private static partial Regex FileNameRegex();[m
 [31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}(?<line>,*)", RegexOptions.ExplicitCapture)][m
 [31m-        private static partial Regex StartOfLineRegex();[m
 [32m+[m[32m        [GeneratedRegex(@$"^@@", RegexOptions.ExplicitCapture)][m
 [32m+[m[32m        private static partial Regex StartOfChunkRegex();[m
-         [GeneratedRegex(@$"^{_escapeSequenceRegex}?[ -+@]", RegexOptions.ExplicitCapture)][m
+         [GeneratedRegex(@$"^{_escapeSequenceRegex}?[\-+@ ]", RegexOptions.ExplicitCapture)][m
          private static partial Regex StartOfContentsRegex();[m
 [31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}?@@", RegexOptions.ExplicitCapture)][m
 [31m-        private static partial Regex StartOfChunkRegex();[m

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/testdata/color.diff
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/testdata/color.diff
@@ -17,7 +17,7 @@
 [31m-        private static partial Regex DiffCommandRegex();[m
 [31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}diff --(cc|combined) [""]?(?<filenamea>.*?)[""]?{_escapeSequenceRegex}$", RegexOptions.ExplicitCapture)][m
 [31m-        private static partial Regex CombinedDiffCommandRegex();[m
-[31m-        [GeneratedRegex(@$"{_escapeSequenceRegex}[-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?{_escapeSequenceRegex}", RegexOptions.ExplicitCapture)][m
+[31m-        [GeneratedRegex(@$"{_escapeSequenceRegex}[\-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?{_escapeSequenceRegex}", RegexOptions.ExplicitCapture)][m
 [32m+[m
 [32m+[m[32m        // diff --git a/GitCommands/CommitInformationTest.cs b/GitCommands/CommitInformationTest.cs[m
 [32m+[m[32m        // diff --git b/Benchmarks/App.config a/Benchmarks/App.config[m
@@ -28,13 +28,13 @@
 [32m+[m[32m        ////private static partial Regex DiffCommandRegex();[m
 [32m+[m[32m        ////[GeneratedRegex(@$"^diff --(cc|combined) [""]?(?<filenamea>.*?)[""]?$", RegexOptions.ExplicitCapture)][m
 [32m+[m[32m        ////private static partial Regex CombinedDiffCommandRegex();[m
-[32m+[m[32m        [GeneratedRegex(@$"[-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        [GeneratedRegex(@$"[\-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)][m
          private static partial Regex FileNameRegex();[m
 [31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}(?<line>,*)", RegexOptions.ExplicitCapture)][m
 [31m-        private static partial Regex StartOfLineRegex();[m
 [32m+[m[32m        [GeneratedRegex(@$"^@@", RegexOptions.ExplicitCapture)][m
 [32m+[m[32m        private static partial Regex StartOfChunkRegex();[m
-         [GeneratedRegex(@$"^{_escapeSequenceRegex}?[ -+@]", RegexOptions.ExplicitCapture)][m
+         [GeneratedRegex(@$"^{_escapeSequenceRegex}?[\-+@ ]", RegexOptions.ExplicitCapture)][m
          private static partial Regex StartOfContentsRegex();[m
 [31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}?@@", RegexOptions.ExplicitCapture)][m
 [31m-        private static partial Regex StartOfChunkRegex();[m


### PR DESCRIPTION
Fixes #12066

## Proposed changes

- `PatchProcessor.StartOfContentsRegex`: Move `'-'` to first position inside `"[ -+@]"` in order to avoid special meaning in regex.
  This made `CreatePatchFromString` choose the wrong encoding for removed line.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/bd128b9c-a56c-406f-b5d4-784a6824fe7c)

### After

![image](https://github.com/user-attachments/assets/10d17554-103c-467f-92ef-39dee678dc9a)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).