### PR TITLE
fix: Adapt hardcoded colors

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -15,13 +15,14 @@
 
         /// <summary>
         ///  Blends the color with the default background color, halves each value first.
+        ///  Keep the original alpha, SystemColors.Window.A==255 and we do not want rounding errors.
         /// </summary>
         public static Color DimColor(Color color)
         {
             const uint maskWithoutLeastSignificantBits = 0xFE_FE_FE_FE;
             uint defaultBackground = (uint)SystemColors.Window.ToArgb();
             int dimCode = (int)((((uint)color.ToArgb() & maskWithoutLeastSignificantBits) >> 1) + ((defaultBackground & maskWithoutLeastSignificantBits) >> 1));
-            return Color.FromArgb((dimCode >> 16) & 0xff, (dimCode >> 8) & 0xff, dimCode & 0xff);
+            return Color.FromArgb(color.A, (dimCode >> 16) & 0xff, (dimCode >> 8) & 0xff, dimCode & 0xff);
         }
 
         public static void SetForeColorForBackColor(this Control control) =>
@@ -200,7 +201,9 @@
 
             double actualL = ActualL(originalRgbHsl.rgb, perceptedL);
 
+            // Keep the original alpha (not expected to have alpha!=255 in the SystemColors)
             Color result = originalRgbHsl.hsl.WithLuminosity(actualL).ToColor();
+            result = Color.FromArgb(original.A, result);
             return result;
 
             double PerceptedL((Color rgb, HslColor hsl) c) =>

--- a/src/app/GitUI/Avatars/SafetynetAvatarProvider.cs
+++ b/src/app/GitUI/Avatars/SafetynetAvatarProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using GitExtUtils.GitUI.Theming;
 
 namespace GitUI.Avatars
 {
@@ -59,7 +60,7 @@ namespace GitUI.Avatars
         private static Image GenerateSafetynetFallback()
         {
             Bitmap bmp = new(1, 1);
-            bmp.SetPixel(0, 0, Color.Red);
+            bmp.SetPixel(0, 0, Color.Red.AdaptBackColor());
             return bmp;
         }
     }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -4,6 +4,7 @@ using GitCommands;
 using GitCommands.UserRepositoryHistory;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
@@ -42,7 +43,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         private readonly Font _secondaryFont;
-        private static readonly Color DefaultFavouriteColor = Color.DarkGoldenrod;
+        private static readonly Color DefaultFavouriteColor = Color.DarkGoldenrod.AdaptBackColor();
         private static readonly Color DefaultBranchNameColor = SystemColors.HotTrack;
         private Color _favouriteColor = DefaultFavouriteColor;
         private Color _branchNameColor = DefaultBranchNameColor;
@@ -81,6 +82,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
             _secondaryFont = new Font(AppSettings.Font.FontFamily, AppSettings.Font.SizeInPoints - 1f);
             lblRecentRepositories.Font = new Font(AppSettings.Font.FontFamily, AppSettings.Font.SizeInPoints + 5.5f);
+            lblRecentRepositories.ForeColor.AdaptTextColor();
 
             textBoxSearch.PlaceholderText = _repositorySearchPlaceholder.Text;
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using GitCommands;
 using GitCommands.UserRepositoryHistory;
+using GitExtUtils.GitUI.Theming;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
@@ -156,7 +157,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             if (!Directory.Exists(repo.Repo.Path))
             {
-                item.ForeColor = Color.Red;
+                item.ForeColor = Color.Red.AdaptTextColor();
             }
 
             return item;

