### PR TITLE
fix(Editor): Adapt selection length on replace

### DIFF
--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -367,13 +367,21 @@ namespace GitUI
             textArea.Document.UndoStack.StartUndoGroup();
             try
             {
+                int removedLength = 0;
                 if (textArea.SelectionManager.HasSomethingSelected)
                 {
+                    removedLength = textArea.SelectionManager.SelectionCollection[0].Length;
                     textArea.Caret.Position = textArea.SelectionManager.SelectionCollection[0].StartPosition;
                     textArea.SelectionManager.RemoveSelectedText();
                 }
 
                 textArea.InsertString(text);
+                if (_search.HasScanRegion)
+                {
+                    // EndOffset actually is a LastOffset
+                    int selectionLength = _search.EndOffset + 1 - _search.BeginOffset;
+                    _search.SetScanRegion(_search.BeginOffset, selectionLength + text.Length - removedLength);
+                }
             }
             finally
             {


### PR DESCRIPTION
Fixes #12084

## Proposed changes

- `Editor/FindAndReplaceForm`: Adapt selection length on replace

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).