### PR TITLE
TreeView: Revert horizontal scroll

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -150,7 +150,7 @@ See the changes in the commit form.");
                 tvGitTree.AfterSelect -= new TreeViewEventHandler(tvGitTree_AfterSelect);
                 tvGitTree.SelectedNode = foundNode;
                 tvGitTree.AfterSelect += new TreeViewEventHandler(tvGitTree_AfterSelect);
-                tvGitTree.SelectedNode.EnsureVisible();
+                tvGitTree.SelectedNode.EnsureVerticallyVisible();
 
                 this.InvokeAndForget(() => ShowGitItemAsync(gitItem, line));
             }
@@ -231,7 +231,7 @@ See the changes in the commit form.");
                         if (_revisionFileTreeController.SelectFileOrFolder(tvGitTree, path))
                         {
                             // Try scroll
-                            tvGitTree.SelectedNode.EnsureVisible();
+                            tvGitTree.SelectedNode.EnsureVerticallyVisible();
                             break;
                         }
                     }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -3,6 +3,7 @@ using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Settings;
 using GitExtUtils.GitUI;
 using GitUI.Properties;
+using GitUI.UserControls;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
@@ -151,7 +152,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             foreach (TreeNode node in _nodesFoundByTextBox)
             {
                 HighlightNode(node, true);
-                node.EnsureVisible();
+                node.EnsureVerticallyVisible();
             }
 
             if (_nodesFoundByTextBox.Any())

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -491,7 +491,7 @@ namespace GitUI.LeftPanel
                 return;
             }
 
-            node.EnsureVisible();
+            node.EnsureVerticallyVisible();
             treeMain.SelectedNode = node;
 
             return;

--- a/src/app/GitUI/LeftPanel/Tree.cs
+++ b/src/app/GitUI/LeftPanel/Tree.cs
@@ -194,27 +194,14 @@ namespace GitUI.LeftPanel
 
         private void ExpandPathToSelectedNode()
         {
-            if (TreeViewNode.TreeView.SelectedNode is not null)
+            if (TreeViewNode.TreeView.Nodes.Count == 0)
             {
-                EnsureNodeVisible(TreeViewNode.TreeView.Handle, TreeViewNode.TreeView.SelectedNode);
-            }
-            else if (TreeViewNode.TreeView.Nodes.Count > 0)
-            {
-                // No selected node, just make sure the first node is visible
-                EnsureNodeVisible(TreeViewNode.TreeView.Handle, TreeViewNode.TreeView.Nodes[0]);
+                return;
             }
 
-            return;
-
-            static void EnsureNodeVisible(IntPtr hwnd, TreeNode node)
-            {
-                node.EnsureVisible();
-
-                // EnsureVisible leads to horizontal scrolling in some cases. We make sure to force horizontal
-                // scroll back to 0. Note that we use SendMessage rather than SetScrollPos as the former works
-                // outside of Begin/EndUpdate.
-                NativeMethods.SendMessageW(hwnd, NativeMethods.WM_HSCROLL, (IntPtr)NativeMethods.SBH.LEFT, IntPtr.Zero);
-            }
+            // If no selected node, just make sure that the first node is visible
+            TreeNode node = TreeViewNode.TreeView.SelectedNode ?? TreeViewNode.TreeView.Nodes[0];
+            node.EnsureVerticallyVisible();
         }
     }
 }

