### PR TITLE
feat(git-grep): Show function name of matches

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2380,6 +2380,7 @@ namespace GitCommands
             ArgumentString extraArgs,
             string grepString,
             bool useGitColoring,
+            bool showFunctionName,
             IGitCommandConfiguration commandConfiguration,
             CancellationToken cancellationToken)
         {
@@ -2388,6 +2389,7 @@ namespace GitCommands
             GitArgumentBuilder args = new("grep", commandConfiguration: commandConfiguration)
             {
                 "--line-number",
+                { showFunctionName, "--show-function" },
                 { !useGitColoring, "--column" },
                 { useGitColoring, "--color=always" },
                 extraArgs,

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -509,6 +509,7 @@ public interface IGitModule
         ArgumentString extraArgs,
         string grepString,
         bool useGitColoring,
+        bool showFunctionName,
         IGitCommandConfiguration commandConfiguration,
         CancellationToken cancellationToken);
 

--- a/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
@@ -90,12 +90,6 @@ public partial class GrepHighlightService : TextHighlightService
         {
             if (line == "--")
             {
-                if (sb.Length > 0)
-                {
-                    _diffLinesInfo.Add(GetDiffLineInfo(DiffLineInfo.NotApplicableLineNum, false));
-                    sb.Append('\n');
-                }
-
                 continue;
             }
 
@@ -115,8 +109,7 @@ public partial class GrepHighlightService : TextHighlightService
                 continue;
             }
 
-            bool isMatch = match.Groups["kind"].Success && match.Groups["kind"].Value == ":";
-            _diffLinesInfo.Add(GetDiffLineInfo(lineNo, isMatch));
+            _diffLinesInfo.Add(GetDiffLineInfo(lineNo, match.Groups["kind"].Success ? match.Groups["kind"].Value : ""));
             string grepText = match.Groups["text"].Value;
 
             AnsiEscapeUtilities.ParseEscape(grepText, sb, _textMarkers);
@@ -138,15 +131,15 @@ public partial class GrepHighlightService : TextHighlightService
     /// for git-diff this is parsed dynamically.
     /// </summary>
     /// <returns>The type of contents for all editor lines.</returns>
-    private DiffLineInfo GetDiffLineInfo(int lineno, bool match)
+    private DiffLineInfo GetDiffLineInfo(int lineno, string kind)
         => new()
         {
             LineNumInDiff = _diffLinesInfo.DiffLines.Count + 1,
             LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
             RightLineNumber = lineno,
-            LineType = lineno == DiffLineInfo.NotApplicableLineNum
+            LineType = lineno == DiffLineInfo.NotApplicableLineNum || kind == "="
                     ? DiffLineType.Header
-                    : match
+                    : kind == ":"
                         ? DiffLineType.Grep
                         : DiffLineType.Context
         };

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -110,6 +110,7 @@ namespace GitUI
                         fileViewer.GetExtraGrepArguments(),
                         item.Item.GrepString,
                         useGitColoring: true,
+                        showFunctionName: true,
                         commandConfiguration: commandConfiguration,
                         cancellationToken);
 


### PR DESCRIPTION
## Proposed changes

- Pass argument `--show-function` to `git grep` 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/2e239e93-b7f8-43ef-8dc4-adfd5214a4f9)

### After

first commit with
```
git config --global color.grep.matchSelected "yellow reverse"
```
![image](https://github.com/user-attachments/assets/b378a039-370f-4841-9255-66ee652044d3)

second commit
![image](https://github.com/user-attachments/assets/373743f9-1fef-4ad1-8857-ccfec225af26)

second commit with additional git config
```
git config --global color.grep.function "white reverse"
```
![image](https://github.com/user-attachments/assets/d9743690-4a12-421b-8487-4a800ebed45b)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).