### PR TITLE
fix(git config settings pages): Add system-wide settings

### DIFF
--- a/src/app/GitCommands/Config/SettingKeyString.cs
+++ b/src/app/GitCommands/Config/SettingKeyString.cs
@@ -9,17 +9,17 @@
         /// <summary>
         /// "branch.{0}.remote"
         /// </summary>
-        public static string BranchRemote = "branch.{0}.remote";
+        public static readonly string BranchRemote = "branch.{0}.remote";
 
         /// <summary>
         /// "credential.helper"
         /// </summary>
-        public static string CredentialHelper = "credential.helper";
+        public static readonly string CredentialHelper = "credential.helper";
 
         /// <summary>
         /// "i18n.filesencoding"
         /// </summary>
-        public static readonly string FilesEncoding = "i18n.filesEncoding";
+        public static readonly string FilesEncoding = "i18n.filesencoding";
 
         /// <summary>
         /// "remote.{0}.color"
@@ -29,51 +29,51 @@
         /// <summary>
         /// "remote.{0}.push"
         /// </summary>
-        public static string RemotePush = "remote.{0}.push";
+        public static readonly string RemotePush = "remote.{0}.push";
 
         /// <summary>
         /// "remote.{0}.pushurl"
         /// </summary>
-        public static string RemotePushUrl = "remote.{0}.pushurl";
+        public static readonly string RemotePushUrl = "remote.{0}.pushurl";
 
         /// <summary>
         /// "remote.{0}.url"
         /// </summary>
-        public static string RemoteUrl = "remote.{0}.url";
+        public static readonly string RemoteUrl = "remote.{0}.url";
 
         /// <summary>
         /// "remote.{0}.puttykeyfile"
         /// </summary>
-        public static string RemotePuttySshKey = "remote.{0}.puttykeyfile";
+        public static readonly string RemotePuttySshKey = "remote.{0}.puttykeyfile";
 
         /// <summary>
         /// user.name
         /// </summary>
-        public static string UserName = "user.name";
+        public static readonly string UserName = "user.name";
 
         /// <summary>
         /// user.email
         /// </summary>
-        public static string UserEmail = "user.email";
+        public static readonly string UserEmail = "user.email";
 
         /// <summary>
         /// diff.guitool
         /// </summary>
-        public static string DiffToolKey = "diff.guitool";
+        public static readonly string DiffToolKey = "diff.guitool";
 
         /// <summary>
         /// merge.guitool, requires Git 2.20.0
         /// </summary>
-        public static string MergeToolKey = "merge.guitool";
+        public static readonly string MergeToolKey = "merge.guitool";
 
         /// <summary>
         /// merge.tool
         /// </summary>
-        public static string MergeToolNoGuiKey = "merge.tool";
+        public static readonly string MergeToolNoGuiKey = "merge.tool";
 
         /// <summary>
         /// protocol.file.allow
         /// </summary>
-        public static string AllowFileProtocol = "protocol.file.allow";
+        public static readonly string AllowFileProtocol = "protocol.file.allow";
     }
 }

--- a/src/app/GitCommands/Config/SettingKeyString.cs
+++ b/src/app/GitCommands/Config/SettingKeyString.cs
@@ -17,6 +17,11 @@
         public static string CredentialHelper = "credential.helper";
 
         /// <summary>
+        /// "i18n.filesencoding"
+        /// </summary>
+        public static readonly string FilesEncoding = "i18n.filesEncoding";
+
+        /// <summary>
         /// "remote.{0}.color"
         /// </summary>
         public static string RemoteColor = "remote.{0}.color";

--- a/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
+++ b/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
@@ -2,6 +2,7 @@
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Configurations;
+using GitExtensions.Extensibility.Settings;
 
 namespace GitCommands.DiffMergeTools
 {
@@ -74,8 +75,8 @@ namespace GitCommands.DiffMergeTools
 
             (string toolKey, string prefix) = GetInfo(toolType);
             fileSettings.SetValue(toolKey, toolName);
-            fileSettings.SetPathValue(string.Concat(prefix, ".", toolName, ".path"), toolPath);
-            fileSettings.SetPathValue(string.Concat(prefix, ".", toolName, ".cmd"), toolCommand);
+            fileSettings.SetValue(string.Concat(prefix, ".", toolName, ".path"), toolPath.ConvertPathToGitSetting());
+            fileSettings.SetValue(string.Concat(prefix, ".", toolName, ".cmd"), toolCommand.ConvertPathToGitSetting());
         }
 
         /// <summary>

--- a/src/app/GitCommands/Git/Commands.Execution.cs
+++ b/src/app/GitCommands/Git/Commands.Execution.cs
@@ -1,0 +1,93 @@
+﻿using GitExtensions.Extensibility;
+using GitExtensions.Extensibility.Git;
+using GitExtUtils;
+
+namespace GitCommands.Git;
+
+public static partial class Commands
+{
+    /// <summary>
+    ///  Get all config settings from git according to the scope.
+    /// </summary>
+    /// <param name="gitExecutable">The <see cref="IGitModule.GitExecutable"/> for the affected repo.</param>
+    /// <param name="settingLevel">The scope for the config.</param>
+    /// <returns>The names and values of the settings delimited by '\0'.</returns>
+    public static string GetGitSettings(this IExecutable gitExecutable, GitSettingLevel settingLevel)
+    {
+        GitArgumentBuilder args = new("config")
+            {
+                gitExecutable.SupportNewGitConfigSyntax() ? "list" : "--list",
+                settingLevel switch
+                {
+                    GitSettingLevel.Effective => "",
+                    GitSettingLevel.Local => "--local",
+                    GitSettingLevel.Global => "--global",
+                    GitSettingLevel.SystemWide => "--system",
+                    _ => throw new ArgumentOutOfRangeException(nameof(settingLevel))
+                },
+                "--includes",
+                "--null"
+            };
+        ExecutionResult result = gitExecutable.Execute(args, throwOnErrorExit: false);
+
+        if (result.ExitedSuccessfully)
+        {
+            return result.StandardOutput;
+        }
+
+        if (result.StandardError.StartsWith("fatal: unable to read config file") && result.StandardError.TrimEnd().EndsWith(": No such file or directory"))
+        {
+            return "";
+        }
+
+        result.ThrowIfErrorExit("Error getting config values");
+        return "unreachable code";
+    }
+
+    /// <summary>
+    ///  Sets or unsets a git config setting.
+    /// </summary>
+    /// <param name="gitExecutable">The <see cref="IGitModule.GitExecutable"/> for the affected repo.</param>
+    /// <param name="settingLevel">The scope for the config (must not be <see cref="GitSettingLevel.Effective"/>).</param>
+    /// <param name="setting">The name of the setting (may contain dots, e.g. "core.autocrlf").</param>
+    /// <param name="value">The value of the setting or <see langword="null"/> for removing the setting.</param>
+    public static void SetGitSetting(this IExecutable gitExecutable, GitSettingLevel settingLevel, string setting, string? value)
+    {
+        bool isSet = !string.IsNullOrEmpty(value);
+        bool newSyntax = gitExecutable.SupportNewGitConfigSyntax();
+        GitArgumentBuilder args = new("config")
+            {
+                { newSyntax, isSet ? "set" : "unset" },
+                { !newSyntax && !isSet, "--unset" },
+                settingLevel switch
+                {
+                    GitSettingLevel.Local => "--local",
+                    GitSettingLevel.Global => "--global",
+                    GitSettingLevel.SystemWide => "--system",
+                    GitSettingLevel.Effective or _ => throw new ArgumentOutOfRangeException(nameof(settingLevel))
+                },
+                setting,
+                { isSet, QuoteSettingValue(value) }
+            };
+        ExecutionResult result = gitExecutable.Execute(args, throwOnErrorExit: false);
+        const int exitCodeOnUnsetNotExistingSetting = 5;
+        if (isSet || result.ExitCode != exitCodeOnUnsetNotExistingSetting)
+        {
+            result.ThrowIfErrorExit();
+        }
+
+        return;
+
+        string QuoteSettingValue(string value)
+        {
+            value = value.Quote();
+
+            // Quote diff / merge placeholders so that they are not evaluated by the WSL shell
+            return PathUtil.IsWslPath(gitExecutable.WorkingDir)
+                ? value.Replace("$", @"\$")
+                : value;
+        }
+    }
+
+    private static bool SupportNewGitConfigSyntax(this IExecutable gitExecutable) => GitVersion.CurrentVersion(gitExecutable).SupportNewGitConfigSyntax;
+}

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2115,10 +2115,10 @@ namespace GitCommands
             return ((ConfigFileSettings)LocalConfigFile).GetValues(setting);
         }
 
-        public string GetSetting(string setting) => LocalConfigFile.GetValue(setting);
+        public string GetSetting(string setting) => LocalConfigFile.GetValue(setting) ?? "";
         public T? GetSetting<T>(string setting) where T : struct => LocalConfigFile.GetValue<T>(setting);
 
-        public string GetEffectiveSetting(string setting) => EffectiveConfigFile.GetValue(setting);
+        public string GetEffectiveSetting(string setting, string defaultValue = "") => EffectiveConfigFile.GetValue(setting) ?? defaultValue;
         public T? GetEffectiveSetting<T>(string setting) where T : struct => EffectiveConfigFile.GetValue<T>(setting);
 
         public SettingsSource GetEffectiveSettingsByPath(string path)

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1606,7 +1606,7 @@ namespace GitCommands
             return new ArgumentBuilder
             {
                 { string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("fetch.parallel")), "-c fetch.parallel=0" },
-                { string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("submodule.fetchJobs")), "-c submodule.fetchJobs=0" },
+                { string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("submodule.fetchjobs")), "-c submodule.fetchjobs=0" },
             };
         }
 

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1,5 +1,4 @@
 using System.Collections.Frozen;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security;
@@ -654,7 +653,7 @@ namespace GitCommands
             }
 
             byte[] blobData = blobStream.ToArray();
-            if (((ConfigFileSettings)EffectiveConfigFile).ByPath("core").GetNullableEnum<AutoCRLFType>("autocrlf") is AutoCRLFType.@true)
+            if (GetEffectiveSetting<AutoCRLFType>("core.autocrlf") is AutoCRLFType.@true)
             {
                 if (!FileHelper.IsBinaryFileName(this, saveAs) && !FileHelper.IsBinaryFileAccordingToContent(blobData))
                 {
@@ -2120,11 +2119,6 @@ namespace GitCommands
 
         public string GetEffectiveSetting(string setting, string defaultValue = "") => EffectiveConfigFile.GetValue(setting) ?? defaultValue;
         public T? GetEffectiveSetting<T>(string setting) where T : struct => EffectiveConfigFile.GetValue<T>(setting);
-
-        public SettingsSource GetEffectiveSettingsByPath(string path)
-        {
-            return ((ConfigFileSettings)EffectiveConfigFile).ByPath(path);
-        }
 
         public string? GetGitSetting(string setting, string scopeArg, bool cache = false)
         {

--- a/src/app/GitCommands/Git/GitRef.cs
+++ b/src/app/GitCommands/Git/GitRef.cs
@@ -153,7 +153,7 @@ namespace GitCommands
         /// <inheritdoc />
         public string GetTrackingRemote(ISettingsValueGetter configFile)
         {
-            return configFile.GetValue(_remoteSettingName);
+            return configFile.GetValue(_remoteSettingName) ?? "";
         }
 
         /// <inheritdoc />
@@ -177,7 +177,7 @@ namespace GitCommands
         /// <inheritdoc />
         public string GetMergeWith(ISettingsValueGetter configFile)
         {
-            return configFile.GetValue(_mergeSettingName).RemovePrefix(GitRefName.RefsHeadsPrefix);
+            return (configFile.GetValue(_mergeSettingName) ?? "").RemovePrefix(GitRefName.RefsHeadsPrefix);
         }
 
         public static GitRef NoHead(IGitModule module)

--- a/src/app/GitCommands/Git/GitVersion.cs
+++ b/src/app/GitCommands/Git/GitVersion.cs
@@ -14,6 +14,7 @@ public class GitVersion : IComparable<GitVersion>, IGitVersion
     private static readonly GitVersion _v2_32_0 = new("2.32.0");
     private static readonly GitVersion _v2_35_0 = new("2.35.0");
     private static readonly GitVersion _v2_38_0 = new("2.38.0");
+    private static readonly GitVersion _v2_46_0 = new("2.46.0");
 
     /// <summary>
     /// The recommended Git version (normally latest official before a GE release).
@@ -141,6 +142,7 @@ public class GitVersion : IComparable<GitVersion>, IGitVersion
 
     public bool SupportAmendCommits => this >= _v2_32_0;
     public bool SupportGuiMergeTool => this >= _v2_20_0;
+    public bool SupportNewGitConfigSyntax => this >= _v2_46_0;
     public bool SupportRangeDiffPath => this >= _v2_38_0;
     public bool SupportRangeDiffTool => this >= _v2_19_0;
     public bool SupportRebaseMerges => this >= _v2_19_0;

--- a/src/app/GitCommands/Patches/PatchProcessor.cs
+++ b/src/app/GitCommands/Patches/PatchProcessor.cs
@@ -51,7 +51,7 @@ namespace GitCommands.Patches
         /// Everything else (header, warnings, ...) is printed in git encoding (<see cref="GitModule.SystemEncoding"/>).
         /// <para />
         /// Since a patch may contain the diff of more than one file, it would be nice to obtain the encoding for each file
-        /// from <c>.gitattributes</c>. For now, one encoding is used for every file in the repo (<see cref="ConfigFileSettings.FilesEncoding"/>).
+        /// from <c>.gitattributes</c>. For now, one encoding is used for every file in the repo (<see cref="GitEncodingSettingsGetter.FilesEncoding"/>).
         /// <para />
         /// File paths can be quoted (see <c>core.quotepath</c>). They are unquoted by <see cref="GitModule.ReEncodeFileNameFromLossless"/>.
         /// </remarks>

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -488,7 +488,7 @@ namespace GitCommands
 
         public static CommitInfoPosition CommitInfoPosition
         {
-            get => DetailedSettingsPath.GetNullableEnum<CommitInfoPosition>("CommitInfoPosition") ?? (
+            get => ((ISettingsValueGetter)DetailedSettingsPath).GetValue<CommitInfoPosition>("CommitInfoPosition") ?? (
                 DetailedSettingsPath.GetBool("ShowRevisionInfoNextToRevisionGrid") == true // legacy setting
                     ? CommitInfoPosition.RightwardFromList
                     : CommitInfoPosition.BelowList);
@@ -2170,8 +2170,8 @@ namespace GitCommands
         public static T GetEnum<T>(string name, T defaultValue) where T : struct, Enum => SettingsContainer.GetEnum(name, defaultValue);
         public static void SetEnum<T>(string name, T value) where T : Enum => SettingsContainer.SetEnum(name, value);
 
-        public static T? GetNullableEnum<T>(string name) where T : struct => SettingsContainer.GetNullableEnum<T>(name);
-        public static void SetNullableEnum<T>(string name, T? value) where T : struct, Enum => SettingsContainer.SetNullableEnum(name, value);
+        public static T? GetNullableEnum<T>(string name) where T : struct, Enum => ((ISettingsValueGetter)SettingsContainer).GetValue<T>(name);
+        public static void SetNullableEnum<T>(string name, T? value) where T : struct, Enum => SettingsContainer.SetValue(name, value?.ToString());
         #endregion
 
         private static void LoadEncodings()

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -752,8 +752,8 @@ namespace GitCommands
             EnvironmentConfiguration.SetEnvironmentVariables();
             ConfigFileSettings configFileGlobalSettings = ConfigFileSettings.CreateGlobal(useSharedCache: false);
 
-            string path = configFileGlobalSettings.GetValue("core.editor");
-            if (!path.Contains("Program Files (x86)/GitExtensions", StringComparison.CurrentCultureIgnoreCase))
+            string? path = configFileGlobalSettings.GetValue("core.editor");
+            if (path?.Contains("Program Files (x86)/GitExtensions", StringComparison.CurrentCultureIgnoreCase) is not true)
             {
                 return;
             }

--- a/src/app/GitCommands/Settings/ConfigFileSettings.cs
+++ b/src/app/GitCommands/Settings/ConfigFileSettings.cs
@@ -1,8 +1,6 @@
 ﻿#nullable enable
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using GitExtensions.Extensibility.Configurations;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Settings;
@@ -114,56 +112,6 @@ namespace GitCommands.Settings
         public void RemoveConfigSection(string configSectionName, bool performSave = false)
         {
             SettingsCache.RemoveConfigSection(configSectionName, performSave);
-        }
-
-        [MaybeNull]
-        public Encoding? FilesEncoding
-        {
-            get => GetEncoding("i18n.filesEncoding");
-            set => SetEncoding("i18n.filesEncoding", value);
-        }
-
-        public Encoding? CommitEncoding => GetEncoding("i18n.commitEncoding");
-
-        public Encoding? LogOutputEncoding => GetEncoding("i18n.logoutputencoding");
-
-        private Encoding? GetEncoding(string settingName)
-        {
-            string? encodingName = GetValue(settingName);
-
-            if (string.IsNullOrEmpty(encodingName))
-            {
-                return null;
-            }
-
-            // The keys in AppSettings.AvailableEncodings are lower-case, and the actual
-            // configuration is case-insensitive, and can be configured uppercase on the
-            // command line. If configured as UTF-8, then if we don't use the predefined
-            // encoding, it will use the default, which adds BOM.
-            // Convert it to lowercase, to ensure matching.
-            encodingName = encodingName.ToLowerInvariant();
-
-            if (AppSettings.AvailableEncodings.TryGetValue(encodingName, out Encoding? result))
-            {
-                return result;
-            }
-
-            try
-            {
-                return Encoding.GetEncoding(encodingName);
-            }
-            catch (ArgumentException)
-            {
-                Debug.WriteLine(
-                    "Unsupported encoding set in git config file: {0}\n" +
-                    "Please check the setting {1} in config file.", encodingName, settingName);
-                return null;
-            }
-        }
-
-        private void SetEncoding(string settingName, Encoding? encoding)
-        {
-            SetValue(settingName, encoding?.WebName);
         }
     }
 }

--- a/src/app/GitCommands/Settings/ConfigFileSettings.cs
+++ b/src/app/GitCommands/Settings/ConfigFileSettings.cs
@@ -72,8 +72,6 @@ namespace GitCommands.Settings
                 SettingLevel.SystemWide);
         }
 
-        public new string GetValue(string setting) => GetString(setting, string.Empty);
-
         /// <summary>
         ///  Gets the config setting from git converted in an expected C# value type (bool, int, etc.).
         /// </summary>

--- a/src/app/GitCommands/Settings/ConfigFileSettings.cs
+++ b/src/app/GitCommands/Settings/ConfigFileSettings.cs
@@ -117,7 +117,7 @@ namespace GitCommands.Settings
         }
 
         [MaybeNull]