--- a/src/app/GitUI/UserControls/TreeViewExtensions.cs
+++ b/src/app/GitUI/UserControls/TreeViewExtensions.cs
@@ -1,87 +1,86 @@
-﻿namespace GitUI.UserControls
+﻿namespace GitUI.UserControls;
+
+public static class TreeViewExtensions
 {
-    public static class TreeViewExtensions
+    /// <summary>
+    /// Similar to TreeNode.FullPath, this function returns a full path made up of TreeNode.Name rather
+    /// than TreeNode.Text, if the former is non-empty. This is useful as it allows the node's Text to
+    /// be changed, while the node's Name can remain a key for operations such as getting and restoring
+    /// the expanded node state.
+    /// </summary>
+    public static string GetFullNamePath(this TreeNode node)
     {
-        /// <summary>
-        /// Similar to TreeNode.FullPath, this function returns a full path made up of TreeNode.Name rather
-        /// than TreeNode.Text, if the former is non-empty. This is useful as it allows the node's Text to
-        /// be changed, while the node's Name can remain a key for operations such as getting and restoring
-        /// the expanded node state.
-        /// </summary>
-        public static string GetFullNamePath(this TreeNode node)
+        string sep = node.TreeView is not null ? node.TreeView.PathSeparator : "\\";
+
+        string result = GetNameOrText(node);
+        TreeNode currNode = node;
+        while (currNode.Parent is not null)
         {
-            string sep = node.TreeView is not null ? node.TreeView.PathSeparator : "\\";
+            currNode = currNode.Parent;
+            result = GetNameOrText(currNode) + sep + result;
+        }
 
-            string result = GetNameOrText(node);
-            TreeNode currNode = node;
-            while (currNode.Parent is not null)
+        return result;
+
+        string GetNameOrText(TreeNode n)
+        {
+            return n.Name.Length > 0 ? n.Name : n.Text;
+        }
+    }
+
+    /// <summary>
+    /// Returns a set of expanded node paths to be used with RestoreExpandedNodeState starting from the input node.
+    /// This function makes use of GetFullNamePath, rather than TreeNode.FullPath, so you can vary the node's Text,
+    /// as long as the node's Name remains stable.
+    /// </summary>
+    public static HashSet<string> GetExpandedNodesState(this TreeNode node)
+    {
+        HashSet<string> result = [];
+        node.DoGetExpandedNodesState(result);
+        return result;
+    }
+
+    /// <summary>
+    /// Restores the expanded state of nodes under the input node using the set returned by GetExpandedNodesState.
+    /// </summary>
+    public static void RestoreExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
+    {
+        foreach (string path in expandedNodes)
+        {
+            TreeNode foundNode = GetNodeFromPath(node, path);
+            foundNode?.Expand();
+        }
+    }
+
+    private static void DoGetExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
+    {
+        if (node.IsExpanded)
+        {
+            expandedNodes.Add(GetFullNamePath(node));
+        }
+
+        foreach (TreeNode childNode in node.Nodes)
+        {
+            DoGetExpandedNodesState(childNode, expandedNodes);
+        }
+    }
+
+    public static TreeNode? GetNodeFromPath(this TreeNode node, string? path)
+    {
+        if (GetFullNamePath(node) == path)
+        {
+            return node;
+        }
+
+        foreach (TreeNode childNode in node.Nodes)
+        {
+            TreeNode foundNode = GetNodeFromPath(childNode, path);
+            if (foundNode is not null)
             {
-                currNode = currNode.Parent;
-                result = GetNameOrText(currNode) + sep + result;
-            }
-
-            return result;
-
-            string GetNameOrText(TreeNode n)
-            {
-                return n.Name.Length > 0 ? n.Name : n.Text;
+                return foundNode;
             }
         }
 
-        /// <summary>
-        /// Returns a set of expanded node paths to be used with RestoreExpandedNodeState starting from the input node.
-        /// This function makes use of GetFullNamePath, rather than TreeNode.FullPath, so you can vary the node's Text,
-        /// as long as the node's Name remains stable.
-        /// </summary>
-        public static HashSet<string> GetExpandedNodesState(this TreeNode node)
-        {
-            HashSet<string> result = [];
-            node.DoGetExpandedNodesState(result);
-            return result;
-        }
-
-        /// <summary>
-        /// Restores the expanded state of nodes under the input node using the set returned by GetExpandedNodesState.
-        /// </summary>
-        public static void RestoreExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
-        {
-            foreach (string path in expandedNodes)
-            {
-                TreeNode foundNode = GetNodeFromPath(node, path);
-                foundNode?.Expand();
-            }
-        }
-
-        private static void DoGetExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
-        {
-            if (node.IsExpanded)
-            {
-                expandedNodes.Add(GetFullNamePath(node));
-            }
-
-            foreach (TreeNode childNode in node.Nodes)
-            {
-                DoGetExpandedNodesState(childNode, expandedNodes);
-            }
-        }
-
-        public static TreeNode? GetNodeFromPath(this TreeNode node, string? path)
-        {
-            if (GetFullNamePath(node) == path)
-            {
-                return node;
-            }
-
-            foreach (TreeNode childNode in node.Nodes)
-            {
-                TreeNode foundNode = GetNodeFromPath(childNode, path);
-                if (foundNode is not null)
-                {
-                    return foundNode;
-                }
-            }
-
-            return null;
-        }
+        return null;
     }
 }

