### PR TITLE
fix(bare repo): Skip "git status" and "git stash list"

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -471,7 +471,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     return;
                 }
 
-                if (!Directory.Exists(_workTreeWatcher.Path))
+                if (!Directory.Exists(_workTreeWatcher.Path) || Module.IsBareRepository())
                 {
                     // The directory no longer exists, watcher cannot be enabled
                     return;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -926,7 +926,7 @@ namespace GitUI
 
             // Get the "main" stash commit, including the reflog selector
             Lazy<IReadOnlyCollection<GitRevision>> getStashRevs = new(() =>
-                !AppSettings.ShowStashes
+                !AppSettings.ShowStashes || Module.IsBareRepository()
                 ? Array.Empty<GitRevision>()
                 : new RevisionReader(capturedModule).GetStashes(cancellationToken));
 


### PR DESCRIPTION
## Proposed changes

- `GitStatusMonitor`: Deactivate if bare repo
- `RevisionGridControl`: Skip `GetStashes` if bare repo

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/c4f01806-fe5c-4b58-9f6e-848f2acb0adf)

![image](https://github.com/user-attachments/assets/e957b05f-a395-4c00-9b7d-036e4e96babf)

### After

![image](https://github.com/user-attachments/assets/d205efad-7a1c-4262-b562-5e9155834c66)

no error messages in Output tab

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).