### PR TITLE
feat: Avoid just "app" / "repo" / "repository" in app title

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -2095,6 +2095,8 @@ namespace GitCommands
 
         public static ISetting<bool> IsEditorSettingsMigrated { get; } = Setting.Create(MigrationSettingsPath, nameof(IsEditorSettingsMigrated), false);
 
+        public static ISetting<string> UninformativeRepoNameRegex { get; } = Setting.Create(DetailedSettingsPath, nameof(UninformativeRepoNameRegex), "app|(repo(sitory)?)");
+
         private static IEnumerable<(string name, string value)> GetSettingsFromRegistry()
         {
             RegistryKey oldSettings = VersionIndependentRegKey.OpenSubKey("GitExtensions");

--- a/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using GitCommands.Git;
 
 namespace GitCommands.UserRepositoryHistory
@@ -21,10 +22,14 @@ namespace GitCommands.UserRepositoryHistory
     ///  https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain:
     ///  ...The description file is used only by the GitWeb program, so don’t worry about it...
     /// </remarks>
-    public sealed class RepositoryDescriptionProvider : IRepositoryDescriptionProvider
+    public sealed partial class RepositoryDescriptionProvider : IRepositoryDescriptionProvider
     {
         private const string RepositoryDescriptionFileName = "description";
         private const string DefaultDescription = "Unnamed repository; edit this file 'description' to name the repository.";
+
+        [GeneratedRegex("^(repo(sitory)?)$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
+        private static partial Regex UninformativeNameRegex();
+
         private readonly IGitDirectoryResolver _gitDirectoryResolver;
 
         public RepositoryDescriptionProvider(IGitDirectoryResolver gitDirectoryResolver)
@@ -51,6 +56,11 @@ namespace GitCommands.UserRepositoryHistory
             if (!string.IsNullOrWhiteSpace(desc))
             {
                 return desc;
+            }
+
+            if (UninformativeNameRegex().IsMatch(dirInfo.Name))
+            {
+                dirInfo = dirInfo.Parent;
             }
 
             return dirInfo.Name;

--- a/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -22,13 +22,12 @@ namespace GitCommands.UserRepositoryHistory
     ///  https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain:
     ///  ...The description file is used only by the GitWeb program, so don’t worry about it...
     /// </remarks>
-    public sealed partial class RepositoryDescriptionProvider : IRepositoryDescriptionProvider
+    public sealed class RepositoryDescriptionProvider : IRepositoryDescriptionProvider
     {
         private const string RepositoryDescriptionFileName = "description";
         private const string DefaultDescription = "Unnamed repository; edit this file 'description' to name the repository.";
 
-        [GeneratedRegex("^(repo(sitory)?)$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
-        private static partial Regex UninformativeNameRegex();
+        private readonly Regex _uninformativeNameRegex = new($"^{AppSettings.UninformativeRepoNameRegex.Value}$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 
         private readonly IGitDirectoryResolver _gitDirectoryResolver;
 
@@ -58,7 +57,7 @@ namespace GitCommands.UserRepositoryHistory
                 return desc;
             }
 
-            if (UninformativeNameRegex().IsMatch(dirInfo.Name))
+            while (dirInfo.Parent is not null && _uninformativeNameRegex.IsMatch(dirInfo.Name))
             {
                 dirInfo = dirInfo.Parent;
             }

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -380,6 +380,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.AutomaticContinuousScroll)], false, false, false);
                 yield return (properties[nameof(AppSettings.AutomaticContinuousScrollDelay)], 600, false, false);
                 yield return (properties[nameof(AppSettings.IsEditorSettingsMigrated)], false, isNotNullable, isISetting);
+                yield return (properties[nameof(AppSettings.UninformativeRepoNameRegex)], "app|(repo(sitory)?)", isNotNullable, isISetting);
             }
 
             static IEnumerable<object> Values()


### PR DESCRIPTION
## Proposed changes

Some repos include submodules with additional subfolders
- "super/submodule1/repo"
- "super/submodule2/repo"
Currently, these submodules cannot be distinguished in GE's title bar.
Add a regex for skipping uninformative repo names "repo" and "repository".

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/6d4690df-4bcc-4ac2-b2b6-f7cfbba20b5f)

### After

![image](https://github.com/user-attachments/assets/6878f63e-ea24-403b-a92b-f72ee208ba18)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).