### PR TITLE
fix: bold+italic for current left panel node

### DIFF
--- a/src/app/GitUI/LeftPanel/LocalBranchNode.cs
+++ b/src/app/GitUI/LeftPanel/LocalBranchNode.cs
@@ -18,7 +18,7 @@ namespace GitUI.LeftPanel
         public bool IsCurrent { get; }
 
         protected override FontStyle GetFontStyle()
-            => base.GetFontStyle() | (IsCurrent ? FontStyle.Bold : FontStyle.Regular);
+            => base.GetFontStyle() | (IsCurrent ? FontStyle.Bold | FontStyle.Italic : FontStyle.Regular);
 
         public override bool Equals(object obj)
             => base.Equals(obj) && obj is LocalBranchNode;

--- a/src/app/GitUI/LeftPanel/SubmoduleNode.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleNode.cs
@@ -128,7 +128,7 @@ namespace GitUI.LeftPanel
         }
 
         protected override FontStyle GetFontStyle()
-            => base.GetFontStyle() | (IsCurrent ? FontStyle.Bold : FontStyle.Regular);
+            => base.GetFontStyle() | (IsCurrent ? FontStyle.Bold | FontStyle.Italic : FontStyle.Regular);
 
         private void ApplyStatus()
         {


### PR DESCRIPTION
## Proposed changes

Current submodule and branch can be hard to see, especially for upcoming dark mode.
This PR adds italics in addition to bold to the current node.
(selected is still underlined and backcolor for infocus unchanged)

Colors could be used too, but that need to be themable too.
I would prefer to not change italics in dark mode, that is unexpected type of change.

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://github.com/user-attachments/assets/e7630003-527c-4593-ab12-82eff034d79b)

![image](https://github.com/user-attachments/assets/dc35529f-ec04-4df9-b05e-8634ceb23b38)

For dark mode

![image](https://github.com/user-attachments/assets/840e0094-106d-4ca2-a66f-9b3aa9670643)

![image](https://github.com/user-attachments/assets/f332c6bd-5ac5-4508-a255-04c9bb2b0d3c)

## Test methodology <!-- How did you ensure quality? -->

Visual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
