### PR TITLE
feat(BackgroundFetchPlugin): Add option to fetch on repo opening

### DIFF
--- a/src/app/GitUI/Translation/English.Plugins.xlf
+++ b/src/app/GitUI/Translation/English.Plugins.xlf
@@ -52,6 +52,10 @@
         <source>Fetch all submodules</source>
         <target />
       </trans-unit>
+      <trans-unit id="_fetchImmediatelyOnRepoOpening.Caption">
+        <source>Fetch immediately on repository opening</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_fetchInterval.Caption">
         <source>Fetch every (seconds) - set to 0 to disable</source>
         <target />


### PR DESCRIPTION
Fixes #6457

Note: the fetching is not "immediate" because the background fetch is waiting that no git process is running but should be triggered quickly enough so that user hardly noticed.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

![image](https://github.com/user-attachments/assets/64d47e01-f995-4a65-907f-14355a16f480)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build c16f47d4fbe4a8c415888267a013405c6b99465c (Dirty)
- Git 2.47.0.windows.1
- Microsoft Windows NT 10.0.26100.0
- .NET 8.0.12
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 8.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 9.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
