### PR TITLE
chore: Remove ImageTransparentColor

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -230,7 +230,6 @@ namespace GitUI.CommandsDialogs
             // 
             RefreshButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             RefreshButton.Image = Properties.Images.ReloadRevisions;
-            RefreshButton.ImageTransparentColor = Color.White;
             RefreshButton.Name = "RefreshButton";
             RefreshButton.Size = new Size(23, 22);
             RefreshButton.ToolTipText = "Refresh";
@@ -305,7 +304,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolStripButtonLevelUp.DisplayStyle = ToolStripItemDisplayStyle.Image;
             toolStripButtonLevelUp.Image = Properties.Images.SubmodulesManage;
-            toolStripButtonLevelUp.ImageTransparentColor = Color.Magenta;
             toolStripButtonLevelUp.Name = "toolStripButtonLevelUp";
             toolStripButtonLevelUp.Size = new Size(32, 22);
             toolStripButtonLevelUp.ToolTipText = "Submodules";
@@ -320,7 +318,6 @@ namespace GitUI.CommandsDialogs
             // branchSelect
             // 
             branchSelect.Image = Properties.Resources.branch;
-            branchSelect.ImageTransparentColor = Color.Magenta;
             branchSelect.Name = "branchSelect";
             branchSelect.Size = new Size(60, 22);
             branchSelect.Text = "Branch";
@@ -344,7 +341,6 @@ namespace GitUI.CommandsDialogs
             manageStashesToolStripMenuItem,
             createAStashToolStripMenuItem});
             toolStripSplitStash.Image = Properties.Images.Stash;
-            toolStripSplitStash.ImageTransparentColor = Color.Magenta;
             toolStripSplitStash.Name = "toolStripSplitStash";
             toolStripSplitStash.Size = new Size(32, 22);
             toolStripSplitStash.ToolTipText = "Manage stashes";
@@ -398,7 +394,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolStripButtonCommit.Image = Properties.Images.RepoStateClean;
             toolStripButtonCommit.ImageAlign = ContentAlignment.MiddleLeft;
-            toolStripButtonCommit.ImageTransparentColor = Color.Magenta;
             toolStripButtonCommit.Name = "toolStripButtonCommit";
             toolStripButtonCommit.Size = new Size(71, 22);
             toolStripButtonCommit.Text = "Commit";
@@ -419,7 +414,6 @@ namespace GitUI.CommandsDialogs
             toolStripSeparator14,
             setDefaultPullButtonActionToolStripMenuItem});
             toolStripButtonPull.Image = Properties.Images.Pull;
-            toolStripButtonPull.ImageTransparentColor = Color.Magenta;
             toolStripButtonPull.Name = "toolStripButtonPull";
             toolStripButtonPull.Size = new Size(32, 22);
             toolStripButtonPull.Text = "Pull";
@@ -491,7 +485,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolStripButtonPush.DisplayStyle = ToolStripItemDisplayStyle.Image;
             toolStripButtonPush.Image = Properties.Images.Push;
-            toolStripButtonPush.ImageTransparentColor = Color.Magenta;
             toolStripButtonPush.Name = "toolStripButtonPush";
             toolStripButtonPush.Size = new Size(23, 22);
             toolStripButtonPush.Text = "Push";
@@ -506,7 +499,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolStripFileExplorer.Enabled = false;
             toolStripFileExplorer.Image = Properties.Images.BrowseFileExplorer;
-            toolStripFileExplorer.ImageTransparentColor = Color.Gray;
             toolStripFileExplorer.Name = "toolStripFileExplorer";
             toolStripFileExplorer.Size = new Size(23, 22);
             toolStripFileExplorer.ToolTipText = "File Explorer";
@@ -515,7 +507,6 @@ namespace GitUI.CommandsDialogs
             // userShell
             // 
             userShell.Image = Properties.Images.GitForWindows;
-            userShell.ImageTransparentColor = Color.Magenta;
             userShell.Name = "userShell";
             userShell.Size = new Size(23, 22);
             userShell.ToolTipText = "Git bash";
