### PR TITLE
fix(GetTagMessage): Do not truncate last line

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -3119,25 +3119,13 @@ namespace GitCommands
             }
 
             string output = exec.StandardOutput;
-            string[] messageLines = output.Split(
-                new string[] { "\r\n", "\r", "\n" },
-                StringSplitOptions.None);
+            string[] messageLines = output.Split(Delimiters.NewLines, StringSplitOptions.None);
 
-            if (messageLines.Length <= StandardCatFileTagHeaderLength)
-            {
-                return null;
-            }
-
-            StringBuilder annotationBuilder = new();
-
-            // skip the last line as it will always be an empty line (for nice console output)
-            for (int i = StandardCatFileTagHeaderLength; i < messageLines.Length - 1; ++i)
-            {
-                annotationBuilder.AppendLine(messageLines[i]);
-            }
-
-            // return message, trimming off last new line (added by AppendLine)
-            return annotationBuilder.ToString().Trim();
+            return messageLines.Length <= StandardCatFileTagHeaderLength
+                ? null
+                : messageLines[StandardCatFileTagHeaderLength..]
+                    .Join(Environment.NewLine)
+                    .TrimEnd();
         }
 
         /// <summary>

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -641,7 +641,7 @@ namespace GitCommandsTests
         [TestCase("", "")] // empty message
         [TestCase("a\r\nb\r\n\r\nc\r\n\r\n\r\n\r\nd", "a\r\nb\r\n\r\nc\r\n\r\nd")] // various amount of new lines between text lines
         [TestCase("\r\n\r\n\r\n\r\na\r\nb\r\n\r\n\r\n\r\n\r\n\r\n", "a\r\nb")] // trimmable message
-        [TestCase("a\n\n\nb\r\n\r\nc\r\rd", "a\r\n\r\nb\r\n\r\nc\r\n\r\nd")] // mix of new line types
+        [TestCase("a\n\n\nb\r\n\r\nc\n\nd", "a\r\n\r\nb\r\n\r\nc\r\n\r\nd")] // mix of new line types
         [TestCase("Hello, this is a single line message", "Hello, this is a single line message")] // single line message
         [TestCase("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13", "1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\r\n10\r\n11\r\n12\r\n13")] // message with more than 10 lines (a previous limitation)
         public void GetTagMessage(string tagMessage, string expectedReturnedMessage)


### PR DESCRIPTION
Fixes #11241

## Proposed changes

- Use `Trim` instead of skipping the last line (as suggested by @toesus)
- Remove pointless support for Mac line end (git does not use it) 

## Test methodology <!-- How did you ensure quality? -->

- adapt exisiting tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).