### PR TITLE
feat: Clarify update & git exe path

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs.BrowseDialog
+﻿using GitUI.UserControls.Settings;
+
+namespace GitUI.CommandsDialogs.BrowseDialog
 {
     partial class FormUpdates
     {
@@ -34,7 +36,7 @@
             btnUpdateNow = new Button();
             linkDirectDownload = new LinkLabel();
             tlpnlContent = new TableLayoutPanel();
-            linkRequiredNetRuntime = new LinkLabel();
+            linkRequiredDotNetRuntime = new SettingsLinkLabel();
             MainPanel.SuspendLayout();
             tlpnlContent.SuspendLayout();
             SuspendLayout();
@@ -42,7 +44,7 @@
             // MainPanel
             // 
             MainPanel.Controls.Add(tlpnlContent);
-            MainPanel.Size = new Size(462, 91);
+            MainPanel.Size = new Size(462, 103);
             MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
@@ -73,13 +75,13 @@
             // linkChangeLog
             // 
             linkChangeLog.AutoSize = true;
-            linkChangeLog.Dock = DockStyle.Fill;
-            linkChangeLog.Location = new Point(3, 64);
+            linkChangeLog.Dock = DockStyle.Bottom;
+            linkChangeLog.Location = new Point(3, 71);
             linkChangeLog.Name = "linkChangeLog";
-            linkChangeLog.Size = new Size(432, 15);
+            linkChangeLog.Size = new Size(432, 8);
             linkChangeLog.TabIndex = 3;
             linkChangeLog.TabStop = true;
-            linkChangeLog.Text = "Show Change&Log";
+            linkChangeLog.Text = "Show release notes and change &log";
             linkChangeLog.Visible = false;
             linkChangeLog.LinkClicked += linkChangeLog_LinkClicked;
             // 
@@ -117,8 +119,8 @@
             tlpnlContent.ColumnStyles.Add(new ColumnStyle());
             tlpnlContent.Controls.Add(UpdateLabel, 0, 0);
             tlpnlContent.Controls.Add(progressBar1, 0, 1);
-            tlpnlContent.Controls.Add(linkRequiredNetRuntime, 0, 3);
-            tlpnlContent.Controls.Add(linkChangeLog, 0, 4);
+            tlpnlContent.Controls.Add(linkRequiredDotNetRuntime, 0, 3);
+            tlpnlContent.Controls.Add(linkChangeLog, 0, 5);
             tlpnlContent.Dock = DockStyle.Fill;
             tlpnlContent.Location = new Point(12, 12);
             tlpnlContent.Margin = new Padding(0);
@@ -130,26 +132,32 @@
             tlpnlContent.RowStyles.Add(new RowStyle());
             tlpnlContent.RowStyles.Add(new RowStyle());
             tlpnlContent.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            tlpnlContent.Size = new Size(438, 67);
+            tlpnlContent.Size = new Size(438, 79);
             tlpnlContent.TabIndex = 3;
             // 
-            // linkRequiredNetRuntime
+            // linkRequiredDotNetRuntime
             // 
-            linkRequiredNetRuntime.AutoSize = true;
-            linkRequiredNetRuntime.Dock = DockStyle.Fill;
-            linkRequiredNetRuntime.LinkArea = new LinkArea(0, 0);
-            linkRequiredNetRuntime.Location = new Point(3, 49);
-            linkRequiredNetRuntime.Name = "linkRequiredNetRuntime";
-            linkRequiredNetRuntime.Size = new Size(432, 15);
-            linkRequiredNetRuntime.TabIndex = 2;
-            linkRequiredNetRuntime.Text = "Required: .NET {0} Desktop Runtime {1} or later {2}.x";
-            linkRequiredNetRuntime.LinkClicked += linkRequiredNetRuntime_LinkClicked;
+            linkRequiredDotNetRuntime.AutoSize = true;
+            linkRequiredDotNetRuntime.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            linkRequiredDotNetRuntime.Dock = DockStyle.Fill;
+            linkRequiredDotNetRuntime.LinkArea = new LinkArea(0, 0);
+            linkRequiredDotNetRuntime.Location = new Point(4, 52);
+            linkRequiredDotNetRuntime.ManualSectionAnchorName = null;
+            linkRequiredDotNetRuntime.Margin = new Padding(4, 3, 4, 3);
+            linkRequiredDotNetRuntime.Name = "linkRequiredDotNetRuntime";
+            linkRequiredDotNetRuntime.Size = new Size(430, 18);
+            linkRequiredDotNetRuntime.TabIndex = 2;
+            linkRequiredDotNetRuntime.Text = "Required: .NET {0} Desktop Runtime {1} or later {2}.x";
+            linkRequiredDotNetRuntime.ToolTipIcon = UserControls.Settings.ToolTipIcon.Information;
+            linkRequiredDotNetRuntime.ToolTipText = "Download latest .NET Desktop Runtime. See docs on how to install .NET runtime without administrative privileges.";
+            linkRequiredDotNetRuntime.InfoClicked += linkRequiredDotNetRuntime_InfoClicked;
+            linkRequiredDotNetRuntime.LinkClicked += linkRequiredDotNetRuntime_LinkClicked;
             // 
             // FormUpdates
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(462, 132);
+            ClientSize = new Size(462, 135);
             FormBorderStyle = FormBorderStyle.FixedToolWindow;
             MaximizeBox = false;
             MinimizeBox = false;
@@ -171,6 +179,6 @@
         private Button btnUpdateNow;
         private LinkLabel linkDirectDownload;
         private TableLayoutPanel tlpnlContent;
-        private LinkLabel linkRequiredNetRuntime;
+        private SettingsLinkLabel linkRequiredDotNetRuntime;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.resx
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
@@ -142,7 +142,7 @@
             label50.Name = "label50";
             label50.Size = new Size(603, 13);
             label50.TabIndex = 0;
-            label50.Text = "Set the correct paths to Git for Windows. (WSL Git will be used for WSL repositories).";
+            label50.Text = "Set the correct paths to Git for Windows. (WSL Git will automatically be used for WSL repositories.)";
             label50.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // downloadGitForWindows

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -7628,15 +7628,19 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <target />
       </trans-unit>
       <trans-unit id="linkChangeLog.Text">
-        <source>Show Change&amp;Log</source>
+        <source>Show release notes and change &amp;log</source>
         <target />
       </trans-unit>
       <trans-unit id="linkDirectDownload.Text">
         <source>&amp;Direct Download</source>
         <target />
       </trans-unit>
-      <trans-unit id="linkRequiredNetRuntime.Text">
+      <trans-unit id="linkRequiredDotNetRuntime.Text">
         <source>Required: .NET {0} Desktop Runtime {1} or later {2}.x</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="linkRequiredDotNetRuntime.ToolTipText">
+        <source>Download latest .NET Desktop Runtime. See docs on how to install .NET runtime without administrative privileges.</source>
         <target />
       </trans-unit>
     </body>
@@ -8226,7 +8230,7 @@ Check if file is accessible.</source>
         <target />
       </trans-unit>
       <trans-unit id="label50.Text">
-        <source>Set the correct paths to Git for Windows. (WSL Git will be used for WSL repositories).</source>
+        <source>Set the correct paths to Git for Windows. (WSL Git will automatically be used for WSL repositories.)</source>
         <target />
       </trans-unit>
       <trans-unit id="lblGitCommand.Text">

--- a/src/app/GitUI/UserControls/Settings/SettingsLinkLabel.Designer.cs
+++ b/src/app/GitUI/UserControls/Settings/SettingsLinkLabel.Designer.cs
@@ -1,0 +1,100 @@
+﻿namespace GitUI.UserControls.Settings
+{
+    partial class SettingsLinkLabel
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components is not null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            tableLayoutPanel = new TableLayoutPanel();
+            linkLabel = new LinkLabel();
+            pictureBox = new PictureBox();
+            tableLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox).BeginInit();
+            SuspendLayout();
+            // 
+            // tableLayoutPanel
+            // 
+            tableLayoutPanel.AutoSize = true;
+            tableLayoutPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel.ColumnCount = 2;
+            tableLayoutPanel.ColumnStyles.Add(new ColumnStyle());
+            tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tableLayoutPanel.Controls.Add(linkLabel, 0, 0);
+            tableLayoutPanel.Controls.Add(pictureBox, 1, 0);
+            tableLayoutPanel.Dock = DockStyle.Fill;
+            tableLayoutPanel.Location = new Point(0, 0);
+            tableLayoutPanel.Margin = new Padding(0);
+            tableLayoutPanel.Name = "tableLayoutPanel";
+            tableLayoutPanel.RowCount = 1;
+            tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            tableLayoutPanel.Size = new Size(104, 17);
+            tableLayoutPanel.TabIndex = 0;
+            // 
+            // linkLabel
+            // 
+            linkLabel.AutoSize = true;
+            linkLabel.Location = new Point(0, 0);
+            linkLabel.Margin = new Padding(0, 0, 2, 0);
+            linkLabel.Name = "linkLabel";
+            linkLabel.Size = new Size(84, 17);
+            linkLabel.TabIndex = 0;
+            linkLabel.Text = "Settings label";
+            // 
+            // pictureBox
+            // 
+            pictureBox.Cursor = Cursors.Hand;
+            pictureBox.Image = Properties.Resources.information;
+            pictureBox.Location = new Point(88, 0);
+            pictureBox.Margin = new Padding(2, 0, 0, 0);
+            pictureBox.Name = "pictureBox";
+            pictureBox.Size = new Size(16, 16);
+            pictureBox.TabIndex = 1;
+            pictureBox.TabStop = false;
+            pictureBox.Visible = false;
+            // 
+            // SettingsLinkLabel
+            // 
+            AutoScaleDimensions = new SizeF(6F, 13F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            Controls.Add(tableLayoutPanel);
+            Name = "SettingsLinkLabel";
+            Size = new Size(104, 17);
+            tableLayoutPanel.ResumeLayout(false);
+            tableLayoutPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private TableLayoutPanel tableLayoutPanel;
+        private LinkLabel linkLabel;
+        private PictureBox pictureBox;
+    }
+}

--- a/src/app/GitUI/UserControls/Settings/SettingsLinkLabel.cs
+++ b/src/app/GitUI/UserControls/Settings/SettingsLinkLabel.cs
@@ -1,0 +1,109 @@
+﻿using System.ComponentModel;
+using GitCommands;
+
+namespace GitUI.UserControls.Settings
+{
+    public partial class SettingsLinkLabel : UserControl
+    {
+        private string? _toolTipText;
+        private ToolTipIcon _toolTipIcon;
+        private ToolTip? _tooltip;
+
+        public SettingsLinkLabel()
+        {
+            InitializeComponent();
+
+            pictureBox.Click += (_, _) =>
+            {
+                if (string.IsNullOrWhiteSpace(ManualSectionAnchorName))
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(ManualSectionSubfolder))
+                {
+                    ManualSectionSubfolder = "settings";
+                }
+
+                string url = UserManual.UserManual.UrlFor(ManualSectionSubfolder, ManualSectionAnchorName);
+                OsShellUtil.OpenUrlInDefaultBrowser(url);
+            };
+        }
+
+        public LinkArea LinkArea
+        {
+            get => linkLabel.LinkArea;
+            set => linkLabel.LinkArea = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the anchor pointing to a section in the manual pertaining to this control.
+        /// </summary>
+        /// <remarks>
+        /// The URL structure:
+        /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
+        /// </remarks>
+        public string? ManualSectionAnchorName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of a document pertaining to this control.
+        /// Default is "settings
+        /// </summary>
+        /// <remarks>
+        /// The URL structure:
+        /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
+        /// </remarks>
+        [DefaultValue(null)]
+        public string? ManualSectionSubfolder { get; set; }
+
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        [Browsable(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [Bindable(true)]
+        public override string Text
+        {
+            get => linkLabel.Text;
+            set => linkLabel.Text = value;
+        }
+
+        public string? ToolTipText
+        {
+            get => _toolTipText;
+            set
+            {
+                _toolTipText = value;
+                _tooltip ??= new ToolTip();
+                _tooltip.SetToolTip(linkLabel, _toolTipText);
+                _tooltip.SetToolTip(pictureBox, _toolTipText);
+                pictureBox.Visible = !string.IsNullOrEmpty(_toolTipText);
+            }
+        }
+
+        public ToolTipIcon ToolTipIcon
+        {
+            get => _toolTipIcon;
+            set
+            {
+                _toolTipIcon = value;
+                pictureBox.Image = _toolTipIcon switch
+                {
+                    ToolTipIcon.Warning => Properties.Resources.Warning,
+                    ToolTipIcon.Information => Properties.Resources.information,
+                    _ => throw new NotImplementedException(),
+                };
+            }
+        }
+
+        public event EventHandler InfoClicked
+        {
+            add { pictureBox.Click += value; }
+            remove { pictureBox.Click -= value; }
+        }
+
+        public event LinkLabelLinkClickedEventHandler LinkClicked
+        {
+            add { linkLabel.LinkClicked += value; }
+            remove { linkLabel.LinkClicked -= value; }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #12217

## Proposed changes

- Mention update of .NET runtime only if required
- Mention local install using new control `SettingsLinkLabel` pointing to new Wiki page
- Change ChangeLog link to https://github.com/gitextensions/gitextensions/releases (added link to `ChangeLog.md` there)
- `GitSettingsPage`: Clearer description of WSL git executable

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/26fd77d4-d3e5-474c-9516-fe2756a8ba7d)

### After

![image](https://github.com/user-attachments/assets/d3bad5e4-d268-4751-a760-c42b21b303ac)

![image](https://github.com/user-attachments/assets/20e32f36-06db-477e-82b3-d85907a99f67)

### Before

![image](https://github.com/user-attachments/assets/9862d67e-c655-4ef2-88e0-5cd768e0e40b)

![image](https://github.com/user-attachments/assets/7f10ce89-0b93-43ac-b4c9-7ba6b643f99a)

## Test methodology <!-- How did you ensure quality? -->

- manual

BTW: after several tries
![image](https://github.com/user-attachments/assets/2f24e258-23a6-4a3f-af36-1170e725fe94)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).