@@ -790,7 +781,6 @@ namespace GitUI.CommandsDialogs
             // refreshToolStripMenuItem
             // 
             refreshToolStripMenuItem.Image = Properties.Images.ReloadRevisions;
-            refreshToolStripMenuItem.ImageTransparentColor = Color.Transparent;
             refreshToolStripMenuItem.Name = "refreshToolStripMenuItem";
             refreshToolStripMenuItem.Size = new Size(221, 22);
             refreshToolStripMenuItem.Text = "&Refresh";
@@ -799,7 +789,6 @@ namespace GitUI.CommandsDialogs
             // refreshDashboardToolStripMenuItem
             // 
             refreshDashboardToolStripMenuItem.Image = Properties.Images.ReloadRevisions;
-            refreshDashboardToolStripMenuItem.ImageTransparentColor = Color.Transparent;
             refreshDashboardToolStripMenuItem.Name = "refreshDashboardToolStripMenuItem";
             refreshDashboardToolStripMenuItem.Size = new Size(113, 22);
             refreshDashboardToolStripMenuItem.Text = "&Refresh";

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -160,7 +160,6 @@ namespace GitUI.CommandsDialogs
                 ToolStripButton clonedToolStripMenuItem = new()
                 {
                     Image = toolStripMenuItem.Image,
-                    ImageTransparentColor = toolStripMenuItem.ImageTransparentColor,
                     Name = FetchPullToolbarShortcutsPrefix + toolStripMenuItem.Name,
                     Size = toolStripMenuItem.Size,
                     Text = toolTipText,

--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -754,7 +754,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolRefreshItem.DisplayStyle = ToolStripItemDisplayStyle.Image;
             toolRefreshItem.Image = Properties.Images.ReloadRevisions;
-            toolRefreshItem.ImageTransparentColor = Color.Magenta;
             toolRefreshItem.Name = "toolRefreshItem";
             toolRefreshItem.Size = new Size(23, 20);
             toolRefreshItem.Text = "Refresh";
@@ -944,7 +943,6 @@ namespace GitUI.CommandsDialogs
             toolStageAllItem.Alignment = ToolStripItemAlignment.Right;
             toolStageAllItem.DisplayStyle = ToolStripItemDisplayStyle.Image;
             toolStageAllItem.Image = Properties.Images.StageAll;
-            toolStageAllItem.ImageTransparentColor = Color.Magenta;
             toolStageAllItem.Name = "toolStageAllItem";
             toolStageAllItem.Size = new Size(23, 23);
             toolStageAllItem.Click += toolStageAllItem_Click;
@@ -960,7 +958,6 @@ namespace GitUI.CommandsDialogs
             toolStageItem.Alignment = ToolStripItemAlignment.Right;
             toolStageItem.AutoToolTip = false;
             toolStageItem.Image = Properties.Images.Stage;
-            toolStageItem.ImageTransparentColor = Color.Magenta;
             toolStageItem.Name = "toolStageItem";
             toolStageItem.Size = new Size(56, 23);
             toolStageItem.Text = "&Stage";
@@ -971,7 +968,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolUnstageAllItem.DisplayStyle = ToolStripItemDisplayStyle.Image;
             toolUnstageAllItem.Image = Properties.Images.UnstageAll;
-            toolUnstageAllItem.ImageTransparentColor = Color.Magenta;
             toolUnstageAllItem.Name = "toolUnstageAllItem";
             toolUnstageAllItem.Size = new Size(23, 23);
             toolUnstageAllItem.Click += toolUnstageAllItem_Click;
@@ -985,7 +981,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolUnstageItem.AutoToolTip = false;
             toolUnstageItem.Image = Properties.Images.Unstage;
-            toolUnstageItem.ImageTransparentColor = Color.Magenta;
             toolUnstageItem.Name = "toolUnstageItem";
             toolUnstageItem.Size = new Size(70, 23);
             toolUnstageItem.Text = "&Unstage";
@@ -1407,7 +1402,6 @@ namespace GitUI.CommandsDialogs
             // createBranchToolStripButton
             // 
             createBranchToolStripButton.Image = Properties.Images.BranchCreate;
-            createBranchToolStripButton.ImageTransparentColor = Color.Magenta;
             createBranchToolStripButton.Name = "createBranchToolStripButton";
             createBranchToolStripButton.Size = new Size(101, 20);
             createBranchToolStripButton.Text = "Create &branch";

--- a/src/app/GitUI/CommandsDialogs/FormEditor.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormEditor.Designer.cs
@@ -120,7 +120,6 @@
             // 
             toolStripSaveButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             toolStripSaveButton.Image = Properties.Images.Save;
-            toolStripSaveButton.ImageTransparentColor = Color.Magenta;
             toolStripSaveButton.Name = "toolStripSaveButton";
             toolStripSaveButton.Size = new Size(23, 22);
             toolStripSaveButton.ToolTipText = "Save";

--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -329,7 +329,6 @@ namespace GitUI.CommandsDialogs
             loadHistoryOnShowToolStripMenuItem,
             loadBlameOnShowToolStripMenuItem});
             toolStripSplitLoad.Image = Properties.Images.ReloadRevisions;
