### PR TITLE
fix(FileStatusList): Avoid focus confusion on AppActivate

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -379,7 +379,10 @@ namespace GitUI
             cboFindInCommitFilesGitGrep.Visible = visible;
             if (visible)
             {
-                ActiveControl = cboFindInCommitFilesGitGrep;
+                if (ActiveControl is not null)
+                {
+                    ActiveControl = cboFindInCommitFilesGitGrep;
+                }
 
                 // Adjust sizes "automatically" changed by visibility
                 cboFindInCommitFilesGitGrep.Top = 0;

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -379,6 +379,7 @@ namespace GitUI
             cboFindInCommitFilesGitGrep.Visible = visible;
             if (visible)
             {
+                // Focus the box if it is becoming shown, but not on init of parent controls (which broke the form's focus management)
                 if (ActiveControl is not null)
                 {
                     ActiveControl = cboFindInCommitFilesGitGrep;


### PR DESCRIPTION
Fixes regression caused by #12033

## Proposed changes

`FileStatusList`:
- Avoid setting `ActiveControl` on startup which makes `RevisionGrid` (sic!) get focused on `AppActivate`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

`FileStatusList` loses focus when switching to another app and back

### After

`FileStatusList` is still focused

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).