### PR TITLE
fix(GPG): Remove max length of key id

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1391,7 +1391,6 @@ namespace GitUI.CommandsDialogs
             // toolStripGpgKeyTextBox
             // 
             toolStripGpgKeyTextBox.BorderStyle = BorderStyle.FixedSingle;
-            toolStripGpgKeyTextBox.MaxLength = 40;
             toolStripGpgKeyTextBox.Name = "toolStripGpgKeyTextBox";
             toolStripGpgKeyTextBox.Size = new Size(230, 23);
             toolStripGpgKeyTextBox.Visible = false;

--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1391,7 +1391,7 @@ namespace GitUI.CommandsDialogs
             // toolStripGpgKeyTextBox
             // 
             toolStripGpgKeyTextBox.BorderStyle = BorderStyle.FixedSingle;
-            toolStripGpgKeyTextBox.MaxLength = 16;
+            toolStripGpgKeyTextBox.MaxLength = 40;
             toolStripGpgKeyTextBox.Name = "toolStripGpgKeyTextBox";
             toolStripGpgKeyTextBox.Size = new Size(230, 23);
             toolStripGpgKeyTextBox.Visible = false;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12099

## Proposed changes

- Set `toolStripGpgKeyTextBox.MaxLength` to 40

## Test methodology <!-- How did you ensure quality? -->

- to be tested manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).