### PR TITLE
style: Darker panel background

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/AppColor.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/AppColor.cs
@@ -9,6 +9,7 @@
     /// </remarks>
     public enum AppColor
     {
+        PanelBackground,
         AuthoredHighlight,
         HighlightAllOccurences,
         InactiveSelectionHighlight,

--- a/src/app/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
@@ -7,6 +7,7 @@
         private static readonly Dictionary<AppColor, Color> Values =
             new()
             {
+                { AppColor.PanelBackground, Color.FromArgb(0xf6, 0xf6, 0xf6) }, // KnownColor.Control.MakeBackgroundDarkerBy(-0.02)
                 { AppColor.AuthoredHighlight, Color.FromArgb(0xea, 0xf1, 0xff) },
                 { AppColor.HighlightAllOccurences, Color.FromArgb(0xe8, 0xe8, 0xff) },
                 { AppColor.InactiveSelectionHighlight, Color.FromArgb(0xe6, 0xe6, 0xe6) },

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -5,10 +5,12 @@ using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Properties;
 using GitUI.ScriptsEngine;
+using GitUI.Theming;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -58,6 +60,7 @@ See the changes in the commit form.");
         public RevisionFileTreeControl()
         {
             InitializeComponent();
+            tvGitTree.BackColor = AppColor.PanelBackground.GetThemeColor();
             InitializeComplete();
             HotkeysEnabled = true;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -78,8 +78,6 @@ namespace GitUI.Editor
             };
             TextEditor.ActiveTextAreaControl.TextArea.MouseWheel += TextArea_MouseWheel;
 
-            HighlightingManager.Manager.DefaultHighlighting.SetColorFor("LineNumbers",
-                new HighlightColor(SystemColors.ControlText, SystemColors.Control, false, false));
             TextEditor.ActiveTextAreaControl.TextEditorProperties.EnableFolding = false;
 
             _lineNumbersControl = new DiffViewerLineNumberControl(TextEditor.ActiveTextAreaControl.TextArea);

--- a/src/app/GitUI/GitExtensionsDialog.cs
+++ b/src/app/GitUI/GitExtensionsDialog.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
 
 namespace GitUI
 {
@@ -23,6 +24,7 @@ namespace GitUI
 
             // Lighten up the control panel
             ControlsPanel.BackColor = KnownColor.ControlLight.MakeBackgroundDarkerBy(-0.04);
+            MainPanel.BackColor = AppColor.PanelBackground.GetThemeColor();
 
             // Draw a separator line at the top of the footer panel, similar to what Task Dialog does
             ControlsPanel.Paint += (s, e)

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -10,6 +10,7 @@ using GitExtUtils.GitUI.Theming;
 using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
+using GitUI.Theming;
 using GitUI.UserControls;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
@@ -48,6 +49,8 @@ namespace GitUI.LeftPanel
             InitImageList();
             _txtBranchCriterion = CreateSearchBox();
             branchSearchPanel.Controls.Add(_txtBranchCriterion, 1, 0);
+            treeMain.BackColor = AppColor.PanelBackground.GetThemeColor();
+            leftPanelToolStrip.BackColor = SystemColors.Control;
 
             mnubtnCollapse.AdaptImageLightness();
             tsbCollapseAll.AdaptImageLightness();

--- a/src/app/GitUI/Themes/invariant.css
+++ b/src/app/GitUI/Themes/invariant.css
@@ -38,6 +38,7 @@
 .WindowText              { color: #000000; }
 
 /* Application colors */
+.PanelBackground         { color: #f6f6f6; }
 .AuthoredHighlight { color: #eaf1ff; }
 .HighlightAllOccurences { color: #e8e8ff; }
 .InactiveSelectionHighlight { color: #e6e6e6; }

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -39,6 +39,7 @@ namespace GitUI
         private readonly ToolStripItem _showDiffForAllParentsSeparator = new ToolStripSeparator() { Name = $"{_showDiffForAllParentsItemName}Separator" };
         private readonly ToolStripItem _sortBySeparator = new ToolStripSeparator();
         private readonly SolidBrush _inactiveSelectionHighlightBrush = new(AppColor.InactiveSelectionHighlight.GetThemeColor());
+        private readonly SolidBrush _backgroundBrush = new(AppColor.PanelBackground.GetThemeColor());
 
         private int _nextIndexToSelect = -1;
         private bool _enableSelectedIndexChangeEvent = true;
@@ -92,6 +93,7 @@ namespace GitUI
 
             SetupUnifiedDiffListSorting();
             lblSplitter.Height = DpiUtil.Scale(1);
+            FileStatusListView.BackColor = AppColor.PanelBackground.GetThemeColor();
             InitializeComplete();
 
             SelectFirstItemOnSetItems = true;
@@ -100,7 +102,9 @@ namespace GitUI
             FileStatusListView.LargeImageList = _imageListData.ImageList;
 
             NoFiles.Text = TranslatedStrings.NoChanges;
+            NoFiles.BackColor = AppColor.PanelBackground.GetThemeColor();
             LoadingFiles.Text = TranslatedStrings.LoadingData;
+            LoadingFiles.BackColor = AppColor.PanelBackground.GetThemeColor();
 
             NoFiles.Font = new Font(NoFiles.Font, FontStyle.Italic);
             LoadingFiles.Font = new Font(LoadingFiles.Font, FontStyle.Italic);
@@ -1628,10 +1632,12 @@ namespace GitUI
 
             (Image? image, string? prefix, string text, string? suffix, int prefixTextStartX, int _, int textMaxWidth) = FormatListViewItem(item, formatter, item.Bounds.Width);
 
-            if (item.Selected)
-            {
-                e.Graphics.FillRectangle(Focused ? SystemBrushes.Highlight : _inactiveSelectionHighlightBrush, e.Bounds);
-            }
+            Brush backgroundBrush = item.Selected
+                ? Focused
+                    ? SystemBrushes.Highlight
+                    : _inactiveSelectionHighlightBrush
+                : _backgroundBrush;
+            e.Graphics.FillRectangle(backgroundBrush, e.Bounds);
 
             if (image is not null)
             {


### PR DESCRIPTION
## Proposed changes

Change to make the GE default theme changes the panel backgrounds not so extremely bright, more like Visual Studio Code "Modern Light" theme.
The GitExtensionsDialog are updated too but not the old style GitExtensionsForm.
The grid view and editors are unchanged.

The line number panel is made darker to contrast to the text and panels.

The dark mode look very dull without changing the panel colors, this is a preparation to align looks.

PR is needed for ICSharp too

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/aa6fe5c7-ace2-4e91-84e6-44b5f492b73a)

<!-- TODO -->

### After

![image](https://github.com/user-attachments/assets/c88bf5e1-b1ca-492e-a5f7-412fc5db94ab)

VS Code inspiration

![image](https://github.com/user-attachments/assets/2bfbbde2-f98b-41b1-bf3b-1ac1f6a4bca5)

## Test methodology <!-- How did you ensure quality? -->

Visual

## Test environment(s) <!-- Remove any that don't apply -->

Win 11 24H2

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
