### PR TITLE
fix(Submodules): Allow spaces in folder name

### DIFF
--- a/src/app/GitCommands/Git/SubmoduleHelpers.cs
+++ b/src/app/GitCommands/Git/SubmoduleHelpers.cs
@@ -7,7 +7,7 @@ namespace GitCommands.Git
 {
     public static partial class SubmoduleHelpers
     {
-        [GeneratedRegex(@"diff --git [^/\s]+/(?<filenamea>.+)\s[^/\s]+/(?<filenameb>.+)", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"diff --git\s+[ab]/(?<filenamea>.+)\s+[ba]/(?<filenameb>.+)", RegexOptions.ExplicitCapture)]
         private static partial Regex DiffCommandRegex();
         [GeneratedRegex(@"diff --cc (?<filenamea>.+)", RegexOptions.ExplicitCapture)]
         private static partial Regex CombinedDiffCommandRegex();

--- a/tests/app/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
@@ -35,8 +35,8 @@ namespace GitCommandsTests.Git
 
             // Submodule name with spaces in the name
 
-            text = "diff --git a/Assets/Core/Vehicle Physics core assets b/Assets/Core/Vehicle Physics core assets\nindex 2fb8851..0cc457d 160000\n--- a/Assets/Core/Vehicle Physics core assets\t\n+++ b/Assets/Core/Vehicle Physics core assets\t\n@@ -1 +1 @@\n-Subproject commit 2fb88514cfdc37a2708c24f71eca71c424b8d402\n+Subproject commit 0cc457d030e92f804569407c7cd39893320f9740\n";
-            fileName = "Assets/Core/Vehicle Physics core assets";
+            text = "diff --git a/Main Assets/Core/Vehicle Physics core assets b/Main Assets/Core/Vehicle Physics core assets\nindex 2fb8851..0cc457d 160000\n--- a/Main Assets/Core/Vehicle Physics core assets\t\n+++ b/Main Assets/Core/Vehicle Physics core assets\t\n@@ -1 +1 @@\n-Subproject commit 2fb88514cfdc37a2708c24f71eca71c424b8d402\n+Subproject commit 0cc457d030e92f804569407c7cd39893320f9740\n";
+            fileName = "Main Assets/Core/Vehicle Physics core assets";
 
             status = SubmoduleHelpers.ParseSubmoduleStatus(text, testModule, fileName);
 
@@ -69,7 +69,7 @@ namespace GitCommandsTests.Git
 
             // With user customized `diff.srcPrefix` and `diff.dstPrefix` settings: Submodule name with spaces in the name
 
-            text = "diff --git before:/Assets/Core/Vehicle Physics core assets after:/Assets/Core/Vehicle Physics core assets\nindex 2fb8851..0cc457d 160000\n--- before:/Assets/Core/Vehicle Physics core assets\t\n+++ after:/Assets/Core/Vehicle Physics core assets\t\n@@ -1 +1 @@\n-Subproject commit 2fb88514cfdc37a2708c24f71eca71c424b8d402\n+Subproject commit 0cc457d030e92f804569407c7cd39893320f9740\n";
+            text = "diff --git b/Assets/Core/Vehicle Physics core assets a/Assets/Core/Vehicle Physics core assets\nindex 2fb8851..0cc457d 160000\n--- b/Assets/Core/Vehicle Physics core assets\t\n+++ a/Assets/Core/Vehicle Physics core assets\t\n@@ -1 +1 @@\n-Subproject commit 2fb88514cfdc37a2708c24f71eca71c424b8d402\n+Subproject commit 0cc457d030e92f804569407c7cd39893320f9740\n";
             fileName = "Assets/Core/Vehicle Physics core assets";
 
             status = SubmoduleHelpers.ParseSubmoduleStatus(text, testModule, fileName);

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_with_spaces.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.CreatePatchFromString_with_spaces.verified.json
@@ -1,0 +1,10 @@
+﻿[
+  {
+    "Header": "diff --git a/sub modules/test submodule b/sub modules/test submodule",
+    "FileType": "Text",
+    "FileNameA": "sub modules/test submodule",
+    "FileNameB": "sub modules/test submodule",
+    "ChangeType": "ChangeFile",
+    "Text": "diff --git a/sub modules/test submodule b/sub modules/test submodule\n--- a/sub modules/test submodule\n+++ b/sub modules/test submodule\n@@ -1 +1 @@\n-Subproject commit 4c54fbefd8032acb59aa33ade3fb4bdff32bdde7\n+Subproject commit 4c54fbefd8032acb59aa33ade3fb4bdff32bdde7-dirty"
+  }
+]

--- a/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.cs
@@ -244,6 +244,20 @@ index cdf8bebba,55ff37bb9..000000000
             }
         }
 
+        [Test]
+        public async Task CreatePatchFromString_with_spaces()
+        {
+            string patchText = """
+                diff --git a/sub modules/test submodule b/sub modules/test submodule
+                --- a/sub modules/test submodule    
+                +++ b/sub modules/test submodule    
+                @@ -1 +1 @@
+                -Subproject commit 4c54fbefd8032acb59aa33ade3fb4bdff32bdde7
+                +Subproject commit 4c54fbefd8032acb59aa33ade3fb4bdff32bdde7-dirty
+                """;
+            await Verifier.Verify(PatchProcessor.CreatePatchesFromString(patchText, new Lazy<Encoding>(Encoding.UTF8)));
+        }
+
         [TestCaseSource(typeof(CreatePatchFromStringTestData), nameof(CreatePatchFromStringTestData.TestCases))]
         public async Task CreatePatchFromString_Text_ChangeFile(Encoding filesContentEncoding)
         {


### PR DESCRIPTION
Fixes #11891

## Proposed changes

- Fixup `SubmoduleHelpers.DiffCommandRegex` to support spaces in folder names of super repo
- Add test for `CreatePatchFromString` which uses a similar regex (not changed because it has a more generic scope)

## Test methodology <!-- How did you ensure quality? -->

- extend tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).