### PR TITLE
feat: Clickable links in console output

### DIFF
--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -38,6 +38,7 @@ namespace GitUI.UserControls
                 ReadOnly = true
             };
             Controls.Add(_editbox);
+            _editbox.LinkClicked += editbox_LinkClicked;
 
             _outputThrottle = new ProcessOutputThrottle(AppendMessage);
 
@@ -261,6 +262,18 @@ namespace GitUI.UserControls
             }
 
             base.Dispose(disposing);
+        }
+
+        private void editbox_LinkClicked(object? sender, LinkClickedEventArgs e)
+        {
+            try
+            {
+                OsShellUtil.OpenUrlInDefaultBrowser(e.LinkText);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
 
         #region ProcessOutputThrottle

--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -272,7 +272,7 @@ namespace GitUI.UserControls
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.ShowError(this, ex.Message);
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Whe conbemu is not used for longrunning commands like git-fetch
Links were previously detected but not clickable.

Similar handling in the output pane recently added and in CommitInfo (where also Git links are handled and translated to internal links).

## Screenshots <!-- Remove this section if PR does not change UI -->

### After
The  "hand" appears as before, but something now happens when the link is clicked.

With dark mode and the background set to the theme EditorPanel, by default it is Control.
![image](https://github.com/user-attachments/assets/cbfbd1dc-17d5-4c03-94cf-fe71410a87d6)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
