### PR TITLE
Handle exceptions

### DIFF
--- a/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -106,7 +106,7 @@ namespace GitUI.BuildServerIntegration
                                                                       .Retry()
                                                                       .Repeat())
                                          .ObserveOn(MainThreadScheduler.Instance)
-                                         .Subscribe(OnBuildInfoUpdate),
+                                         .Subscribe(UpdateAndReportExceptions),
 
                         runningBuildsObservable.Do(buildInfo =>
                                                     {
@@ -118,11 +118,18 @@ namespace GitUI.BuildServerIntegration
                                                .Finally(() => anyRunningBuilds = false)
                                                .Repeat()
                                                .ObserveOn(MainThreadScheduler.Instance)
-                                               .Subscribe(OnBuildInfoUpdate)
+                                               .Subscribe(UpdateAndReportExceptions)
                     };
             }
 
             await _revisionGridView.SwitchToMainThreadAsync(launchToken);
+
+            return;
+
+            void UpdateAndReportExceptions(BuildInfo buildInfo)
+            {
+                TaskManager.HandleExceptions(() => OnBuildInfoUpdate(buildInfo), Application.OnThreadException);
+            }
         }
 
         public void CancelBuildStatusFetchOperation()

--- a/src/app/GitUI/CommandsDialogs/FormLog.cs
+++ b/src/app/GitUI/CommandsDialogs/FormLog.cs
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
-                DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions());
+                TaskManager.HandleExceptions(() => DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions()), Application.OnThreadException);
             }
         }
 

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -119,7 +119,7 @@ namespace GitUI.CommitInfo
                         h => richTextBox.ContentsResized -= h)
                     .Throttle(TimeSpan.FromMilliseconds(100))
                     .ObserveOn(MainThreadScheduler.Instance)
-                    .Subscribe(_ => handler(_.EventArgs));
+                    .Subscribe(eventPattern => TaskManager.HandleExceptions(() => handler(eventPattern.EventArgs), Application.OnThreadException));
 
             commitInfoHeader.SetContextMenuStrip(commitInfoContextMenuStrip);
 

--- a/src/app/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -44,7 +44,7 @@ namespace GitUI.CommitInfo
                     h => rtbRevisionHeader.ContentsResized -= h)
                 .Throttle(TimeSpan.FromMilliseconds(100))
                 .ObserveOn(MainThreadScheduler.Instance)
-                .Subscribe(_ => rtbRevisionHeader_ContentsResized(_.EventArgs));
+                .Subscribe(eventPattern => TaskManager.HandleExceptions(() => rtbRevisionHeader_ContentsResized(eventPattern.EventArgs), Application.OnThreadException));
         }
 
         public void SetContextMenuStrip(ContextMenuStrip contextMenuStrip)

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1107,7 +1107,7 @@ namespace GitUI
                     .Where(x => _enableSelectedIndexChangeEvent)
                     .Throttle(SelectedIndexChangeThrottleDuration, MainThreadScheduler.Instance)
                     .ObserveOn(MainThreadScheduler.Instance)
-                    .Subscribe(_ => FileStatusListView_SelectedIndexChanged());
+                    .Subscribe(_ => TaskManager.HandleExceptions(FileStatusListView_SelectedIndexChanged, Application.OnThreadException));
             }
         }
 
@@ -1824,7 +1824,7 @@ namespace GitUI
                 .Throttle(TimeSpan.FromMilliseconds(250))
                 .ObserveOn(synchronizationContext)
                 .Subscribe(
-                    filterText =>
+                    filterText => TaskManager.HandleExceptions(() =>
                     {
                         _toolTipText = "";
                         int fileCount = 0;
@@ -1841,7 +1841,8 @@ namespace GitUI
                         {
                             AddToSelectionFilter(filterText);
                         }
-                    });
+                    },
+                    Application.OnThreadException));
 
             void AddToSelectionFilter(string filter)
             {


### PR DESCRIPTION
Fixes "unhandled exception" popup (repeatedly seen on `OperationCanceledException` in test execution)

## Proposed changes

- Wrap handler code with `TaskManager.HandleExceptions(..., Application.OnThreadException)`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- run the tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).