--- a/src/app/GitUI/CommandsDialogs/FormApplyPatch.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormApplyPatch.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs
+﻿using GitExtUtils.GitUI.Theming;
+
+namespace GitUI.CommandsDialogs
 {
     partial class FormApplyPatch
     {
@@ -205,7 +207,7 @@
             // 
             // SolveMergeConflicts
             // 
-            SolveMergeConflicts.BackColor = Color.Salmon;
+            SolveMergeConflicts.BackColor = OtherColors.MergeConflictsColor;
             SolveMergeConflicts.Dock = DockStyle.Top;
             SolveMergeConflicts.FlatStyle = FlatStyle.Flat;
             SolveMergeConflicts.Location = new Point(3, 213);

--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using System.Windows.Forms;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Editor;
 using GitUI.SpellChecker;
 using GitUI.UserControls.RevisionGrid;
@@ -1038,7 +1039,7 @@ namespace GitUI.CommandsDialogs
             //
             // SolveMergeconflicts
             // 
-            SolveMergeconflicts.BackColor = Color.SeaShell;
+            SolveMergeconflicts.BackColor = OtherColors.MergeConflictsColor;
             SolveMergeconflicts.FlatStyle = FlatStyle.Flat;
             SolveMergeconflicts.Image = Properties.Images.SolveMerge;
             SolveMergeconflicts.ImageAlign = ContentAlignment.MiddleLeft;

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -2927,7 +2927,7 @@ namespace GitUI.CommandsDialogs
                             len = lineLength - offset;
                             if (len > 0)
                             {
-                                Message.ChangeTextColor(line, offset, len, Color.Red);
+                                Message.ChangeTextColor(line, offset, len, Color.Red.AdaptTextColor());
                             }
                         }
                     }

--- a/src/app/GitUI/CommandsDialogs/FormRebase.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRebase.cs
@@ -190,14 +190,12 @@ namespace GitUI.CommandsDialogs
             btnSolveConflicts.ForeColor = SystemColors.ControlText;
             MergeToolPanel.BackColor = Color.Transparent;
 