-            toolStripSplitLoad.ImageTransparentColor = Color.Magenta;
             toolStripSplitLoad.Name = "toolStripSplitLoad";
             toolStripSplitLoad.Size = new Size(32, 22);
             toolStripSplitLoad.ToolTipText = "Load file history";
@@ -360,7 +359,6 @@ namespace GitUI.CommandsDialogs
             showFullHistoryToolStripMenuItem,
             simplifyMergesToolStripMenuItem});
             ShowFullHistory.Image = Properties.Images.FileHistory;
-            ShowFullHistory.ImageTransparentColor = Color.Magenta;
             ShowFullHistory.Name = "ShowFullHistory";
             ShowFullHistory.Size = new Size(29, 22);
             ShowFullHistory.ToolTipText = "Show Full History";
@@ -397,7 +395,6 @@ namespace GitUI.CommandsDialogs
             showLineNumbersToolStripMenuItem,
             showOriginalFilePathToolStripMenuItem});
             toolStripBlameOptions.Image = Properties.Images.Blame;
-            toolStripBlameOptions.ImageTransparentColor = Color.Magenta;
             toolStripBlameOptions.Name = "toolStripBlameOptions";
             toolStripBlameOptions.Size = new Size(29, 22);
             toolStripBlameOptions.Text = "Blame options";

--- a/src/app/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -327,7 +327,6 @@ namespace GitUI.CommandsDialogs
             refreshToolStripButton.Alignment = ToolStripItemAlignment.Right;
             refreshToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             refreshToolStripButton.Image = Properties.Images.ReloadRevisions;
-            refreshToolStripButton.ImageTransparentColor = Color.Magenta;
             refreshToolStripButton.Name = "refreshToolStripButton";
             refreshToolStripButton.Overflow = ToolStripItemOverflow.Never;
             refreshToolStripButton.Size = new Size(36, 37);

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -31,7 +31,6 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
 
         Image = Properties.Resources.RepoOpen;
         ImageAlign = ContentAlignment.MiddleLeft;
-        ImageTransparentColor = Color.Magenta;
         TextAlign = ContentAlignment.MiddleLeft;
     }
 

--- a/src/app/GitUI/CommandsDialogs/SearchWindow.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SearchWindow.Designer.cs
@@ -66,6 +66,7 @@ namespace GitUI.CommandsDialogs
             // 
             AutoSize = true;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            BackColor = Color.Lime;
             ClientSize = new Size(325, 213);
             ControlBox = false;
             Controls.Add(tableLayoutPanel1);
@@ -77,6 +78,7 @@ namespace GitUI.CommandsDialogs
             ShowInTaskbar = false;
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;
+            TransparencyKey = Color.Lime;
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
             ResumeLayout(false);

--- a/src/app/GitUI/CommandsDialogs/SearchWindow.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SearchWindow.Designer.cs
@@ -66,7 +66,6 @@ namespace GitUI.CommandsDialogs
             // 
             AutoSize = true;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            BackColor = Color.Transparent;
             ClientSize = new Size(325, 213);
             ControlBox = false;
             Controls.Add(tableLayoutPanel1);