-        public Encoding FilesEncoding
+        public Encoding? FilesEncoding
         {
             get => GetEncoding("i18n.filesEncoding");
             set => SetEncoding("i18n.filesEncoding", value);

--- a/src/app/GitCommands/Settings/ConfigFileSettings.cs
+++ b/src/app/GitCommands/Settings/ConfigFileSettings.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿#nullable enable
+
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using GitExtensions.Extensibility.Configurations;
@@ -73,36 +75,6 @@ namespace GitCommands.Settings
         }
 
         /// <summary>
-        ///  Gets the config setting from git converted in an expected C# value type (bool, int, etc.).
-        /// </summary>
-        /// <typeparam name="T">The expected type of the git setting.</typeparam>
-        /// <param name="setting">The git setting key.</param>
-        /// <returns>The value converted to the <typeparamref name="T" /> type; <see langword="null"/> if the settings is not set.</returns>
-        /// <exception cref="GitExtensions.Extensibility.Settings.GitConfigFormatException">
-        ///  The value of the git setting <paramref name="setting" /> cannot be converted in the specified type <typeparamref name="T" />.
-        /// </exception>
-        public T? GetValue<T>(string setting) where T : struct => ConvertValue<T>(GetValue(setting), setting);
-
-        private T? ConvertValue<T>(string value, string setting) where T : struct
-        {
-            // Handle case where setting is not set
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return null;
-            }
-
-            Type targetType = typeof(T);
-            try
-            {
-                return (T)Convert.ChangeType(value, targetType);
-            }
-            catch (Exception)
-            {
-                throw new GitConfigFormatException($"Git setting '{setting}': failed to convert value '{value}' into type '{targetType}'");
-            }
-        }
-
-        /// <summary>
         /// Gets all configured values for a git setting that accepts multiple values for the same key.
         /// </summary>
         /// <param name="setting">The git setting key</param>
@@ -118,17 +90,6 @@ namespace GitCommands.Settings
             }
 
             SetString(setting, value);
-        }
-
-        public void SetPathValue(string setting, string? value)
-        {
-            // for using unc paths -> these need to be backward slashes
-            if (!string.IsNullOrWhiteSpace(value) && !value.StartsWith("\\\\"))
-            {
-                value = value.ToPosixPath();
-            }
-
-            SetValue(setting, value);
         }
 
         public IReadOnlyList<IConfigSection> GetConfigSections()
@@ -182,7 +143,7 @@ namespace GitCommands.Settings
             // Convert it to lowercase, to ensure matching.
             encodingName = encodingName.ToLowerInvariant();
 
-            if (AppSettings.AvailableEncodings.TryGetValue(encodingName, out Encoding result))
+            if (AppSettings.AvailableEncodings.TryGetValue(encodingName, out Encoding? result))
             {
                 return result;
             }