-            Color highlightColor = Color.Yellow.AdaptBackColor();
-
             if (conflictedMerge)
             {
                 AcceptButton = btnSolveConflicts;
                 btnSolveConflicts.Focus();
                 btnSolveConflicts.Text = _solveConflictsText2.Text;
-                MergeToolPanel.BackColor = highlightColor;
+                MergeToolPanel.BackColor = Color.Yellow.AdaptBackColor();
             }
             else if (Module.InTheMiddleOfRebase())
             {

--- a/src/app/GitUI/CommandsDialogs/FormReflog.cs
+++ b/src/app/GitUI/CommandsDialogs/FormReflog.cs
@@ -5,6 +5,7 @@ using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
@@ -39,6 +40,7 @@ namespace GitUI.CommandsDialogs
             : base(uiCommands)
         {
             InitializeComponent();
+            lblDirtyWorkingDirectory.ForeColor.AdaptTextColor();
             InitializeComplete();
 
             gridReflog.RowTemplate.Height = DpiUtil.Scale(24);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.Designer.cs
@@ -145,7 +145,7 @@
             GcmDetected.Cursor = Cursors.Hand;
             GcmDetected.Dock = DockStyle.Fill;
             GcmDetected.FlatAppearance.BorderSize = 0;
-            GcmDetected.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            GcmDetected.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             GcmDetected.FlatStyle = FlatStyle.Flat;
             GcmDetected.ForeColor = SystemColors.ControlText;
             GcmDetected.Location = new Point(3, 348);
@@ -202,7 +202,7 @@
             GitFound.Cursor = Cursors.Hand;
             GitFound.Dock = DockStyle.Fill;
             GitFound.FlatAppearance.BorderSize = 0;
-            GitFound.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            GitFound.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             GitFound.FlatStyle = FlatStyle.Flat;
             GitFound.ForeColor = SystemColors.ControlText;
             GitFound.Location = new Point(3, 24);
@@ -222,7 +222,7 @@
             translationConfig.Cursor = Cursors.Hand;
             translationConfig.Dock = DockStyle.Fill;
             translationConfig.FlatAppearance.BorderSize = 0;
-            translationConfig.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            translationConfig.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             translationConfig.FlatStyle = FlatStyle.Flat;
             translationConfig.ForeColor = SystemColors.ControlText;
             translationConfig.Location = new Point(3, 312);
@@ -281,7 +281,7 @@
             SshConfig.Cursor = Cursors.Hand;
             SshConfig.Dock = DockStyle.Fill;
             SshConfig.FlatAppearance.BorderSize = 0;
-            SshConfig.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            SshConfig.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             SshConfig.FlatStyle = FlatStyle.Flat;
             SshConfig.ForeColor = SystemColors.ControlText;
             SshConfig.Location = new Point(3, 276);
@@ -301,7 +301,7 @@
             UserNameSet.Cursor = Cursors.Hand;
             UserNameSet.Dock = DockStyle.Fill;
             UserNameSet.FlatAppearance.BorderSize = 0;
-            UserNameSet.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            UserNameSet.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             UserNameSet.FlatStyle = FlatStyle.Flat;
             UserNameSet.ForeColor = SystemColors.ControlText;
             UserNameSet.Location = new Point(3, 60);
@@ -360,7 +360,7 @@
             MergeTool.Cursor = Cursors.Hand;
             MergeTool.Dock = DockStyle.Fill;
             MergeTool.FlatAppearance.BorderSize = 0;
-            MergeTool.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            MergeTool.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             MergeTool.FlatStyle = FlatStyle.Flat;
             MergeTool.ForeColor = SystemColors.ControlText;
             MergeTool.Location = new Point(3, 96);
@@ -380,7 +380,7 @@
             GitExtensionsInstall.Cursor = Cursors.Hand;
             GitExtensionsInstall.Dock = DockStyle.Fill;
             GitExtensionsInstall.FlatAppearance.BorderSize = 0;
-            GitExtensionsInstall.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            GitExtensionsInstall.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             GitExtensionsInstall.FlatStyle = FlatStyle.Flat;
             GitExtensionsInstall.ForeColor = SystemColors.ControlText;
             GitExtensionsInstall.Location = new Point(3, 240);
@@ -400,7 +400,7 @@
             GitBinFound.Cursor = Cursors.Hand;
             GitBinFound.Dock = DockStyle.Fill;
             GitBinFound.FlatAppearance.BorderSize = 0;
-            GitBinFound.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            GitBinFound.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             GitBinFound.FlatStyle = FlatStyle.Flat;
             GitBinFound.ForeColor = SystemColors.ControlText;
             GitBinFound.Location = new Point(3, 204);
@@ -446,7 +446,7 @@
             DiffTool.Cursor = Cursors.Hand;
             DiffTool.Dock = DockStyle.Fill;
             DiffTool.FlatAppearance.BorderSize = 0;
-            DiffTool.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            DiffTool.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             DiffTool.FlatStyle = FlatStyle.Flat;
             DiffTool.ForeColor = SystemColors.ControlText;
             DiffTool.Location = new Point(3, 132);
@@ -466,7 +466,7 @@
             ShellExtensionsRegistered.Cursor = Cursors.Hand;
             ShellExtensionsRegistered.Dock = DockStyle.Fill;
             ShellExtensionsRegistered.FlatAppearance.BorderSize = 0;
-            ShellExtensionsRegistered.FlatAppearance.MouseOverBackColor = Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            ShellExtensionsRegistered.FlatAppearance.MouseOverBackColor = Color.FromArgb(192, 192, 255);
             ShellExtensionsRegistered.FlatStyle = FlatStyle.Flat;
             ShellExtensionsRegistered.ForeColor = SystemColors.ControlText;
             ShellExtensionsRegistered.Location = new Point(3, 168);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -3,6 +3,7 @@ using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Utils;
 using GitExtensions.Extensibility.Translations;
+using GitExtUtils.GitUI.Theming;
 using GitUI.CommandsDialogs.SettingsDialog.ShellExtension;
 using Microsoft;
 using ResourceManager;
@@ -138,6 +139,16 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             : base(serviceProvider)
         {
             InitializeComponent();
+            GcmDetected.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            GitFound.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            translationConfig.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            SshConfig.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            UserNameSet.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            MergeTool.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            GitExtensionsInstall.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            GitBinFound.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            DiffTool.FlatAppearance.MouseOverBackColor.AdaptBackColor();
+            ShellExtensionsRegistered.FlatAppearance.MouseOverBackColor.AdaptBackColor();
             InitializeComplete();
         }
 
@@ -568,8 +579,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// </summary>
         private static void RenderSettingSet(Button settingButton, Button settingFixButton, string text)
         {
-            settingButton.BackColor = Color.PaleGreen;
-            settingButton.ForeColor = Color.DarkGreen;
+            settingButton.BackColor = Color.PaleGreen.AdaptBackColor();
+            settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
             settingButton.Text = text;
             settingFixButton.Visible = false;
         }
@@ -579,16 +590,16 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// </summary>
         private static void RenderSettingUnset(Button settingButton, Button settingFixButton, string text)
         {
-            settingButton.BackColor = Color.LavenderBlush;
-            settingButton.ForeColor = Color.Crimson;
+            settingButton.BackColor = Color.LavenderBlush.AdaptBackColor();
+            settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
             settingButton.Text = text;
             settingFixButton.Visible = true;
         }
 
         private static void RenderSettingNotRecommended(Button settingButton, Button settingFixButton, string text)
         {
-            settingButton.BackColor = Color.Coral;
-            settingButton.ForeColor = Color.Black;
+            settingButton.BackColor = Color.Coral.AdaptBackColor();
+            settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
             settingButton.Text = text;
             settingFixButton.Visible = true;
         }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
@@ -1,4 +1,5 @@
 ﻿using GitExtUtils;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Hotkey;
 using Microsoft;
 using ResourceManager;
@@ -53,6 +54,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public ControlHotkeys()
         {
             InitializeComponent();
+            txtHotkey.ForeColor.AdaptTextColor();
             InitializeComplete();
 
             cmbSettings.DisplayMember = nameof(HotkeySettings.Name);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
@@ -1,4 +1,5 @@
 ﻿using GitExtUtils;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Hotkey;
 using ResourceManager.Hotkey;
 
@@ -37,7 +38,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 if (_keyData != Keys.None)
                 {
                     // TODO: do not change text color on already assigned keys, which occur only once
-                    ForeColor = HotkeySettingsManager.IsUniqueKey(_keyData) ? Color.Red : SystemColors.WindowText;
+                    ForeColor = HotkeySettingsManager.IsUniqueKey(_keyData) ? Color.Red.AdaptTextColor() : SystemColors.WindowText;
                 }
 
                 Text = _keyData.ToText();

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -165,7 +165,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         private static void HighlightNode(TreeNode treeNode, bool highlight)
         {
             treeNode.ForeColor = highlight ? SystemColors.HighlightText : SystemColors.ControlText;
-            treeNode.BackColor = highlight ? SystemColors.Highlight : new Color();
+            treeNode.BackColor = highlight ? SystemColors.Highlight : Color.Empty;
         }
 
         private void ResetAllNodeHighlighting()

--- a/src/app/GitUI/Editor/CommitMessageHighlightingStrategy.cs
+++ b/src/app/GitUI/Editor/CommitMessageHighlightingStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using GitExtensions.Extensibility.Git;
+using GitExtUtils.GitUI.Theming;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
@@ -10,8 +11,8 @@ namespace GitUI.Editor
 
         private readonly List<TextMarker> _overlengthDescriptionMarkers = [];
 
-        private readonly TextMarker _markerSummaryTooLong = new(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "Summary line is too long." };
-        private readonly TextMarker _markerSpacerNeeded = new(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "There must be a blank line after the summary." };
+        private readonly TextMarker _markerSummaryTooLong = new(0, 0, TextMarkerType.WaveLine, Color.Red.AdaptBackColor()) { ToolTip = "Summary line is too long." };
+        private readonly TextMarker _markerSpacerNeeded = new(0, 0, TextMarkerType.WaveLine, Color.Red.AdaptBackColor()) { ToolTip = "There must be a blank line after the summary." };
 
         public CommitMessageHighlightingStrategy(IGitModule module)
             : base("GitCommitMessage", module)
@@ -140,7 +141,7 @@ namespace GitUI.Editor
                     }
                     else
                     {
-                        overlengthMarker = new TextMarker(markerOffset, markerLength, TextMarkerType.WaveLine, Color.Red) { ToolTip = "Line is too long." };
+                        overlengthMarker = new TextMarker(markerOffset, markerLength, TextMarkerType.WaveLine, Color.Red.AdaptBackColor()) { ToolTip = "Line is too long." };
                         _overlengthDescriptionMarkers.Add(overlengthMarker);
                         document.MarkerStrategy.AddMarker(overlengthMarker);
                     }

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -74,6 +74,8 @@ namespace GitUI.Editor
             ShowEntireFile = false;
             NumberOfContextLines = AppSettings.NumberOfContextLines;
             InitializeComponent();
+            _NO_TRANSLATE_lblShowPreview.BackColor.AdaptBackColor();
+
             InitializeComplete();
 
             UICommandsSourceSet += OnUICommandsSourceSet;

--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -1,4 +1,5 @@
 ﻿using GitExtensions.Extensibility;
+using GitExtUtils.GitUI.Theming;
 using GitUI.UserControls;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
@@ -263,7 +264,7 @@ namespace GitUI
                     count++;
 
                     TextMarker m = new(range.Offset, range.Length,
-                                           TextMarkerType.SolidBlock, Color.Yellow, Color.Black);
+                                           TextMarkerType.SolidBlock, Color.Yellow.AdaptBackColor());
                     group.AddMarker(m);
                 }
 
