### PR TITLE
fix: remove override highlight linenumber control

### DIFF
--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -78,12 +78,8 @@ namespace GitUI.Editor
             };
             TextEditor.ActiveTextAreaControl.TextArea.MouseWheel += TextArea_MouseWheel;
 
-            HighlightingManager.Manager.DefaultHighlighting.SetColorFor("LineNumbers",
-                new HighlightColor(SystemColors.ControlText, SystemColors.Control, false, false));
             TextEditor.ActiveTextAreaControl.TextEditorProperties.EnableFolding = false;
-
             _lineNumbersControl = new DiffViewerLineNumberControl(TextEditor.ActiveTextAreaControl.TextArea);
-
             VRulerPosition = AppSettings.DiffVerticalRulerPosition;
         }
 


### PR DESCRIPTION
## Proposed changes

for files without explicit highlighting

Note: I may want to have a separate color for the linenumber display, but it should be adapted for theming.
This override (including the ICSharpCode change) is required for consistent handling, so that is a separate PR.
This looks very weird in dark mode.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://github.com/user-attachments/assets/2849b002-1383-47e6-bee5-2fc8c2e1c49d)

but explicit strategies are OK
![image](https://github.com/user-attachments/assets/048dbe3a-6628-4986-8d99-b8ac3d5d6eb9)

### After

![image](https://github.com/user-attachments/assets/30a1cacb-a872-41e0-9f0a-b74b49b1da34)

## Test methodology <!-- How did you ensure quality? -->

Visual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