--- a/src/app/GitCommands/Settings/EffectiveGitConfigSettings.cs
+++ b/src/app/GitCommands/Settings/EffectiveGitConfigSettings.cs
@@ -1,0 +1,43 @@
+#nullable enable
+
+using System.Diagnostics;
+using GitExtensions.Extensibility;
+using GitExtensions.Extensibility.Configurations;
+using GitExtensions.Extensibility.Git;
+
+namespace GitCommands.Settings;
+
+/// <summary>
+///  Provides read-only access to the effective git config settings (by running "git config list").
+///  <br>Only the last value of multi-value settings is provided - in contrast to <see cref="GitConfigSettings"/>.</br>
+///  <br>"Implements" <see cref="IConfigValueStore"/> so it can be used with <see cref="SettingsSource{T}"/>.</br>
+/// </summary>
+/// <param name="gitExecutable">The <see cref="IGitModule.GitExecutable"/> for the repo of interest.</param>
+[DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
+public sealed class EffectiveGitConfigSettings(IExecutable gitExecutable) : GitConfigSettingsBase(gitExecutable, GitSettingLevel.Effective), IConfigValueStore
+{
+    private void Clear()
+    {
+        _uniqueValueSettings.Clear();
+    }
+
+    public override string? GetValue(string name)
+    {
+        name = NormalizeSettingName(name);
+        Update();
+        return _uniqueValueSettings.TryGetValue(name, out string? value) ? value : null;
+    }
+
+    public void SetValue(string setting, string? value)
+    {
+        throw new InvalidOperationException("Effective Git settings are read-only.");
+    }
+
+    protected override void Update() => Update(Clear, StoreSetting);
+
+    private void StoreSetting(string name, string value)
+    {
+        // "git config list" yields entries from all scopes starting with the most generic scope, use the last one, i.e. the most specific
+        _uniqueValueSettings[name] = value;
+    }
+}

--- a/src/app/GitCommands/Settings/GitConfigSettings.cs
+++ b/src/app/GitCommands/Settings/GitConfigSettings.cs
@@ -1,0 +1,116 @@
+#nullable enable
+
+using System.Diagnostics;
+using GitCommands.Git;
+using GitExtensions.Extensibility;
+using GitExtensions.Extensibility.Configurations;
+using GitExtensions.Extensibility.Git;
+
+namespace GitCommands.Settings;
+
+/// <summary>
+///  Provides read/write access to git config settings of a specific scope (by running "git config").
+/// </summary>
+[DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
+public sealed class GitConfigSettings : GitConfigSettingsBase, IPersistentConfigValueStore
+{
+    private readonly Dictionary<string, string?> _modifiedSettings = [];
+    private readonly HashSet<string> _multiValueSettings = [];
+
+    /// <summary>
+    ///  The constructor.
+    /// </summary>
+    /// <param name="gitExecutable">The <see cref="IGitModule.GitExecutable"/> for the repo of interest.</param>
+    /// <param name="gitSettingLevel">The scope (excluding <see cref="GitSettingLevel.Effective"/>) of the git config settings.</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public GitConfigSettings(IExecutable gitExecutable, GitSettingLevel gitSettingLevel)
+        : base(gitExecutable, gitSettingLevel)
+    {
+        ArgumentOutOfRangeException.ThrowIfEqual(gitSettingLevel == GitSettingLevel.Effective, true, $"Use read-only {nameof(EffectiveGitConfigSettings)} instance instead.");
+    }
+
+    private void Clear()
+    {
+        _multiValueSettings.Clear();
+        _uniqueValueSettings.Clear();
+    }
+
+    public override string? GetValue(string name)
+    {
+        name = NormalizeSettingName(name);
+        if (_modifiedSettings.TryGetValue(name, out string? value))
+        {
+            return value;
+        }
+
+        Update();
+        return _uniqueValueSettings.TryGetValue(name, out value) ? value : null;
+    }
+
+    public void Save()
+    {
+        foreach ((string name, string? value) in _modifiedSettings)
+        {
+            _gitExecutable.SetGitSetting(_gitSettingLevel, name, value);
+
+            if (value is null)
+            {
+                _uniqueValueSettings.Remove(name);
+            }
+            else
+            {
+                _uniqueValueSettings[name] = value;
+            }
+        }
+
+        _modifiedSettings.Clear();
+    }
+
+    public void SetValue(string name, string? value)
+    {
+        if (_multiValueSettings.Contains(name))
+        {
+            throw new InvalidOperationException(@"Changing multi-value git settings is not supported. Tried to set ""{name}"" = ""{value}"".");
+        }
+
+        name = NormalizeSettingName(name);
+
+        if (value?.Length is 0)
+        {
+            value = null;
+        }
+
+        if (value == GetValue(name))
+        {
+            return;
+        }
+
+        if (_uniqueValueSettings.TryGetValue(name, out string? storedValue) && value == storedValue)
+        {
+            _modifiedSettings.Remove(name);
+        }
+        else
+        {
+            _modifiedSettings[name] = value;
+        }
+    }
+
+    private void StoreSetting(string name, string value)
+    {
+        if (_multiValueSettings.Contains(name))
+        {
+            // ignore additional value
+            return;
+        }
+
+        if (!_uniqueValueSettings.TryAdd(name, value))
+        {
+            _multiValueSettings.Add(name);
+            _uniqueValueSettings.Remove(name);
+        }
+    }
+
+    protected override void Update() => Update(Clear, StoreSetting);
+
+    private new string DebuggerDisplay => $"{{ {_gitSettingLevel}, {(Valid ? "" : "in")}valid, {_uniqueValueSettings.Count} + {_modifiedSettings.Count} - {_multiValueSettings.Count} }}";
+}

--- a/src/app/GitCommands/Settings/GitConfigSettingsBase.cs
+++ b/src/app/GitCommands/Settings/GitConfigSettingsBase.cs
@@ -1,0 +1,132 @@
+#nullable enable
+
+using System.Diagnostics;
+using GitCommands.Git;
+using GitExtensions.Extensibility;
+using GitExtensions.Extensibility.Git;
+using GitExtensions.Extensibility.Settings;
+using GitUI;
+
+namespace GitCommands.Settings;
+
+/// <summary>
+///  Provides read-only access to git config settings of different scopes (by running "git config list").
+/// </summary>
+/// <param name="gitExecutable">The <see cref="IGitModule.GitExecutable"/> for the repo of interest.</param>
+/// <param name="gitSettingLevel">The scope (<see cref="GitSettingLevel"/>) of the git config settings.</param>
+[DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
+public abstract class GitConfigSettingsBase(IExecutable gitExecutable, GitSettingLevel gitSettingLevel) : ISettingsValueGetter
+{
+    protected readonly GitSettingLevel _gitSettingLevel = gitSettingLevel;
+    protected readonly IExecutable _gitExecutable = gitExecutable;
+    protected readonly Dictionary<string, string> _uniqueValueSettings = [];
+    protected bool Valid { get; private set; }
+
+    public abstract string? GetValue(string name);
+
+    public void Invalidate()
+    {
+        Valid = false;
+        ThreadHelper.FileAndForget(async () =>
+        {
+            await Task.Delay(millisecondsDelay: 250);
+            if (Path.Exists(_gitExecutable.WorkingDir))
+            {
+                try
+                {
+                    Update();
+                }
+                catch (ExternalOperationException ex)
+                {
+                    Trace.WriteLine($"{nameof(GitConfigSettingsBase)}: Background update failed:\n{ex}");
+                }
+            }
+        });
+    }
+
+    /// <summary>
+    ///  Turns the section and value names to lower case in order to match the output of "git config list".
+    ///  The case-sensitive subsection is not modified.
+    /// </summary>
+    /// <param name="name">The setting name.</param>
+    /// <returns>The normalized setting name.</returns>
+    protected static string NormalizeSettingName(string name)
+    {
+        if (name.Any(char.IsAsciiLetterUpper))
+        {
+            int firstDotIndex = name.IndexOf('.');
+            int lastDotIndex = name.LastIndexOf('.');
+            if (lastDotIndex < 0 || firstDotIndex == lastDotIndex)
+            {
+                Debug.WriteLine(@$"(No Exception) Setting name should be lowercase: ""{name}"".");
+                return name.ToLowerInvariant();
+            }
+
+            ReadOnlySpan<char> section = name.AsSpan(0, firstDotIndex);
+            ReadOnlySpan<char> variable = name.AsSpan(lastDotIndex + 1);
+
+            if (!section.ContainsAnyInRange('A', 'Z') && !variable.ContainsAnyInRange('A', 'Z'))
+            {
+                return name;
+            }
+
+            Debug.WriteLine(@$"(No Exception) Setting section and variable name should be lowercase: ""{name}"".");
+
+            ReadOnlySpan<char> caseSignificant = name.AsSpan(firstDotIndex, length: lastDotIndex + 1 - firstDotIndex);
+            return $"{section.ToString().ToLowerInvariant()}{caseSignificant}{variable.ToString().ToLowerInvariant()}";
+        }
+
+        return name;
+    }
+
+    private static void Parse(string settings, Action<string, string> storeSetting)
+    {
+        foreach (string setting in settings.TrimEnd('\0').LazySplit('\0'))
+        {
+            int linefeedIndex = setting.IndexOf('\n');
+            if (linefeedIndex > 0)
+            {
+                storeSetting(setting[..linefeedIndex], setting[(linefeedIndex + 1)..]);
+            }
+            else
+            {
+                storeSetting(setting, "true");
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Reloads the settings if invalid.
+    /// </summary>
+    protected abstract void Update();
+
+    /// <summary>
+    ///  Reloads the settings if invalid (generic implementation).
+    /// </summary>
+    /// <param name="clear">Shall clear (previously loaded) git settings, but keep modified settings.</param>
+    /// <param name="storeSetting">Shall store a parsed git setting.</param>
+    protected void Update(Action clear, Action<string, string> storeSetting)
+    {
+        if (Valid)
+        {
+            return;
+        }
+
+        lock (_uniqueValueSettings)
+        {
+            if (Valid)
+            {
+                return;
+            }
+
+            string settings = _gitExecutable.GetGitSettings(_gitSettingLevel);
+
+            clear();
+            Parse(settings, storeSetting);
+
+            Valid = true;
+        }
+    }
+
+    protected string DebuggerDisplay => $"{{ {_gitSettingLevel}, {(Valid ? "" : "in")}valid, {_uniqueValueSettings.Count} }}";
+}

--- a/src/app/GitCommands/Settings/GitEncodingSettingsGetter.cs
+++ b/src/app/GitCommands/Settings/GitEncodingSettingsGetter.cs
@@ -16,7 +16,7 @@ public sealed class GitEncodingSettingsGetter(ISettingsValueGetter settingsValue
 
     public Encoding? FilesEncoding => GetEncoding(SettingKeyString.FilesEncoding);
 
-    public Encoding? CommitEncoding => GetEncoding("i18n.commitEncoding");
+    public Encoding? CommitEncoding => GetEncoding("i18n.commitencoding");
 
     public Encoding? LogOutputEncoding => GetEncoding("i18n.logoutputencoding");
 

--- a/src/app/GitCommands/Settings/GitEncodingSettingsGetter.cs
+++ b/src/app/GitCommands/Settings/GitEncodingSettingsGetter.cs
@@ -1,0 +1,54 @@
+﻿#nullable enable
+
+using System.Diagnostics;
+using System.Text;
+using GitCommands.Config;
+using GitExtensions.Extensibility.Settings;
+
+namespace GitCommands.Settings;
+
+/// <summary>
+///  Provides read access to git config settings for encodings.
+/// </summary>
+public sealed class GitEncodingSettingsGetter(ISettingsValueGetter settingsValueGetter)
+{
+    public ISettingsValueGetter SettingsValueGetter { get; } = settingsValueGetter;
+
+    public Encoding? FilesEncoding => GetEncoding(SettingKeyString.FilesEncoding);
+
+    public Encoding? CommitEncoding => GetEncoding("i18n.commitEncoding");
+
+    public Encoding? LogOutputEncoding => GetEncoding("i18n.logoutputencoding");
+
+    private Encoding? GetEncoding(string settingName)
+    {
+        string? encodingName = SettingsValueGetter.GetValue(settingName);
+
+        if (string.IsNullOrEmpty(encodingName))
+        {
+            return null;
+        }
+
+        // The keys in AppSettings.AvailableEncodings are lower-case, and the actual
+        // configuration is case-insensitive, and can be configured uppercase on the
+        // command line. If configured as UTF-8, then if we don't use the predefined
+        // encoding, it will use the default, which adds BOM.
+        // Convert it to lowercase, to ensure matching.
+        encodingName = encodingName.ToLowerInvariant();
+
+        if (AppSettings.AvailableEncodings.TryGetValue(encodingName, out Encoding? result))
+        {
+            return result;
+        }
+
+        try
+        {
+            return Encoding.GetEncoding(encodingName);
+        }
+        catch (ArgumentException)
+        {
+            Trace.WriteLine($"Unsupported encoding \"{encodingName}\"\nPlease check the setting \"{settingName}\" in the git config file.");
+            return null;
+        }
+    }
+}

--- a/src/app/GitCommands/Settings/GitEncodingSettingsSetter.cs
+++ b/src/app/GitCommands/Settings/GitEncodingSettingsSetter.cs
@@ -1,0 +1,20 @@
+﻿#nullable enable
+
+using System.Text;
+using GitCommands.Config;
+using GitExtensions.Extensibility.Configurations;
+
+namespace GitCommands.Settings;
+
+/// <summary>
+///  Provides write access to git config settings for encodings.
+/// </summary>
+public sealed class GitEncodingSettingsSetter(IConfigValueStore configValueStore)
+{
+    public IConfigValueStore ConfigValueStore { get; } = configValueStore;
+
+    public Encoding? FilesEncoding
+    {
+        set => ConfigValueStore.SetValue(SettingKeyString.FilesEncoding, value?.WebName);
+    }
+}

--- a/src/app/GitCommands/Settings/SettingsPath.cs
+++ b/src/app/GitCommands/Settings/SettingsPath.cs
@@ -1,14 +1,17 @@
-﻿using GitExtensions.Extensibility.Settings;
+﻿#nullable enable
+
+using GitExtensions.Extensibility.Configurations;
+using GitExtensions.Extensibility.Settings;
 using Microsoft;
 
 namespace GitCommands.Settings
 {
     public class SettingsPath : SettingsSource
     {
-        private readonly SettingsSource? _parent;
+        private readonly IConfigValueStore? _parent;
         private readonly string _pathNameWithSeparator;
 
-        public SettingsPath(SettingsSource? parent, string pathName)
+        public SettingsPath(IConfigValueStore? parent, string pathName)
         {
             _parent = parent;
             _pathNameWithSeparator = string.IsNullOrWhiteSpace(pathName) ? "" : $"{pathName}.";

--- a/src/app/GitCommands/Settings/SettingsSourceExtension.cs
+++ b/src/app/GitCommands/Settings/SettingsSourceExtension.cs
@@ -1,13 +1,12 @@
-﻿using GitExtensions.Extensibility.Settings;
+﻿#nullable enable
+
+using GitExtensions.Extensibility.Settings;
 using GitUIPluginInterfaces.BuildServerIntegration;
 
 namespace GitCommands.Settings
 {
     public static class SettingsSourceExtension
     {
-        public static SettingsSource ByPath(this SettingsSource settingsSource, string pathName)
-            => new SettingsPath(settingsSource, pathName);
-
         public static IDetailedSettings Detailed(this SettingsSource settingsSource)
             => new DetailedSettings(settingsSource);
 

--- a/src/app/GitCommands/Settings/SettingsSource_T.cs
+++ b/src/app/GitCommands/Settings/SettingsSource_T.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+using GitExtensions.Extensibility.Configurations;
+using GitExtensions.Extensibility.Settings;
+
+namespace GitCommands.Settings;
+
+/// <summary>
+///  Adapter for using an <see cref="IConfigValueStore"/>-compatible instance as <see cref="SettingsSource"/>.
+/// </summary>
+/// <typeparam name="T">The actual config-value-store type.</typeparam>
+/// <param name="configValueStore">The config-value-store instance.</param>
+public sealed class SettingsSource<T>(T configValueStore) : SettingsSource where T : IConfigValueStore
+{
+    public T ConfigValueStore { get; } = configValueStore;
+
+    public override string? GetValue(string name) => ConfigValueStore.GetValue(name);
+    public override void SetValue(string name, string? value) => ConfigValueStore.SetValue(name, value);
+}

--- a/src/app/GitExtUtils/GitCommandConfiguration.cs
+++ b/src/app/GitExtUtils/GitCommandConfiguration.cs
@@ -18,15 +18,15 @@ namespace GitExtUtils
             // The set of default configuration items for Git Extensions
             Default = new GitCommandConfiguration();
 
-            Default.Add(new GitConfigItem("rebase.autoSquash", "false"), "rebase");
+            Default.Add(new GitConfigItem("rebase.autosquash", "false"), "rebase");
 
-            Default.Add(new GitConfigItem("log.showSignature", "false"), "log", "show", "whatchanged");
+            Default.Add(new GitConfigItem("log.showsignature", "false"), "log", "show", "whatchanged");
 
             Default.Add(new GitConfigItem("color.ui", "never"), "diff", "range-diff", "grep");
             Default.Add(new GitConfigItem("diff.submodule", "short"), "diff");
             Default.Add(new GitConfigItem("diff.noprefix", "false"), "diff");
             Default.Add(new GitConfigItem("diff.mnemonicprefix", "false"), "diff");
-            Default.Add(new GitConfigItem("diff.ignoreSubmodules", "none"), "diff", "status");
+            Default.Add(new GitConfigItem("diff.ignoresubmodules", "none"), "diff", "status");
             Default.Add(new GitConfigItem("core.safecrlf", "false"), "diff");
         }
 

--- a/src/app/GitExtensions.Extensibility/Configurations/IConfigFileSettings.cs
+++ b/src/app/GitExtensions.Extensibility/Configurations/IConfigFileSettings.cs
@@ -15,9 +15,6 @@ public interface IConfigFileSettings : IConfigValueStore
     /// </summary>
     IReadOnlyList<IConfigSection> GetConfigSections();
 
-    [return: NotNullIfNotNull("defaultValue")]
-    string? GetString(string name, string? defaultValue);
-
     /// <summary>
     /// Removes the specific configuration section from the .git/config file.
     /// </summary>

--- a/src/app/GitExtensions.Extensibility/Configurations/IConfigFileSettings.cs
+++ b/src/app/GitExtensions.Extensibility/Configurations/IConfigFileSettings.cs
@@ -1,8 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
+#nullable enable
 
 namespace GitExtensions.Extensibility.Configurations;
 
-public interface IConfigFileSettings : IConfigValueStore
+public interface IConfigFileSettings : IPersistentConfigValueStore
 {
     /// <summary>
     /// Adds the specific configuration section to the .git/config file.
@@ -21,9 +21,4 @@ public interface IConfigFileSettings : IConfigValueStore
     /// <param name="configSectionName">The name of the configuration section.</param>
     /// <param name="performSave">If <see langword="true"/> the configuration changes will be saved immediately.</param>
     void RemoveConfigSection(string configSectionName, bool performSave = false);
-
-    /// <summary>
-    /// Save pending changes.
-    /// </summary>
-    void Save();
 }

--- a/src/app/GitExtensions.Extensibility/Configurations/IConfigValueStore.cs
+++ b/src/app/GitExtensions.Extensibility/Configurations/IConfigValueStore.cs
@@ -1,9 +1,10 @@
+#nullable enable
+
 using GitExtensions.Extensibility.Settings;
 
 namespace GitExtensions.Extensibility.Configurations;
 
 public interface IConfigValueStore : ISettingsValueGetter
 {
-    void SetPathValue(string setting, string? value);
     void SetValue(string setting, string? value);
 }

--- a/src/app/GitExtensions.Extensibility/Configurations/IPersistentConfigValueStore.cs
+++ b/src/app/GitExtensions.Extensibility/Configurations/IPersistentConfigValueStore.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+namespace GitExtensions.Extensibility.Configurations;
+
+public interface IPersistentConfigValueStore : IConfigValueStore
+{
+    /// <summary>
+    ///  Saves pending changes.
+    /// </summary>
+    void Save();
+}

--- a/src/app/GitExtensions.Extensibility/FontParser.cs
+++ b/src/app/GitExtensions.Extensibility/FontParser.cs
@@ -1,4 +1,6 @@
-﻿using System.Globalization;
+﻿#nullable enable
+
+using System.Globalization;
 
 namespace GitExtensions.Extensibility;
 
@@ -13,7 +15,7 @@ public static class FontParser
             "{0};{1};{2};{3};{4}", value.FontFamily.Name, value.Size, InvariantCultureId, value.Bold ? 1 : 0, value.Italic ? 1 : 0);
     }
 
-    public static Font Parse(this string value, Font defaultValue)
+    public static Font Parse(this string? value, Font defaultValue)
     {
         if (string.IsNullOrWhiteSpace(value))
         {

--- a/src/app/GitExtensions.Extensibility/Git/GitSettingLevel.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitSettingLevel.cs
@@ -1,0 +1,13 @@
+﻿namespace GitExtensions.Extensibility.Git;
+
+/// <summary>
+///  The scope of git config settings.
+/// </summary>
+public enum GitSettingLevel
+{
+    SystemWide,
+    Global,
+    Local,
+    ////WorkTree is shown with Effective. Separate get/set is not imlemented as it is dynamic and requires explicit "extensions.worktreeConfig" setting.
+    Effective
+}

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -186,7 +186,7 @@ public interface IGitModule
     /// </exception>
     T? GetSetting<T>(string setting) where T : struct;
 
-    string GetEffectiveSetting(string setting);
+    string GetEffectiveSetting(string setting, string defaultValue = "");
 
     /// <summary>
     ///  Gets the config setting from git converted in an expected C# value type (bool, int, etc.).

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -216,8 +216,6 @@ public interface IGitModule
     /// <returns>The value of the setting or <see langword="null"/> if the value is not set.</returns>
     string? GetEffectiveGitSetting(string setting, bool cache = false);
 
-    SettingsSource GetEffectiveSettingsByPath(string path);
-
     /// <summary>
     /// Gets the name of the currently checked out branch.
     /// </summary>

--- a/src/app/GitExtensions.Extensibility/Git/IGitVersion.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitVersion.cs
@@ -5,6 +5,7 @@ public interface IGitVersion : IComparable<IGitVersion>
     bool IsUnknown { get; }
     bool SupportAmendCommits { get; }
     bool SupportGuiMergeTool { get; }
+    bool SupportNewGitConfigSyntax { get; }
     bool SupportRangeDiffPath { get; }
     bool SupportRangeDiffTool { get; }
     bool SupportRebaseMerges { get; }

--- a/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
@@ -15,5 +15,22 @@ public interface ISettingsValueGetter
     /// <exception cref="GitConfigFormatException">
     ///  The value of the git setting <paramref name="setting" /> cannot be converted in the specified type <typeparamref name="T" />.
     /// </exception>
-    T? GetValue<T>(string setting) where T : struct;
+    T? GetValue<T>(string setting) where T : struct
+    {
+        string? value = GetValue(setting);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        Type targetType = typeof(T);
+        try
+        {
+            return (T)Convert.ChangeType(value, targetType);
+        }
+        catch (Exception)
+        {
+            throw new GitConfigFormatException($"Git setting '{setting}': failed to convert value '{value}' into type '{targetType}'");
+        }
+    }
 }

--- a/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
@@ -1,8 +1,10 @@
-﻿namespace GitExtensions.Extensibility.Settings;
+﻿#nullable enable
+
+namespace GitExtensions.Extensibility.Settings;
 
 public interface ISettingsValueGetter
 {
-    string GetValue(string setting);
+    string? GetValue(string setting);
 
     /// <summary>
     ///  Gets the config setting from git converted in an expected C# value type (bool, int, etc.).

--- a/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
@@ -24,6 +24,12 @@ public interface ISettingsValueGetter
         }
 
         Type targetType = typeof(T);
+
+        if (targetType.IsEnum && Enum.TryParse(value, true, out T result))
+        {
+            return result;
+        }
+
         try
         {
             return (T)Convert.ChangeType(value, targetType);

--- a/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/ISettingsValueGetter.cs
@@ -39,4 +39,11 @@ public interface ISettingsValueGetter
             throw new GitConfigFormatException($"Git setting '{setting}': failed to convert value '{value}' into type '{targetType}'");
         }
     }
+
+    /// <summary>
+    ///  Invalidates the data in order to trigger a reload on next access or in the background.
+    /// </summary>
+    void Invalidate()
+    {
+    }
 }

--- a/src/app/GitExtensions.Extensibility/Settings/PathSetting.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/PathSetting.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+namespace GitExtensions.Extensibility.Settings;
+
+public static class PathSetting
+{
+    /// <summary>
+    ///  Converts a path value with POSIX directory separators for storing as git config setting.
+    ///  UNC paths need to be stored with backward slashes.
+    /// </summary>
+    public static string? ConvertPathToGitSetting(this string? path)
+    {
+        if (path?.StartsWith(@"\\") is false)
+        {
+            path = path.Replace(Path.DirectorySeparatorChar, '/');
+        }
+
+        return path;
+    }
+}

--- a/src/app/GitExtensions.Extensibility/Settings/SettingsSource.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/SettingsSource.cs
@@ -5,7 +5,7 @@ namespace GitExtensions.Extensibility.Settings;
 
 public abstract class SettingsSource
 {
-    public virtual SettingLevel SettingLevel { get; set; } = SettingLevel.Unknown;
+    public virtual SettingLevel SettingLevel { get; init; } = SettingLevel.Unknown;
 
     public abstract string? GetValue(string name);
 

--- a/src/app/GitExtensions.Extensibility/Settings/SettingsSource.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/SettingsSource.cs
@@ -1,9 +1,12 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using GitExtensions.Extensibility.Configurations;
 
 namespace GitExtensions.Extensibility.Settings;
 
-public abstract class SettingsSource
+public abstract class SettingsSource : IConfigValueStore
 {
     public virtual SettingLevel SettingLevel { get; init; } = SettingLevel.Unknown;
 
@@ -110,7 +113,7 @@ public abstract class SettingsSource
         SetValue(name, stringValue);
     }
 
-    public Font GetFont(string name, Font defaultValue) => GetValue(name).Parse(defaultValue);
+    public Font GetFont(string name, Font defaultValue) => FontParser.Parse(GetValue(name), defaultValue);
 
     public void SetFont(string name, Font value) => SetValue(name, value.AsString());
 
@@ -151,31 +154,7 @@ public abstract class SettingsSource
 
     public void SetEnum<T>(string name, T value) where T : Enum
     {
-        string? stringValue = value.ToString();
-
-        SetValue(name, stringValue);
-    }
-
-    public T? GetNullableEnum<T>(string name) where T : struct
-    {
-        string? stringValue = GetValue(name);
-
-        if (string.IsNullOrEmpty(stringValue))
-        {
-            return null;
-        }
-
-        if (Enum.TryParse(stringValue, true, out T result))
-        {
-            return result;
-        }
-
-        return null;
-    }
-
-    public void SetNullableEnum<T>(string name, T? value) where T : struct, Enum
-    {
-        string? stringValue = value.HasValue ? value.ToString() : string.Empty;
+        string stringValue = value.ToString();
 
         SetValue(name, stringValue);
     }

--- a/src/app/GitExtensions/Program.cs
+++ b/src/app/GitExtensions/Program.cs
@@ -239,7 +239,7 @@ namespace GitExtensions
             {
                 // If no working dir is yet found, try to find one relative to the current working directory.
                 // This allows the `fileeditor` command to discover repository configuration which is
-                // required for core.commentChar support.
+                // required for core.commentchar support.
                 workingDir = GitModule.TryFindGitWorkingDir(Environment.CurrentDirectory);
             }
 

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -509,7 +509,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnLoad(EventArgs e)
         {
-            showUntrackedFilesToolStripMenuItem.Checked = Module.EffectiveConfigFile.GetValue("status.showUntrackedFiles") != "no";
+            showUntrackedFilesToolStripMenuItem.Checked = Module.EffectiveConfigFile.GetValue("status.showuntrackedfiles") != "no";
             MinimizeBox = Owner is null;
             LoadCustomDifftools();
 

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -340,7 +340,7 @@ namespace GitUI.CommandsDialogs
                     GitRef? selectedLocalBranch = (_NO_TRANSLATE_Branch.SelectedItem ?? _gitRefs.FirstOrDefault(b => b.IsHead && b.Name == _NO_TRANSLATE_Branch.Text)) as GitRef;
                     track = selectedLocalBranch is not null && string.IsNullOrEmpty(selectedLocalBranch.TrackingRemote) &&
                             !UserGitRemotes.Any(x => _NO_TRANSLATE_Branch.Text.StartsWith(x.Name, StringComparison.OrdinalIgnoreCase));
-                    string autoSetupMerge = Module.EffectiveConfigFile.GetValue("branch.autoSetupMerge");
+                    string autoSetupMerge = Module.EffectiveConfigFile.GetValue("branch.autosetupmerge");
                     if (!string.IsNullOrWhiteSpace(autoSetupMerge) && autoSetupMerge.ToLowerInvariant() == "false")
                     {
                         track = false;

--- a/src/app/GitUI/CommandsDialogs/FormRebase.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRebase.cs
@@ -130,7 +130,7 @@ namespace GitUI.CommandsDialogs
 
             // Honor the rebase.autosquash configuration.
             chkAutosquash.Checked = Module.GetEffectiveSetting<bool>("rebase.autosquash") is true;
-            if (Module.GitVersion.SupportUpdateRefs && Module.GetEffectiveSetting<bool>("rebase.updateRefs") is true)
+            if (Module.GitVersion.SupportUpdateRefs && Module.GetEffectiveSetting<bool>("rebase.updaterefs") is true)
             {
                 checkBoxUpdateRefs.Checked = true;
             }
@@ -329,7 +329,7 @@ namespace GitUI.CommandsDialogs
                 Skipped.Clear();
 
                 bool? updateRefChoice = null;
-                if (Module.GitVersion.SupportUpdateRefs && Module.GetEffectiveSetting<bool>("rebase.updateRefs") != checkBoxUpdateRefs.Checked)
+                if (Module.GitVersion.SupportUpdateRefs && Module.GetEffectiveSetting<bool>("rebase.updaterefs") != checkBoxUpdateRefs.Checked)
                 {
                     updateRefChoice = checkBoxUpdateRefs.Checked;
                 }

--- a/src/app/GitUI/CommandsDialogs/FormSettings.cs
+++ b/src/app/GitUI/CommandsDialogs/FormSettings.cs
@@ -237,8 +237,8 @@ namespace GitUI.CommandsDialogs
                     settingsPage.SaveSettings();
                 }
 
-                _commonLogic.GitConfigSettingsSet.EffectiveSettings.Save();
-                _commonLogic.DistributedSettingsSet.EffectiveSettings.Save();
+                _commonLogic.GitConfigSettingsSet.Save();
+                _commonLogic.DistributedSettingsSet.Save();
 
                 if (EnvUtils.RunningOnWindows())
                 {

--- a/src/app/GitUI/CommandsDialogs/FormSettings.cs
+++ b/src/app/GitUI/CommandsDialogs/FormSettings.cs
@@ -1,4 +1,6 @@
-﻿using GitCommands;
+﻿#nullable enable
+
+using GitCommands;
 using GitCommands.Settings;
 using GitCommands.Utils;
 using GitExtensions.Extensibility.Git;
@@ -235,7 +237,7 @@ namespace GitUI.CommandsDialogs
                     settingsPage.SaveSettings();
                 }
 
-                _commonLogic.ConfigFileSettingsSet.EffectiveSettings.Save();
+                _commonLogic.GitConfigSettingsSet.EffectiveSettings.Save();
                 _commonLogic.DistributedSettingsSet.EffectiveSettings.Save();
 
                 if (EnvUtils.RunningOnWindows())

--- a/src/app/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/src/app/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -10,7 +10,7 @@ namespace GitUI.CommandsDialogs
     {
         public static readonly string RefreshWorkingCopyCommandName = "read-tree -m -u HEAD";
 
-        public static readonly string SettingCoreSparseCheckout = "core.sparseCheckout";
+        public static readonly string SettingCoreSparseCheckout = "core.sparsecheckout";
 
         private readonly IGitUICommands _gitCommands;
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -29,8 +29,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             valid = SolveGitExtensionsDir() && valid;
             valid = SolveEditor(CommonLogic) && valid;
 
-            CommonLogic.GitConfigSettingsSet.EffectiveSettings.Save();
-            CommonLogic.DistributedSettingsSet.EffectiveSettings.Save();
+            CommonLogic.GitConfigSettingsSet.Save();
+            CommonLogic.DistributedSettingsSet.Save();
 
             return valid;
         }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             valid = SolveGitExtensionsDir() && valid;
             valid = SolveEditor(CommonLogic) && valid;
 
-            CommonLogic.ConfigFileSettingsSet.EffectiveSettings.Save();
+            CommonLogic.GitConfigSettingsSet.EffectiveSettings.Save();
             CommonLogic.DistributedSettingsSet.EffectiveSettings.Save();
 
             return valid;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -54,13 +54,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 distributedGlobalSettings);
 
             IExecutable gitExecutable = module.GitExecutable;
+            GitConfigSettings systemGitConfigSettings = new(gitExecutable, GitSettingLevel.SystemWide);
             GitConfigSettings globalGitConfigSettings = new(gitExecutable, GitSettingLevel.Global);
             GitConfigSettings localGitConfigSettings = new(gitExecutable, GitSettingLevel.Local);
             EffectiveGitConfigSettings effectiveGitConfigSettings = new(gitExecutable);
             GitConfigSettingsSet = new GitConfigSettingsSet(
                 new SettingsSource<IConfigValueStore>(effectiveGitConfigSettings),
                 new SettingsSource<IPersistentConfigValueStore>(localGitConfigSettings),
-                new SettingsSource<IPersistentConfigValueStore>(globalGitConfigSettings));
+                new SettingsSource<IPersistentConfigValueStore>(globalGitConfigSettings),
+                new SettingsSource<IConfigValueStore>(systemGitConfigSettings));
         }
 
         /// <summary>

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿#nullable enable
+
+using System.Text;
 using GitCommands;
 using GitCommands.Settings;
 using GitExtensions.Extensibility.Git;
@@ -21,7 +23,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             new("Select file");
 
         public readonly DistributedSettingsSet DistributedSettingsSet;
-        public readonly ConfigFileSettingsSet ConfigFileSettingsSet;
+        public readonly GitConfigSettingsSet GitConfigSettingsSet;
         public readonly IGitModule Module;
 
         private CommonLogic()
@@ -57,7 +59,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 distributedPulledSettings,
                 distributedGlobalSettings);
 
-            ConfigFileSettingsSet = new ConfigFileSettingsSet(
+            GitConfigSettingsSet = new GitConfigSettingsSet(
                 configFileEffectiveSettings,
                 configFileLocalSettings,
                 configFileGlobalSettings);
@@ -97,10 +99,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             return GetEditorOptions().FirstOrDefault(o => !string.IsNullOrEmpty(o));
 
-            IEnumerable<string> GetEditorOptions()
+            IEnumerable<string?> GetEditorOptions()
             {
                 yield return Environment.GetEnvironmentVariable(PresetGitEditorEnvVariableName);
-                yield return ConfigFileSettingsSet.GlobalSettings.GetValue("core.editor");
+                yield return GitConfigSettingsSet.GlobalSettings.GetValue("core.editor");
                 yield return Environment.GetEnvironmentVariable("VISUAL");
                 yield return Environment.GetEnvironmentVariable(AmbientGitEditorEnvVariableName);
             }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/ConfigFileSettingsSet.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/ConfigFileSettingsSet.cs
@@ -1,9 +1,0 @@
-﻿using GitCommands.Settings;
-
-namespace GitUI.CommandsDialogs.SettingsDialog
-{
-    public readonly record struct ConfigFileSettingsSet(
-        ConfigFileSettings EffectiveSettings,
-        ConfigFileSettings LocalSettings,
-        ConfigFileSettings GlobalSettings);
-}

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/DistributedSettingsSet.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/DistributedSettingsSet.cs
@@ -1,4 +1,6 @@
-﻿using GitCommands.Settings;
+﻿#nullable enable
+
+using GitCommands.Settings;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
@@ -6,5 +8,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         DistributedSettings EffectiveSettings,
         DistributedSettings LocalSettings,
         DistributedSettings DistributedSettings,
-        DistributedSettings GlobalSettings);
+        DistributedSettings GlobalSettings)
+    {
+        public void Save() => EffectiveSettings.Save();
+    }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
@@ -3,67 +3,66 @@
 using GitExtensions.Extensibility.Settings;
 using Microsoft;
 
-namespace GitUI.CommandsDialogs.SettingsDialog
+namespace GitUI.CommandsDialogs.SettingsDialog;
+
+public partial class GitConfigBaseSettingsPage : SettingsPageWithHeader, IGitConfigSettingsPage
 {
-    public partial class GitConfigBaseSettingsPage : SettingsPageWithHeader, IGitConfigSettingsPage
+    public GitConfigBaseSettingsPage(IServiceProvider serviceProvider)
+        : base(serviceProvider)
     {
-        public GitConfigBaseSettingsPage(IServiceProvider serviceProvider)
-            : base(serviceProvider)
+    }
+
+    protected GitConfigSettingsSet GitConfigSettingsSet => CommonLogic.GitConfigSettingsSet;
+    protected SettingsSource? CurrentSettings { get; private set; }
+
+    protected override void Init(ISettingsPageHost pageHost)
+    {
+        base.Init(pageHost);
+
+        CurrentSettings = GitConfigSettingsSet.EffectiveSettings;
+    }
+
+    protected override SettingsSource GetCurrentSettings()
+    {
+        Validates.NotNull(CurrentSettings);
+        return CurrentSettings;
+    }
+
+    protected override void PageToSettings()
+    {
+        base.PageToSettings();
+        GitConfigSettingsSet.Save();
+    }
+
+    public void SetEffectiveSettings()
+    {
+        SetCurrentSettings(GitConfigSettingsSet.EffectiveSettings);
+    }
+
+    public void SetLocalSettings()
+    {
+        SetCurrentSettings(GitConfigSettingsSet.LocalSettings);
+    }
+
+    public override void SetGlobalSettings()
+    {
+        SetCurrentSettings(GitConfigSettingsSet.GlobalSettings);
+    }
+
+    public void SetSystemSettings()
+    {
+        SetCurrentSettings(GitConfigSettingsSet.SystemSettings);
+    }
+
+    private void SetCurrentSettings(SettingsSource settings)
+    {
+        if (CurrentSettings is not null)
         {
+            SaveSettings();
         }
 
-        protected GitConfigSettingsSet GitConfigSettingsSet => CommonLogic.GitConfigSettingsSet;
-        protected SettingsSource? CurrentSettings { get; private set; }
+        CurrentSettings = settings;
 
-        protected override void Init(ISettingsPageHost pageHost)
-        {
-            base.Init(pageHost);
-
-            CurrentSettings = GitConfigSettingsSet.EffectiveSettings;
-        }
-
-        protected override SettingsSource GetCurrentSettings()
-        {
-            Validates.NotNull(CurrentSettings);
-            return CurrentSettings;
-        }
-
-        protected override void PageToSettings()
-        {
-            base.PageToSettings();
-            GitConfigSettingsSet.Save();
-        }
-
-        public void SetEffectiveSettings()
-        {
-            SetCurrentSettings(GitConfigSettingsSet.EffectiveSettings);
-        }
-
-        public void SetLocalSettings()
-        {
-            SetCurrentSettings(GitConfigSettingsSet.LocalSettings);
-        }
-
-        public override void SetGlobalSettings()
-        {
-            SetCurrentSettings(GitConfigSettingsSet.GlobalSettings);
-        }
-
-        public void SetSystemSettings()
-        {
-            SetCurrentSettings(GitConfigSettingsSet.SystemSettings);
-        }
-
-        private void SetCurrentSettings(SettingsSource settings)
-        {
-            if (CurrentSettings is not null)
-            {
-                SaveSettings();
-            }
-
-            CurrentSettings = settings;
-
-            LoadSettings();
-        }
+        LoadSettings();
     }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
@@ -28,6 +28,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             return CurrentSettings;
         }
 
+        protected override void PageToSettings()
+        {
+            base.PageToSettings();
+            GitConfigSettingsSet.Save();
+        }
+
         public void SetEffectiveSettings()
         {
             SetCurrentSettings(GitConfigSettingsSet.EffectiveSettings);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
@@ -1,24 +1,26 @@
-﻿using GitCommands.Settings;
+﻿#nullable enable
+
+using GitCommands.Settings;
 using GitExtensions.Extensibility.Settings;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
-    public partial class ConfigFileSettingsPage : SettingsPageWithHeader, ILocalSettingsPage
+    public partial class GitConfigBaseSettingsPage : SettingsPageWithHeader, ILocalSettingsPage
     {
-        public ConfigFileSettingsPage(IServiceProvider serviceProvider)
+        public GitConfigBaseSettingsPage(IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
         }
 
-        protected ConfigFileSettingsSet ConfigFileSettingsSet => CommonLogic.ConfigFileSettingsSet;
+        protected GitConfigSettingsSet GitConfigSettingsSet => CommonLogic.GitConfigSettingsSet;
         protected ConfigFileSettings? CurrentSettings { get; private set; }
 
         protected override void Init(ISettingsPageHost pageHost)
         {
             base.Init(pageHost);
 
-            CurrentSettings = CommonLogic.ConfigFileSettingsSet.EffectiveSettings;
+            CurrentSettings = GitConfigSettingsSet.EffectiveSettings;
         }
 
         protected override SettingsSource GetCurrentSettings()
@@ -29,26 +31,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public void SetEffectiveSettings()
         {
-            if (ConfigFileSettingsSet.EffectiveSettings is not null)
-            {
-                SetCurrentSettings(ConfigFileSettingsSet.EffectiveSettings);
-            }
+            SetCurrentSettings(GitConfigSettingsSet.EffectiveSettings);
         }
 
         public void SetLocalSettings()
         {
-            if (ConfigFileSettingsSet.LocalSettings is not null)
-            {
-                SetCurrentSettings(ConfigFileSettingsSet.LocalSettings);
-            }
+            SetCurrentSettings(GitConfigSettingsSet.LocalSettings);
         }
 
         public override void SetGlobalSettings()
         {
-            if (ConfigFileSettingsSet.GlobalSettings is not null)
-            {
-                SetCurrentSettings(ConfigFileSettingsSet.GlobalSettings);
-            }
+            SetCurrentSettings(GitConfigSettingsSet.GlobalSettings);
         }
 
         private void SetCurrentSettings(ConfigFileSettings settings)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 
-using GitCommands.Settings;
 using GitExtensions.Extensibility.Settings;
 using Microsoft;
 
@@ -14,7 +13,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         }
 
         protected GitConfigSettingsSet GitConfigSettingsSet => CommonLogic.GitConfigSettingsSet;
-        protected ConfigFileSettings? CurrentSettings { get; private set; }
+        protected SettingsSource? CurrentSettings { get; private set; }
 
         protected override void Init(ISettingsPageHost pageHost)
         {
@@ -44,7 +43,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             SetCurrentSettings(GitConfigSettingsSet.GlobalSettings);
         }
 
-        private void SetCurrentSettings(ConfigFileSettings settings)
+        private void SetCurrentSettings(SettingsSource settings)
         {
             if (CurrentSettings is not null)
             {

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigBaseSettingsPage.cs
@@ -5,7 +5,7 @@ using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
-    public partial class GitConfigBaseSettingsPage : SettingsPageWithHeader, ILocalSettingsPage
+    public partial class GitConfigBaseSettingsPage : SettingsPageWithHeader, IGitConfigSettingsPage
     {
         public GitConfigBaseSettingsPage(IServiceProvider serviceProvider)
             : base(serviceProvider)
@@ -47,6 +47,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public override void SetGlobalSettings()
         {
             SetCurrentSettings(GitConfigSettingsSet.GlobalSettings);
+        }
+
+        public void SetSystemSettings()
+        {
+            SetCurrentSettings(GitConfigSettingsSet.SystemSettings);
         }
 
         private void SetCurrentSettings(SettingsSource settings)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
@@ -9,7 +9,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog;
 public readonly record struct GitConfigSettingsSet(
     SettingsSource<IConfigValueStore> EffectiveSettings,
     SettingsSource<IPersistentConfigValueStore> LocalSettings,
-    SettingsSource<IPersistentConfigValueStore> GlobalSettings)
+    SettingsSource<IPersistentConfigValueStore> GlobalSettings,
+    SettingsSource SystemSettings)
 {
     public void Save()
     {

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
@@ -7,4 +7,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog;
 public readonly record struct GitConfigSettingsSet(
     ConfigFileSettings EffectiveSettings,
     ConfigFileSettings LocalSettings,
-    ConfigFileSettings GlobalSettings);
+    ConfigFileSettings GlobalSettings)
+{
+    public void Save() => EffectiveSettings.Save();
+}

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
@@ -1,13 +1,20 @@
 ﻿#nullable enable
 
 using GitCommands.Settings;
+using GitExtensions.Extensibility.Configurations;
+using GitExtensions.Extensibility.Settings;
 
 namespace GitUI.CommandsDialogs.SettingsDialog;
 
 public readonly record struct GitConfigSettingsSet(
-    ConfigFileSettings EffectiveSettings,
-    ConfigFileSettings LocalSettings,
-    ConfigFileSettings GlobalSettings)
+    SettingsSource<IConfigValueStore> EffectiveSettings,
+    SettingsSource<IPersistentConfigValueStore> LocalSettings,
+    SettingsSource<IPersistentConfigValueStore> GlobalSettings)
 {
-    public void Save() => EffectiveSettings.Save();
+    public void Save()
+    {
+        LocalSettings.ConfigValueStore.Save();
+        GlobalSettings.ConfigValueStore.Save();
+        EffectiveSettings.ConfigValueStore.Invalidate();
+    }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/GitConfigSettingsSet.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+
+using GitCommands.Settings;
+
+namespace GitUI.CommandsDialogs.SettingsDialog;
+
+public readonly record struct GitConfigSettingsSet(
+    ConfigFileSettings EffectiveSettings,
+    ConfigFileSettings LocalSettings,
+    ConfigFileSettings GlobalSettings);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -1,4 +1,6 @@
-﻿using GitCommands;
+﻿#nullable enable
+
+using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Git;
@@ -161,9 +163,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             CheckSettings();
         }
 
-        private string GetGlobalSetting(string settingName)
+        private string? GetGlobalSetting(string settingName)
         {
-            return CommonLogic.ConfigFileSettingsSet.GlobalSettings.GetValue(settingName);
+            return CommonLogic.GitConfigSettingsSet.GlobalSettings.GetValue(settingName);
         }
 
         private void translationConfig_Click(object sender, EventArgs e)
@@ -229,7 +231,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private void DiffToolFix_Click(object sender, EventArgs e)
         {
             Validates.NotNull(_diffMergeToolConfigurationManager);
-            string diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
+            string? diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
             if (string.IsNullOrEmpty(diffTool))
             {
                 GotoPageGlobalSettings();
@@ -242,7 +244,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private void MergeToolFix_Click(object sender, EventArgs e)
         {
             Validates.NotNull(_diffMergeToolConfigurationManager);
-            string mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
+            string? mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
             if (string.IsNullOrEmpty(mergeTool))
             {
                 GotoPageGlobalSettings();
@@ -297,7 +299,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         public bool CheckSettings()
         {
-            _diffMergeToolConfigurationManager = new DiffMergeToolConfigurationManager(() => CheckSettingsLogic.CommonLogic.ConfigFileSettingsSet.EffectiveSettings);
+            _diffMergeToolConfigurationManager = new DiffMergeToolConfigurationManager(() => CheckSettingsLogic.CommonLogic.GitConfigSettingsSet.EffectiveSettings);
 
             bool isValid = PerformChecks();
             CheckAtStartup.Checked = IsCheckAtStartupChecked(isValid);
@@ -449,7 +451,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Validates.NotNull(_diffMergeToolConfigurationManager);
 
             DiffTool.Visible = true;
-            string diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
+            string? diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
             if (string.IsNullOrEmpty(diffTool))
             {
                 RenderSettingUnset(DiffTool, DiffTool_Fix, _adviceDiffToolConfiguration.Text);
@@ -472,7 +474,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Validates.NotNull(_diffMergeToolConfigurationManager);
 
             MergeTool.Visible = true;
-            string mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
+            string? mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
             if (string.IsNullOrEmpty(mergeTool))
             {
                 RenderSettingUnset(MergeTool, MergeTool_Fix, _configureMergeTool.Text);
@@ -539,7 +541,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             GitExtensionsInstall.Visible = true;
 
-            string installDir = AppSettings.GetInstallDir();
+            string? installDir = AppSettings.GetInstallDir();
 
             if (string.IsNullOrEmpty(installDir))
             {

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
@@ -33,26 +33,29 @@
             checkBoxPullRebase = new CheckBox();
             checkBoxRebaseAutosquash = new CheckBox();
             checkBoxUpdateRefs = new CheckBox();
+            checkboxMergeAutoStash = new CheckBox();
             SuspendLayout();
             // 
             // checkBoxRebaseAutostash
             // 
             checkBoxRebaseAutostash.AutoSize = true;
-            checkBoxRebaseAutostash.Location = new Point(19, 82);
+            checkBoxRebaseAutostash.Location = new Point(19, 89);
             checkBoxRebaseAutostash.Name = "checkBoxRebaseAutostash";
             checkBoxRebaseAutostash.Size = new Size(247, 19);
-            checkBoxRebaseAutostash.TabIndex = 3;
+            checkBoxRebaseAutostash.TabIndex = 4;
             checkBoxRebaseAutostash.Text = "Automatically stash before doing a rebase";
+            checkBoxRebaseAutostash.ThreeState = true;
             checkBoxRebaseAutostash.UseVisualStyleBackColor = true;
             // 
             // checkBoxFetchPrune
             // 
             checkBoxFetchPrune.AutoSize = true;
-            checkBoxFetchPrune.Location = new Point(19, 48);
+            checkBoxFetchPrune.Location = new Point(19, 39);
             checkBoxFetchPrune.Name = "checkBoxFetchPrune";
             checkBoxFetchPrune.Size = new Size(217, 19);
             checkBoxFetchPrune.TabIndex = 2;
             checkBoxFetchPrune.Text = "Prune remote branches during fetch";
+            checkBoxFetchPrune.ThreeState = true;
             checkBoxFetchPrune.UseVisualStyleBackColor = true;
             // 
             // checkBoxPullRebase
@@ -63,32 +66,47 @@
             checkBoxPullRebase.Size = new Size(303, 19);
             checkBoxPullRebase.TabIndex = 1;
             checkBoxPullRebase.Text = "Rebase local branch when pulling (instead of merge)";
+            checkBoxPullRebase.ThreeState = true;
             checkBoxPullRebase.UseVisualStyleBackColor = true;
             // 
             // checkBoxRebaseAutosquash
             // 
             checkBoxRebaseAutosquash.AutoSize = true;
-            checkBoxRebaseAutosquash.Location = new Point(19, 116);
+            checkBoxRebaseAutosquash.Location = new Point(19, 114);
             checkBoxRebaseAutosquash.Name = "checkBoxRebaseAutosquash";
             checkBoxRebaseAutosquash.Size = new Size(367, 19);
-            checkBoxRebaseAutosquash.TabIndex = 3;
+            checkBoxRebaseAutosquash.TabIndex = 5;
             checkBoxRebaseAutosquash.Text = "Automatically squash commits when doing an interactive rebase";
+            checkBoxRebaseAutosquash.ThreeState = true;
             checkBoxRebaseAutosquash.UseVisualStyleBackColor = true;
             // 
             // checkBoxUpdateRefs
             // 
             checkBoxUpdateRefs.AutoSize = true;
-            checkBoxUpdateRefs.Location = new Point(19, 152);
+            checkBoxUpdateRefs.Location = new Point(19, 139);
             checkBoxUpdateRefs.Name = "checkBoxUpdateRefs";
             checkBoxUpdateRefs.Size = new Size(198, 19);
-            checkBoxUpdateRefs.TabIndex = 3;
+            checkBoxUpdateRefs.TabIndex = 6;
             checkBoxUpdateRefs.Text = "Rebase also dependent branches";
+            checkBoxUpdateRefs.ThreeState = true;
             checkBoxUpdateRefs.UseVisualStyleBackColor = true;
+            // 
+            // checkboxMergeAutoStash
+            // 
+            checkboxMergeAutoStash.AutoSize = true;
+            checkboxMergeAutoStash.Location = new Point(19, 64);
+            checkboxMergeAutoStash.Name = "checkboxMergeAutoStash";
+            checkboxMergeAutoStash.Size = new Size(247, 19);
+            checkboxMergeAutoStash.TabIndex = 3;
+            checkboxMergeAutoStash.Text = "Automatically stash before doing a merge";
+            checkboxMergeAutoStash.ThreeState = true;
+            checkboxMergeAutoStash.UseVisualStyleBackColor = true;
             // 
             // GitConfigAdvancedSettingsPage
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
+            Controls.Add(checkboxMergeAutoStash);
             Controls.Add(checkBoxRebaseAutostash);
             Controls.Add(checkBoxFetchPrune);
             Controls.Add(checkBoxPullRebase);
@@ -99,7 +117,6 @@
             Text = "Advanced";
             ResumeLayout(false);
             PerformLayout();
-
         }
 
         #endregion
@@ -109,5 +126,6 @@
         private CheckBox checkBoxPullRebase;
         private CheckBox checkBoxRebaseAutosquash;
         private CheckBox checkBoxUpdateRefs;
+        private CheckBox checkboxMergeAutoStash;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -20,9 +20,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             [
                 new("pull.rebase", checkBoxPullRebase),
                 new("fetch.prune", checkBoxFetchPrune),
-                new("rebase.autoStash", checkBoxRebaseAutostash),
+                new("rebase.autostash", checkBoxRebaseAutostash),
                 new("rebase.autosquash", checkBoxRebaseAutosquash),
-                new("rebase.updateRefs", checkBoxUpdateRefs)
+                new("rebase.updaterefs", checkBoxUpdateRefs)
             ];
 
             checkBoxUpdateRefs.Visible = GitVersion.Current.SupportUpdateRefs;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -1,9 +1,11 @@
-﻿using GitCommands.Git;
+﻿#nullable enable
+
+using GitCommands.Git;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
-    public partial class GitConfigAdvancedSettingsPage : ConfigFileSettingsPage
+    public partial class GitConfigAdvancedSettingsPage : GitConfigBaseSettingsPage
     {
         private record GitSettingUiMapping(string GitSettingKey, CheckBox MappedCheckbox);
         private readonly List<GitSettingUiMapping> _gitSettings;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -20,6 +20,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             [
                 new("pull.rebase", checkBoxPullRebase),
                 new("fetch.prune", checkBoxFetchPrune),
+                new("merge.autostash", checkboxMergeAutoStash),
                 new("rebase.autostash", checkBoxRebaseAutostash),
                 new("rebase.autosquash", checkBoxRebaseAutosquash),
                 new("rebase.updaterefs", checkBoxUpdateRefs)
@@ -57,9 +58,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             Validates.NotNull(CurrentSettings);
-            foreach (GitSettingUiMapping gitSetting in _gitSettings.Where(s => s.MappedCheckbox.CheckState != CheckState.Indeterminate))
+            foreach (GitSettingUiMapping gitSetting in _gitSettings)
             {
-                CurrentSettings.SetValue(gitSetting.GitSettingKey, gitSetting.MappedCheckbox.Checked ? "true" : "false");
+                CurrentSettings.SetValue(gitSetting.GitSettingKey, gitSetting.MappedCheckbox.CheckState switch { CheckState.Checked => "true", CheckState.Unchecked => "false", _ => null });
             }
 
             base.PageToSettings();

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.resx
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -68,6 +68,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             txtMergeToolPath.Enabled = canFindGitCmd;
             txtMergeToolCommand.Enabled = canFindGitCmd;
             InvalidGitPathGlobal.Visible = !canFindGitCmd;
+
+            if (ReadOnly)
+            {
+                // Unselect has no effect in SettingsToPage because ComboBox asynchronously lives its own life
+                GlobalEditor.Select(start: GlobalEditor.Text.Length, length: 0);
+            }
         }
 
         protected override void SettingsToPage()

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -122,7 +122,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             CurrentSettings.SetValue(SettingKeyString.UserName, GlobalUserName.Text);
             CurrentSettings.SetValue(SettingKeyString.UserEmail, GlobalUserEmail.Text);
             CurrentSettings.SetValue("commit.template", txtCommitTemplatePath.Text);
-            CurrentSettings.SetPathValue("core.editor", GlobalEditor.Text);
+            CurrentSettings.SetValue("core.editor", GlobalEditor.Text.ConvertPathToGitSetting());
 
             Validates.NotNull(_diffMergeToolConfigurationManager);
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -11,7 +11,7 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
-    public partial class GitConfigSettingsPage : ConfigFileSettingsPage
+    public partial class GitConfigSettingsPage : GitConfigBaseSettingsPage
     {
         private readonly TranslationString _selectFile = new("Select file");
         private readonly GitConfigSettingsPageController _controller;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -78,7 +78,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             string? mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
             string? diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
 
-            Global_FilesEncoding.Text = CurrentSettings.FilesEncoding?.EncodingName ?? "";
+            Global_FilesEncoding.Text = new GitEncodingSettingsGetter(CurrentSettings).FilesEncoding?.EncodingName ?? "";
 
             GlobalUserName.Text = CurrentSettings.GetValue(SettingKeyString.UserName);
             GlobalUserEmail.Text = CurrentSettings.GetValue(SettingKeyString.UserEmail);
@@ -111,7 +111,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             Validates.NotNull(CurrentSettings);
 
-            CurrentSettings.FilesEncoding = (Encoding?)Global_FilesEncoding.SelectedItem;
+            new GitEncodingSettingsSetter(CurrentSettings).FilesEncoding = (Encoding?)Global_FilesEncoding.SelectedItem;
 
             base.PageToSettings();
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -84,7 +84,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             string? mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
             string? diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
 
-            Global_FilesEncoding.Text = new GitEncodingSettingsGetter(CurrentSettings).FilesEncoding?.EncodingName ?? "";
+            Global_FilesEncoding.SelectedItem = new GitEncodingSettingsGetter(CurrentSettings).FilesEncoding;
 
             GlobalUserName.Text = CurrentSettings.GetValue(SettingKeyString.UserName);
             GlobalUserEmail.Text = CurrentSettings.GetValue(SettingKeyString.UserEmail);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿#nullable enable
+
+using System.Text;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
@@ -73,8 +75,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Validates.NotNull(_diffMergeToolConfigurationManager);
             Validates.NotNull(CurrentSettings);
 
-            string mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
-            string diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
+            string? mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
+            string? diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
 
             Global_FilesEncoding.Text = CurrentSettings.FilesEncoding?.EncodingName ?? "";
 
@@ -91,8 +93,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             txtDiffToolPath.Text = _diffMergeToolConfigurationManager.GetToolPath(diffTool, DiffMergeToolType.Diff);
             txtDiffToolCommand.Text = _diffMergeToolConfigurationManager.GetToolCommand(diffTool, DiffMergeToolType.Diff);
 
-            AutoCRLFType? autocrlf = CurrentSettings.ByPath("core")
-                .GetNullableEnum<AutoCRLFType>("autocrlf");
+            AutoCRLFType? autocrlf = ((ISettingsValueGetter)CurrentSettings).GetValue<AutoCRLFType>("core.autocrlf");
 
             globalAutoCrlfFalse.Checked = autocrlf is AutoCRLFType.@false;
             globalAutoCrlfInput.Checked = autocrlf is AutoCRLFType.input;
@@ -110,7 +111,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             Validates.NotNull(CurrentSettings);
 
-            CurrentSettings.FilesEncoding = (Encoding)Global_FilesEncoding.SelectedItem;
+            CurrentSettings.FilesEncoding = (Encoding?)Global_FilesEncoding.SelectedItem;
 
             base.PageToSettings();
 
@@ -148,27 +149,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 _diffMergeToolConfigurationManager.UnsetCurrentTool(DiffMergeToolType.Merge);
             }
 
-            SettingsSource coreSectionSettingsSource = CurrentSettings.ByPath("core");
-
-            if (globalAutoCrlfFalse.Checked)
-            {
-                coreSectionSettingsSource.SetNullableEnum<AutoCRLFType>("autocrlf", AutoCRLFType.@false);
-            }
-
-            if (globalAutoCrlfInput.Checked)
-            {
-                coreSectionSettingsSource.SetNullableEnum<AutoCRLFType>("autocrlf", AutoCRLFType.input);
-            }
-
-            if (globalAutoCrlfTrue.Checked)
-            {
-                coreSectionSettingsSource.SetNullableEnum<AutoCRLFType>("autocrlf", AutoCRLFType.@true);
-            }
-
-            if (globalAutoCrlfNotSet.Checked)
-            {
-                coreSectionSettingsSource.SetNullableEnum<AutoCRLFType>("autocrlf", null);
-            }
+            AutoCRLFType? autoCRLFType =
+                globalAutoCrlfFalse.Checked ? AutoCRLFType.@false
+                : globalAutoCrlfInput.Checked ? AutoCRLFType.input
+                : globalAutoCrlfTrue.Checked ? AutoCRLFType.@true
+                : null;
+            CurrentSettings.SetValue("core.autocrlf", autoCRLFType?.ToString());
         }
 
         private string BrowseDiffMergeTool(string toolName, string path, DiffMergeToolType toolType)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
@@ -290,7 +290,6 @@
             gbPaths.ResumeLayout(false);
             gbPaths.PerformLayout();
             ResumeLayout(false);
-
         }
 
         #endregion

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.resx
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -1,8 +1,11 @@
-﻿using GitCommands.Settings;
+﻿#nullable enable
+
+using GitCommands.Settings;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Settings;
 using GitExtUtils.GitUI.Theming;
 using JetBrains.Annotations;
+using Microsoft;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
@@ -43,6 +46,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public virtual bool IsInstantSavePage => false;
 
+        public virtual bool ReadOnly => false;
+
         protected IGitModule? Module => CommonLogic.Module;
 
         public virtual SettingsPageReference PageReference => new SettingsPageReferenceByType(GetType());
@@ -61,7 +66,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public static T Create<[MeansImplicitUse] T>(ISettingsPageHost pageHost, IServiceProvider serviceProvider) where T : SettingsPageBase
         {
-            T result = (T)Activator.CreateInstance(typeof(T), serviceProvider);
+            T? result = (T?)Activator.CreateInstance(typeof(T), serviceProvider);
+            Validates.NotNull(result);
 
             result.AdjustForDpiScaling();
             result.EnableRemoveWordHotkey();
@@ -107,7 +113,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public void SaveSettings()
         {
-            PageToSettings();
+            if (!ReadOnly)
+            {
+                PageToSettings();
+            }
         }
 
         protected virtual void SettingsToPage()

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.Designer.cs
@@ -43,6 +43,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             GlobalRB = new RadioButton();
             EffectiveRB = new RadioButton();
             arrowLocal = new Label();
+            arrowSystem = new Label();
+            SystemRB = new RadioButton();
             settingsPagePanel = new Panel();
             HeaderPanel.SuspendLayout();
             tableLayoutPanel2.SuspendLayout();
@@ -114,7 +116,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             tableLayoutPanel1.Anchor = AnchorStyles.None;
             tableLayoutPanel1.AutoSize = true;
             tableLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            tableLayoutPanel1.ColumnCount = 7;
+            tableLayoutPanel1.ColumnCount = 9;
+            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
+            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
@@ -129,13 +133,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             tableLayoutPanel1.Controls.Add(DistributedRB, 4, 0);
             tableLayoutPanel1.Controls.Add(arrowGlobal, 5, 0);
             tableLayoutPanel1.Controls.Add(GlobalRB, 6, 0);
+            tableLayoutPanel1.Controls.Add(arrowSystem, 7, 0);
+            tableLayoutPanel1.Controls.Add(SystemRB, 8, 0);
             tableLayoutPanel1.Location = new Point(99, 4);
             tableLayoutPanel1.Margin = new Padding(3, 4, 3, 4);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.RowCount = 1;
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
             tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
-            tableLayoutPanel1.Size = new Size(711, 27);
+            tableLayoutPanel1.Size = new Size(751, 27);
             // 
             // DistributedRB
             // 
@@ -211,6 +217,27 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             arrowLocal.Size = new Size(23, 15);
             arrowLocal.Text = "<<";
             // 
+            // arrowSystem
+            // 
+            arrowSystem.Anchor = AnchorStyles.Left;
+            arrowSystem.AutoSize = true;
+            arrowSystem.Location = new Point(714, 6);
+            arrowSystem.Name = "arrowSystem";
+            arrowSystem.Size = new Size(23, 15);
+            arrowSystem.TabIndex = 7;
+            arrowSystem.Text = "<<";
+            // 
+            // SystemRB
+            // 
+            SystemRB.Anchor = AnchorStyles.Left;
+            SystemRB.AutoSize = true;
+            SystemRB.Location = new Point(743, 4);
+            SystemRB.Margin = new Padding(3, 4, 3, 4);
+            SystemRB.Name = "SystemRB";
+            SystemRB.Size = new Size(63, 19);
+            SystemRB.Text = "System";
+            SystemRB.UseVisualStyleBackColor = true;
+            // 
             // settingsPagePanel
             // 
             settingsPagePanel.Dock = DockStyle.Fill;
@@ -256,5 +283,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         private RadioButton GlobalRB;
         private RadioButton EffectiveRB;
         private Label arrowLocal;
+        private Label arrowSystem;
+        private RadioButton SystemRB;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
@@ -19,6 +19,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         void SetDistributedSettings();
     }
 
+    public interface IGitConfigSettingsPage : ILocalSettingsPage
+    {
+        void SetSystemSettings();
+    }
+
     public partial class SettingsPageHeader
     {
         private readonly SettingsPageWithHeader? _page;
@@ -50,65 +55,84 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         private void ConfigureHeader(bool canSaveInsideRepo)
         {
-            if (!(_page is ILocalSettingsPage localSettingsPage) || !canSaveInsideRepo)
+            if (!canSaveInsideRepo || _page is not ILocalSettingsPage localSettingsPage)
             {
                 GlobalRB.Checked = true;
 
                 EffectiveRB.Visible = false;
-                DistributedRB.Visible = false;
-                LocalRB.Visible = false;
                 arrowLocal.Visible = false;
+                LocalRB.Visible = false;
                 arrowDistributed.Visible = false;
+                DistributedRB.Visible = false;
                 arrowGlobal.Visible = false;
+                arrowSystem.Visible = false;
+                SystemRB.Visible = false;
                 tableLayoutPanel2.RowStyles[2].Height = 0;
+                return;
             }
-            else
+
+            LocalRB.CheckedChanged += (s, e) =>
             {
-                LocalRB.CheckedChanged += (a, b) =>
+                if (LocalRB.Checked)
                 {
-                    if (LocalRB.Checked)
-                    {
-                        localSettingsPage.SetLocalSettings();
-                        ReadOnly = false;
-                    }
-                };
+                    localSettingsPage.SetLocalSettings();
+                    ReadOnly = false;
+                }
+            };
 
-                EffectiveRB.CheckedChanged += (a, b) =>
+            EffectiveRB.CheckedChanged += (s, e) =>
+            {
+                if (EffectiveRB.Checked)
                 {
-                    if (EffectiveRB.Checked)
-                    {
-                        arrowLocal.ForeColor = EffectiveRB.ForeColor;
-                        localSettingsPage.SetEffectiveSettings();
-                        ReadOnly = true;
-                    }
-                    else
-                    {
-                        arrowLocal.ForeColor = arrowLocal.BackColor;
-                    }
-
-                    arrowDistributed.ForeColor = arrowLocal.ForeColor;
-                    arrowGlobal.ForeColor = arrowLocal.ForeColor;
-                };
-
-                EffectiveRB.Checked = true;
-                ReadOnly = true;
-
-                if (!(localSettingsPage is IDistributedSettingsPage distributedSettingsPage))
-                {
-                    DistributedRB.Visible = false;
-                    arrowDistributed.Visible = false;
+                    arrowLocal.ForeColor = EffectiveRB.ForeColor;
+                    localSettingsPage.SetEffectiveSettings();
+                    ReadOnly = true;
                 }
                 else
                 {
-                    DistributedRB.CheckedChanged += (a, b) =>
-                    {
-                        if (DistributedRB.Checked)
-                        {
-                            distributedSettingsPage.SetDistributedSettings();
-                            ReadOnly = false;
-                        }
-                    };
+                    arrowLocal.ForeColor = arrowLocal.BackColor;
                 }
+
+                arrowDistributed.ForeColor = arrowLocal.ForeColor;
+                arrowGlobal.ForeColor = arrowLocal.ForeColor;
+                arrowSystem.ForeColor = arrowLocal.ForeColor;
+            };
+
+            EffectiveRB.Checked = true;
+            ReadOnly = true;
+
+            if (localSettingsPage is not IDistributedSettingsPage distributedSettingsPage)
+            {
+                DistributedRB.Visible = false;
+                arrowDistributed.Visible = false;
+            }
+            else
+            {
+                DistributedRB.CheckedChanged += (s, e) =>
+                {
+                    if (DistributedRB.Checked)
+                    {
+                        distributedSettingsPage.SetDistributedSettings();
+                        ReadOnly = false;
+                    }
+                };
+            }
+
+            if (localSettingsPage is not IGitConfigSettingsPage configFileSettingsPage)
+            {
+                SystemRB.Visible = false;
+                arrowSystem.Visible = false;
+            }
+            else
+            {
+                SystemRB.CheckedChanged += (s, e) =>
+                {
+                    if (SystemRB.Checked)
+                    {
+                        configFileSettingsPage.SetSystemSettings();
+                        ReadOnly = true;
+                    }
+                };
             }
         }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs.SettingsDialog
+﻿#nullable enable
+
+namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public interface IGlobalSettingsPage : ISettingsPage
     {
@@ -37,6 +39,15 @@
             }
         }
 
+        public bool ReadOnly
+        {
+            get => !settingsPagePanel.Enabled;
+            private set
+            {
+                settingsPagePanel.Enabled = !value;
+            }
+        }
+
         private void ConfigureHeader(bool canSaveInsideRepo)
         {
             if (!(_page is ILocalSettingsPage localSettingsPage) || !canSaveInsideRepo)
@@ -58,6 +69,7 @@
                     if (LocalRB.Checked)
                     {
                         localSettingsPage.SetLocalSettings();
+                        ReadOnly = false;
                     }
                 };
 
@@ -67,6 +79,7 @@
                     {
                         arrowLocal.ForeColor = EffectiveRB.ForeColor;
                         localSettingsPage.SetEffectiveSettings();
+                        ReadOnly = true;
                     }
                     else
                     {
@@ -78,6 +91,7 @@
                 };
 
                 EffectiveRB.Checked = true;
+                ReadOnly = true;
 
                 if (!(localSettingsPage is IDistributedSettingsPage distributedSettingsPage))
                 {
@@ -91,6 +105,7 @@
                         if (DistributedRB.Checked)
                         {
                             distributedSettingsPage.SetDistributedSettings();
+                            ReadOnly = false;
                         }
                     };
                 }
@@ -102,6 +117,7 @@
             if (GlobalRB.Checked)
             {
                 _page?.SetGlobalSettings();
+                ReadOnly = false;
             }
         }
     }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
@@ -1,25 +1,48 @@
-﻿using GitCommands;
+﻿#nullable enable
+
+using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Settings;
-using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public partial class SettingsPageWithHeader : SettingsPageBase, IGlobalSettingsPage
     {
-        private SettingsPageHeader? _header;
-        private bool _canSaveInsideRepo;
+        private readonly bool _canSaveInsideRepo;
+        private readonly Lazy<SettingsPageHeader> _header;
 
         public SettingsPageWithHeader(IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
+            _header = new(() => new SettingsPageHeader(this, _canSaveInsideRepo));
             if (serviceProvider is IGitUICommands uiCommands)
             {
                 _canSaveInsideRepo = uiCommands.Module.IsValidGitWorkingDir();
             }
         }
 
-        public override Control GuiControl => _header ??= new SettingsPageHeader(this, _canSaveInsideRepo);
+        public override Control GuiControl => _header.Value;
+
+        public override bool ReadOnly
+        {
+            get
+            {
+                // Lazy might be being initialized yet, the EffectiveSettings are current, then return true
+                return TryGetHeader()?.ReadOnly ?? true;
+
+                SettingsPageHeader? TryGetHeader()
+                {
+                    try
+                    {
+                        return _header.Value;
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        return null;
+                    }
+                }
+            }
+        }
 
         public virtual void SetGlobalSettings()
         {

--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -173,7 +173,7 @@ public partial class AnsiEscapeUtilities
             int len = sb.Length - currentHighlight.DocOffset;
             if (len == 1 && sb[^1] == '\r')
             {
-                // Marker without any visible effect, likely diff.colorMovedWS
+                // Marker without any visible effect, likely diff.colormovedws
                 currentHighlight.Length = -1;
                 ++currentHighlight.DocOffset;
                 return;

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -46,14 +46,14 @@ public abstract class DiffHighlightService : TextHighlightService
 
         // https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---color-moved-wsltmodesgt
         // Disable by default, document that this can be enabled.
-        SetIfUnsetInGit(key: "diff.colorMovedWS", value: "no");
+        SetIfUnsetInGit(key: "diff.colormovedws", value: "no");
 
         // https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-diffwordRegex
         // Set to "minimal" diff unless configured.
-        SetIfUnsetInGit(key: "diff.wordRegex", value: "\"[a-z0-9_]+|.\"");
+        SetIfUnsetInGit(key: "diff.wordregex", value: "\"[a-z0-9_]+|.\"");
 
         // dimmed-zebra highlights borders better than the default "zebra"
-        SetIfUnsetInGit(key: "diff.colorMoved", value: "dimmed-zebra");
+        SetIfUnsetInGit(key: "diff.colormoved", value: "dimmed-zebra");
 
         // Use reverse color to follow GE theme
         string reverse = AppSettings.ReverseGitColoring.Value ? "reverse" : "";
@@ -67,34 +67,34 @@ public abstract class DiffHighlightService : TextHighlightService
             GitVersion supportsBrightColors = new("2.26.0.0");
             if (module.GitVersion >= supportsBrightColors)
             {
-                SetIfUnsetInGit(key: "color.diff.oldMoved", value: "black brightmagenta");
-                SetIfUnsetInGit(key: "color.diff.newMoved", value: "black brightblue");
-                SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: "black brightcyan");
-                SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: "black brightyellow");
+                SetIfUnsetInGit(key: "color.diff.oldmoved", value: "black brightmagenta");
+                SetIfUnsetInGit(key: "color.diff.newmoved", value: "black brightblue");
+                SetIfUnsetInGit(key: "color.diff.oldmovedalternative", value: "black brightcyan");
+                SetIfUnsetInGit(key: "color.diff.newmovedalternative", value: "black brightyellow");
             }
             else
             {
-                SetIfUnsetInGit(key: "color.diff.oldMoved", value: "reverse bold magenta");
-                SetIfUnsetInGit(key: "color.diff.newMoved", value: "reverse bold blue");
-                SetIfUnsetInGit(key: "color.diff.oldMovedAlternative", value: "reverse bold cyan");
-                SetIfUnsetInGit(key: "color.diff.newMovedAlternative", value: "reverse bold yellow");
+                SetIfUnsetInGit(key: "color.diff.oldmoved", value: "reverse bold magenta");
+                SetIfUnsetInGit(key: "color.diff.newmoved", value: "reverse bold blue");
+                SetIfUnsetInGit(key: "color.diff.oldmovedalternative", value: "reverse bold cyan");
+                SetIfUnsetInGit(key: "color.diff.newmovedalternative", value: "reverse bold yellow");
             }
         }
 
         // Set dimmed colors, default is gray dimmed/italic
-        SetIfUnsetInGit(key: "color.diff.oldMovedDimmed", value: $"magenta dim {reverse}");
-        SetIfUnsetInGit(key: "color.diff.newMovedDimmed", value: $"blue dim {reverse}");
-        SetIfUnsetInGit(key: "color.diff.oldMovedAlternativeDimmed", value: $"cyan dim {reverse}");
-        SetIfUnsetInGit(key: "color.diff.newMovedAlternativeDimmed", value: $"yellow dim {reverse}");
+        SetIfUnsetInGit(key: "color.diff.oldmoveddimmed", value: $"magenta dim {reverse}");
+        SetIfUnsetInGit(key: "color.diff.newmoveddimmed", value: $"blue dim {reverse}");
+        SetIfUnsetInGit(key: "color.diff.oldmovedalternativedimmed", value: $"cyan dim {reverse}");
+        SetIfUnsetInGit(key: "color.diff.newmovedalternativedimmed", value: $"yellow dim {reverse}");
 
         // range-diff
         if (command == "range-diff")
         {
             // No override for contextBold, contextDimmed
-            SetIfUnsetInGit(key: "color.diff.oldBold", value: $"brightred {reverse}");
-            SetIfUnsetInGit(key: "color.diff.newBold", value: $"brightgreen {reverse}");
-            SetIfUnsetInGit(key: "color.diff.oldDimmed", value: $"red dim {reverse}");
-            SetIfUnsetInGit(key: "color.diff.newDimmed", value: $"green dim {reverse}");
+            SetIfUnsetInGit(key: "color.diff.oldbold", value: $"brightred {reverse}");
+            SetIfUnsetInGit(key: "color.diff.newbold", value: $"brightgreen {reverse}");
+            SetIfUnsetInGit(key: "color.diff.olddimmed", value: $"red dim {reverse}");
+            SetIfUnsetInGit(key: "color.diff.newdimmed", value: $"green dim {reverse}");
         }
 
         return commandConfiguration;

--- a/src/app/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/src/app/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -171,7 +171,7 @@ public partial class DiffLineNumAnalyzer
         return ret;
 
         // git-diff colors moved lines in other than red green
-        // However, Git may mark trailing whitespaces (diff.colorMovedWS is ignored)
+        // However, Git may mark trailing whitespaces (diff.colormovedws is ignored)
         bool IsMovedLine(List<TextMarker> textMarkers, DiffLineInfo meta)
             => textMarkers.Count > 0
                 && !MarkerColorMatch(textMarkers[0], meta.LineType)

--- a/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/GrepHighlightService.cs
@@ -68,13 +68,13 @@ public partial class GrepHighlightService : TextHighlightService
         }
 
         // No coloring, values are parsed
-        commandConfiguration.Add(new GitConfigItem("color.grep.lineNumber", ""), "grep");
+        commandConfiguration.Add(new GitConfigItem("color.grep.linenumber", ""), "grep");
         commandConfiguration.Add(new GitConfigItem("color.grep.separator", ""), "grep");
 
         SetIfUnsetInGit(key: "color.grep.function", value: "white dim reverse");
         if (AppSettings.ReverseGitColoring.Value)
         {
-            SetIfUnsetInGit(key: "color.grep.matchSelected", value: "red bold reverse");
+            SetIfUnsetInGit(key: "color.grep.matchselected", value: "red bold reverse");
         }
 
         return commandConfiguration;

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -1841,7 +1841,7 @@ namespace GitUI.Editor
                 }
             }
 
-            ClipboardUtil.TrySetText(code.AdjustLineEndings(Module.GetEffectiveSettingsByPath("core").GetNullableEnum<AutoCRLFType>("autocrlf")));
+            ClipboardUtil.TrySetText(code.AdjustLineEndings(Module.GetEffectiveSetting<AutoCRLFType>("core.autocrlf")));
 
             return;
 

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -533,7 +533,7 @@ namespace GitUI.Editor
                 text = string.Join("\n", lines);
             }
 
-            ClipboardUtil.TrySetText(text.AdjustLineEndings(Module.GetEffectiveSettingsByPath("core").GetNullableEnum<AutoCRLFType>("autocrlf")));
+            ClipboardUtil.TrySetText(text.AdjustLineEndings(Module.GetEffectiveSetting<AutoCRLFType>("core.autocrlf")));
         }
 
         public int HScrollPosition

--- a/src/app/GitUI/Editor/GitHighlightingStrategyBase.cs
+++ b/src/app/GitUI/Editor/GitHighlightingStrategyBase.cs
@@ -32,9 +32,9 @@ namespace GitUI.Editor
             // characters for each line[0] and take the character with most.
             // That would work well in practice.
 
-            string commentCharSetting = module.EffectiveConfigFile.GetString("core.commentChar", "#");
-
-            _commentChar = commentCharSetting?.Length == 1 ? commentCharSetting[0] : '#';
+            const string defaultValue = "#";
+            string commentCharSetting = module.GetEffectiveSetting("core.commentChar", defaultValue);
+            _commentChar = commentCharSetting.Length == 1 ? commentCharSetting[0] : defaultValue[0];
         }
 
         protected abstract void MarkTokens(IDocument document, IList<LineSegment> lines);

--- a/src/app/GitUI/Editor/GitHighlightingStrategyBase.cs
+++ b/src/app/GitUI/Editor/GitHighlightingStrategyBase.cs
@@ -19,9 +19,9 @@ namespace GitUI.Editor
 
             // By default, comments start with '#'.
             //
-            // This can be overridden via the "core.commentChar" configuration setting.
+            // This can be overridden via the "core.commentchar" configuration setting.
             //
-            // However, if "core.commentChar" is "auto", then git attempts to choose a
+            // However, if "core.commentchar" is "auto", then git attempts to choose a
             // character from "#;@!$%^&|:" which is not present in the message.
             // In such cases it does not appear that the character is provided to the
             // editor. The only way to determine the character is to inspect the message,
@@ -33,7 +33,7 @@ namespace GitUI.Editor
             // That would work well in practice.
 
             const string defaultValue = "#";
-            string commentCharSetting = module.GetEffectiveSetting("core.commentChar", defaultValue);
+            string commentCharSetting = module.GetEffectiveSetting("core.commentchar", defaultValue);
             _commentChar = commentCharSetting.Length == 1 ? commentCharSetting[0] : defaultValue[0];
         }
 

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1546,9 +1546,9 @@ namespace GitUI
         {
             ConfigFileSettings configFileGlobalSettings = ConfigFileSettings.CreateGlobal(false);
 
-            string coreEditor = configFileGlobalSettings.GetValue("core.editor");
-            string path = AppSettings.GetInstallDir().ToPosixPath();
-            if (path is not null && coreEditor.ToLowerInvariant().Contains(path.ToLowerInvariant()))
+            string? coreEditor = configFileGlobalSettings.GetValue("core.editor");
+            string? path = AppSettings.GetInstallDir().ToPosixPath();
+            if (path is not null && coreEditor?.Contains(path, StringComparison.InvariantCultureIgnoreCase) is true)
             {
                 configFileGlobalSettings.SetValue("core.editor", "");
             }

--- a/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -2,6 +2,7 @@ using GitCommands;
 using GitCommands.Config;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitExtensions.Extensibility.Settings;
 using GitUI.Infrastructure;
 using GitUI.UserControls;
 using ResourceManager;
@@ -94,7 +95,7 @@ Do you want to register the host's fingerprint and restart the process?");
                         if (!string.IsNullOrEmpty(loadedKey) && !string.IsNullOrEmpty(Remote) &&
                             string.IsNullOrEmpty(Commands.Module.GetSetting("remote.{0}.puttykeyfile")))
                         {
-                            Commands.Module.LocalConfigFile.SetPathValue(string.Format("remote.{0}.puttykeyfile", Remote), loadedKey);
+                            Commands.Module.SetSetting(string.Format("remote.{0}.puttykeyfile", Remote), loadedKey.ConvertPathToGitSetting());
                         }
 
                         // Retry the command.

--- a/src/app/GitUI/Plugin/GitPluginSettingsContainer.cs
+++ b/src/app/GitUI/Plugin/GitPluginSettingsContainer.cs
@@ -28,7 +28,7 @@ public class GitPluginSettingsContainer : SettingsSource, IGitPluginSettingsCont
     public override SettingLevel SettingLevel
     {
         get => ExternalSettings.SettingLevel;
-        set => throw new InvalidOperationException(nameof(SettingLevel));
+        init => throw new InvalidOperationException(nameof(SettingLevel));
     }
 
     public override string? GetValue(string name)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -10020,6 +10020,10 @@ Diff selection:
         <source>Local for current repository</source>
         <target />
       </trans-unit>
+      <trans-unit id="SystemRB.Text">
+        <source>System</source>
+        <target />
+      </trans-unit>
       <trans-unit id="label1.Text">
         <source>Settings source:</source>
         <target />

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -7996,6 +7996,10 @@ Context menu for additional operations</source>
         <source>Rebase also dependent branches</source>
         <target />
       </trans-unit>
+      <trans-unit id="checkboxMergeAutoStash.Text">
+        <source>Automatically stash before doing a merge</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="GitConfigSettingsPage" source-language="en">

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -87,7 +87,7 @@ namespace GitUI
 
             string[] doneCommits = ReadCommitsDataFromRebaseFile(doneFilePath);
             string[] todoCommits = ReadCommitsDataFromRebaseFile(rebaseTodoFilePath);
-            string commentChar = Module.GetEffectiveSetting("core.commentChar", defaultValue: "#");
+            string commentChar = Module.GetEffectiveSetting("core.commentchar", defaultValue: "#");
 
             // Filter comment lines and keep only lines containing at least 3 columns
             // (action, commit hash and commit subject -- that could contain spaces and be cut in more --)

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -87,7 +87,7 @@ namespace GitUI
 
             string[] doneCommits = ReadCommitsDataFromRebaseFile(doneFilePath);
             string[] todoCommits = ReadCommitsDataFromRebaseFile(rebaseTodoFilePath);
-            string commentChar = Module.EffectiveConfigFile.GetString("core.commentChar", "#");
+            string commentChar = Module.GetEffectiveSetting("core.commentChar", defaultValue: "#");
 
             // Filter comment lines and keep only lines containing at least 3 columns
             // (action, commit hash and commit subject -- that could contain spaces and be cut in more --)

--- a/tests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/tests/CommonTestUtils/GitModuleTestHelper.cs
@@ -141,7 +141,7 @@ namespace CommonTestUtils
             ConfigFileSettings localConfigFile = (ConfigFileSettings)module.LocalConfigFile;
             localConfigFile.SetString(SettingKeyString.UserName, "author");
             localConfigFile.SetString(SettingKeyString.UserEmail, "author@mail.com");
-            localConfigFile.FilesEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            new GitEncodingSettingsSetter(localConfigFile).FilesEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
             localConfigFile.SetString(SettingKeyString.AllowFileProtocol, "always"); // git version 2.38.1 and later disabled file protocol by default
             localConfigFile.Save();
         }

--- a/tests/app/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
@@ -229,7 +229,7 @@ namespace GitCommandsTests
         public async Task WriteCommitMessageToFileAsync_no_bom(string encodingName)
         {
             GitModule module = _referenceRepository.Module;
-            ((ConfigFileSettings)module.EffectiveConfigFile).SetString("i18n.commitEncoding", encodingName);
+            ((ConfigFileSettings)module.EffectiveConfigFile).SetString("i18n.commitencoding", encodingName);
             module.CommitEncoding.Preamble.Length.Should().Be(0);
             CommitMessageManager manager = new(_owner, _referenceRepository.Module.WorkingDir, _referenceRepository.Module.CommitEncoding);
 

--- a/tests/app/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
@@ -535,7 +535,7 @@ namespace GitCommandsTests.Config
 ";
             ConfigFile cfg = new("");
             cfg.LoadFromString(configFileContent);
-            string actual = cfg.GetValue("status.showUntrackedFiles", string.Empty);
+            string actual = cfg.GetValue("status.showuntrackedfiles", string.Empty);
             string expected = "no";
             Assert.AreEqual(expected, actual);
         }
@@ -551,7 +551,7 @@ namespace GitCommandsTests.Config
 ";
             ConfigFile cfg = new("");
             cfg.LoadFromString(configFileContent);
-            string actual = cfg.GetValue("status.showUntrackedFiles", string.Empty);
+            string actual = cfg.GetValue("status.showuntrackedfiles", string.Empty);
             string expected = "no";
             Assert.AreEqual(expected, actual);
         }
@@ -568,7 +568,7 @@ namespace GitCommandsTests.Config
 ";
             ConfigFile cfg = new("");
             cfg.LoadFromString(configFileContent);
-            string actual = cfg.GetValue("status.showUntrackedFiles", string.Empty);
+            string actual = cfg.GetValue("status.showuntrackedfiles", string.Empty);
             string expected = "no";
             Assert.AreEqual(expected, actual);
         }
@@ -585,7 +585,7 @@ namespace GitCommandsTests.Config
 ";
             ConfigFile cfg = new("");
             cfg.LoadFromString(configFileContent);
-            IEnumerable<string> actual = cfg.GetValues("status.showUntrackedFiles");
+            IEnumerable<string> actual = cfg.GetValues("status.showuntrackedfiles");
             IEnumerable<string> expected = new[] { "yes", "no" };
             Assert.True(expected.SequenceEqual(actual));
         }

