### PR TITLE
fix(Jump List): Use unique name for recent repos

### DIFF
--- a/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -22,12 +22,6 @@ namespace GitCommands.UserRepositoryHistory
         /// </summary>
         /// <param name="repositoryDir">Path to repository.</param>
         string GetDescriptiveUnique(string repositoryDir);
-
-        /// <summary>
-        ///  Returns a unique name for the repository.
-        /// </summary>
-        /// <param name="repositoryDir">Path to repository.</param>
-        string GetUnique(string repositoryDir);
     }
 
     /// <summary>
@@ -114,13 +108,8 @@ namespace GitCommands.UserRepositoryHistory
             descriptiveEnd = Math.Min(descriptiveEnd, maxDescriptiveLength);
             ReadOnlySpan<char> shortName = descriptive.AsSpan(0, descriptiveEnd).Trim();
 
-            string unique = GetUnique(repositoryDir);
+            string unique = repositoryDir.TrimEnd(Path.DirectorySeparatorChar);
             return shortName.Length == 0 ? unique : $"{shortName} ({unique})";
-        }
-
-        public string GetUnique(string repositoryDir)
-        {
-            return repositoryDir.TrimEnd(Path.DirectorySeparatorChar);
         }
 
         /// <summary>

--- a/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -2,6 +2,7 @@
 
 using System.Text.RegularExpressions;
 using GitCommands.Git;
+using GitExtensions.Extensibility;
 
 namespace GitCommands.UserRepositoryHistory
 {
@@ -15,6 +16,18 @@ namespace GitCommands.UserRepositoryHistory
         /// <param name="repositoryDir">Path to repository.</param>
         /// <returns>Short name for repository.</returns>
         string Get(string repositoryDir, Func<string, bool>? isValidGitWorkingDir = default);
+
+        /// <summary>
+        ///  Returns a short name for the repository followed by a unique name.
+        /// </summary>
+        /// <param name="repositoryDir">Path to repository.</param>
+        string GetDescriptiveUnique(string repositoryDir);
+
+        /// <summary>
+        ///  Returns a unique name for the repository.
+        /// </summary>
+        /// <param name="repositoryDir">Path to repository.</param>
+        string GetUnique(string repositoryDir);
     }
 
     /// <summary>
@@ -90,6 +103,24 @@ namespace GitCommands.UserRepositoryHistory
 
                 return dirInfo.Name;
             }
+        }
+
+        public string GetDescriptiveUnique(string repositoryDir)
+        {
+            const int maxDescriptiveLength = 25;
+            string descriptive = Get(repositoryDir, isValidGitWorkingDir: default);
+            int endOfLineIndex = descriptive.IndexOfAny(Delimiters.LineFeedAndCarriageReturnAndNull);
+            int descriptiveEnd = endOfLineIndex >= 0 ? endOfLineIndex : descriptive.Length;
+            descriptiveEnd = Math.Min(descriptiveEnd, maxDescriptiveLength);
+            ReadOnlySpan<char> shortName = descriptive.AsSpan(0, descriptiveEnd).Trim();
+
+            string unique = GetUnique(repositoryDir);
+            return shortName.Length == 0 ? unique : $"{shortName} ({unique})";
+        }
+
+        public string GetUnique(string repositoryDir)
+        {
+            return repositoryDir.TrimEnd(Path.DirectorySeparatorChar);
         }
 
         /// <summary>

--- a/src/app/GitUI/WindowsJumpListManager.cs
+++ b/src/app/GitUI/WindowsJumpListManager.cs
@@ -93,7 +93,7 @@ namespace GitUI
 
             SafeInvoke(() =>
             {
-                string repositoryDescription = _repositoryDescriptionProvider.Get(workingDir);
+                string repositoryDescription = _repositoryDescriptionProvider.GetDescriptiveUnique(workingDir);
                 if (string.IsNullOrWhiteSpace(repositoryDescription))
                 {
                     return;
@@ -107,6 +107,7 @@ namespace GitUI
 
                 // sanitise
                 StringBuilder sb = new(repositoryDescription);
+                sb.Replace(@":\", "_");
                 foreach (char c in Path.GetInvalidFileNameChars())
                 {
                     sb.Replace(c, '_');


### PR DESCRIPTION
Fixes #10845

## Proposed changes

- `WindowsJumpListManager` / `RepositoryDescriptionProvider`: Use unique name for recent repos
  descriptive name with full path appended

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/6258ee77-e229-469f-ae19-208d2bd16c3e)

with

`repo.gitext` containing
`D:\Downloads\super\submodule2\repo\`
or
`D:\Downloads\super\submodule1\repo\`

### After

![image](https://github.com/user-attachments/assets/0bb62409-de94-4d28-a8ef-3061618ab4e9)   ![image](https://github.com/user-attachments/assets/86e218a7-7837-4e75-908d-d7a085fe735c)

with `.git/description` containing:
- "super_repo"
- "sm1_repo"
- "sm2_repo"

## Test methodology <!-- How did you ensure quality? -->

- manual 

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).