### PR TITLE
feat: SystemColors.Window in Dashboard theme

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.Designer.cs
@@ -46,7 +46,6 @@
             // pnlLeft
             // 
             pnlLeft.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
-            pnlLeft.BackColor = Color.FromArgb(((int)(((byte)(223)))), ((int)(((byte)(228)))), ((int)(((byte)(235)))));
             pnlLeft.Controls.Add(flpnlStart);
             pnlLeft.Controls.Add(flpnlContribute);
             pnlLeft.Controls.Add(pnlLogo);
@@ -58,7 +57,6 @@
             // 
             // flpnlStart
             // 
-            flpnlStart.BackColor = Color.FromArgb(((int)(((byte)(46)))), ((int)(((byte)(50)))), ((int)(((byte)(58)))));
             flpnlStart.Dock = DockStyle.Fill;
             flpnlStart.FlowDirection = FlowDirection.TopDown;
             flpnlStart.Location = new Point(0, 68);
@@ -71,7 +69,6 @@
             // 
             // flpnlContribute
             // 
-            flpnlContribute.BackColor = Color.Transparent;
             flpnlContribute.Controls.Add(lblContribute);
             flpnlContribute.Dock = DockStyle.Bottom;
             flpnlContribute.FlowDirection = FlowDirection.TopDown;
@@ -87,7 +84,6 @@
             // 
             lblContribute.AutoSize = true;
             lblContribute.Font = new Font("Segoe UI", 14.25F);
-            lblContribute.ForeColor = SystemColors.GrayText;
             lblContribute.Location = new Point(22, 20);
             lblContribute.Margin = new Padding(2, 0, 2, 8);
             lblContribute.Name = "lblContribute";
@@ -97,7 +93,6 @@
             // 
             // pnlLogo
             // 
-            pnlLogo.BackColor = Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(40)))), ((int)(((byte)(57)))));
             pnlLogo.Controls.Add(pbLogo);
             pnlLogo.Dock = DockStyle.Top;
             pnlLogo.Location = new Point(0, 0);
@@ -119,14 +114,9 @@
             // 
             // userRepositoriesList
             // 
-            userRepositoriesList.BranchNameColor = SystemColors.HotTrack;
             userRepositoriesList.Dock = DockStyle.Fill;
-            userRepositoriesList.HeaderBackColor = Color.FromArgb(((int)(((byte)(160)))), ((int)(((byte)(183)))), ((int)(((byte)(226)))));
-            userRepositoriesList.HeaderColor = Color.Empty;
             userRepositoriesList.HeaderHeight = 70;
-            userRepositoriesList.HoverColor = Color.Empty;
             userRepositoriesList.Location = new Point(246, 0);
-            userRepositoriesList.MainBackColor = Color.Empty;
             userRepositoriesList.Margin = new Padding(0);
             userRepositoriesList.Name = "userRepositoriesList";
             userRepositoriesList.Size = new Size(405, 358);
