### PR TITLE
fix(theme): Do not adapt system colors

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -2147,7 +2147,7 @@ namespace GitCommands
         public static Font GetFont(string name, Font defaultValue) => SettingsContainer.GetFont(name, defaultValue);
         public static void SetFont(string name, Font value) => SettingsContainer.SetFont(name, value);
 
-        [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is")]
+        [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is. Only used by ThemeMigration.")]
         public static Color GetColor(AppColor name)
         {
             return SettingsContainer.GetColor(name.ToString().ToLowerInvariant() + "color", AppColorDefaults.GetBy(name));

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -3408,7 +3408,7 @@ namespace GitUI.CommandsDialogs
             {
                 CommitAndPush.BackColor = PushForced
                     ? OtherColors.AmendButtonForcedColor
-                    : SystemColors.ButtonFace.AdaptBackColor();
+                    : SystemColors.ButtonFace;
 
                 CommitAndPush.SetForeColorForBackColor();
             }

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -158,8 +158,8 @@ namespace GitUI.LeftPanel
 
                 search.SearchBoxBorderStyle = BorderStyle.FixedSingle;
                 search.SearchBoxBorderDefaultColor = Color.LightGray.AdaptBackColor();
-                search.SearchBoxBorderHoveredColor = SystemColors.Highlight.AdaptBackColor();
-                search.SearchBoxBorderFocusedColor = SystemColors.HotTrack.AdaptBackColor();
+                search.SearchBoxBorderHoveredColor = SystemColors.Highlight;
+                search.SearchBoxBorderFocusedColor = SystemColors.HotTrack;
 
                 return search;
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -446,7 +446,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             AppSettings.CloseCommitDialogAfterLastCommit = false;
             AppSettings.CloseProcessDialog = true;
 
-            int defaultBackColor = SystemColors.ButtonFace.AdaptBackColor().ToArgb();
+            int defaultBackColor = SystemColors.ButtonFace.ToArgb();
             int forceBackColor = OtherColors.AmendButtonForcedColor.ToArgb();
 
             const string originalCommitMessage = "commit to be amended by reset soft";


### PR DESCRIPTION
Preparation for #12111 
Simplify review of the theme update.
This PR does not change behavior for the invariant theme.
There may be tweaks required to the theme handling in #12111 when that is actively reviewed, that review should be based on this (and similar) PRs.
Will likely be merged together with similar preparing PRs.

## Proposed changes

System colors are already adapted to the Windows theme and should not be transformed.
.net9 dark mode does not allow tweaking system colors even, but also the old solution should not have tweaked the system colors.

## Test methodology <!-- How did you ensure quality? -->

review

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