--- a/src/app/GitUI/CommandsDialogs/SearchWindow.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SearchWindow.Designer.cs
@@ -66,7 +66,7 @@ namespace GitUI.CommandsDialogs
             // 
             AutoSize = true;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            BackColor = Color.Lime;
+            BackColor = Color.Transparent;
             ClientSize = new Size(325, 213);
             ControlBox = false;
             Controls.Add(tableLayoutPanel1);
@@ -78,7 +78,6 @@ namespace GitUI.CommandsDialogs
             ShowInTaskbar = false;
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;
-            TransparencyKey = Color.Lime;
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
             ResumeLayout(false);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -149,7 +149,6 @@
             // 
             Add.BackColor = SystemColors.Control;
             Add.Image = Properties.Resources.FileStatusAdded;
-            Add.ImageTransparentColor = Color.Magenta;
             Add.Name = "Add";
             Add.Size = new Size(61, 22);
             Add.Text = "Add";
@@ -163,7 +162,6 @@
             // Remove
             // 
             Remove.Image = Properties.Resources.FileStatusRemoved;
-            Remove.ImageTransparentColor = Color.Magenta;
             Remove.Name = "Remove";
             Remove.Size = new Size(70, 22);
             Remove.Text = "Remove";

--- a/src/app/GitUI/Editor/FileViewer.Designer.cs
+++ b/src/app/GitUI/Editor/FileViewer.Designer.cs
@@ -218,7 +218,6 @@ namespace GitUI.Editor
             // showSyntaxHighlightingToolStripMenuItem
             // 
             showSyntaxHighlightingToolStripMenuItem.Image = Properties.Resources.SyntaxHighlighting;
-            showSyntaxHighlightingToolStripMenuItem.ImageTransparentColor = Color.Magenta;
             showSyntaxHighlightingToolStripMenuItem.Name = "showSyntaxHighlightingToolStripMenuItem";
             showSyntaxHighlightingToolStripMenuItem.Size = new Size(243, 22);
             showSyntaxHighlightingToolStripMenuItem.Text = "Show synta&x highlighting";
@@ -331,7 +330,6 @@ namespace GitUI.Editor
             // 
             nextChangeButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             nextChangeButton.Image = Properties.Images.ArrowDown;
-            nextChangeButton.ImageTransparentColor = Color.Magenta;
             nextChangeButton.Name = "nextChangeButton";
             nextChangeButton.Size = new Size(23, 20);
             nextChangeButton.ToolTipText = "Next change";
@@ -341,7 +339,6 @@ namespace GitUI.Editor
             // 
             previousChangeButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             previousChangeButton.Image = Properties.Images.ArrowUp;
-            previousChangeButton.ImageTransparentColor = Color.Magenta;
             previousChangeButton.Name = "previousChangeButton";
             previousChangeButton.Size = new Size(23, 20);
             previousChangeButton.ToolTipText = "Previous change";
@@ -356,7 +353,6 @@ namespace GitUI.Editor
             // 
             increaseNumberOfLines.DisplayStyle = ToolStripItemDisplayStyle.Image;
             increaseNumberOfLines.Image = Properties.Images.NumberOfLinesIncrease;
-            increaseNumberOfLines.ImageTransparentColor = Color.Magenta;
             increaseNumberOfLines.Name = "increaseNumberOfLines";
             increaseNumberOfLines.Size = new Size(23, 20);
             increaseNumberOfLines.ToolTipText = "Increase the number of lines of context";
@@ -366,7 +362,6 @@ namespace GitUI.Editor
             // 
             decreaseNumberOfLines.DisplayStyle = ToolStripItemDisplayStyle.Image;
             decreaseNumberOfLines.Image = Properties.Images.NumberOfLinesDecrease;
-            decreaseNumberOfLines.ImageTransparentColor = Color.Magenta;
             decreaseNumberOfLines.Name = "decreaseNumberOfLines";
             decreaseNumberOfLines.Size = new Size(23, 20);
             decreaseNumberOfLines.ToolTipText = "Decrease the number of lines of context";