--- a/tests/app/UnitTests/GitCommands.Tests/DiffMergeTools/DiffMergeToolConfigurationManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/DiffMergeTools/DiffMergeToolConfigurationManagerTests.cs
@@ -77,7 +77,6 @@ namespace GitCommandsTests.DiffMergeTools
             }
 
             _fileSettings.DidNotReceive().SetValue(Arg.Any<string>(), Arg.Any<string>());
-            _fileSettings.DidNotReceive().SetPathValue(Arg.Any<string>(), Arg.Any<string>());
         }
 
         [Test]
@@ -95,12 +94,10 @@ namespace GitCommandsTests.DiffMergeTools
         {
             _configurationManager.ConfigureDiffMergeTool(toolName, toolType, toolPath, toolCommand);
 
-            _fileSettings.Received(1).SetValue(Arg.Any<string>(), Arg.Any<string>());
+            _fileSettings.Received(3).SetValue(Arg.Any<string>(), Arg.Any<string>());
             _fileSettings.Received(1).SetValue(expectedValueKey, "bla");
-
-            _fileSettings.Received(2).SetPathValue(Arg.Any<string>(), Arg.Any<string>());
-            _fileSettings.Received(1).SetPathValue(expectedPathKey, toolPath);
-            _fileSettings.Received(1).SetPathValue(expectedCommandKey, toolCommand);
+            _fileSettings.Received(1).SetValue(expectedPathKey, toolPath.ToPosixPath());
+            _fileSettings.Received(1).SetValue(expectedCommandKey, toolCommand.ToPosixPath());
         }
 
         [TestCase(null)]

