### PR TITLE
test(ExecutableTests): Relax timeout for slow AppVeyor

### DIFF
--- a/tests/app/UnitTests/GitCommands.Tests/ExecutableTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/ExecutableTests.cs
@@ -55,7 +55,7 @@ namespace GitCommandsTests
             process.Dispose();
 
             TimeSpan durationWaitTimeout = DateTime.Now - startedAt;
-            durationWaitTimeout.Should().BeGreaterThan(1.5 * cancelDelay).And.BeLessThan(2.5 * cancelDelay);
+            durationWaitTimeout.Should().BeGreaterThan(1.5 * cancelDelay).And.BeLessThan(4 * cancelDelay);
 
             CommandLogEntry? cmd = CommandLog.Commands.LastOrDefault();
             (cmd?.Exception?.Message).Should().Be("Process killed");


### PR DESCRIPTION
## Proposed changes

Several CI builds failed because the testcase execution on AppVeyor took more than 3 seconds.
Relax the regarding timer.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).