@@ -381,7 +376,6 @@ namespace GitUI.Editor
             // 
             showEntireFileButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             showEntireFileButton.Image = Properties.Images.ShowEntireFile;
-            showEntireFileButton.ImageTransparentColor = Color.Magenta;
             showEntireFileButton.Name = "showEntireFileButton";
             showEntireFileButton.Size = new Size(23, 20);
             showEntireFileButton.ToolTipText = "Show entire file";
@@ -391,7 +385,6 @@ namespace GitUI.Editor
             // 
             showNonPrintChars.DisplayStyle = ToolStripItemDisplayStyle.Image;
             showNonPrintChars.Image = Properties.Images.ShowWhitespace;
-            showNonPrintChars.ImageTransparentColor = Color.Magenta;
             showNonPrintChars.Name = "showNonPrintChars";
             showNonPrintChars.Size = new Size(23, 20);
             showNonPrintChars.ToolTipText = "Show nonprinting characters";
@@ -400,7 +393,6 @@ namespace GitUI.Editor
             // ignoreWhitespaceAtEol
             // 
             ignoreWhitespaceAtEol.DisplayStyle = ToolStripItemDisplayStyle.Image;
-            ignoreWhitespaceAtEol.ImageTransparentColor = Color.Magenta;
             ignoreWhitespaceAtEol.Name = "ignoreWhitespaceAtEol";
             ignoreWhitespaceAtEol.Size = new Size(23, 4);
             ignoreWhitespaceAtEol.ToolTipText = "Ignore whitespace changes at end of line";
@@ -409,7 +401,6 @@ namespace GitUI.Editor
             // ignoreWhiteSpaces
             // 
             ignoreWhiteSpaces.DisplayStyle = ToolStripItemDisplayStyle.Image;
-            ignoreWhiteSpaces.ImageTransparentColor = Color.Magenta;
             ignoreWhiteSpaces.Name = "ignoreWhiteSpaces";
             ignoreWhiteSpaces.Size = new Size(23, 4);
             ignoreWhiteSpaces.ToolTipText = "Ignore changes in amount of whitespace";
@@ -428,7 +419,6 @@ namespace GitUI.Editor
             // 
             settingsButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             settingsButton.Image = Properties.Images.Settings;
-            settingsButton.ImageTransparentColor = Color.Magenta;
             settingsButton.Name = "settingsButton";
             settingsButton.Size = new Size(23, 20);
             settingsButton.ToolTipText = "Settings";
@@ -437,7 +427,6 @@ namespace GitUI.Editor
             // ignoreAllWhitespaces
             // 
             ignoreAllWhitespaces.DisplayStyle = ToolStripItemDisplayStyle.Image;
-            ignoreAllWhitespaces.ImageTransparentColor = Color.Magenta;
             ignoreAllWhitespaces.Name = "ignoreAllWhitespaces";
             ignoreAllWhitespaces.Size = new Size(23, 4);
             ignoreAllWhitespaces.ToolTipText = "Ignore all whitespace changes";
@@ -488,7 +477,6 @@ namespace GitUI.Editor
             // 
             showSyntaxHighlighting.DisplayStyle = ToolStripItemDisplayStyle.Image;
             showSyntaxHighlighting.Image = Properties.Resources.SyntaxHighlighting;
-            showSyntaxHighlighting.ImageTransparentColor = Color.Magenta;
             showSyntaxHighlighting.Name = "showSyntaxHighlighting";
             showSyntaxHighlighting.Size = new Size(23, 22);
             showSyntaxHighlighting.ToolTipText = "Show syntax highlighting";

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.Designer.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.Designer.cs
@@ -590,7 +590,6 @@ namespace GitUI.LeftPanel
             // 
             tsbCollapseAll.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsbCollapseAll.Image = Properties.Images.CollapseAll;
-            tsbCollapseAll.ImageTransparentColor = Color.Magenta;
             tsbCollapseAll.Name = "tsbCollapseAll";
             tsbCollapseAll.Size = new Size(29, 24);
             tsbCollapseAll.Click += btnCollapseAll_Click;
