### PR TITLE
fix: Remove TreeView "explorer" style

### DIFF
--- a/src/app/GitUI/UserControls/NativeListView.cs
+++ b/src/app/GitUI/UserControls/NativeListView.cs
@@ -4,21 +4,11 @@ namespace GitUI.UserControls
 {
     public class NativeListView : ListView
     {
-        internal static event EventHandler? BeginCreateHandle;
-        internal static event EventHandler? EndCreateHandle;
         internal event ScrollEventHandler? Scroll;
 
         public NativeListView()
         {
             DoubleBuffered = true;
-        }
-
-        protected override void CreateHandle()
-        {
-            BeginCreateHandle?.Invoke(this, EventArgs.Empty);
-            base.CreateHandle();
-            NativeMethods.SetWindowTheme(Handle, "explorer", null);
-            EndCreateHandle?.Invoke(this, EventArgs.Empty);
         }
 
         protected override void WndProc(ref Message m)

--- a/src/app/GitUI/UserControls/NativeTreeView.cs
+++ b/src/app/GitUI/UserControls/NativeTreeView.cs
@@ -6,11 +6,5 @@
         {
             DoubleBuffered = true;
         }
-
-        protected override void CreateHandle()
-        {
-            base.CreateHandle();
-            NativeMethods.SetWindowTheme(Handle, "explorer", null);
-        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Remove the native Win override to use "explorer" theme, part of #4491.
This seem to affect the TreeView selected item.
(ListView already changed).

Note: If this is not merged, the winow theme must be set to "DarkMode_Explorer" in dark mode.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/03f52a0a-fca7-46a4-b1b1-bf8c9c2a2985)

inactive selected in FileStatus
![image](https://github.com/user-attachments/assets/94f9fb6c-e481-42cd-a992-616f14af9b87)

Unchanged below

Not in focus
![image](https://github.com/user-attachments/assets/44dfa663-0c62-4dfe-a350-1a02a62746f3)

![image](https://github.com/user-attachments/assets/2fab855f-584c-42e9-8c3f-52e9927eea35)

with #12116 
![image](https://github.com/user-attachments/assets/f771c593-e155-4f46-8723-d84afde6edc3)
![image](https://github.com/user-attachments/assets/f170a99a-9a40-4e6d-9fb1-7281d50a4366)

### After

![image](https://github.com/user-attachments/assets/9c230bb3-5515-457e-94e3-4ce63b297357)

![image](https://github.com/user-attachments/assets/f16ee417-6f52-4d61-8038-973710a8bef0)


## Test methodology <!-- How did you ensure quality? -->

Visual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