@@ -538,9 +539,9 @@ namespace GitUI
         public void SetScanRegion(int offset, int length)
         {
             Validates.NotNull(_document);
-            Color bkgColor = _document.HighlightingStrategy.GetColorFor("Default").BackgroundColor;
+            Color bkgColor = _document.HighlightingStrategy.GetColorFor("Default").BackgroundColor.AdaptBackColor();
             _region = new TextMarker(offset, length, TextMarkerType.SolidBlock,
-                                     Globals.HalfMix(bkgColor, Color.FromArgb(160, 160, 160)));
+                                     Globals.HalfMix(bkgColor, Color.FromArgb(160, 160, 160).AdaptTextColor()));
             _document.MarkerStrategy.AddMarker(_region);
             _document.TextContentChanged += DocumentOnTextContentChanged;
             ScanRegionChanged?.Invoke(this, EventArgs.Empty);

--- a/src/app/GitUI/Editor/GitHighlightingStrategyBase.cs
+++ b/src/app/GitUI/Editor/GitHighlightingStrategyBase.cs
@@ -1,4 +1,5 @@
 ﻿using GitExtensions.Extensibility.Git;
+using GitExtUtils.GitUI.Theming;
 using ICSharpCode.TextEditor.Document;
 
 namespace GitUI.Editor
