### PR TITLE
fix: expand last column to ListView size

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -122,6 +122,7 @@
             lvParentsList.TabIndex = 7;
             lvParentsList.UseCompatibleStateImageBehavior = false;
             lvParentsList.View = View.Details;
+            lvParentsList.Resize += lvParentsList_Resize;
             // 
             // columnHeader1
             // 

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -202,5 +202,10 @@ namespace GitUI.CommandsDialogs
 
             OnRevisionChanged();
         }
+
+        private void lvParentsList_Resize(object sender, EventArgs e)
+        {
+            lvParentsList.Columns[1].Width = lvParentsList.ClientSize.Width - lvParentsList.Columns[0].Width - lvParentsList.Columns[2].Width - lvParentsList.Columns[3].Width;
+        }
     }
 }

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
@@ -106,6 +106,7 @@
             lvParentsList.TabIndex = 4;
             lvParentsList.UseCompatibleStateImageBehavior = false;
             lvParentsList.View = View.Details;
+            lvParentsList.Resize += lvParentsList_Resize;
             // 
             // columnHeader1
             // 

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -166,6 +166,11 @@ namespace GitUI.CommandsDialogs
             Close();
         }
 
+        private void lvParentsList_Resize(object sender, EventArgs e)
+        {
+            lvParentsList.Columns[1].Width = lvParentsList.ClientSize.Width - lvParentsList.Columns[0].Width - lvParentsList.Columns[2].Width - lvParentsList.Columns[3].Width;
+        }
+
         private void btnAbort_Click(object sender, EventArgs e)
         {
             DialogResult = DialogResult.Cancel;

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
@@ -163,6 +163,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _pullRequestsList.UseCompatibleStateImageBehavior = false;
             _pullRequestsList.View = View.Details;
             _pullRequestsList.SelectedIndexChanged += _pullRequestsList_SelectedIndexChanged;
+            _pullRequestsList.Resize += _pullRequestsList_Resize;
             // 
             // columnHeaderId
             // 

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -319,6 +319,11 @@ namespace GitUI.CommandsDialogs.RepoHosting
             LoadDiscussion();
         }
 
+        private void _pullRequestsList_Resize(object sender, EventArgs e)
+        {
+            _pullRequestsList.Columns[1].Width = _pullRequestsList.ClientSize.Width - _pullRequestsList.Columns[0].Width - _pullRequestsList.Columns[2].Width - _pullRequestsList.Columns[3].Width - _pullRequestsList.Columns[4].Width;
+        }
+
         private void LoadDiscussion()
         {
             ThreadHelper.FileAndForget(async () =>

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.Designer.cs
@@ -98,6 +98,7 @@
             listMappings.UseCompatibleStateImageBehavior = false;
             listMappings.View = View.Details;
             listMappings.SelectedIndexChanged += listMappings_SelectedIndexChanged;
+            listMappings.Resize += listMappings_Resize;
             // 
             // columnCommand
             // 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
@@ -175,6 +175,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
         }
 
+        private void listMappings_Resize(object sender, EventArgs e)
+        {
+            columnKey.Width = listMappings.ClientSize.Width - columnCommand.Width;
+        }
+
         private void bResetToDefaults_Click(object sender, EventArgs e)
         {
             Settings = HotkeySettingsManager.CreateDefaultSettings();

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -123,6 +123,7 @@
             lvScripts.TileSize = new Size(136, 18);
             lvScripts.UseCompatibleStateImageBehavior = false;
             lvScripts.View = View.Details;
+            lvScripts.Resize += lvScripts_Resize;
             // 
             // chdrNames
             // 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -393,6 +393,11 @@ Diff selection:
             btnMoveDown.Enabled = index < _scripts.Count - 1;
         }
 
+        private void lvScripts_Resize(object sender, EventArgs e)
+        {
+            lvScripts.Columns[^1].Width = lvScripts.ClientSize.Width - lvScripts.Columns[0].Width - lvScripts.Columns[1].Width;
+        }
+
         private void SetPropertyGridWidthOnce()
         {
             const string widthSetTag = "width_set";


### PR DESCRIPTION
## Proposed changes

ListView table columns did not expand to the size of the table. This expands the most reasonable column like name to the size of the table.

To find the forms where this occurred, I looked for NativeListView that seem to have more than one column by searching for AddRange(). There may be more (and one form was ignored).

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://github.com/user-attachments/assets/efbdd69d-90e1-490b-ac14-673961a7ad25)  ![image](https://github.com/user-attachments/assets/a0fcb007-a6d8-4ce0-a484-d7192a0a1382)

![image](https://github.com/user-attachments/assets/e1947c1a-ee38-47b3-a9d2-484b9ef457e9) ![image](https://github.com/user-attachments/assets/f59dd1a4-9657-4088-8cff-6f9dd39992c3)

![image](https://github.com/user-attachments/assets/a71e1659-dfc7-4291-9cd0-15a1f6961d2f) ![image](https://github.com/user-attachments/assets/bfc43301-03da-430c-a988-635354b3ac5f)

![image](https://github.com/user-attachments/assets/5f4d3abd-b46f-4694-b28f-de379ffa3169) ![image](https://github.com/user-attachments/assets/7669aa4e-18cb-4e6f-bc5f-eebb60c496ba)

![image](https://github.com/user-attachments/assets/e278425f-c9a3-4b21-afad-b4ad719d7c86) ![image](https://github.com/user-attachments/assets/4112f2c7-5ba9-49a4-8978-ccfc9d763d68)

Note: There is a similar issue in GitHub Fork&Clone, not getting it to work now and ignore it

![image](https://github.com/user-attachments/assets/4dd09627-9ac2-441e-8349-6b5fd2a10efc)

![image](https://github.com/user-attachments/assets/000fcd6c-906b-4875-a5ca-784db702d04c)

## Test methodology <!-- How did you ensure quality? -->

Visual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
