### PR TITLE
fix(theme): Check for default theme

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -112,7 +112,7 @@
 
         public static Color AdaptColor(Color original, bool isForeground)
         {
-            if (IsDefaultTheme())
+            if (IsDefaultTheme)
             {
                 return original;
             }
@@ -200,7 +200,7 @@
 
         public static Bitmap AdaptLightness(this Bitmap original)
         {
-            if (IsDefaultTheme())
+            if (IsDefaultTheme)
             {
                 return original;
             }
@@ -331,7 +331,7 @@
         /// Note that the theme is parsed, so ThemeSettings.Default is another instance.
         /// </summary>
         /// <returns><see langword="true"/> if the theme is default; otherwise <see langword="false"/>.</returns>
-        private static bool IsDefaultTheme() => string.IsNullOrWhiteSpace(ThemeSettings.Theme.Id.Name);
+        private static bool IsDefaultTheme => string.IsNullOrWhiteSpace(ThemeSettings.Theme.Id.Name);
 
         public static Color Lerp(Color colour, Color to, float amount)
         {

--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -112,7 +112,7 @@
 
         public static Color AdaptColor(Color original, bool isForeground)
         {
-            if (ThemeSettings == ThemeSettings.Default)
+            if (IsDefaultTheme())
             {
                 return original;
             }
@@ -200,7 +200,7 @@
 
         public static Bitmap AdaptLightness(this Bitmap original)
         {
-            if (ThemeSettings == ThemeSettings.Default)
+            if (IsDefaultTheme())
             {
                 return original;
             }
@@ -325,6 +325,13 @@
             double correctedH = (excludeHTo + correctedDelta).Modulo(360);
             return new HslColor(correctedH / 360d, hsl.S, hsl.L).ToColor();
         }
+
+        /// <summary>
+        /// Find if the theme is the default.
+        /// Note that the theme is parsed, so ThemeSettings.Default is another instance.
+        /// </summary>
+        /// <returns><see langword="true"/> if the theme is default; otherwise <see langword="false"/>.</returns>
+        private static bool IsDefaultTheme() => string.IsNullOrWhiteSpace(ThemeSettings.Theme.Id.Name);
 
         public static Color Lerp(Color colour, Color to, float amount)
         {


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/pull/12125#discussion_r1903343778

## Proposed changes

The check for the default theme must use the theme name, as the theme is a separate instance.

Unneeded processing and potential issues like https://github.com/gitextensions/gitextensions/pull/12125#discussion_r1903343778

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