@@ -600,7 +599,6 @@ namespace GitUI.LeftPanel
             tsbShowBranches.CheckOnClick = true;
             tsbShowBranches.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsbShowBranches.Image = Properties.Images.BranchLocalRoot;
-            tsbShowBranches.ImageTransparentColor = Color.Magenta;
             tsbShowBranches.Name = "tsbShowBranches";
             tsbShowBranches.Size = new Size(29, 24);
             tsbShowBranches.Text = "&Branches";
@@ -611,7 +609,6 @@ namespace GitUI.LeftPanel
             tsbShowRemotes.CheckOnClick = true;
             tsbShowRemotes.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsbShowRemotes.Image = Properties.Images.BranchRemoteRoot;
-            tsbShowRemotes.ImageTransparentColor = Color.Magenta;
             tsbShowRemotes.Name = "tsbShowRemotes";
             tsbShowRemotes.Size = new Size(29, 24);
             tsbShowRemotes.Text = "&Remotes";
@@ -622,7 +619,6 @@ namespace GitUI.LeftPanel
             tsbShowTags.CheckOnClick = true;
             tsbShowTags.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsbShowTags.Image = Properties.Images.TagHorizontal;
-            tsbShowTags.ImageTransparentColor = Color.Magenta;
             tsbShowTags.Name = "tsbShowTags";
             tsbShowTags.Size = new Size(29, 24);
             tsbShowTags.Text = "&Tags";
@@ -633,7 +629,6 @@ namespace GitUI.LeftPanel
             tsbShowSubmodules.CheckOnClick = true;
             tsbShowSubmodules.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsbShowSubmodules.Image = Properties.Images.FolderSubmodule;
-            tsbShowSubmodules.ImageTransparentColor = Color.Magenta;
             tsbShowSubmodules.Name = "tsbShowSubmodules";
             tsbShowSubmodules.Size = new Size(29, 24);
             tsbShowSubmodules.Text = "&Submodules";
@@ -644,7 +639,6 @@ namespace GitUI.LeftPanel
             tsbShowStashes.CheckOnClick = true;
             tsbShowStashes.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsbShowStashes.Image = Properties.Images.Stash;
-            tsbShowStashes.ImageTransparentColor = Color.Magenta;
             tsbShowStashes.Name = "tsbShowStashes";
             tsbShowStashes.Size = new Size(29, 24);
             tsbShowStashes.Text = "St&ashes";

--- a/src/app/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/src/app/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -245,7 +245,6 @@ namespace GitUI.UserControls
             tsmiCommitterFilter,
             tsmiAuthorFilter,
             tsmiDiffContainsFilter});
-            tsddbtnRevisionFilter.ImageTransparentColor = Color.Magenta;
             tsddbtnRevisionFilter.Name = "tsddbtnRevisionFilter";
             tsddbtnRevisionFilter.Size = new Size(29, 22);
             tsddbtnRevisionFilter.Tag = "ToolBar_group:Text filter";
@@ -255,7 +254,6 @@ namespace GitUI.UserControls
             // 
             tsmiShowOnlyFirstParent.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsmiShowOnlyFirstParent.Image = Properties.Images.ShowOnlyFirstParent;
-            tsmiShowOnlyFirstParent.ImageTransparentColor = Color.Magenta;
             tsmiShowOnlyFirstParent.Name = "tsmiShowOnlyFirstParent";
             tsmiShowOnlyFirstParent.Size = new Size(23, 20);
             tsmiShowOnlyFirstParent.Click += tsmiShowOnlyFirstParent_Click;


### PR DESCRIPTION
Preparation for https://github.com/gitextensions/gitextensions/pull/12111
See #12123 for motivation.
This PR removes use of hardcoded colors so it is feasible to manually review that #12125 is handled, reducong hits to `Color`

## Proposed changes

The default Color.Transparent is used in the GE icons. When set, it was mostly Color.Magenta and that is not used by GE icons as well the few other colors.

## Test methodology <!-- How did you ensure quality? -->

Review

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