@@ -7,7 +8,7 @@ namespace GitUI.Editor
     {
         protected static HighlightColor ColorNormal { get; } = new(SystemColors.WindowText, bold: false, italic: false);
 
-        private static HighlightColor ColorComment { get; } = new(Color.DarkGreen, bold: false, italic: false);
+        private static HighlightColor ColorComment { get; } = new(Color.DarkGreen.AdaptBackColor(), bold: false, italic: false);
 
         private readonly DefaultHighlightingStrategy _defaultHighlightingStrategy = new();
 

--- a/src/app/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
+++ b/src/app/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using GitExtensions.Extensibility.Git;
+using GitExtUtils.GitUI.Theming;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
@@ -19,13 +20,13 @@ namespace GitUI.Editor
 
         private static readonly Dictionary<char, (string longForm, HighlightColor color, string[] options)> _commandByFirstChar = new()
         {
-            { 'p', ("pick", new HighlightColor(Color.Black, bold: true, italic: false), Array.Empty<string>()) },
-            { 'r', ("reword", new HighlightColor(Color.Purple, bold: true, italic: false), Array.Empty<string>()) },
-            { 'e', ("edit", new HighlightColor(Color.Black, bold: true, italic: false), Array.Empty<string>()) },
-            { 's', ("squash", new HighlightColor(Color.DarkBlue, bold: true, italic: false), Array.Empty<string>()) },
-            { 'f', ("fixup", new HighlightColor(Color.LightCoral, bold: true, italic: false), new[] { "-C", "-c" }) },
-            { 'x', ("exec", new HighlightColor(Color.Black, bold: true, italic: false), Array.Empty<string>()) },
-            { 'd', ("drop", new HighlightColor(Color.Red, bold: true, italic: false), Array.Empty<string>()) }
+            { 'p', ("pick", new HighlightColor(SystemColors.InfoText, bold: true, italic: false), Array.Empty<string>()) },
+            { 'r', ("reword", new HighlightColor(Color.Purple.AdaptTextColor(), bold: true, italic: false), Array.Empty<string>()) },
+            { 'e', ("edit", new HighlightColor(Color.DarkGray.AdaptTextColor(), bold: true, italic: false), Array.Empty<string>()) },
+            { 's', ("squash", new HighlightColor(Color.DarkBlue.AdaptTextColor(), bold: true, italic: false), Array.Empty<string>()) },
+            { 'f', ("fixup", new HighlightColor(Color.LightCoral.AdaptTextColor(), bold: true, italic: false), new[] { "-C", "-c" }) },
+            { 'x', ("exec", new HighlightColor(SystemColors.GrayText, bold: true, italic: false), Array.Empty<string>()) },
+            { 'd', ("drop", new HighlightColor(Color.Red.AdaptTextColor(), bold: true, italic: false), Array.Empty<string>()) }
         };
 
         public RebaseTodoHighlightingStrategy(IGitModule module)

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
@@ -118,7 +118,7 @@
             // 
             // labelResetBranchWarning
             // 
-            labelResetBranchWarning.ForeColor = Color.Black;
+            labelResetBranchWarning.ForeColor = SystemColors.WindowText;
             labelResetBranchWarning.Location = new Point(25, 0);
             labelResetBranchWarning.Name = "labelResetBranchWarning";
             labelResetBranchWarning.Size = new Size(250, 20);

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -31,6 +31,7 @@ namespace GitUI.HelperDialogs
             pictureBox1.Image = DpiUtil.Scale(pictureBox1.Image);
             labelResetBranchWarning.AutoSize = true;
             labelResetBranchWarning.Dock = DockStyle.Fill;
+            labelResetBranchWarning.SetForeColorForBackColor();
 
             Height = tableLayoutPanel1.Height + tableLayoutPanel1.Top;
             tableLayoutPanel1.Dock = DockStyle.Fill;
@@ -38,8 +39,6 @@ namespace GitUI.HelperDialogs
             ActiveControl = Branches;
 
             InitializeComplete();
-
-            labelResetBranchWarning.SetForeColorForBackColor();
 
             Ok.Enabled = false;
         }
