### PR TITLE
fix(FormCommit): Improve selection handling

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1195,18 +1195,11 @@ namespace GitUI.CommandsDialogs
 
             if (item?.Item is null)
             {
+                SelectedDiff.Clear();
                 return;
             }
 
             SelectedDiff.InvokeAndForget(() => SelectedDiff.ViewChangesAsync(item, openWithDiffTool: OpenWithDiffTool, cancellationToken: _viewChangesSequence.Next()));
-        }
-
-        private void ClearDiffViewIfNoFilesLeft()
-        {
-            if ((Staged.IsEmpty && Unstaged.IsEmpty) || (!Unstaged.SelectedItems.Any() && !Staged.SelectedItems.Any()))
-            {
-                SelectedDiff.Clear();
-            }
         }
 
         private void CommitClick(object sender, EventArgs e)
@@ -1636,12 +1629,11 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ClearDiffViewIfNoFilesLeft();
             Staged.ClearSelected();
 
             _currentSelection = Unstaged.SelectedItems.Items().ToList();
             FileStatusItem? item = Unstaged.SelectedItem;
-            ShowChanges(item, false);
+            ShowChanges(item, staged: false);
 
             Unstaged.ContextMenuStrip = (item?.Item.IsSubmodule ?? false) ? UnstagedSubmoduleContext : UnstagedFileContext;
         }
@@ -1950,12 +1942,11 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ClearDiffViewIfNoFilesLeft();
-
             Unstaged.ClearSelected();
+
             _currentSelection = Staged.SelectedItems.Items().ToList();
-            FileStatusItem item = Staged.SelectedItem;
-            ShowChanges(item, true);
+            FileStatusItem? item = Staged.SelectedItem;
+            ShowChanges(item, staged: true);
         }
 
         private void Staged_DataSourceChanged(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1711,17 +1711,14 @@ namespace GitUI.CommandsDialogs
 
         private void Unstaged_Enter(object sender, EnterEventArgs e)
         {
-            if (_currentFilesList != Unstaged)
+            _currentFilesList = Unstaged;
+            _skipUpdate = false;
+            if (!Unstaged.HasSelection)
             {
-                _currentFilesList = Unstaged;
-                _skipUpdate = false;
-                if (!e.ByMouse && !Unstaged.HasSelection)
-                {
-                    Unstaged.SelectFirstVisibleItem();
-                }
-
-                UnstagedSelectionChanged(Unstaged, EventArgs.Empty);
+                Unstaged.SelectFirstVisibleItem();
             }
+
+            UnstagedSelectionChanged(Unstaged, EventArgs.Empty);
         }
 
         private void Unstaged_FilterChanged(object sender, EventArgs e)
@@ -1970,17 +1967,14 @@ namespace GitUI.CommandsDialogs
 
         private void Staged_Enter(object sender, EnterEventArgs e)
         {
-            if (_currentFilesList != Staged)
+            _currentFilesList = Staged;
+            _skipUpdate = false;
+            if (!Staged.HasSelection)
             {
-                _currentFilesList = Staged;
-                _skipUpdate = false;
-                if (!e.ByMouse && !Staged.HasSelection)
-                {
-                    Staged.SelectFirstVisibleItem();
-                }
-
-                StagedSelectionChanged(Staged, EventArgs.Empty);
+                Staged.SelectFirstVisibleItem();
             }
+
+            StagedSelectionChanged(Staged, EventArgs.Empty);
         }
 
         private void Stage(IReadOnlyList<GitItemStatus> items)


### PR DESCRIPTION
## Proposed changes

FormCommit:
- Handle clicks in empty area of Unstaged & Staged lists
- Clear displayed diff if focused Unstaged / Staged list is empty

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/f4978662-ceb0-4690-adc4-2e5c6d5c58d9)

### After

![image](https://github.com/user-attachments/assets/e85f9548-9538-418f-8874-0862d71a5f1a)

### Unchanged

![image](https://github.com/user-attachments/assets/7b84a20e-6761-4f7a-af9a-2dacd4c2d6a9)

## Test methodology <!-- How did you ensure quality? -->

- manual
- existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).