### PR TITLE
feat: Bring to front on drag drop of patch file(s)

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1313,13 +1313,13 @@ namespace GitUI.CommandsDialogs
 
         private void CommitToolStripMenuItemClick(object sender, EventArgs e)
         {
-            ForceActivate();
+            this.ForceActivate();
             UICommands.StartCommitDialog(this);
         }
 
         private void PushToolStripMenuItemClick(object sender, EventArgs e)
         {
-            ForceActivate();
+            this.ForceActivate();
             UICommands.StartPushDialog(this, pushOnShow: ModifierKeys.HasFlag(Keys.Shift));
         }
 
@@ -2308,7 +2308,7 @@ namespace GitUI.CommandsDialogs
 
         private void PullToolStripMenuItemClick(object sender, EventArgs e)
         {
-            ForceActivate();
+            this.ForceActivate();
 
             // "Pull/Fetch..." menu item always opens the dialog
             DoPull(pullAction: AppSettings.FormPullAction, isSilent: false);
@@ -2746,17 +2746,6 @@ namespace GitUI.CommandsDialogs
             string? shellType = AppSettings.ConEmuTerminal.Value;
             IShellDescriptor shell = _shellProvider.GetShell(shellType);
             _terminal?.ChangeFolder(shell, path);
-        }
-
-        /// <summary>
-        ///  Brings this window to the front and activates it. Needed when a <see cref="WindowsThumbnailToolbarButton"/> is clicked.
-        /// </summary>
-        private void ForceActivate()
-        {
-            TopMost = true;
-            BringToFront();
-            TopMost = false;
-            Activate();
         }
 
         private void menuitemSparseWorkingCopy_Click(object sender, EventArgs e)

--- a/src/app/GitUI/FormExtensions.cs
+++ b/src/app/GitUI/FormExtensions.cs
@@ -1,0 +1,20 @@
+namespace GitUI;
+
+public static class FormExtensions
+{
+    /// <summary>
+    ///  Brings the window to the front and activates it. Needed on drag drop and on button click from Windows Jump List.
+    /// </summary>
+    public static void ForceActivate(this Form? form)
+    {
+        if (form is null)
+        {
+            return;
+        }
+
+        form.TopMost = true;
+        form.BringToFront();
+        form.TopMost = false;
+        form.Activate();
+    }
+}

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -3144,6 +3144,8 @@ namespace GitUI
         {
             if (e.Data.GetData(DataFormats.FileDrop) is Array fileNameArray)
             {
+                FindForm()?.ForceActivate();
+
                 if (fileNameArray.Length > 10)
                 {
                     // Some users need to be protected against themselves!


### PR DESCRIPTION
## Proposed changes

Patch files can be dropped onto the RevisionGrid. But the app stays in the background.
Force the window to the front using a factored out extension method.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).