### PR TITLE
refactor(`FileStatusList`): Remove `SelectedIndex` API

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -675,18 +675,14 @@ namespace GitUI.CommandsDialogs
             SelectedDiff.ScrollToTop();
         }
 
-        private void MoveSelection(int direction)
+        private void MoveSelection(bool backwards)
         {
             if (Message.Focused)
             {
                 _currentFilesList = Staged;
             }
 
-            int itemsCount = _currentFilesList.AllItemsCount;
-            if (itemsCount != 0)
-            {
-                _currentFilesList.SelectedIndex = (_currentFilesList.SelectedIndex + direction + itemsCount) % itemsCount;
-            }
+            _currentFilesList.SelectNextItem(backwards, loop: true);
         }
 
         #region Hotkey commands
@@ -907,10 +903,10 @@ namespace GitUI.CommandsDialogs
                 case Command.Refresh: RescanChanges(); return true;
                 case Command.SelectNext:
                 case Command.SelectNext_AlternativeHotkey1:
-                case Command.SelectNext_AlternativeHotkey2: MoveSelection(1); return true;
+                case Command.SelectNext_AlternativeHotkey2: MoveSelection(backwards: false); return true;
                 case Command.SelectPrevious:
                 case Command.SelectPrevious_AlternativeHotkey1:
-                case Command.SelectPrevious_AlternativeHotkey2: MoveSelection(-1); return true;
+                case Command.SelectPrevious_AlternativeHotkey2: MoveSelection(backwards: true); return true;
                 default: return base.ExecuteCommand(cmd);
             }
         }
@@ -1611,7 +1607,7 @@ namespace GitUI.CommandsDialogs
             }
             else if (Staged.IsFilterActive)
             {
-                Staged.SelectedGitItems = Staged.AllItems.Items();
+                Staged.SelectedGitItems = Staged.AllItems.Items().ToArray();
                 Unstage(canUseUnstageAll: false);
                 Staged.SetFilter(string.Empty);
             }
@@ -1719,9 +1715,9 @@ namespace GitUI.CommandsDialogs
             {
                 _currentFilesList = Unstaged;
                 _skipUpdate = false;
-                if (!e.ByMouse && Unstaged.AllItems.Any() && Unstaged.SelectedIndex == -1)
+                if (!e.ByMouse && !Unstaged.HasSelection)
                 {
-                    Unstaged.SelectedIndex = 0;
+                    Unstaged.SelectFirstVisibleItem();
                 }
 
                 UnstagedSelectionChanged(Unstaged, EventArgs.Empty);
@@ -1978,9 +1974,9 @@ namespace GitUI.CommandsDialogs
             {
                 _currentFilesList = Staged;
                 _skipUpdate = false;
-                if (!e.ByMouse && Staged.AllItems.Any() && Staged.SelectedIndex == -1)
+                if (!e.ByMouse && !Staged.HasSelection)
                 {
-                    Staged.SelectedIndex = 0;
+                    Staged.SelectFirstVisibleItem();
                 }
 
                 StagedSelectionChanged(Staged, EventArgs.Empty);
@@ -3461,7 +3457,7 @@ namespace GitUI.CommandsDialogs
             if (Staged.AllItemsCount != 0 && !Staged.SelectedItems.Any())
             {
                 _currentFilesList = Staged;
-                Staged.SelectedIndex = 0;
+                Staged.SelectFirstVisibleItem();
                 StagedSelectionChanged(this, EventArgs.Empty);
             }
         }

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -412,32 +412,16 @@ namespace GitUI.CommandsDialogs
             };
         }
 
-        private bool GetNextPatchFile(bool searchBackward, bool loop, out int fileIndex, out Task loadFileContent)
+        private bool GetNextPatchFile(bool searchBackward, bool loop, out FileStatusItem? selectedItem, out Task loadFileContent)
         {
-            fileIndex = -1;
+            selectedItem = null;
             loadFileContent = Task.CompletedTask;
-            if (DiffFiles.SelectedItem is null)
+
+            FileStatusItem prevItem = DiffFiles.SelectedItem;
+            selectedItem = DiffFiles.SelectNextItem(searchBackward, loop, notify: false);
+            if (selectedItem is null || (!loop && selectedItem == prevItem))
             {
                 return false;
-            }
-
-            int idx = DiffFiles.SelectedIndex;
-            if (idx == -1)
-            {
-                return false;
-            }
-
-            fileIndex = DiffFiles.GetNextIndex(searchBackward, loop);
-            if (fileIndex == idx)
-            {
-                if (!loop)
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                DiffFiles.SetSelectedIndex(fileIndex, notify: false);
             }
 
             loadFileContent = ShowSelectedFileDiffAsync(ensureNoSwitchToFilter: false, line: 0);

--- a/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -51,7 +51,7 @@ namespace GitUI
             List<FileStatusWithDescription> fileStatusDescs = refreshDiff
                 ? CalculateDiffs(_fileStatusDiffCalculatorInfo.Revisions, selectedRev,
                     _fileStatusDiffCalculatorInfo.HeadId, _fileStatusDiffCalculatorInfo.AllowMultiDiff, cancellationToken)
-                : prevList.Where(p => !p.Summary.StartsWith(_grepSummaryPrefix)).ToList();
+                : prevList.Where(p => !IsGrepItemStatuses(p)).ToList();
 
             FileStatusWithDescription? grepItemStatuses = refreshGrep
                 ? GetGrepItemStatuses(selectedRev, cancellationToken)

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
@@ -49,7 +49,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             _fileStatusList.SetDiffs(firstRev: firstRev, secondRev: secondRev, items: items);
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
-            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0);
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
 
