### PR TITLE
fix(File History): Indicate not identifiable file

### DIFF
--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -4689,6 +4689,10 @@ If you are not sure just close this window.</source>
         <source>Build Report</source>
         <target />
       </trans-unit>
+      <trans-unit id="_fileNotFound.Text">
+        <source> - Git could not identify the file {0}</source>
+        <target />
+      </trans-unit>
       <trans-unit id="blameSettingsToolStripMenuItem.Text">
         <source>Blame settings:</source>
         <target />


### PR DESCRIPTION
Improves UX on #12088, which is basically a git issue

## Proposed changes

`FormFileHistory`:
- Hide tabs "Diff", "View" and "Blame" if Git cannot identify the file blob, e.g. because it was deleted, or was renamed in an not merged branch 
- Show an error message in the "Commit" tab title, i.e. in the place where the tabs disappear
- Remove unused `FormFileHistoryController` instance

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/aef7a2d7-ac2d-49ae-9212-49c4ebe5124c)

![image](https://github.com/user-attachments/assets/cc52b19d-a60c-46db-b8e7-7104a2802a62)

![image](https://github.com/user-attachments/assets/cac7c09a-ca78-465d-8943-1bdc3378d389)

### After

![image](https://github.com/user-attachments/assets/feb9e80d-ad59-48af-b2cb-f698bfdcda82)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).