### PR TITLE
fix: prevent double call to SetGitModule on repo change

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -264,8 +264,6 @@ namespace GitUI.CommandsDialogs
             toolsToolStripMenuItem.Initialize(() => UICommands);
             _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem, closeToolStripMenuItem);
 
-            _repositoryHistoryUIService.GitModuleChanged += SetGitModule;
-
             BackColor = OtherColors.BackgroundColor;
 
             WorkaroundPaddingIncreaseBug();
@@ -452,11 +450,6 @@ namespace GitUI.CommandsDialogs
         {
             if (disposing)
             {
-                if (_repositoryHistoryUIService is not null)
-                {
-                    _repositoryHistoryUIService.GitModuleChanged -= SetGitModule;
-                }
-
                 _formBrowseMenus?.Dispose();
                 components?.Dispose();
                 _gitStatusMonitor?.Dispose();


### PR DESCRIPTION
`SetGitModule` is already call in `StartToolStripMenuItem.repositoryHistoryUIService_GitModuleChanged()` registered with `FormBrowse.cs@770`:
`fileToolStripMenuItem.GitModuleChanged += new System.EventHandler<GitModuleEventArgs>(SetGitModule);`


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
