### PR TITLE
fix(GIT_SSH): Avoid "error: cannot spawn : No such file or directory" with .NET9

### DIFF
--- a/src/app/GitCommands/Git/GitSshHelpers.cs
+++ b/src/app/GitCommands/Git/GitSshHelpers.cs
@@ -6,7 +6,7 @@ namespace GitCommands
         public static void SetGitSshEnvironmentVariable(string path)
         {
             // Git will use the embedded OpenSSH ssh.exe if empty/unset
-            Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("GIT_SSH", path?.Length is > 0 ? path : null, EnvironmentVariableTarget.Process);
         }
 
         // Note that variants like TortoisePlink.exe are supported too


### PR DESCRIPTION
Fixes "error: cannot spawn : No such file or directory" e.g. on "git fetch" (with space in front of the second colon)

## Proposed changes

The behavior of `Environment.SetEnvironmentVariable` for empty string seems to have changed with .NET9.
It does not unset the environment variable, but creates "GIT_SSH=" in the environment.
This makes git attempt to run the empty string as SSH command (on some machines only).

So, explicitly unset "GIT_SSH" if an empty string was read from the registry.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).