@@ -145,7 +144,7 @@ namespace GitUI.HelperDialogs
             CancellationToken cancellationToken = _cancellationTokenSequence.Next();
 
             IGitRef? gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == branch);
-            Branches.BackColor = gitRefToReset is null && ActiveControl != Branches ? Color.LightCoral : SystemColors.Window;
+            Branches.BackColor = gitRefToReset is null && ActiveControl != Branches ? Color.LightCoral.AdaptBackColor() : SystemColors.Window;
 
             Ok.Enabled = gitRefToReset is not null && ForceReset.Checked;
             Ok.BackColor = SystemColors.ButtonFace;
@@ -171,7 +170,7 @@ namespace GitUI.HelperDialogs
                 Ok.Enabled = executionResult.ExitedSuccessfully;
                 if (!executionResult.ExitedSuccessfully)
                 {
-                    Ok.BackColor = Color.LightCoral;
+                    Ok.BackColor = Color.LightCoral.AdaptBackColor();
                 }
             });
         }

--- a/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
@@ -94,7 +94,6 @@
             Soft.BackColor = Color.FromArgb(((int)(((byte)(128)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
             Soft.Checked = true;
             Soft.Dock = DockStyle.Fill;
-            Soft.ForeColor = Color.Black;
             Soft.Location = new Point(3, 3);
             Soft.Name = "Soft";
             Soft.Padding = new Padding(3);
@@ -108,7 +107,6 @@
             Mixed.AutoSize = true;
             Mixed.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
             Mixed.Dock = DockStyle.Fill;
-            Mixed.ForeColor = Color.Black;
             Mixed.Location = new Point(3, 45);
             Mixed.Name = "Mixed";
             Mixed.Padding = new Padding(3);
@@ -123,7 +121,6 @@
             Keep.AutoSize = true;
             Keep.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
             Keep.Dock = DockStyle.Fill;
-            Keep.ForeColor = Color.Black;
             Keep.Location = new Point(3, 87);
             Keep.Name = "Keep";
             Keep.Padding = new Padding(3);
@@ -138,7 +135,6 @@
             Merge.AutoSize = true;
             Merge.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
             Merge.Dock = DockStyle.Fill;
-            Merge.ForeColor = Color.Black;
             Merge.Location = new Point(3, 129);
             Merge.Name = "Merge";
             Merge.Padding = new Padding(3);
@@ -153,7 +149,6 @@
             Hard.AutoSize = true;
             Hard.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(128)))));
             Hard.Dock = DockStyle.Fill;
-            Hard.ForeColor = Color.Black;
             Hard.Location = new Point(3, 171);
             Hard.Name = "Hard";
             Hard.Padding = new Padding(3);

--- a/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -31,10 +31,15 @@ namespace GitUI.HelperDialogs
             Revision = revision;
 
             InitializeComponent();
+            Soft.BackColor.AdaptBackColor();
             Soft.SetForeColorForBackColor();
+            Hard.BackColor.AdaptBackColor();
             Hard.SetForeColorForBackColor();
+            Mixed.BackColor.AdaptBackColor();
             Mixed.SetForeColorForBackColor();
+            Merge.BackColor.AdaptBackColor();
             Merge.SetForeColorForBackColor();
