### PR TITLE
refactor(BlameControl): Use clearer interface

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="LibGit2Sharp" Version="0.27.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
+    <PackageVersion Include="StrongOf" Version="1.2.4" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="6.0.0" /> <!-- Required by GitExtensions.PluginManager -->
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />

--- a/setup/installer/Product.wxs
+++ b/setup/installer/Product.wxs
@@ -197,6 +197,9 @@
       <Component Id="SpellChecker.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\SpellChecker.dll" />
       </Component>
+      <Component Id="StrongOf.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\BenjaminAbt.StrongOf.dll" />
+      </Component>
       <Component Id="System.ComponentModel.Composition.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\System.ComponentModel.Composition.dll" />
       </Component>
@@ -674,6 +677,7 @@
       <ComponentRef Id="SmartFormat.dll" />
       <ComponentRef Id="SmartFormat.ZString.dll" />
       <ComponentRef Id="SpellChecker.dll" />
+      <ComponentRef Id="StrongOf.dll" />
       <ComponentRef Id="System.ComponentModel.Composition.dll" />
       <ComponentRef Id="System.Composition.AttributedModel.dll" />
       <ComponentRef Id="System.Composition.Convention.dll" />

--- a/src/app/GitExtensions.Extensibility/Git/RelativePath.cs
+++ b/src/app/GitExtensions.Extensibility/Git/RelativePath.cs
@@ -1,0 +1,10 @@
+﻿using StrongOf;
+
+namespace GitExtensions.Extensibility.Git;
+
+/// <summary>
+///  Contains a path relative to the root of a repository (with POSIX path separators).
+/// </summary>
+public sealed class RelativePath(string value) : StrongString<RelativePath>(value)
+{
+}

--- a/src/app/GitExtensions.Extensibility/GitExtensions.Extensibility.csproj
+++ b/src/app/GitExtensions.Extensibility/GitExtensions.Extensibility.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdysTech.CredentialManager" />
+    <PackageReference Include="StrongOf" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -11,7 +11,7 @@ using GitCommands.Settings;
 using GitExtensions.Extensibility.BuildServerIntegration;
 using GitExtensions.Extensibility.Configurations;
 using GitExtensions.Extensibility.Git;
-using GitUI.CommandDialogs;
+using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUI.HelperDialogs;
 using GitUI.UserControls;

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -1,7 +1,6 @@
 ﻿using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
-using GitUI.CommandDialogs;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using ResourceManager;

--- a/src/app/GitUI/CommandsDialogs/FormBlame.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBlame.cs
@@ -26,7 +26,7 @@ namespace GitUI.CommandsDialogs
 
             FileName = fileName;
 
-            _ = blameControl1.LoadBlameAsync(revision ?? Module.GetRevision(), children: null, fileName, revisionGridInfo: null, revisionGridUpdate: null, controlToMask: null, Module.FilesEncoding, initialLine);
+            _ = blameControl1.LoadBlameAsync(revision ?? Module.GetRevision(), children: null, fileName, revisionGridInfo: null, revisionGridFileUpdate: null, controlToMask: null, Module.FilesEncoding, initialLine);
             blameControl1.ConfigureRepositoryHostPlugin(PluginRegistry.TryGetGitHosterForModule(Module));
         }
 

--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -551,11 +551,11 @@ namespace GitUI.CommandsDialogs
             if (e.Command == "gotocommit")
             {
                 Validates.NotNull(e.Data);
-                if (Module.TryResolvePartialCommitId(e.Data, out ObjectId? objectId))
+                if (Module.TryResolvePartialCommitId(e.Data, out ObjectId? commitId))
                 {
-                    if (!RevisionGrid.SetSelectedRevision(objectId))
+                    if (!RevisionGrid.SetSelectedRevision(commitId))
                     {
-                        MessageBoxes.RevisionFilteredInGrid(this, objectId);
+                        MessageBoxes.RevisionFilteredInGrid(this, commitId);
                     }
                }
             }