@@ -58,32 +58,32 @@ namespace GitExtensions.UITests.CommandsDialogs
 
             // SelectedIndex
 
-            _fileStatusList.SelectedIndex = 1;
+            _fileStatusList.SelectedGitItems = [itemAt1];
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
-            _fileStatusList.SelectedIndex = -1;
+            _fileStatusList.SelectedItems = [];
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
-            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
             _fileStatusList.SelectedGitItem.Should().BeNull();
             _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
-            _fileStatusList.SelectedIndex = 2;
-            _fileStatusList.SelectedIndex = 42; // clears the selection
+            _fileStatusList.SelectedGitItems = [itemAt2];
+            _fileStatusList.SelectedGitItems = [itemNotInList]; // clears the selection
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
-            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
             _fileStatusList.SelectedGitItem.Should().BeNull();
             _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
-            _fileStatusList.SelectedIndex = 1;
+            _fileStatusList.SelectedGitItems = [itemAt1];
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
@@ -92,14 +92,14 @@ namespace GitExtensions.UITests.CommandsDialogs
             _fileStatusList.SelectedGitItem = itemAt1;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
             _fileStatusList.SelectedGitItem = null;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
-            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
             _fileStatusList.SelectedGitItem.Should().BeNull();
             _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
@@ -107,14 +107,14 @@ namespace GitExtensions.UITests.CommandsDialogs
             _fileStatusList.SelectedGitItem = itemNotInList; // clears the selection
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
-            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
             _fileStatusList.SelectedGitItem.Should().BeNull();
             _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItem = itemAt1;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
@@ -123,21 +123,21 @@ namespace GitExtensions.UITests.CommandsDialogs
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt1 };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
             _fileStatusList.SelectedItems = null;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
-            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
             _fileStatusList.SelectedGitItem.Should().BeNull();
             _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
-            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
             _fileStatusList.SelectedGitItem.Should().BeNull();
             _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
@@ -145,52 +145,52 @@ namespace GitExtensions.UITests.CommandsDialogs
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemNotInList }; // clears the selection
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
-            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
             _fileStatusList.SelectedGitItem.Should().BeNull();
             _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt1 };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
             // SelectedItems.Items() (multiple items)
 
-            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectedGitItems = [itemAt2];
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt2, itemAt0, itemNotInList };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
-            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0); // focused item
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
 
             accessor.FileStatusListView.Items[1].Focused = true;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt2); // LastSelectedItem
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt2); // LastSelectedItem
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
 
-            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectedGitItems = [itemAt2];
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt2, itemAt1, itemNotInList };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1); // focused item
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
 
             accessor.FileStatusListView.Items[0].Focused = true;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
-            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt2); // LastSelectedItem
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt2); // LastSelectedItem
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
 
             // SelectAll
 
-            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectedGitItems = [itemAt2];
             _fileStatusList.SelectAll();
 
             foreach (ListViewItem item in accessor.FileStatusListView.Items())
@@ -199,17 +199,17 @@ namespace GitExtensions.UITests.CommandsDialogs
             }
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
-            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0); // focused item
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt1, itemAt2 });
 
             // SelectFirstVisibleItem
 
-            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectedGitItems = [itemAt2];
             _fileStatusList.SelectFirstVisibleItem();
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
-            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Item.Should().Be(itemAt0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0); // focused item
             _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
         }

--- a/tests/app/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
@@ -1,4 +1,7 @@
-﻿using GitUI;
+﻿using GitExtensions.Extensibility.Git;
+using GitUI;
+using GitUI.UserControls;
+using GitUIPluginInterfaces;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
@@ -182,11 +185,12 @@ namespace GitUITests.Editor
             TextRange[] expectedRanges)
         {
             int currentIndex = 0;
+            FileStatusItem dummy = new(firstRev: null, secondRev: new GitRevision(ObjectId.Random()), new GitItemStatus(nameof(dummy)));
 
-            bool FileLoader(bool backward, bool loop, out int index, out Task content)
+            bool FileLoader(bool backward, bool loop, out FileStatusItem? fileStatusItem, out Task content)
             {
                 currentIndex = (currentIndex + 1) % texts.Length;
-                index = currentIndex;
+                fileStatusItem = dummy;
                 content = Task.CompletedTask;
                 _textEditorControl.Text = texts[currentIndex];
 


### PR DESCRIPTION
## Proposed changes

Remove `SelectedIndex` API from `FileStatusList`
- Add `HasSelection`
- `SelectedGitItems` takes `IReadOnlyList`
- Replace `GetNextIndex` with `SelectNextItem`
- Use `SelectFirstVisibleItem`

## Screenshots <!-- Remove this section if PR does not change UI -->

unchanged

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).