### PR TITLE
fix: Improve blame loading and other minor

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -338,7 +338,7 @@ namespace GitUI.CommandsDialogs
 
             if (tabControl1.SelectedTab == BlameTab)
             {
-                _ = Blame.LoadBlameAsync(revision, children, fileName, revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, controlToMask: BlameTab, Diff.Encoding, force: force, cancellationToken: _viewChangesSequence.Next());
+                _ = Blame.LoadBlameAsync(revision, children, fileName, revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, controlToMask: BlameTab, Diff.Encoding, force: force, cancellationTokenSequence: _viewChangesSequence);
             }
             else if (tabControl1.SelectedTab == ViewTab)
             {

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -304,13 +304,14 @@ namespace GitUI.CommandsDialogs
             FileStatusItem prevSelectedItem = DiffFiles.SelectedItem;
             FileStatusItem prevDiffItem = DiffFiles.FirstGroupItems.Contains(prevSelectedItem) ? prevSelectedItem : null;
             await DiffFiles.SetDiffsAsync(revisions, _revisionGridInfo.CurrentCheckout, cancellationToken);
+            FileStatusItem[] firstGroupItems = DiffFiles.FirstGroupItems.ToArray();
             await this.SwitchToMainThreadAsync(cancellationToken);
 
             _isImplicitListSelection = true;
 
             // First try the last item explicitly selected
             if (_lastExplicitlySelectedItem is not null
-                && DiffFiles.FirstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(_lastExplicitlySelectedItem.Item.Name))?.Item is GitItemStatus explicitItem)
+                && firstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(_lastExplicitlySelectedItem.Item.Name))?.Item is GitItemStatus explicitItem)
             {
                 DiffFiles.SelectedGitItem = explicitItem;
                 return;
@@ -318,7 +319,7 @@ namespace GitUI.CommandsDialogs
 
             // Second go back to the filtered file
             if (!string.IsNullOrWhiteSpace(FallbackFollowedFile)
-                && DiffFiles.FirstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(FallbackFollowedFile))?.Item is GitItemStatus fallbackItem)
+                && firstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(FallbackFollowedFile))?.Item is GitItemStatus fallbackItem)
             {
                 DiffFiles.SelectedGitItem = fallbackItem;
                 return;
@@ -326,7 +327,7 @@ namespace GitUI.CommandsDialogs
 
             // Third try to restore the previous item
             if (prevDiffItem is not null
-                && DiffFiles.FirstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(prevDiffItem.Item.Name))?.Item is GitItemStatus prevItem)
+                && firstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(prevDiffItem.Item.Name))?.Item is GitItemStatus prevItem)
             {
                 DiffFiles.SelectedGitItem = prevItem;
             }

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -586,7 +586,7 @@ namespace GitUI.CommandsDialogs
                 ? _revisionGridInfo.GetActualRevision(_revisionGridInfo.CurrentCheckout)
                 : DiffFiles.SelectedItem.SecondRevision;
             await BlameControl.LoadBlameAsync(rev, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGridInfo, _revisionGridUpdate,
-                controlToMask: null, DiffText.Encoding, line, cancellationToken: _viewChangesSequence.Next());
+                controlToMask: null, DiffText.Encoding, line, cancellationTokenSequence: _viewChangesSequence);
         }
 
         /// <summary>

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -456,7 +456,7 @@ See the changes in the commit form.");
 
                         FileText.Visible = false;
                         BlameControl.Visible = true;
-                        return BlameControl.LoadBlameAsync(_revision, children: null, gitItem.FileName, _revisionGridInfo, _revisionGridUpdate, controlToMask: null, FileText.Encoding, line, cancellationToken: _viewBlameSequence.Next());
+                        return BlameControl.LoadBlameAsync(_revision, children: null, gitItem.FileName, _revisionGridInfo, _revisionGridUpdate, controlToMask: null, FileText.Encoding, line, cancellationTokenSequence: _viewBlameSequence);
                     }
 
                 case GitObjectType.Commit:

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1517,7 +1517,7 @@ namespace GitUI
             }
 
             // Show 'Show file differences for all parents' menu item if it is possible that there are multiple first revisions
-            bool mayBeMultipleRevs = _enableDisablingShowDiffForAllParents && GitItemStatusesWithDescription.Count > 1;
+            bool mayBeMultipleRevs = _enableDisablingShowDiffForAllParents;
 
             ToolStripItem[] diffItem = cm.Items.Find(_showDiffForAllParentsItemName, true);
             if (diffItem.Length == 0)


### PR DESCRIPTION
Fixes
- very occasionally not loaded blame
- disappearing context menu item "Show differences for all parents in browse dialog"

## Proposed changes

- `BlameControl`: Do not cancel loading if nothing changed; combine cancellation tokens; use safe init values for `_lastTooltipX/Y`
- `AsyncLoader`: Make clearer & enable `nullable`
- `RevisionDiffControl`: Convert `IEnumerable` to array in order to avoid possible multiple evaluation
- `FileStatusList`: Avoid one-way menu item "Show differences for all parents in browse dialog"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

menu item disappeared when unchecked

### After

![image](https://github.com/user-attachments/assets/76cf5e49-0a66-4a1b-baac-a8248b818211)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).