### PR TITLE
fix(AheadBehindDataProvider): Restrict debug output

### DIFF
--- a/src/app/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/src/app/GitCommands/Git/AheadBehindDataProvider.cs
@@ -51,7 +51,7 @@ namespace GitCommands.Git
                 // Callers setting branch name has the responsibility to ensure that not all are needed
                 if (string.IsNullOrWhiteSpace(branchName) && !string.IsNullOrWhiteSpace(_branchName))
                 {
-                    Trace.WriteLine($"Call for all branches after cache filled with specific branch {_branchName}");
+                    Debug.WriteLine($"Call for all branches after cache filled with specific branch {_branchName}");
                     ResetCache();
                 }
 


### PR DESCRIPTION
Fixes #12005

## Proposed changes

- `AheadBehindDataProvider`: Restrict debug output to debug build and never to Output tab
(The case is properly handled. So, there is no need to bother users with this output.)

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).