+            Keep.BackColor.AdaptBackColor();
             Keep.SetForeColorForBackColor();
             InitializeComplete();
 

--- a/src/app/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/src/app/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -2,6 +2,7 @@
 using GitCommands;
 using GitCommands.Utils;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 
 namespace GitUI.SpellChecker
 {
@@ -151,7 +152,7 @@ namespace GitUI.SpellChecker
 
         private void DrawWave(Point start, Point end)
         {
-            using Pen pen = new(Color.Red, DpiUtil.ScaleX);
+            using Pen pen = new(Color.Red.AdaptTextColor(), DpiUtil.ScaleX);
             int waveWidth = DpiUtil.Scale(4);
             int waveHalfWidth = waveWidth >> 1;
             if ((end.X - start.X) > waveWidth)
@@ -174,7 +175,7 @@ namespace GitUI.SpellChecker
 
         private void DrawMark(Point start, Point end)
         {
-            Color col = Color.FromArgb(120, 255, 255, 0);
+            Color col = Color.FromArgb(120, 255, 255, 0).AdaptBackColor();
             int lineHeight = LineHeight();
             using Pen pen = new(col, lineHeight);
             start.Offset(0, -lineHeight / 2);

--- a/src/app/GitUI/UserControls/CommitSummaryUserControl.cs
+++ b/src/app/GitUI/UserControls/CommitSummaryUserControl.cs
@@ -18,8 +18,8 @@ namespace GitUI.UserControls
         private readonly IDateFormatter _dateFormatter = new DateFormatter();
         private readonly string _tagsCaption;
         private readonly string _branchesCaption;
-        private readonly Color _tagsBackColor = Color.LightSteelBlue;
-        private readonly Color _branchesBackColor = Color.LightSalmon;
+        private readonly Color _tagsBackColor = Color.LightSteelBlue.AdaptBackColor();
+        private readonly Color _branchesBackColor = Color.LightSalmon.AdaptBackColor();
         private GitRevision? _revision;
 
         private readonly int _messageY;
@@ -38,6 +38,7 @@ namespace GitUI.UserControls
 
             labelMessage.Font = new Font(labelMessage.Font, FontStyle.Bold);
             labelAuthor.Font = new Font(labelAuthor.Font, FontStyle.Bold);
+            labelTags.BackColor.AdaptBackColor();
         }
 
         /// <summary>

--- a/src/app/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/src/app/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -37,6 +37,7 @@ namespace GitUI.UserControls
         public InteractiveGitActionControl()
         {
             InitializeComponent();
+            BackColor.AdaptBackColor();
             InitializeComplete();
         }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -19,7 +19,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         private readonly RevisionDataGridView _gridView;
         private readonly Func<IGitModule> _module;
 
-        // Increase contrast to selected rows
+        // Increase contrast to selected rows (adapted to theme at use)
         private readonly Color _lightBlue = Color.FromArgb(130, 180, 240);
         private Font? _fontWithUnicodeCache = null;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -329,7 +329,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     style.NormalFont,
                     ref currentOffset,
                     label,
-                    Color.OrangeRed,
+                    headColor: Color.OrangeRed.AdaptTextColor(),
                     isSelected ? RefArrowType.Filled : RefArrowType.NotFilled,
                     messageBounds,
                     e.Graphics,

--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -28,7 +28,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             if (branchColors.Length < 2)
             {
                 Trace.WriteLine("At least two graph colors must be configured");
-                branchColors = [Color.Magenta, Color.Cyan];
+                branchColors = [Color.Magenta.AdaptTextColor(), Color.Cyan.AdaptTextColor()];
             }
 
             foreach (Color color in branchColors)

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -1,5 +1,6 @@
 using GitCommands;
 using GitCommands.Git;
+using GitExtUtils.GitUI.Theming;
 using GitUI.UserControls.RevisionGrid;
 using Timer = System.Windows.Forms.Timer;
 
@@ -176,7 +177,7 @@ namespace GitUI
             }
             else
             {
-                _label.ForeColor = Color.DarkRed;
+                _label.ForeColor = Color.DarkRed.AdaptTextColor();
             }
 
             int? SearchForward()

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.Composition;
 using GitCommands;
 using GitExtensions.Extensibility.Settings;
+using GitExtUtils.GitUI.Theming;
 using GitUI;
 using GitUIPluginInterfaces.BuildServerIntegration;
 using Microsoft;
@@ -30,6 +31,7 @@ namespace AzureDevOpsIntegration.Settings
         public SettingsUserControl()
         {
             InitializeComponent();
+            labelRegexError.ForeColor.AdaptTextColor();
             InitializeComplete();
 
             Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top;

--- a/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.Composition;
 using System.Text.RegularExpressions;
 using GitExtensions.Extensibility.Settings;
+using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces.BuildServerIntegration;
 using ResourceManager;
 
@@ -26,6 +27,7 @@ namespace TeamCityIntegration.Settings
         public TeamCitySettingsUserControl()
         {
             InitializeComponent();
+            labelRegexError.ForeColor.AdaptTextColor();
             InitializeComplete();
 
             Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top;

--- a/src/plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/src/plugins/Statistics/GitImpact/ImpactControl.cs
@@ -2,6 +2,7 @@
 using System.Drawing.Drawing2D;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 
 namespace GitExtensions.Plugins.GitImpact
 {
@@ -322,7 +323,7 @@ namespace GitExtensions.Plugins.GitImpact
                         // Create a new random brush for the author if none exists yet
                         if (!_brushes.ContainsKey(author))
                         {
-                            Color color = Color.FromArgb((int)(author.GetHashCode() | 0xFF000000));
+                            Color color = Color.FromArgb((int)(author.GetHashCode() | 0xFF000000)).AdaptBackColor();
                             _brushes.Add(author, new SolidBrush(color));
                         }
 

--- a/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -3,6 +3,7 @@ using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Plugins.GitStatistics.PieChart;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using GitUI;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
@@ -130,7 +131,7 @@ namespace GitExtensions.Plugins.GitStatistics
             pie.SetFitChart(false);
             pie.SetEdgeColorType(EdgeColorType.DarkerThanSurface);
             pie.SetSliceRelativeHeight(0.20f);
-            pie.SetColors(DecentColors);
+            pie.SetColors(DecentColors.Select(c => c.AdaptBackColor()).ToArray());
             pie.SetShadowStyle(ShadowStyle.GradualShadow);
 
             if (pie.Parent.Width > pie.Parent.Height)

--- a/src/plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
+++ b/src/plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
@@ -1,4 +1,5 @@
 using GitExtensions.Extensibility;
+using GitExtUtils.GitUI.Theming;
 using Microsoft;
 
 namespace GitExtensions.Plugins.GitStatistics.PieChart
@@ -677,7 +678,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
                             X + (largestDisplacementEllipseSize.Width / 2) + xDisplacement,
                             Y + (largestDisplacementEllipseSize.Height / 2) + yDisplacement,
                             topEllipseSize.Width, topEllipseSize.Height, PieHeight, (float)(startAngle % 360),
-                            (float)sweepAngle, SliceColors[colorIndex], ShadowStyle, EdgeColorType,
+                            (float)sweepAngle, SliceColors[colorIndex].AdaptBackColor(), ShadowStyle, EdgeColorType,
                             EdgeLineWidth);
                 }
                 else
@@ -685,7 +686,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
                     slice = CreatePieSlice(X + (largestDisplacementEllipseSize.Width / 2) + xDisplacement,
                                            Y + (largestDisplacementEllipseSize.Height / 2) + yDisplacement,
                                            topEllipseSize.Width, topEllipseSize.Height, PieHeight,
-                                           (float)(startAngle % 360), (float)sweepAngle, SliceColors[colorIndex],
+                                           (float)(startAngle % 360), (float)sweepAngle, SliceColors[colorIndex].AdaptBackColor(),
                                            ShadowStyle, EdgeColorType, EdgeLineWidth);
                 }
 


### PR DESCRIPTION
Preparation for https://github.com/gitextensions/gitextensions/pull/12111
Simplify review of the theme update.
This PR does not change behavior for the invariant theme.
There may be tweaks required to the theme handling in https://github.com/gitextensions/gitextensions/pull/12111 when that is actively reviewed, that review should be based on this (and similar) PRs.
Will likely be merged together with similar preparing PRs.

## Proposed changes

Prepare for theming by adopting hardcoded colors to theme colors.

Some colors set in Designer updated in the form code files. 
Requested in the theme PR, make it harder to review this PR.
https://github.com/gitextensions/gitextensions/pull/12111#discussion_r1898818038

## Test methodology <!-- How did you ensure quality? -->

Review

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
