### PR TITLE
fix(File History): Correctly quote filename

### DIFF
--- a/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
+++ b/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
@@ -160,7 +160,7 @@ namespace GitCommands.DiffMergeTools
             else
             {
                 // query static settings for defined fullPath to executable
-                string? command = UnquoteString(GetToolSetting(diffTool.Name, DiffMergeToolType.Merge, "path"));
+                string? command = GetToolSetting(diffTool.Name, DiffMergeToolType.Merge, "path")?.RemoveQuotes();
                 if (!string.IsNullOrWhiteSpace(command))
                 {
                     fullPath = command;
@@ -219,22 +219,6 @@ namespace GitCommands.DiffMergeTools
             return string.IsNullOrWhiteSpace(toolName) ?
                 string.Empty :
                 _getFileSettings()?.GetValue(string.Concat(prefix, ".", toolName, ".", settingSuffix));
-        }
-
-        private static string? UnquoteString(string? str)
-        {
-            if (string.IsNullOrEmpty(str))
-            {
-                return str;
-            }
-
-            int length = str.Length;
-            if (length > 1 && str[0] == '\"' && str[length - 1] == '\"')
-            {
-                str = str.Substring(1, length - 2);
-            }
-
-            return str;
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/app/GitCommands/StringExtensions.cs
+++ b/src/app/GitCommands/StringExtensions.cs
@@ -181,10 +181,20 @@ namespace System
         }
 
         /// <summary>
-        /// Quotes this string if it is not null and not empty.
+        ///  Quotes this string if it is neither null nor empty nor quoted.
         /// </summary>
         [Pure]
-        [return: NotNullIfNotNull("s")]
+        [return: NotNullIfNotNull(nameof(s))]
+        public static string? QuoteIfNotQuotedAndNE(this string? s, string quote = "\"")
+        {
+            return string.IsNullOrEmpty(s) || s.StartsWith(quote) ? s : s.Quote(quote);
+        }
+
+        /// <summary>
+        ///  Quotes this string if it is not null and not empty.
+        /// </summary>
+        [Pure]
+        [return: NotNullIfNotNull(nameof(s))]
         public static string? QuoteNE(this string? s)
         {
             return string.IsNullOrEmpty(s) ? s : s.Quote();
@@ -203,10 +213,10 @@ namespace System
         }
 
         /// <summary>
-        /// Adds parentheses if string is not null and not empty.
+        ///  Adds parentheses if string is not null and not empty.
         /// </summary>
         [Pure]
-        [return: NotNullIfNotNull("s")]
+        [return: NotNullIfNotNull(nameof(s))]
         public static string? AddParenthesesNE(this string? s)
         {
             return string.IsNullOrEmpty(s) ? s : "(" + s + ")";
@@ -224,7 +234,7 @@ namespace System
         }
 
         [Pure]
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static string? RemoveLines(this string? value, Func<string, bool> shouldRemoveLine)
         {
             if (string.IsNullOrEmpty(value))
@@ -248,6 +258,20 @@ namespace System
             }
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        ///  Returns the string with quotes removed from start and end (if they existed).
+        /// </summary>
+        [Pure]
+        public static string RemoveQuotes(this string str, char quote = '"')
+        {
+            if (str.Length >= 2 && str[0] == quote && str[^1] == quote)
+            {
+                return str[1..^1];
+            }
+
+            return str;
         }
 
         /// <summary>

--- a/src/app/GitCommands/StringExtensions.cs
+++ b/src/app/GitCommands/StringExtensions.cs
@@ -264,9 +264,10 @@ namespace System
         ///  Returns the string with quotes removed from start and end (if they existed).
         /// </summary>
         [Pure]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string RemoveQuotes(this string str, char quote = '"')
         {
-            if (str.Length >= 2 && str[0] == quote && str[^1] == quote)
+            if (str?.Length is >= 2 && str[0] == quote && str[^1] == quote)
             {
                 return str[1..^1];
             }

--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs
 
         private BuildReportTabPageExtension? _buildReportTabPageExtension;
 
-        private string FileName { get; set; }
+        private string FileName { get; init; }
 
         /// <summary>
         /// Open FileHistory form.
@@ -79,7 +79,11 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.ShowBuildServerInfo = true;
             RevisionGrid.FilePathByObjectId = [];
 
-            FileName = fileName;
+            // Replace windows path separator to Linux path separator.
+            // This is needed to keep the file history working when started from file tree in
+            // browse dialog.
+            FileName = fileName.RemoveQuotes().ToPosixPath();
+
             SetTitle();
 
             Diff.ExtraDiffArgumentsChanged += (sender, e) => UpdateSelectedFileViewers();
@@ -212,12 +216,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            // Replace windows path separator to Linux path separator.
-            // This is needed to keep the file history working when started from file tree in
-            // browse dialog.
-            FileName = FileName.ToPosixPath();
-
-            RevisionGrid.SetAndApplyPathFilter(FileName);
+            RevisionGrid.SetAndApplyPathFilter(FileName.Quote());
         }
 
         private string? GetFileNameForRevision(GitRevision rev)
@@ -266,7 +265,7 @@ namespace GitUI.CommandsDialogs
             IReadOnlyList<ObjectId> children = RevisionGrid.GetRevisionChildren(revision.ObjectId);
             string fileName = GetFileNameForRevision(revision) ?? FileName;
 
-            SetTitle(fileName);
+            SetTitle(alternativeFileName: fileName);
 
             TabPage preferredTab = null;
             if (revision.IsArtificial)
@@ -282,7 +281,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            if (fileName.EndsWith("/"))
+            if (fileName.EndsWith('/'))
             {
                 // Note that artificial commits for object type tree (folder) will be handled here too,
                 // i.e. no tab at all is visible
@@ -299,7 +298,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            if (revision.IsArtificial || fileName.EndsWith("/"))
+            if (revision.IsArtificial || fileName.EndsWith('/'))
             {
                 BlameTab.Parent = null;
                 ViewTab.Parent = null;

--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -79,7 +79,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.ShowBuildServerInfo = true;
             RevisionGrid.FilePathByObjectId = [];
 
-            // Replace windows path separator to Linux path separator.
+            // Replace Windows path separator to Linux path separator.
             // This is needed to keep the file history working when started from file tree in
             // browse dialog.
             FileName = fileName.RemoveQuotes().ToPosixPath();

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1202,7 +1202,7 @@ namespace GitUI
                     "--follow",
                     FindRenamesAndCopiesOpts(),
                     "--",
-                    path
+                    path.QuoteIfNotQuotedAndNE()
                 };
 
                 HashSet<string?> setOfFileNames = [];
@@ -1580,7 +1580,7 @@ namespace GitUI
                 objectId.ToString(),
                 "--max-count=1",
                 "--",
-                path,
+                path.QuoteIfNotQuotedAndNE(),
             };
 
             return ParseFileNames(args, cancellationToken: default).FirstOrDefault();

--- a/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
@@ -168,6 +168,7 @@
             Assert.AreEqual(expected, str.QuoteIfNotQuotedAndNE());
         }
 
