### PR TITLE
feat: Add SelectInLeftPanel

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -94,6 +94,21 @@ namespace GitUI.CommandsDialogs
 
             RevisionGrid.SelectedId = selectedId;
             RevisionGrid.FirstId = firstId;
+
+            RevisionGrid.SelectInLeftPanel = SelectInLeftPanel;
+
+            return;
+
+            void SelectInLeftPanel(string gitRef)
+            {
+                if (MainSplitContainer.Panel1Collapsed)
+                {
+                    toggleLeftPanel.PerformClick();
+                }
+
+                repoObjectsTree.SelectGitRef(gitRef);
+                repoObjectsTree.Focus();
+            }
         }
     }
 }

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -338,6 +338,20 @@ namespace GitUI.LeftPanel
             }
         }
 
+        public void SelectGitRef(string gitRef)
+        {
+            foreach (TreeNode node in treeMain.Items())
+            {
+                if (node.Tag is BaseRevisionNode revisionNode && revisionNode.FullPath == gitRef)
+                {
+                    SelectNode(revisionNode, multiple: false, includingDescendants: false);
+                    node.EnsureVerticallyVisible();
+                    treeMain.SelectedNode = node;
+                    return;
+                }
+            }
+        }
+
         protected override void OnRuntimeLoad()
         {
             base.OnRuntimeLoad();

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -9681,7 +9681,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="deleteTagToolStripMenuItem.Text">
-        <source>De&amp;lete tag...</source>
+        <source>&amp;Delete tag...</source>
         <target />
       </trans-unit>
       <trans-unit id="dropStashToolStripMenuItem.Text">
@@ -9786,6 +9786,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="stopBisectToolStripMenuItem.Text">
         <source>Stop bisect</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiSelectInLeftPanel.Text">
+        <source>Se&amp;lect in left panel</source>
         <target />
       </trans-unit>
       <trans-unit id="viewToolStripMenuItem.Text">

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -68,6 +68,7 @@ namespace GitUI
             amendCommitToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator1 = new ToolStripSeparator();
             navigateToolStripMenuItem = new ToolStripMenuItem();
+            tsmiSelectInLeftPanel = new ToolStripMenuItem();
             viewToolStripMenuItem = new ToolStripMenuItem();
             runScriptToolStripMenuItem = new ToolStripMenuItem();
             openBuildReportToolStripMenuItem = new ToolStripMenuItem();
@@ -152,6 +153,7 @@ namespace GitUI
             compareToolStripMenuItem,
             toolStripSeparator5,
             navigateToolStripMenuItem,
+            tsmiSelectInLeftPanel,
             viewToolStripMenuItem,
             runScriptToolStripMenuItem,
             openBuildReportToolStripMenuItem,
@@ -404,7 +406,7 @@ namespace GitUI
             deleteTagToolStripMenuItem.Image = Properties.Images.TagDelete;
             deleteTagToolStripMenuItem.Name = "deleteTagToolStripMenuItem";
             deleteTagToolStripMenuItem.Size = new Size(264, 24);
-            deleteTagToolStripMenuItem.Text = "De&lete tag...";
+            deleteTagToolStripMenuItem.Text = "&Delete tag...";
             deleteTagToolStripMenuItem.Click += deleteBranchTagToolStripMenuItem_Click;
             // 
             // toolStripSeparator2
@@ -490,6 +492,14 @@ namespace GitUI
             navigateToolStripMenuItem.Name = "navigateToolStripMenuItem";
             navigateToolStripMenuItem.Size = new Size(223, 22);
             navigateToolStripMenuItem.Text = "&Navigate";
+            // 
+            // tsmiSelectInLeftPanel
+            // 
+            tsmiSelectInLeftPanel.Image = Properties.Images.FileTree;
+            tsmiSelectInLeftPanel.Name = "tsmiSelectInLeftPanel";
+            tsmiSelectInLeftPanel.Size = new Size(300, 22);
+            tsmiSelectInLeftPanel.Text = "Se&lect in left panel";
+            tsmiSelectInLeftPanel.Click += SelectInLeftPanel_Click;
             // 
             // viewToolStripMenuItem
             // 
@@ -613,6 +623,7 @@ namespace GitUI
         private ToolStripMenuItem squashCommitToolStripMenuItem;
         private ToolStripMenuItem renameBranchToolStripMenuItem;
         private ToolStripMenuItem bisectSkipRevisionToolStripMenuItem;
+        private ToolStripMenuItem tsmiSelectInLeftPanel;
         private ToolStripMenuItem viewToolStripMenuItem;
         private ToolStripMenuItem openCommitsWithDiffToolMenuItem;
         private ToolStripMenuItem compareToBranchToolStripMenuItem;


### PR DESCRIPTION
## Proposed changes

`RevisionGridControl`:
- Add context menu item "Select in left panel" for branches and tags

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before | After

![image](https://github.com/user-attachments/assets/08e34091-049e-4f85-b3ad-e4f3a58526f5)   ![image](https://github.com/user-attachments/assets/2682aa08-d13c-4ef3-b5e8-8c1267640ea8)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).