### PR TITLE
fix(FileStatusList): Do not loop around with wheel

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1442,7 +1442,7 @@ namespace GitUI
 
         public void SelectPreviousVisibleItem()
         {
-            if (SelectNextItem(backwards: true, loop: true) is null)
+            if (SelectNextItem(backwards: true, loop: false) is null)
             {
                 SelectFirstVisibleItem();
             }
@@ -1450,7 +1450,7 @@ namespace GitUI
 
         public void SelectNextVisibleItem()
         {
-            if (SelectNextItem(backwards: false, loop: true) is null)
+            if (SelectNextItem(backwards: false, loop: false) is null)
             {
                 SelectFirstVisibleItem();
             }


### PR DESCRIPTION
Fixes #12128

## Proposed changes

- `SelectPreviousVisibleItem` / `SelectNextVisibleItem` shall not loop around to last / first item, e.g. when using (`Alt`+) mouse wheel

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).