### PR TITLE
fix(WindowPositionManager): Add vertical heuristic

### DIFF
--- a/src/app/GitUI/GitExtensionsForm.cs
+++ b/src/app/GitUI/GitExtensionsForm.cs
@@ -104,8 +104,8 @@ namespace GitUI
 
             _needsPositionRestore = false;
 
-            IReadOnlyList<Rectangle> workingArea = _getScreensWorkingArea();
-            if (!workingArea.Any(screen => screen.IntersectsWith(position.Rect)))
+            IReadOnlyList<Rectangle> workingAreas = _getScreensWorkingArea();
+            if (!workingAreas.Any(screen => screen.IntersectsWith(position.Rect)))
             {
                 if (position.State == FormWindowState.Maximized)
                 {
@@ -130,7 +130,7 @@ namespace GitUI
             {
                 Point calculatedLocation = DpiUtil.Scale(position.Rect.Location, originalDpi: position.DeviceDpi);
 
-                DesktopLocation = WindowPositionManager.FitWindowOnScreen(new Rectangle(calculatedLocation, Size), workingArea);
+                DesktopLocation = WindowPositionManager.FitWindowOnScreen(new Rectangle(calculatedLocation, Size), workingAreas);
             }
             else
             {
@@ -138,7 +138,7 @@ namespace GitUI
                 Point calculatedLocation = new(
                     Owner.Left + (Owner.Width / 2) - (Width / 2),
                     Owner.Top + (Owner.Height / 2) - (Height / 2));
-                Location = WindowPositionManager.FitWindowOnScreen(new Rectangle(calculatedLocation, Size), workingArea);
+                Location = WindowPositionManager.FitWindowOnScreen(new Rectangle(calculatedLocation, Size), workingAreas);
             }
 
             if (WindowState != position.State)

--- a/src/app/GitUI/WindowPositionManager.cs
+++ b/src/app/GitUI/WindowPositionManager.cs
@@ -42,7 +42,7 @@ namespace GitUI
                 }
             }
 
-            return workingAreas.FirstOrDefault().Location;
+            return workingAreas.FirstOrDefault(screen => !screen.IsEmpty).Location;
         }
 
         private static bool IsDisplayedOn10Percent(Rectangle screen, Rectangle window)

--- a/src/app/GitUI/WindowPositionManager.cs
+++ b/src/app/GitUI/WindowPositionManager.cs
@@ -24,22 +24,25 @@ namespace GitUI
     {
         private static WindowPositionList? _windowPositionList;
 
-        public static Point FitWindowOnScreen(Rectangle calculatedWindowBounds, IEnumerable<Rectangle> workingArea)
+        /// <summary>
+        /// Ensures the window with its new size and location will be accessible to the user.
+        /// If all fails, we will display the window at the top left of the first screen or at (0, 0).
+        /// </summary>
+        /// <param name="calculatedWindowBounds">The intended location of the window.</param>
+        /// <param name="workingAreas">The working areas of all available screens.</param>
+        /// <returns>A most likely visible location for the window.</returns>
+        public static Point FitWindowOnScreen(Rectangle calculatedWindowBounds, IEnumerable<Rectangle> workingAreas)
         {
-            // Ensure the window with its new size and location will be accessible to the user
-            // If all fails, we'll display the window the (0, 0)
-            Point location = Point.Empty;
-            foreach (Rectangle screen in workingArea)
+            foreach (Rectangle screen in workingAreas)
             {
                 bool isDisplayed = IsDisplayedOn10Percent(screen, calculatedWindowBounds);
                 if (isDisplayed)
                 {
-                    location = calculatedWindowBounds.Location;
-                    break;
+                    return calculatedWindowBounds.Location;
                 }
             }
 
-            return location;
+            return workingAreas.FirstOrDefault().Location;
         }
 
         private static bool IsDisplayedOn10Percent(Rectangle screen, Rectangle window)
@@ -83,6 +86,25 @@ namespace GitUI
                 if (middleTop)
                 {
                     Debug.WriteLine($"{screen.ToString()} contains {p} (W/2+, T)");
+                    return true;
+                }
+            }
+
+            if (screen.Contains(new Point(window.Left, window.Top + (window.Height / 2))))
+            {
+                p = new Point(window.Left + requireWidth, window.Top + (window.Height / 2) - requiredHeight);
+                bool middleTop = screen.Contains(p);
+                if (middleTop)
+                {
+                    Debug.WriteLine($"{screen.ToString()} contains {p} (L, H/2-)");
+                    return true;
+                }
+
+                p = new Point(window.Left + requireWidth, window.Top + (window.Height / 2) + requiredHeight);
+                middleTop = screen.Contains(p);
+                if (middleTop)
+                {
+                    Debug.WriteLine($"{screen.ToString()} contains {p} (L, H/2+)");
                     return true;
                 }
             }

--- a/tests/app/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
@@ -145,7 +145,7 @@ namespace GitUITests
 
         [TestCase(-1000, 100, /* -1000 + (800 - 300)/2 */ -750, /* 100 + (600-200)/2 */300)]
         [TestCase(0, 0, /* 0 + (800 - 300)/2 */ 250, /* 0 + (600-200)/2 */200)]
-        [TestCase(1000, -400, /* falls off the screen */ 0, /* falls off the screen */ 0)]
+        [TestCase(1000, -500, /* falls off the screen -> first non-empty screen */ -1920, /* falls off the screen */ 0)]
         public void RestorePosition_should_position_window_with_Owner_set_and_CenterParent(int ownerFormTop, int ownerFormLeft, int expectFormTop, int expectedFormLeft)
         {
             if (DpiUtil.IsNonStandard)
@@ -165,6 +165,7 @@ namespace GitUITests
             };
             Rectangle[] screens = new[]
             {
+                new Rectangle(0, 0, 0, 0),
                 new Rectangle(-1920, 0, 1920, 1080),
                 new Rectangle(1920, 0, 1920, 1080),
                 new Rectangle(0, 0, 1920, 1080)

--- a/tests/app/UnitTests/GitUI.Tests/WindowPositionManagerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/WindowPositionManagerTests.cs
@@ -35,7 +35,8 @@ namespace GitUITests
         [TestCase(-500, 100, 500, 500, false)] // less than 10% visible horizontally
         [TestCase(-192, 100, 500, 500, true)] // 10% visible horizontally
         //// clipped on the top
-        [TestCase(50, -50, 500, 500, false)]
+        [TestCase(50, -250, 500, 500, true)]
+        [TestCase(50, -251, 500, 500, false)]
         //// clipped on the right
         [TestCase(1727, 100, 500, 500, true)] // 10% visible horizontally, (1920 * 90% - 1)
         [TestCase(1728, 100, 500, 500, false)] // less than 10% visible horizontally, (1920 * 90%)


### PR DESCRIPTION
Fixes #11589 for maximized FormCommit

## Proposed changes

`WindowPositionManager`:
- Add vertical heuristic analogue to existing horizontal heuristic
- Default to top left of first screen as fallback

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- adapt existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).