+        [TestCase(null, null)]
         [TestCase("", "")]
         [TestCase("\"", "\"")]
         [TestCase("\"\"", "")]

--- a/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/StringExtensionTests.cs
@@ -148,5 +148,40 @@
         {
             Assert.AreEqual(expected, s.EscapeForCommandLine(forWindows));
         }
+
+        [TestCase(null, null)]
+        [TestCase("", "")]
+        [TestCase(" \"", "\" \\\"\"")]
+        [TestCase("\"\"", "\"\"")]
+        [TestCase("file", "\"file\"")]
+        [TestCase("\"file", "\"file")]
+        [TestCase("\"file\"", "\"file\"")]
+        [TestCase("file with spaces", "\"file with spaces\"")]
+        [TestCase("\"file with spaces", "\"file with spaces")]
+        [TestCase("\"file with spaces\"", "\"file with spaces\"")]
+        [TestCase("wei\"rd", "\"wei\\\"rd\"")]
+        [TestCase("\"wei\"rd\"", "\"wei\"rd\"")]
+        [TestCase("weird\"", "\"weird\\\"\"")]
+
+        public void QuoteIfUnquotedAndNE(string? str, string? expected)
+        {
+            Assert.AreEqual(expected, str.QuoteIfNotQuotedAndNE());
+        }
+
+        [TestCase("", "")]
+        [TestCase("\"", "\"")]
+        [TestCase("\"\"", "")]
+        [TestCase("\" \"\"", " \"")]
+        [TestCase("\" \\\"", " \\")]
+        [TestCase("\" \\\"\"", " \\\"")]
+        [TestCase("\"file\"", "file")]
+        [TestCase("\"file", "\"file")]
+        [TestCase("file\"", "file\"")]
+        [TestCase("\"file with spaces\"", "file with spaces")]
+
+        public void RemoveQuotes(string? str, string? expected)
+        {
+            Assert.AreEqual(expected, str.RemoveQuotes());
+        }
     }
 }

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RevisionFileNameTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RevisionFileNameTests.cs
@@ -46,7 +46,7 @@ public class RevisionFileNameTests
     {
         const string path = "a.txt";
         string actualFileName;
-        string line = $"-c log.showSignature=false log --format=\"????%H\" --name-only --follow --diff-merges=separate  --find-renames --find-copies {objectId} --max-count=1 -- a.txt";
+        string line = $"-c log.showSignature=false log --format=\"????%H\" --name-only --follow --diff-merges=separate  --find-renames --find-copies {objectId} --max-count=1 -- \"a.txt\"";
 
         bool originalFollowRenamesInFileHistoryExactOnly = AppSettings.FollowRenamesInFileHistoryExactOnly;
         AppSettings.FollowRenamesInFileHistoryExactOnly = false;


### PR DESCRIPTION
Fixes
part of #12088

## Proposed changes

- `FormFileHistory` and `RevisionGridControl`: Correctly quote filename
- Factor out `DiffMergeToolConfigurationManager.UnquoteString` to `StringExtensions.RemoveQuotes`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual: check Git Command Log
- add & adapt testcases

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).