@@ -696,8 +696,8 @@ namespace GitUI.CommandsDialogs
             FormGitCommandLog.ShowOrActivate(this);
         }
 
-        bool IRevisionGridFileUpdate.SelectFileInRevision(ObjectId objectId, RelativePath ignoredFilename)
-            => RevisionGrid.SetSelectedRevision(objectId);
+        bool IRevisionGridFileUpdate.SelectFileInRevision(ObjectId commitId, RelativePath ignoredFilename)
+            => RevisionGrid.SetSelectedRevision(commitId);
 
         internal TestAccessor GetTestAccessor()
             => new(this);

--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -14,7 +14,7 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public sealed partial class FormFileHistory : GitModuleForm
+    public sealed partial class FormFileHistory : GitModuleForm, IRevisionGridFileUpdate
     {
         private const string FormBrowseName = "FormBrowse";
 
@@ -338,7 +338,7 @@ namespace GitUI.CommandsDialogs
 
             if (tabControl1.SelectedTab == BlameTab)
             {
-                _ = Blame.LoadBlameAsync(revision, children, fileName, revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, controlToMask: BlameTab, Diff.Encoding, force: force, cancellationTokenSequence: _viewChangesSequence);
+                _ = Blame.LoadBlameAsync(revision, children, fileName, revisionGridInfo: RevisionGrid, revisionGridFileUpdate: this, controlToMask: BlameTab, Diff.Encoding, force: force, cancellationTokenSequence: _viewChangesSequence);
             }
             else if (tabControl1.SelectedTab == ViewTab)
             {
@@ -695,6 +695,9 @@ namespace GitUI.CommandsDialogs
         {
             FormGitCommandLog.ShowOrActivate(this);
         }
+
+        bool IRevisionGridFileUpdate.SelectFileInRevision(ObjectId objectId, RelativePath ignoredFilename)
+            => RevisionGrid.SetSelectedRevision(objectId);
 
         internal TestAccessor GetTestAccessor()
             => new(this);

--- a/src/app/GitUI/CommandsDialogs/IRevisionGridFileUpdate.cs
+++ b/src/app/GitUI/CommandsDialogs/IRevisionGridFileUpdate.cs
@@ -1,0 +1,8 @@
+﻿using GitExtensions.Extensibility.Git;
+
+namespace GitUI.CommandsDialogs;
+
+public interface IRevisionGridFileUpdate
+{
+    bool SelectFileInRevision(ObjectId objectId, RelativePath filename);
+}

--- a/src/app/GitUI/CommandsDialogs/IRevisionGridFileUpdate.cs
+++ b/src/app/GitUI/CommandsDialogs/IRevisionGridFileUpdate.cs
@@ -4,5 +4,10 @@ namespace GitUI.CommandsDialogs;
 
 public interface IRevisionGridFileUpdate
 {
-    bool SelectFileInRevision(ObjectId objectId, RelativePath filename);
+    /// <summary>
+    ///  Tries to select the revision having <paramref name="commitId"/> in the <see cref="RevisionGridControl"/>
+    ///  and stores the <paramref name="filename"/> for selection in the <see cref="FileStatusList"/> after asynchronous loading of the revision.
+    /// </summary>
+    /// <returns><c>true</c> if the revision was found.</returns>
+    bool SelectFileInRevision(ObjectId commitId, RelativePath filename);
 }

--- a/src/app/GitUI/CommandsDialogs/IRevisionGridInfo.cs
+++ b/src/app/GitUI/CommandsDialogs/IRevisionGridInfo.cs
@@ -1,16 +1,15 @@
 ﻿using GitExtensions.Extensibility.Git;
 using GitUIPluginInterfaces;
 
-namespace GitUI.CommandDialogs
+namespace GitUI.CommandsDialogs;
+
+public interface IRevisionGridInfo
 {
-    public interface IRevisionGridInfo
-    {
-        ObjectId? CurrentCheckout { get; }
-        GitRevision GetRevision(ObjectId objectId);
-        GitRevision? GetActualRevision(ObjectId objectId);
-        GitRevision GetActualRevision(GitRevision revision);
-        IReadOnlyList<GitRevision> GetSelectedRevisions();
-        string DescribeRevision(GitRevision revision, int maxLength = 0);
-        string GetCurrentBranch();
-    }
+    ObjectId? CurrentCheckout { get; }
+    GitRevision GetRevision(ObjectId objectId);
+    GitRevision? GetActualRevision(ObjectId objectId);
+    GitRevision GetActualRevision(GitRevision revision);
+    IReadOnlyList<GitRevision> GetSelectedRevisions();
+    string DescribeRevision(GitRevision revision, int maxLength = 0);
+    string GetCurrentBranch();
 }

--- a/src/app/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
+++ b/src/app/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
@@ -4,5 +4,5 @@ namespace GitUI.CommandsDialogs;
 
 public interface IRevisionGridUpdate
 {
-    bool SetSelectedRevision(ObjectId? objectId, bool toggleSelection = false, bool updateNavigationHistory = true);
+    bool SetSelectedRevision(ObjectId? commitId, bool toggleSelection = false, bool updateNavigationHistory = true);
 }

--- a/src/app/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
+++ b/src/app/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
@@ -1,9 +1,8 @@
 ﻿using GitExtensions.Extensibility.Git;
 
-namespace GitUI.CommandDialogs
+namespace GitUI.CommandsDialogs;
+
+public interface IRevisionGridUpdate
 {
-    public interface IRevisionGridUpdate
-    {
-        bool SetSelectedRevision(ObjectId? objectId, bool toggleSelection = false, bool updateNavigationHistory = true);
-    }
+    bool SetSelectedRevision(ObjectId? objectId, bool toggleSelection = false, bool updateNavigationHistory = true);
 }

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -4,7 +4,6 @@ using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
-using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;
 using GitUI.ScriptsEngine;

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1486,10 +1486,10 @@ namespace GitUI.CommandsDialogs
             BlameControl.ConfigureRepositoryHostPlugin(PluginRegistry.TryGetGitHosterForModule(Module));
         }
 
-        bool IRevisionGridFileUpdate.SelectFileInRevision(ObjectId objectId, RelativePath filename)
+        bool IRevisionGridFileUpdate.SelectFileInRevision(ObjectId commitId, RelativePath filename)
         {
             _lastExplicitlySelectedItem = filename;
-            return _revisionGridUpdate.SetSelectedRevision(objectId);
+            return _revisionGridUpdate.SetSelectedRevision(commitId);
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -16,7 +16,7 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public partial class RevisionDiffControl : GitModuleControl
+    public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUpdate
     {
         private readonly TranslationString _saveFileFilterCurrentFormat = new("Current format");
         private readonly TranslationString _saveFileFilterAllFiles = new("All files");
@@ -585,7 +585,7 @@ namespace GitUI.CommandsDialogs
             GitRevision rev = DiffFiles.SelectedItem.SecondRevision.IsArtificial
                 ? _revisionGridInfo.GetActualRevision(_revisionGridInfo.CurrentCheckout)
                 : DiffFiles.SelectedItem.SecondRevision;
-            await BlameControl.LoadBlameAsync(rev, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGridInfo, _revisionGridUpdate,
+            await BlameControl.LoadBlameAsync(rev, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGridInfo, revisionGridFileUpdate: this,
                 controlToMask: null, DiffText.Encoding, line, cancellationTokenSequence: _viewChangesSequence);
         }
 
@@ -1484,6 +1484,12 @@ namespace GitUI.CommandsDialogs
         internal void RegisterGitHostingPluginInBlameControl()
         {
             BlameControl.ConfigureRepositoryHostPlugin(PluginRegistry.TryGetGitHosterForModule(Module));
+        }
+
+        bool IRevisionGridFileUpdate.SelectFileInRevision(ObjectId objectId, RelativePath filename)
+        {
+            _lastExplicitlySelectedItem = filename;
+            return _revisionGridUpdate.SetSelectedRevision(objectId);
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -46,9 +46,9 @@ namespace GitUI.CommandsDialogs
         private readonly RememberFileContextMenuController _rememberFileContextMenuController
             = RememberFileContextMenuController.Default;
         private Action? _refreshGitStatus;
-        private FileStatusItem? _selectedBlameItem;
+        private GitItemStatus? _selectedBlameItem;
         private string? _fallbackFollowedFile;
-        private FileStatusItem? _lastExplicitlySelectedItem;
+        private RelativePath? _lastExplicitlySelectedItem;
         private bool _isImplicitListSelection = false;
 
         public RevisionDiffControl()
@@ -310,7 +310,7 @@ namespace GitUI.CommandsDialogs
 
             // First try the last item explicitly selected
             if (_lastExplicitlySelectedItem is not null
-                && firstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(_lastExplicitlySelectedItem.Item.Name))?.Item is GitItemStatus explicitItem)
+                && firstGroupItems.FirstOrDefault(i => i.Item.Name.Equals(_lastExplicitlySelectedItem.Value))?.Item is GitItemStatus explicitItem)
             {
                 DiffFiles.SelectedGitItem = explicitItem;
                 return;
@@ -628,17 +628,17 @@ namespace GitUI.CommandsDialogs
         private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
             // Switch to diff if the selection changes
-            FileStatusItem? item = DiffFiles.SelectedItem;
-            if (item is not null && blameToolStripMenuItem.Checked && item.Item.Name != _selectedBlameItem?.Item.Name)
+            GitItemStatus? item = DiffFiles.SelectedGitItem;
+            if (item is not null && blameToolStripMenuItem.Checked && item.Name != _selectedBlameItem?.Name)
             {
                 blameToolStripMenuItem.Checked = false;
             }
 
             // If this is not occurring after a revision change (implicit selection)
             // save the selected item so it can be the "preferred" selection
-            if (!_isImplicitListSelection && item is not null && !item.Item.IsRangeDiff)
+            if (!_isImplicitListSelection && item is not null && !item.IsRangeDiff)
             {
-                _lastExplicitlySelectedItem = item;
+                _lastExplicitlySelectedItem = RelativePath.From(item.Name);
                 _selectedBlameItem = null;
             }
 
@@ -785,7 +785,7 @@ namespace GitUI.CommandsDialogs
             {
                 int? line = DiffText.Visible ? DiffText.CurrentFileLine : BlameControl.CurrentFileLine;
                 blameToolStripMenuItem.Checked = !blameToolStripMenuItem.Checked;
-                _selectedBlameItem = blameToolStripMenuItem.Checked ? DiffFiles.SelectedItem : null;
+                _selectedBlameItem = blameToolStripMenuItem.Checked ? DiffFiles.SelectedItem.Item : null;
                 ShowSelectedFile(ensureNoSwitchToFilter: true, line);
                 return;
             }

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -984,10 +984,10 @@ See the changes in the commit form.");
             BlameControl.ConfigureRepositoryHostPlugin(PluginRegistry.TryGetGitHosterForModule(Module));
         }
 
-        public bool SelectFileInRevision(ObjectId objectId, RelativePath filename)
+        public bool SelectFileInRevision(ObjectId commitId, RelativePath filename)
         {
             _pathToBlame = filename;
-            return _revisionGridUpdate.SetSelectedRevision(objectId);
+            return _revisionGridUpdate.SetSelectedRevision(commitId);
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -5,7 +5,6 @@ using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
-using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Properties;
 using GitUI.ScriptsEngine;

--- a/src/app/GitUI/LeftPanel/LocalBranchTree.cs
+++ b/src/app/GitUI/LeftPanel/LocalBranchTree.cs
@@ -1,7 +1,7 @@
 ﻿using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
-using GitUI.CommandDialogs;
+using GitUI.CommandsDialogs;
 using GitUI.UserControls.RevisionGrid;
 using Microsoft;
 

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -7,7 +7,6 @@ using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
-using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
 using GitUI.UserControls;

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -669,23 +669,23 @@ namespace GitUI.Blame
         /// <summary>
         /// Blame a specific revision
         /// </summary>
-        /// <param name="revisionId">the commit id to blame</param>
+        /// <param name="commitId">the commit id to blame</param>
         /// <param name="filename">the relative path of the file to blame in this commit (because it could have been renamed)</param>
-        private void BlameRevision(ObjectId revisionId, string filename, GitBlameLine blameLine)
+        private void BlameRevision(ObjectId commitId, string filename, GitBlameLine blameLine)
         {
             _clickedBlameLine = blameLine;
 
             if (_revisionGridFileUpdate is not null)
             {
-                if (!_revisionGridFileUpdate.SelectFileInRevision(revisionId, RelativePath.From(filename)))
+                if (!_revisionGridFileUpdate.SelectFileInRevision(commitId, RelativePath.From(filename)))
                 {
-                    MessageBoxes.RevisionFilteredInGrid(this, revisionId);
+                    MessageBoxes.RevisionFilteredInGrid(this, commitId);
                 }
 
                 return;
             }
 
-            using FormCommitDiff frm = new(UICommands, revisionId);
+            using FormCommitDiff frm = new(UICommands, commitId);
             frm.ShowDialog(this);
         }
 

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -8,7 +8,7 @@ using GitExtensions.Extensibility.Plugins;
 using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Avatars;
-using GitUI.CommandDialogs;
+using GitUI.CommandsDialogs;
 using GitUI.Editor;
 using GitUI.HelperDialogs;
 using GitUI.Properties;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -17,7 +17,6 @@ using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Avatars;
 using GitUI.BuildServerIntegration;
-using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -202,11 +202,11 @@ namespace GitUI
             _quickSearchProvider = new QuickSearchProvider(_gridView, () => Module.WorkingDir);
 
             // Parent-child navigation can expect that SetSelectedRevision is always successful since it always uses first-parents
-            _parentChildNavigationHistory = new ParentChildNavigationHistory(objectId =>
+            _parentChildNavigationHistory = new ParentChildNavigationHistory(commitId =>
             {
-                if (!SetSelectedRevision(objectId))
+                if (!SetSelectedRevision(commitId))
                 {
-                    MessageBoxes.RevisionFilteredInGrid(this, objectId);
+                    MessageBoxes.RevisionFilteredInGrid(this, commitId);
                 }
             });
             _authorHighlighting = new AuthorRevisionHighlighting();
@@ -458,10 +458,10 @@ namespace GitUI
         {
             if (_navigationHistory.CanNavigateBackward)
             {
-                ObjectId objectId = _navigationHistory.NavigateBackward();
-                if (!SetSelectedRevision(objectId))
+                ObjectId commitId = _navigationHistory.NavigateBackward();
+                if (!SetSelectedRevision(commitId))
                 {
-                    MessageBoxes.RevisionFilteredInGrid(this, objectId);
+                    MessageBoxes.RevisionFilteredInGrid(this, commitId);
                 }
             }
         }
@@ -470,10 +470,10 @@ namespace GitUI
         {
             if (_navigationHistory.CanNavigateForward)
             {
-                ObjectId objectId = _navigationHistory.NavigateForward();
-                if (!SetSelectedRevision(objectId))
+                ObjectId commitId = _navigationHistory.NavigateForward();
+                if (!SetSelectedRevision(commitId))
                 {
-                    MessageBoxes.RevisionFilteredInGrid(this, objectId);
+                    MessageBoxes.RevisionFilteredInGrid(this, commitId);
                 }
             }
         }
@@ -590,25 +590,25 @@ namespace GitUI
         }
 
         /// <summary>
-        /// Selects row containing revision matching <paramref name="objectId"/>.
+        /// Selects row containing revision matching <paramref name="commitId"/>.
         /// Returns whether the required revision was found and selected.
         /// </summary>
-        /// <param name="objectId">Id of the revision to select.</param>
+        /// <param name="commitId">Id of the revision to select.</param>
         /// <param name="toggleSelection">Toggle if the selected state for the revision.</param>
         /// <returns><c>true</c> if the required revision was found and selected, otherwise <c>false</c>.</returns>
-        public bool SetSelectedRevision(ObjectId? objectId, bool toggleSelection = false, bool updateNavigationHistory = true)
+        public bool SetSelectedRevision(ObjectId? commitId, bool toggleSelection = false, bool updateNavigationHistory = true)
         {
             _gridView.ClearToBeSelected();
-            if (_gridView.TryGetRevisionIndex(objectId) is not int index || index < 0 || index >= _gridView.RowCount)
+            if (_gridView.TryGetRevisionIndex(commitId) is not int index || index < 0 || index >= _gridView.RowCount)
             {
                 return false;
             }
 
-            Validates.NotNull(objectId);
+            Validates.NotNull(commitId);
             SetSelectedIndex(_gridView, index, toggleSelection);
             if (updateNavigationHistory)
             {
-                _navigationHistory.Push(objectId);
+                _navigationHistory.Push(commitId);
             }
 
             return true;
@@ -2879,10 +2879,10 @@ namespace GitUI
                 return;
             }
 
-            ObjectId objectId = ObjectId.Parse(mergeBaseCommitId);
-            if (!SetSelectedRevision(objectId))
+            ObjectId commitId = ObjectId.Parse(mergeBaseCommitId);
+            if (!SetSelectedRevision(commitId))
             {
-                MessageBoxes.RevisionFilteredInGrid(this, objectId);
+                MessageBoxes.RevisionFilteredInGrid(this, commitId);
             }
         }
 
@@ -2916,12 +2916,12 @@ namespace GitUI
                 refName = sha1;
             }
 
-            ObjectId? revisionId = Module.RevParse(refName);
-            if (revisionId is not null)
+            ObjectId? commitId = Module.RevParse(refName);
+            if (commitId is not null)
             {
-                if (!SetSelectedRevision(revisionId, toggleSelection) && showNoRevisionMsg)
+                if (!SetSelectedRevision(commitId, toggleSelection) && showNoRevisionMsg)
                 {
-                    MessageBoxes.RevisionFilteredInGrid(this, revisionId);
+                    MessageBoxes.RevisionFilteredInGrid(this, commitId);
                 }
             }
             else if (showNoRevisionMsg)

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -509,13 +509,13 @@ namespace GitUI.UserControls.RevisionGrid
                 return;
             }
 
-            ObjectId objectId = formGoToCommit.ValidateAndGetSelectedRevision();
+            ObjectId commitId = formGoToCommit.ValidateAndGetSelectedRevision();
 
-            if (objectId is not null)
+            if (commitId is not null)
             {
-                if (!_revisionGrid.SetSelectedRevision(objectId))
+                if (!_revisionGrid.SetSelectedRevision(commitId))
                 {
-                    MessageBoxes.RevisionFilteredInGrid(_revisionGrid, objectId);
+                    MessageBoxes.RevisionFilteredInGrid(_revisionGrid, commitId);
                 }
             }
             else


### PR DESCRIPTION
## Proposed changes

- chore: Fixup typo in namespace `GitUI.CommandsDialogs`
- refactor(`RevisionDiffControl`): Use simpler types
- refactor(`BlameControl`): Clearly request `PathToBlame` by adding a dedicated interface `IRevisionGridFileUpdate` in favor of `IRevisionGridUpdate`

(Review commit by commit recommended.)

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests
- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).