--- a/tests/app/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -68,78 +68,78 @@ namespace GitCommandsTests.Git_Commands
             GitModule module = new(Path.GetTempPath());
             ConfigFileSettings localConfigFile = (ConfigFileSettings)module.LocalConfigFile;
             localConfigFile.SetString("fetch.parallel", null);
-            localConfigFile.SetString("submodule.fetchJobs", null);
+            localConfigFile.SetString("submodule.fetchjobs", null);
             {
                 // Specifying a remote and a local branch creates a local branch
                 string fetchCmd = module.FetchCmd("origin", "some-branch", "local").Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
             }
 
             {
                 string fetchCmd = module.FetchCmd("origin", "some-branch", "local", true).Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"origin\" +some-branch:refs/heads/local --tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"origin\" +some-branch:refs/heads/local --tags", fetchCmd);
             }
 
             {
                 // Using a URL as remote and passing a local branch creates the branch
                 string fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", "local").Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"https://host.com/repo\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"https://host.com/repo\" +some-branch:refs/heads/local --no-tags", fetchCmd);
             }
 
             {
                 // Using a URL as remote and not passing a local branch
                 string fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", null).Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // No remote branch -> No local branch
                 string fetchCmd = module.FetchCmd("origin", "", "local").Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"origin\" --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"origin\" --no-tags", fetchCmd);
             }
 
             {
                 // Pull doesn't accept a local branch ever
                 string fetchCmd = module.PullCmd("origin", "some-branch", false).Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 pull --progress \"origin\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 pull --progress \"origin\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // Not even for URL remote
                 string fetchCmd = module.PullCmd("https://host.com/repo", "some-branch", false).Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 pull --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 pull --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // Pull with rebase
                 string fetchCmd = module.PullCmd("origin", "some-branch", true).Arguments;
-                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 pull --rebase --progress \"origin\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchjobs=0 pull --rebase --progress \"origin\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // Config test fetch.parallel
                 localConfigFile.SetString("fetch.parallel", "1");
                 string fetchCmd = module.FetchCmd("fetch.parallel", "some-branch", "local").Arguments;
-                Assert.AreEqual("-c submodule.fetchJobs=0 fetch --progress \"fetch.parallel\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+                Assert.AreEqual("-c submodule.fetchjobs=0 fetch --progress \"fetch.parallel\" +some-branch:refs/heads/local --no-tags", fetchCmd);
                 localConfigFile.SetString("fetch.parallel", null);
             }
 
             {
-                // Config test submodule.fetchJobs
-                localConfigFile.SetString("submodule.fetchJobs", "0");
+                // Config test submodule.fetchjobs
+                localConfigFile.SetString("submodule.fetchjobs", "0");
                 string fetchCmd = module.FetchCmd("origin", "some-branch", "local").Arguments;
                 Assert.AreEqual("-c fetch.parallel=0 fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
-                localConfigFile.SetString("submodule.fetchJobs", null);
+                localConfigFile.SetString("submodule.fetchjobs", null);
             }
 
             {
-                // Config test fetch.parallel and submodule.fetchJobs
+                // Config test fetch.parallel and submodule.fetchjobs
                 localConfigFile.SetString("fetch.parallel", "8");
-                localConfigFile.SetString("submodule.fetchJobs", "99");
+                localConfigFile.SetString("submodule.fetchjobs", "99");
                 string fetchCmd = module.FetchCmd("origin", "some-branch", "local").Arguments;
                 Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
                 localConfigFile.SetString("fetch.parallel", null);
-                localConfigFile.SetString("submodule.fetchJobs", null);
+                localConfigFile.SetString("submodule.fetchjobs", null);
             }
         }
 

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -259,43 +259,43 @@ namespace GitCommandsTests_Git
         public void GetAllChangedFilesCmd()
         {
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignored --ignore-submodules",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files --ignored --ignore-submodules",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: false, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files=no --ignore-submodules",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files=no --ignore-submodules",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.No, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files=normal --ignore-submodules",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files=normal --ignore-submodules",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Normal, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files=all --ignore-submodules",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files=all --ignore-submodules",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.All, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.None).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=untracked",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=untracked",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Untracked).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=dirty",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=dirty",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Dirty).Arguments);
             Assert.AreEqual(
-                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=all",
+                "-c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=all",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.All).Arguments);
             Assert.AreEqual(
-                "--no-optional-locks -c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules",
+                "--no-optional-locks -c diff.ignoresubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules",
                 Commands.GetAllChangedFiles(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default, noLocks: true).Arguments);
         }
 