--- a/src/app/GitUI/UserControls/TreeViewExtensions.cs
+++ b/src/app/GitUI/UserControls/TreeViewExtensions.cs
@@ -2,6 +2,19 @@
 
 public static class TreeViewExtensions
 {
+    public static void EnsureVerticallyVisible(this TreeNode? node)
+    {
+        if (node?.TreeView is not TreeView treeView)
+        {
+            return;
+        }
+
+        node.EnsureVisible();
+
+        // EnsureVisible leads to horizontal scrolling in some cases. We make sure to force horizontal scroll back to 0.
+        treeView.ScrollLeftMost();
+    }
+
     /// <summary>
     /// Returns a set of expanded node paths to be used with RestoreExpandedNodeState starting from the input node.
     /// This function makes use of GetFullNamePath, rather than TreeNode.FullPath, so you can vary the node's Text,
@@ -68,6 +81,14 @@ public static class TreeViewExtensions
         {
             TreeNode foundNode = GetNodeFromPath(node, path);
             foundNode?.Expand();
+        }
+    }
+
+    public static void ScrollLeftMost(this TreeView? treeView)
+    {
+        if (treeView is not null)
+        {
+            NativeMethods.SendMessageW(treeView.Handle, NativeMethods.WM_HSCROLL, (IntPtr)NativeMethods.SBH.LEFT, IntPtr.Zero);
         }
     }
 

--- a/src/app/GitUI/UserControls/TreeViewExtensions.cs
+++ b/src/app/GitUI/UserControls/TreeViewExtensions.cs
@@ -3,6 +3,18 @@
 public static class TreeViewExtensions
 {
     /// <summary>
+    /// Returns a set of expanded node paths to be used with RestoreExpandedNodeState starting from the input node.
+    /// This function makes use of GetFullNamePath, rather than TreeNode.FullPath, so you can vary the node's Text,
+    /// as long as the node's Name remains stable.
+    /// </summary>
+    public static HashSet<string> GetExpandedNodesState(this TreeNode node)
+    {
+        HashSet<string> result = [];
+        node.DoGetExpandedNodesState(result);
+        return result;
+    }
+
+    /// <summary>
     /// Similar to TreeNode.FullPath, this function returns a full path made up of TreeNode.Name rather
     /// than TreeNode.Text, if the former is non-empty. This is useful as it allows the node's Text to
     /// be changed, while the node's Name can remain a key for operations such as getting and restoring
@@ -28,16 +40,23 @@ public static class TreeViewExtensions
         }
     }
 
-    /// <summary>
-    /// Returns a set of expanded node paths to be used with RestoreExpandedNodeState starting from the input node.
-    /// This function makes use of GetFullNamePath, rather than TreeNode.FullPath, so you can vary the node's Text,
-    /// as long as the node's Name remains stable.
-    /// </summary>
-    public static HashSet<string> GetExpandedNodesState(this TreeNode node)
+    public static TreeNode? GetNodeFromPath(this TreeNode node, string? path)
     {
-        HashSet<string> result = [];
-        node.DoGetExpandedNodesState(result);
-        return result;
+        if (GetFullNamePath(node) == path)
+        {
+            return node;
+        }
+
+        foreach (TreeNode childNode in node.Nodes)
+        {
+            TreeNode foundNode = GetNodeFromPath(childNode, path);
+            if (foundNode is not null)
+            {
+                return foundNode;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -63,24 +82,5 @@ public static class TreeViewExtensions
         {
             DoGetExpandedNodesState(childNode, expandedNodes);
         }
-    }
-
-    public static TreeNode? GetNodeFromPath(this TreeNode node, string? path)
-    {
-        if (GetFullNamePath(node) == path)
-        {
-            return node;
-        }
-
-        foreach (TreeNode childNode in node.Nodes)
-        {
-            TreeNode foundNode = GetNodeFromPath(childNode, path);
-            if (foundNode is not null)
-            {
-                return foundNode;
-            }
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
## Proposed changes

- chore(`TreeViewExtensions`): Remove namespace block
- chore(`TreeViewExtensions`): Alpha-sort methods
- refactor(`TreeView`): Extract `EnsureVerticallyVisible` and `ScrollLeftMost` from `LeftPanel.Tree.ExpandPathToSelectedNode`
- replace all occurrences of `TreeNode.EnsureVisible`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/347a6fb9-7035-45b7-ac10-5639f7132bc5)

### After

![image](https://github.com/user-attachments/assets/fb3e2728-a363-4275-a47a-f20a90f19001)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Please do not squash-merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).