### PR TITLE
feat(graph): Ensure new lane color is different

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
@@ -1,32 +1,37 @@
 ﻿namespace GitUI.UserControls.RevisionGrid.Graph
 {
-    public class LaneInfo
+    public sealed class LaneInfo
     {
-        public LaneInfo(RevisionGraphSegment startSegment)
+        public LaneInfo(RevisionGraphSegment startSegment, RevisionGraphSegment? segmentToTheLeft, RevisionGraphSegment? segmentToTheRight = null)
         {
             StartRevision = startSegment.Child;
-
-            int colorSeed = StartRevision.Objectid.GetHashCode() ^ startSegment.Parent.Objectid.GetHashCode();
-            Color = RevisionGraphLaneColor.GetColorForLane(colorSeed);
+            Color = GetColor(colorSeed: StartRevision.Objectid.GetHashCode() ^ startSegment.Parent.Objectid.GetHashCode(), segmentToTheLeft, segmentToTheRight);
         }
 
-        public LaneInfo(RevisionGraphSegment startSegment, LaneInfo derivedFrom)
+        public LaneInfo(RevisionGraphSegment startSegment, RevisionGraphSegment? segmentToTheLeft, RevisionGraphSegment? segmentToTheRight, LaneInfo derivedFrom)
         {
             StartRevision = startSegment.Parent;
-            int colorSeed = StartRevision.Objectid.GetHashCode();
-
-            do
-            {
-                Color = RevisionGraphLaneColor.GetColorForLane(colorSeed);
-                ++colorSeed;
-            }
-            while (Color == derivedFrom.Color);
+            Color = GetColor(colorSeed: StartRevision.Objectid.GetHashCode(), segmentToTheLeft, segmentToTheRight, derivedFrom.Color);
         }
 
-        public int Color { get; private set; }
+        public int Color { get; }
 
-        public RevisionGraphRevision StartRevision { get; private set; }
+        public RevisionGraphRevision StartRevision { get; }
 
         public int StartScore => StartRevision.Score;
+
+        private static int GetColor(int colorSeed, RevisionGraphSegment? segmentToTheLeft, RevisionGraphSegment? segmentToTheRight, int? derivedFromColor = null)
+        {
+            int? leftLaneColor = segmentToTheLeft?.LaneInfo?.Color;
+            int? rightLaneColor = segmentToTheRight?.LaneInfo?.Color;
+            for (; ; ++colorSeed)
+            {
+                int color = RevisionGraphLaneColor.GetColorForLane(colorSeed);
+                if (color != leftLaneColor && color != rightLaneColor && color != derivedFromColor)
+                {
+                    return color;
+                }
+            }
+        }
     }
 }

--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -23,12 +23,14 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 .Where(name => name.StartsWith(nameof(AppColor.GraphBranch1)[..^1]))
                 .Select(name => ((AppColor)Enum.Parse(typeof(AppColor), name)).GetThemeColor())
                 .Where(color => !color.IsEmpty)
+                .Distinct()
                 .ToArray();
 
-            if (branchColors.Length < 2)
+            const int minBranchColors = 4;
+            if (branchColors.Length < minBranchColors)
             {
-                Trace.WriteLine("At least two graph colors must be configured");
-                branchColors = [Color.Magenta.AdaptTextColor(), Color.Cyan.AdaptTextColor()];
+                Trace.WriteLine(@"At least {minBranchColors} different graph colors must be configured - using crying fallback");
+                branchColors = [Color.Cyan, Color.Magenta, Color.Yellow, Color.Lime];
             }
 
             foreach (Color color in branchColors)

--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -12,7 +12,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     //     |
     //     *  <- parent revision
     [DebuggerDisplay("{Objectid} {GitRevision.Subject}")]
-    public class RevisionGraphRevision
+    public sealed class RevisionGraphRevision
     {
         // Enough as initial the majority of times because commits nearly never have more than 2 parents.
         private const int _initialParentStackCapacity = 2;

--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -21,7 +21,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     // Segments are not the same as lanes.A crossing segment is a lane, but multiple segments can connect to the revision.
     // Therefore, a single lane can have multiple segments.
     [DebuggerDisplay("{Revision}")]
-    public class RevisionGraphRow : IRevisionGraphRow
+    public sealed class RevisionGraphRow : IRevisionGraphRow
     {
         private static readonly Lane _noLane = new(Index: -1, LaneSharing.ExclusiveOrPrimary);
 

--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -18,7 +18,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     //     | /
     //     *    <- Parent
     [DebuggerDisplay("Child: {Child} - Parent: {Parent}")]
-    public class RevisionGraphSegment
+    public sealed class RevisionGraphSegment
     {
         public RevisionGraphSegment(RevisionGraphRevision parent, RevisionGraphRevision child)
         {


### PR DESCRIPTION
## Proposed changes

- `LaneInfo`: Ensure new lane color is different from adjacent lanes
- `RevisionGraph`: provide `segmentToTheLeft` and `segmentToTheRight`
- `RevisionGraphLaneColor`: ensure that there are configured at least 4 graph colors
- declare graph helper classes as `sealed`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before | After

![image](https://github.com/user-attachments/assets/dea01706-d296-4a4f-90aa-ec2e3919f06c)   ![image](https://github.com/user-attachments/assets/a4df435e-c850-4ba9-ba48-0c800b358685)

![image](https://github.com/user-attachments/assets/0ae2e8aa-655c-4917-8c60-2c3e7422b4e7)   ![image](https://github.com/user-attachments/assets/35813394-6d4b-4b7b-b9f4-04887d14b421)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).