-        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", false)]
-        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra -- ""new""", "new", "old", false, "extra", false)]
-        [TestCase(@"--no-optional-locks -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", true)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoresubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoresubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoresubmodules=none -c core.safecrlf=false diff --no-ext-diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, string oldFileName, bool staged, string extraDiffArguments, bool noLocks)
         {
             Assert.AreEqual(expected, Commands.GetCurrentChanges(fileName, oldFileName, staged,
@@ -495,21 +495,21 @@ namespace GitCommandsTests_Git
             Assert.Throws<ArgumentException>(() => Commands.Rebase(rebaseOptions));
         }
 
-        [TestCase(false, false, false, false, false, false, true, null, "-c rebase.autoSquash=false rebase \"branch\"")]
-        [TestCase(true, false, false, false, false, false, true, null, "-c rebase.autoSquash=false rebase -i --no-autosquash \"branch\"")]
-        [TestCase(false, true, false, false, false, false, true, null, "-c rebase.autoSquash=false rebase --rebase-merges \"branch\"")]
-        [TestCase(false, false, true, false, false, false, true, null, "-c rebase.autoSquash=false rebase \"branch\"")]
-        [TestCase(false, false, false, true, false, false, true, null, "-c rebase.autoSquash=false rebase --autostash \"branch\"")]
-        [TestCase(true, false, true, false, false, false, true, null, "-c rebase.autoSquash=false rebase -i --autosquash \"branch\"")]
-        [TestCase(false, false, false, false, true, false, true, null, "-c rebase.autoSquash=false rebase --ignore-date \"branch\"")]
-        [TestCase(false, false, false, false, false, true, true, null, "-c rebase.autoSquash=false rebase --committer-date-is-author-date \"branch\"")]
-        [TestCase(false, false, false, true, true, false, true, null, "-c rebase.autoSquash=false rebase --ignore-date --autostash \"branch\"")]
-        [TestCase(false, false, false, true, false, true, true, null, "-c rebase.autoSquash=false rebase --committer-date-is-author-date --autostash \"branch\"")]
-        [TestCase(true, true, true, true, true, false, true, null, "-c rebase.autoSquash=false rebase --ignore-date --autostash \"branch\"")]
-        [TestCase(true, true, true, true, false, true, true, null, "-c rebase.autoSquash=false rebase --committer-date-is-author-date --autostash \"branch\"")]
-        [TestCase(true, true, true, true, false, false, true, null, "-c rebase.autoSquash=false rebase -i --autosquash --rebase-merges --autostash \"branch\"")]
-        [TestCase(false, false, false, false, false, false, true, false, "-c rebase.autoSquash=false rebase --no-update-refs \"branch\"")]
-        [TestCase(false, false, false, false, false, false, true, true, "-c rebase.autoSquash=false rebase --update-refs \"branch\"")]
+        [TestCase(false, false, false, false, false, false, true, null, "-c rebase.autosquash=false rebase \"branch\"")]
+        [TestCase(true, false, false, false, false, false, true, null, "-c rebase.autosquash=false rebase -i --no-autosquash \"branch\"")]
+        [TestCase(false, true, false, false, false, false, true, null, "-c rebase.autosquash=false rebase --rebase-merges \"branch\"")]
+        [TestCase(false, false, true, false, false, false, true, null, "-c rebase.autosquash=false rebase \"branch\"")]
+        [TestCase(false, false, false, true, false, false, true, null, "-c rebase.autosquash=false rebase --autostash \"branch\"")]
+        [TestCase(true, false, true, false, false, false, true, null, "-c rebase.autosquash=false rebase -i --autosquash \"branch\"")]
+        [TestCase(false, false, false, false, true, false, true, null, "-c rebase.autosquash=false rebase --ignore-date \"branch\"")]
+        [TestCase(false, false, false, false, false, true, true, null, "-c rebase.autosquash=false rebase --committer-date-is-author-date \"branch\"")]
+        [TestCase(false, false, false, true, true, false, true, null, "-c rebase.autosquash=false rebase --ignore-date --autostash \"branch\"")]
+        [TestCase(false, false, false, true, false, true, true, null, "-c rebase.autosquash=false rebase --committer-date-is-author-date --autostash \"branch\"")]
+        [TestCase(true, true, true, true, true, false, true, null, "-c rebase.autosquash=false rebase --ignore-date --autostash \"branch\"")]
+        [TestCase(true, true, true, true, false, true, true, null, "-c rebase.autosquash=false rebase --committer-date-is-author-date --autostash \"branch\"")]
+        [TestCase(true, true, true, true, false, false, true, null, "-c rebase.autosquash=false rebase -i --autosquash --rebase-merges --autostash \"branch\"")]
+        [TestCase(false, false, false, false, false, false, true, false, "-c rebase.autosquash=false rebase --no-update-refs \"branch\"")]
+        [TestCase(false, false, false, false, false, false, true, true, "-c rebase.autosquash=false rebase --update-refs \"branch\"")]
         public void RebaseCmd(bool interactive, bool preserveMerges, bool autosquash, bool autoStash, bool ignoreDate, bool committerDateIsAuthorDate, bool supportRebaseMerges, bool? updateRefs, string expected)
         {
             Commands.RebaseOptions rebaseOptions = new()
@@ -528,8 +528,8 @@ namespace GitCommandsTests_Git
             Assert.AreEqual(expected, Commands.Rebase(rebaseOptions).Arguments);
         }
 
-        [TestCase(false, false, false, false, false, false, null, "from", "onto", "-c rebase.autoSquash=false rebase --onto onto \"from\" \"branch\"")]
-        [TestCase(false, false, false, false, true, false, null, "from", "onto", "-c rebase.autoSquash=false rebase --ignore-date --onto onto \"from\" \"branch\"")]
+        [TestCase(false, false, false, false, false, false, null, "from", "onto", "-c rebase.autosquash=false rebase --onto onto \"from\" \"branch\"")]
+        [TestCase(false, false, false, false, true, false, null, "from", "onto", "-c rebase.autosquash=false rebase --ignore-date --onto onto \"from\" \"branch\"")]
         public void RebaseCmd_specific_range(bool interactive, bool preserveMerges, bool autoSquash, bool autoStash, bool ignoreDate, bool committerDateIsAuthorDate, bool? updateRefs, string from, string onto, string expected)
         {
             Commands.RebaseOptions rebaseOptions = new()

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -87,42 +87,42 @@ namespace GitCommandsTests
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags",
+                    "-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch").Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --tags",
+                    "-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch",
+                    "-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", null).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --unshallow",
+                    "-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --unshallow",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", isUnshallow: true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force",
+                    "-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force --prune-tags",
+                    "-c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force --prune-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true, pruneRemoteBranchesAndTags: true).Arguments);
             }
         }

--- a/tests/app/UnitTests/GitExtUtils.Tests/GitArgumentBuilderTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/GitArgumentBuilderTests.cs
@@ -31,7 +31,7 @@ namespace GitExtUtilsTests
             };
 
             Assert.AreEqual(
-                "-c log.showSignature=false log -n 1",
+                "-c log.showsignature=false log -n 1",
                 args.ToString());
         }
 
@@ -112,7 +112,7 @@ namespace GitExtUtilsTests
             };
 
             Assert.AreEqual(
-                "-c log.showSignature=false -c bar=baz log -n 1",
+                "-c log.showsignature=false -c bar=baz log -n 1",
                 args.ToString());
         }
 
@@ -126,7 +126,7 @@ namespace GitExtUtilsTests
             };
 
             Assert.AreEqual(
-                "-c log.showSignature=false -c bar=baz log -n 1",
+                "-c log.showsignature=false -c bar=baz log -n 1",
                 args.ToString());
         }
 
@@ -135,12 +135,12 @@ namespace GitExtUtilsTests
         {
             GitArgumentBuilder args = new("log")
             {
-                new GitConfigItem("log.showSignature", "true"),
+                new GitConfigItem("log.showsignature", "true"),
                 "-n 1"
             };
 
             Assert.AreEqual(
-                "-c log.showSignature=true log -n 1",
+                "-c log.showsignature=true log -n 1",
                 args.ToString());
         }
 

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RevisionFileNameTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RevisionFileNameTests.cs
@@ -46,7 +46,7 @@ public class RevisionFileNameTests
     {
         const string path = "a.txt";
         string actualFileName;
-        string line = $"-c log.showSignature=false log --format=\"????%H\" --name-only --follow --diff-merges=separate  --find-renames --find-copies {objectId} --max-count=1 -- \"a.txt\"";
+        string line = $"-c log.showsignature=false log --format=\"????%H\" --name-only --follow --diff-merges=separate  --find-renames --find-copies {objectId} --max-count=1 -- \"a.txt\"";
 
         bool originalFollowRenamesInFileHistoryExactOnly = AppSettings.FollowRenamesInFileHistoryExactOnly;
         AppSettings.FollowRenamesInFileHistoryExactOnly = false;


### PR DESCRIPTION
Fixes #10914
Fixes #11764

## Proposed changes

- Get git settings using `git config list` in order to correctly display effective settings
- Display effective settings read-only (in order to make users explicitly decide in which scope to configure git)
- Display system-wide settings (read-only)
- Add advanced git config "merge.autostash"
- Several refactorings:
  - Extract `IPersistentConfigValueStore` from `IConfigFileSettings`
  - Remove `SettingsSourceExtension.ByPath`
  - Rename to `GitConfigSettingsSet` and to `GitConfigBaseSettingsPage`
  - Add `GitConfig/DistributedSettingsSet.Save`
  - Extract `GitEncodingSettings` from `ConfigFileSettings`

Review commit by commit is recommended.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/fd130bb1-d168-4d43-8d2e-910ffbac6cb1)

### After

![image](https://github.com/user-attachments/assets/342b9208-d3db-46c1-baef-6e293d263715)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).