### PR TITLE
fix(Jump List Buttons): Deactivate on modal dialog

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -561,8 +561,18 @@ namespace GitUI.CommandsDialogs
                         new WindowsThumbnailToolbarButton(_closeAll.Text, Images.DeleteFile, (s, e) => NativeMethods.PostMessageW(NativeMethods.HWND_BROADCAST, _closeAllMessage))));
             }
 
+            _windowsJumpListManager.EnableThumbnailToolbar(_dashboard?.Visible is not true && Module.IsValidGitWorkingDir());
+
             this.InvokeAndForget(OnActivate);
             base.OnActivated(e);
+        }
+
+        protected override void OnDeactivate(EventArgs e)
+        {
+            bool applicationNotActivated = ActiveForm is null;
+            _windowsJumpListManager.EnableThumbnailToolbar(applicationNotActivated && _dashboard?.Visible is not true && Module.IsValidGitWorkingDir());
+
+            base.OnDeactivate(e);
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
@@ -765,6 +775,8 @@ namespace GitUI.CommandsDialogs
 
         private void ShowDashboard()
         {
+            _windowsJumpListManager.EnableThumbnailToolbar(false);
+
             toolPanel.SuspendLayout();
             toolPanel.TopToolStripPanelVisible = false;
             toolPanel.BottomToolStripPanelVisible = false;
@@ -1052,10 +1064,8 @@ namespace GitUI.CommandsDialogs
 
                     ActiveControl = RevisionGrid;
                 }
-                else
-                {
-                    _windowsJumpListManager.DisableThumbnailToolbar();
-                }
+
+                _windowsJumpListManager.EnableThumbnailToolbar(validBrowseDir);
 
                 UICommands.RaisePostBrowseInitialize(this);
             }
@@ -1303,11 +1313,13 @@ namespace GitUI.CommandsDialogs
 
         private void CommitToolStripMenuItemClick(object sender, EventArgs e)
         {
+            ForceActivate();
             UICommands.StartCommitDialog(this);
         }
 
         private void PushToolStripMenuItemClick(object sender, EventArgs e)
         {
+            ForceActivate();
             UICommands.StartPushDialog(this, pushOnShow: ModifierKeys.HasFlag(Keys.Shift));
         }
 
@@ -2296,6 +2308,8 @@ namespace GitUI.CommandsDialogs
 
         private void PullToolStripMenuItemClick(object sender, EventArgs e)
         {
+            ForceActivate();
+
             // "Pull/Fetch..." menu item always opens the dialog
             DoPull(pullAction: AppSettings.FormPullAction, isSilent: false);
         }
@@ -2732,6 +2746,17 @@ namespace GitUI.CommandsDialogs
             string? shellType = AppSettings.ConEmuTerminal.Value;
             IShellDescriptor shell = _shellProvider.GetShell(shellType);
             _terminal?.ChangeFolder(shell, path);
+        }
+
+        /// <summary>
+        ///  Brings this window to the front and activates it. Needed when a <see cref="WindowsThumbnailToolbarButton"/> is clicked.
+        /// </summary>
+        private void ForceActivate()
+        {
+            TopMost = true;
+            BringToFront();
+            TopMost = false;
+            Activate();
         }
 
         private void menuitemSparseWorkingCopy_Click(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -569,8 +569,8 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnDeactivate(EventArgs e)
         {
-            bool applicationNotActivated = ActiveForm is null;
-            _windowsJumpListManager.EnableThumbnailToolbar(applicationNotActivated && _dashboard?.Visible is not true && Module.IsValidGitWorkingDir());
+            bool formDeactivatedByOwnModalDialog = ActiveForm is not null;
+            _windowsJumpListManager.EnableThumbnailToolbar(!formDeactivatedByOwnModalDialog && _dashboard?.Visible is not true && Module.IsValidGitWorkingDir());
 
             base.OnDeactivate(e);
         }

--- a/src/app/GitUI/WindowsJumpListManager.cs
+++ b/src/app/GitUI/WindowsJumpListManager.cs
@@ -203,7 +203,7 @@ namespace GitUI
         }
 
         /// <summary>
-        /// Disables display of thumbnail toolbars.
+        ///  Sets the enabled state of thumbnail toolbar buttons.
         /// </summary>
         public void EnableThumbnailToolbar(bool enable)
         {

--- a/src/app/GitUI/WindowsJumpListManager.cs
+++ b/src/app/GitUI/WindowsJumpListManager.cs
@@ -15,7 +15,7 @@ namespace GitUI
 
         void AddToRecent(string workingDir);
         void CreateJumpList(IntPtr windowHandle, WindowsThumbnailToolbarButtons buttons);
-        void DisableThumbnailToolbar();
+        void EnableThumbnailToolbar(bool enable);
         void UpdateCommitIcon(Image image);
     }
 
@@ -205,7 +205,7 @@ namespace GitUI
         /// <summary>
         /// Disables display of thumbnail toolbars.
         /// </summary>
-        public void DisableThumbnailToolbar()
+        public void EnableThumbnailToolbar(bool enable)
         {
             if (!ToolbarButtonsCreated)
             {
@@ -218,11 +218,13 @@ namespace GitUI
                 Validates.NotNull(_commitButton);
                 Validates.NotNull(_pushButton);
                 Validates.NotNull(_pullButton);
-                _closeAllButton.Enabled = false;
-                _commitButton.Enabled = false;
-                _pushButton.Enabled = false;
-                _pullButton.Enabled = false;
-            }, nameof(DisableThumbnailToolbar));
+
+                // _closeAllButton is applicable always
+
+                _commitButton.Enabled = enable;
+                _pushButton.Enabled = enable;
+                _pullButton.Enabled = enable;
+            }, nameof(EnableThumbnailToolbar));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #3128

## Proposed changes

- Disable Windows Jump List buttons if GE shows a modal dialog or has no valid wdir
- Bring GE to front on click of Windows Jump List button

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).