### PR TITLE
perf(context menus): Cache script icons (for context menus)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,8 @@
   <Import Project="eng\Tests.props" />
 
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <!-- Enable C#13 keyword "field" -->
+    <LangVersion>preview</LangVersion>
     <NoWarn>$(NoWarn);1573;1591;1712</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Frozen;
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
@@ -131,6 +132,8 @@ Diff selection:
             propertyGrid1.PropertyValueChanged += (_, e) =>
                 UpdateScripts(WatchedProxyPropertiesOnValueChanged, e.ChangedItem?.PropertyDescriptor?.Name ?? "");
 
+            return;
+
             void UpdateScripts(string[] watchedProperties, string changedItem)
             {
                 if (watchedProperties.Contains(changedItem))
@@ -161,23 +164,26 @@ Diff selection:
                 return;
             }
 
-            System.Resources.ResourceManager rm = new("GitUI.Properties.Images", Assembly.GetExecutingAssembly());
-
-            // dummy request; for some strange reason the ResourceSets are not loaded until after the first object request... bug?
-            rm.GetObject("dummy");
-
-            using System.Resources.ResourceSet resourceSet = rm.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
-            Validates.NotNull(resourceSet);
-            foreach (DictionaryEntry icon in resourceSet.Cast<DictionaryEntry>().OrderBy(icon => icon.Key))
+            if (EmbeddedIcons.Images.Count == 0)
             {
-                if (icon.Value is Bitmap bitmap)
-                {
-                    EmbeddedIcons.Images.Add(icon.Key.ToString()!, bitmap.AdaptLightness());
-                }
-            }
+                System.Resources.ResourceManager rm = new("GitUI.Properties.Images", Assembly.GetExecutingAssembly());
 
-            resourceSet.Close();
-            rm.ReleaseAllResources();
+                // dummy request; for some strange reason the ResourceSets are not loaded until after the first object request... bug?
+                rm.GetObject("dummy");
+
+                using System.Resources.ResourceSet resourceSet = rm.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
+                Validates.NotNull(resourceSet);
+                foreach (DictionaryEntry icon in resourceSet.Cast<DictionaryEntry>().OrderBy(icon => icon.Key))
+                {
+                    if (icon.Value is Bitmap bitmap)
+                    {
+                        EmbeddedIcons.Images.Add(icon.Key.ToString()!, bitmap.AdaptLightness());
+                    }
+                }
+
+                resourceSet.Close();
+                rm.ReleaseAllResources();
+            }
 
             lvScripts.LargeImageList = lvScripts.SmallImageList = EmbeddedIcons;
             _imagesLoaded = true;
@@ -236,8 +242,16 @@ Diff selection:
                     return;
                 }
 
+                // script.Icon must match in case because assembly resources are case-sensitive
+                FrozenSet<string> imageKeys = EmbeddedIcons.Images.Keys.Cast<string>().ToFrozenSet();
+
                 foreach (ScriptInfoProxy script in scripts)
                 {
+                    if (script.Icon is not null && !imageKeys.Contains(script.Icon))
+                    {
+                        script.Icon = null;
+                    }
+
                     Color color = !script.Enabled ? SystemColors.GrayText : SystemColors.WindowText;
 
                     ListViewItem lvitem = new(script.Name)

--- a/src/app/GitUI/GitUI.csproj
+++ b/src/app/GitUI/GitUI.csproj
@@ -9,10 +9,6 @@
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
      <!-- Suppress suggestion to use experimental API ShowDialogAsync -->
     <NoWarn>$(NoWarn);WFO5002</NoWarn>
-
-    <!-- Enable C#13 keyword "field" -->
-    <LangVersion>preview</LangVersion>
-
     <!--
     For debug purposes uncomment these lines:
 

--- a/src/app/GitUI/GitUI.csproj
+++ b/src/app/GitUI/GitUI.csproj
@@ -9,6 +9,10 @@
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
      <!-- Suppress suggestion to use experimental API ShowDialogAsync -->
     <NoWarn>$(NoWarn);WFO5002</NoWarn>
+
+    <!-- Enable C#13 keyword "field" -->
+    <LangVersion>preview</LangVersion>
+
     <!--
     For debug purposes uncomment these lines:
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptManagerTests.Can_save_settings.verified.xml
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptManagerTests.Can_save_settings.verified.xml
@@ -10,6 +10,5 @@
     <RunInBackground>false</RunInBackground>
     <IsPowerShell>false</IsPowerShell>
     <HotkeyCommandIdentifier>0</HotkeyCommandIdentifier>
-    <Icon>bug</Icon>
   </ScriptInfo>
 </ArrayOfScriptInfo>

--- a/tests/app/UnitTests/GitUI.Tests/GitUI.Tests.csproj
+++ b/tests/app/UnitTests/GitUI.Tests/GitUI.Tests.csproj
@@ -1,4 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+      <!-- Disable C#13+ keyword "field" -->
+    <LangVersion>13</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="JetBrains.Annotations" />


### PR DESCRIPTION
Fixes slow opening of context menus in RevisionGrid and FileStatusList

## Proposed changes

- Cache script icons
- Load assembly icons only once
- Reset invalid script icon names
  including wrong, arguable default icon "bug"
- Enable C#13+ syntax in order to enable the `field` keyword for properties

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/82443b9e-62ed-4514-b15f-31301608891a)

### After

![image](https://github.com/user-attachments/assets/1a7bf149-b1a6-4a76-bfa6-f6a8a826f7d8)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).