@@ -156,7 +146,6 @@
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoScroll = true;
-            BackColor = Color.FromArgb(((int)(((byte)(238)))), ((int)(((byte)(243)))), ((int)(((byte)(253)))));
             Controls.Add(tableLayoutPanel1);
             DoubleBuffered = true;
             Margin = new Padding(2, 1, 2, 1);

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -65,18 +65,19 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             {
                 BackgroundImage = selectedTheme.BackgroundImage;
 
-                BackColor = selectedTheme.Primary;
-                pnlLogo.BackColor = selectedTheme.PrimaryVeryDark;
-                flpnlStart.BackColor = selectedTheme.PrimaryLight;
-                flpnlContribute.BackColor = selectedTheme.PrimaryVeryLight;
+                BackColor = SystemColors.Window;
+                pnlLogo.BackColor = selectedTheme.LogoBackColor;
+                flpnlStart.BackColor = selectedTheme.StartBackColor;
+                flpnlContribute.BackColor = selectedTheme.ContributeBackColor;
                 lblContribute.ForeColor = selectedTheme.SecondaryHeadingText;
+                userRepositoriesList.MainBackColor = SystemColors.Window;
                 userRepositoriesList.BranchNameColor = selectedTheme.SecondaryText;
                 userRepositoriesList.FavouriteColor = selectedTheme.AccentedText;
                 userRepositoriesList.ForeColor = selectedTheme.PrimaryText;
                 userRepositoriesList.HeaderColor = selectedTheme.SecondaryHeadingText;
-                userRepositoriesList.HeaderBackColor = selectedTheme.PrimaryDark;
-                userRepositoriesList.HoverColor = selectedTheme.PrimaryLight;
-                userRepositoriesList.MainBackColor = selectedTheme.Primary;
+                userRepositoriesList.HeaderBackColor = selectedTheme.HeaderBackColor;
+                userRepositoriesList.HoverColor = selectedTheme.StartBackColor;
+                userRepositoriesList.SearchBackColor = selectedTheme.SearchBackColor;
 
                 foreach (LinkLabel item in flpnlContribute.Controls.OfType<LinkLabel>().Union(flpnlStart.Controls.OfType<LinkLabel>()))
                 {

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardTheme.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardTheme.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.Properties;
+﻿using GitExtUtils.GitUI.Theming;
+using GitUI.Properties;
 
 namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 {
@@ -10,11 +11,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         static DashboardTheme()
         {
             // Palette URL: http://paletton.com/#uid=13I0u0k7UUa3cZA5wXlaiQ5cFL3
-            Light = new DashboardTheme(primary: Color.FromArgb(248, 248, 255), // 238, 243, 253), // Color.FromArgb(184, 203, 237),
-                                       primaryLight: Color.FromArgb(219, 235, 248),
-                                       primaryVeryLight: Color.FromArgb(230, 241, 250),
-                                       primaryDark: Color.FromArgb(172, 208, 239),
-                                       primaryVeryDark: Color.FromArgb(19, 122, 212),
+            Light = new DashboardTheme(searchBackColor: Color.FromArgb(248, 248, 255),
+                                       startBackColor: Color.FromArgb(219, 235, 248),
+                                       contributeBackColor: Color.FromArgb(230, 241, 250),
+                                       headerBackColor: Color.FromArgb(172, 208, 239),
+                                       logoBackColor: Color.FromArgb(19, 122, 212),
                                        primaryText: Color.FromArgb(30, 30, 30),
                                        secondaryText: Color.FromArgb(100, 127, 210),
                                        accentedText: Color.DarkGoldenrod,
@@ -22,31 +23,30 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                                        secondaryHeadingText: Color.DimGray,
                                        backgroundImage: Images.DashboardBackgroundBlue);
 
-            // Palette URL: http://paletton.com/#uid=13I0u0k3V4WaYgf7Lb1ac80gJaQ
-            Dark = new DashboardTheme(primary: Color.FromArgb(23, 24, 26),
-                                      primaryLight: Color.FromArgb(46, 50, 58),
-                                      primaryVeryLight: Color.FromArgb(59, 69, 86),
-                                      primaryDark: Color.FromArgb(30, 34, 42),
-                                      primaryVeryDark: Color.FromArgb(30, 40, 57),
-                                      primaryText: Color.Silver,
+            Dark = new DashboardTheme(searchBackColor: SystemColors.Control,
+                                      startBackColor: SystemColors.Control,
+                                      contributeBackColor: SystemColors.ControlLight,
+                                      headerBackColor: SystemColors.ControlDark,
+                                      logoBackColor: SystemColors.ControlDarkDark,
+                                      primaryText: SystemColors.WindowText,
                                       secondaryText: Color.LightSkyBlue,
-                                      accentedText: Color.Goldenrod,
-                                      primaryHeadingText: Color.White,
-                                      secondaryHeadingText: Color.Gray,
+                                      accentedText: Color.Goldenrod.AdaptBackColor(),
+                                      primaryHeadingText: SystemColors.ControlText,
+                                      secondaryHeadingText: SystemColors.GrayText,
                                       backgroundImage: Images.DashboardBackgroundGrey);
         }
 
-        private DashboardTheme(Color primary, Color primaryLight, Color primaryVeryLight,
-                                 Color primaryDark, Color primaryVeryDark,
+        private DashboardTheme(Color searchBackColor, Color startBackColor, Color contributeBackColor,
+                                 Color headerBackColor, Color logoBackColor,
                                  Color primaryText, Color secondaryText, Color accentedText,
                                  Color primaryHeadingText, Color secondaryHeadingText,
                                  Image backgroundImage)
         {
-            Primary = primary;
-            PrimaryLight = primaryLight;
-            PrimaryVeryLight = primaryVeryLight;
-            PrimaryDark = primaryDark;
-            PrimaryVeryDark = primaryVeryDark;
+            SearchBackColor = searchBackColor;
+            StartBackColor = startBackColor;
+            ContributeBackColor = contributeBackColor;
+            HeaderBackColor = headerBackColor;
+            LogoBackColor = logoBackColor;
             PrimaryText = primaryText;
             SecondaryText = secondaryText;
             AccentedText = accentedText;
@@ -57,13 +57,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public Color AccentedText { get; }
         public Image BackgroundImage { get; }
-        public Color Primary { get; }
-        public Color PrimaryDark { get; }
+        public Color SearchBackColor { get; }
+        public Color HeaderBackColor { get; }
         public Color PrimaryHeadingText { get; }
-        public Color PrimaryLight { get; }
+        public Color StartBackColor { get; }
         public Color PrimaryText { get; }
-        public Color PrimaryVeryDark { get; }
-        public Color PrimaryVeryLight { get; }
+        public Color LogoBackColor { get; }
+        public Color ContributeBackColor { get; }
         public Color SecondaryHeadingText { get; }
         public Color SecondaryText { get; }
     }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -221,7 +221,6 @@
             // imageList1
             // 
             imageList1.ImageStream = ((ImageListStreamer)(resources.GetObject("imageList1.ImageStream")));
-            imageList1.TransparentColor = Color.Transparent;
             imageList1.Images.SetKeyName(0, "source_code.png");
             // 
             // textBoxSearch

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -50,6 +50,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private Color _headerColor;
         private Color _headerBackColor;
         private Color _mainBackColor;
+        private Color _searchBackColor;
         private Brush _foreColorBrush;
         private Brush _branchNameColorBrush = new SolidBrush(DefaultBranchNameColor);
         private Brush _favouriteColorBrush = new SolidBrush(DefaultFavouriteColor);
@@ -170,6 +171,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         [Category("Appearance")]
+        [DefaultValue(typeof(SystemColors), "Window")]
         public Color HeaderBackColor
         {
             get { return _headerBackColor; }
@@ -230,6 +232,23 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 _mainBackColor = value;
                 BackColor = value;
                 listView1.BackColor = value;
+            }
+        }
+
+        [Category("Appearance")]
+        [DefaultValue(typeof(SystemColors), "Window")]
+        public Color SearchBackColor
+        {
+            get { return _searchBackColor; }
+            set
+            {
+                if (_searchBackColor == value)
+                {
+                    return;
+                }
+
+                _searchBackColor = value;
+                textBoxSearch.BackColor = value;
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Use SystemColors.Window for dashboard background theme, to be consistent with the normal app.
Some renaming to clarify color usage

Prepare the dark theme to be consistent with the app. The dark colors are not using the blue colors of the default light theme but greyish colors.
The theme does not look better, but is consistent with the .net9 dark mode (that cannot be tweaked much).


## Screenshots <!-- Remove this section if PR does not change UI -->

Recent repo background and searchbox background swapped.

![image](https://github.com/user-attachments/assets/f8dda253-5eee-488e-b6ca-91cda73c947f)
![image](https://github.com/user-attachments/assets/71af900e-fab9-4bc5-b313-bca145410532)

Alternative light theme with system colors as for the dark theme
![image](https://github.com/user-attachments/assets/bf9d9164-3ff2-4d83-b706-22acfaa4431b)

Note that the second header cannot be changed in the darktheme in .net9 (unless ListView is replaced)

![image](https://github.com/user-attachments/assets/48016695-9a4f-4558-a224-c6e95366fa50)
![image](https://github.com/user-attachments/assets/c80b554a-0b8f-40fb-addc-c76c3ad5059e)

## Test methodology <!-- How did you ensure quality? -->

Visual

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11 24H2

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
