### PR TITLE
fix(Output History Panel): Hide with Left Panel

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -497,6 +497,7 @@ namespace GitUI.CommandsDialogs
                     ? new OutputHistoryTabController(UICommands.GetRequiredService<IOutputHistoryProvider>(), new OutputHistoryControl(), parent: CommitInfoTabControl,
                         tabCaption: _outputHistoryTabCaption.Text)
                     : new OutputHistoryPanelController(UICommands.GetRequiredService<IOutputHistoryProvider>(), new OutputHistoryControl(), parent: toolPanel.ContentPanel,
+                        showVerticalSplitContainer1: toggleLeftPanel.PerformClick,
                         verticalSplitContainer1: LeftSplitContainer, verticalSplitContainer2: revisionDiff.LeftSplitContainer, horizontalSplitContainer: revisionDiff.HorizontalSplitter);
 
                 await TaskScheduler.Default;

--- a/src/app/GitUI/UserControls/OutputHistoryPanelController.cs
+++ b/src/app/GitUI/UserControls/OutputHistoryPanelController.cs
@@ -8,6 +8,7 @@ internal partial class OutputHistoryPanelController : OutputHistoryControllerBas
 {
     private readonly SplitContainer _horizontalSplitContainer;
     private readonly OutputHistoryControl _outputHistoryControl;
+    private readonly Action _showVerticalSplitContainer1;
     private readonly SplitContainer _verticalSplitContainer1;
     private readonly SplitContainer _verticalSplitContainer2;
     private readonly Timer _timer = new() { Interval = 25 };
@@ -15,12 +16,14 @@ internal partial class OutputHistoryPanelController : OutputHistoryControllerBas
     internal OutputHistoryPanelController(IOutputHistoryProvider outputHistoryProvider,
                                           OutputHistoryControl outputHistoryControl,
                                           Control parent,
+                                          Action showVerticalSplitContainer1,
                                           SplitContainer verticalSplitContainer1,
                                           SplitContainer verticalSplitContainer2,
                                           SplitContainer horizontalSplitContainer)
         : base(outputHistoryProvider, outputHistoryControl)
     {
         _outputHistoryControl = outputHistoryControl;
+        _showVerticalSplitContainer1 = showVerticalSplitContainer1;
         _verticalSplitContainer1 = verticalSplitContainer1;
         _verticalSplitContainer2 = verticalSplitContainer2;
         _horizontalSplitContainer = horizontalSplitContainer;
@@ -36,6 +39,7 @@ internal partial class OutputHistoryPanelController : OutputHistoryControllerBas
 
         _timer.Tick += SetSizeByVerticalSplitContainer1;
         _verticalSplitContainer1.Invalidated += SetSizeByVerticalSplitContainer1Deferred;
+        _verticalSplitContainer1.Parent.VisibleChanged += SetSizeByVerticalSplitContainer1Deferred;
         _verticalSplitContainer1.SplitterMoved += SetSizeByVerticalSplitContainer1;
         _verticalSplitContainer2.SplitterMoved += SetSizeByVerticalSplitContainer2;
         horizontalSplitContainer.SplitterMoved += SetSizeByVerticalSplitContainer1;
@@ -48,6 +52,7 @@ internal partial class OutputHistoryPanelController : OutputHistoryControllerBas
         {
             _timer.Tick -= SetSizeByVerticalSplitContainer1;
             _verticalSplitContainer1.Invalidated -= SetSizeByVerticalSplitContainer1Deferred;
+            _verticalSplitContainer1.Parent.VisibleChanged -= SetSizeByVerticalSplitContainer1Deferred;
             _verticalSplitContainer1.SplitterMoved -= SetSizeByVerticalSplitContainer1;
             _verticalSplitContainer2.SplitterMoved -= SetSizeByVerticalSplitContainer2;
             horizontalSplitContainer.SplitterMoved -= SetSizeByVerticalSplitContainer1;
@@ -68,7 +73,13 @@ internal partial class OutputHistoryPanelController : OutputHistoryControllerBas
         bool show = !AppSettings.OutputHistoryPanelVisible.Value;
         AppSettings.OutputHistoryPanelVisible.Value = show;
         _verticalSplitContainer1.Panel2Collapsed = !show;
+        if (show && !_verticalSplitContainer1.Visible)
+        {
+            _showVerticalSplitContainer1();
+        }
+
         SetSizeByVerticalSplitContainer1(_outputHistoryControl, EventArgs.Empty);
+
         if (show)
         {
             _textBox.FindForm().ActiveControl = _textBox;


### PR DESCRIPTION
Fixes regression from adding a second SplitControl

## Proposed changes

`OutputHistoryPanelController`:
- Hide Output History Panel with Left Panel (- 
- Show Left Panel on show of Output History Panel

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/b33ff6bc-eb06-4d2d-8c64-6d6c060fc16b)

### After

![image](https://github.com/user-attachments/assets/f712b423-f7da-465d-bda7-ae8e8ad27162)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).