### PR TITLE
FormUpdate: display .NET runtime requirements

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -142,7 +142,7 @@
             linkRequiredNetRuntime.Name = "linkRequiredNetRuntime";
             linkRequiredNetRuntime.Size = new Size(432, 15);
             linkRequiredNetRuntime.TabIndex = 2;
-            linkRequiredNetRuntime.Text = "Required: .NET {0} Desktop Runtime {1} or later";
+            linkRequiredNetRuntime.Text = "Required: .NET {0} Desktop Runtime {1} or later {2}.x";
             linkRequiredNetRuntime.LinkClicked += linkRequiredNetRuntime_LinkClicked;
             // 
             // FormUpdates

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -34,15 +34,16 @@
             btnUpdateNow = new Button();
             linkDirectDownload = new LinkLabel();
             tlpnlContent = new TableLayoutPanel();
+            linkRequiredNetRuntime = new LinkLabel();
             MainPanel.SuspendLayout();
-            ControlsPanel.SuspendLayout();
             tlpnlContent.SuspendLayout();
             SuspendLayout();
             // 
             // MainPanel
             // 
             MainPanel.Controls.Add(tlpnlContent);
-            MainPanel.Size = new Size(456, 73);
+            MainPanel.Size = new Size(462, 91);
+            MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
             // 
@@ -55,7 +56,7 @@
             UpdateLabel.Dock = DockStyle.Fill;
             UpdateLabel.Location = new Point(3, 0);
             UpdateLabel.Name = "UpdateLabel";
-            UpdateLabel.Size = new Size(426, 15);
+            UpdateLabel.Size = new Size(432, 15);
             UpdateLabel.TabIndex = 0;
             UpdateLabel.Text = "Searching for updates";
             // 
@@ -65,7 +66,7 @@
             progressBar1.Location = new Point(3, 18);
             progressBar1.MinimumSize = new Size(0, 20);
             progressBar1.Name = "progressBar1";
-            progressBar1.Size = new Size(426, 20);
+            progressBar1.Size = new Size(432, 20);
             progressBar1.Style = ProgressBarStyle.Continuous;
             progressBar1.TabIndex = 1;
             // 
@@ -73,10 +74,10 @@
             // 
             linkChangeLog.AutoSize = true;
             linkChangeLog.Dock = DockStyle.Fill;
-            linkChangeLog.Location = new Point(3, 41);
+            linkChangeLog.Location = new Point(3, 64);
             linkChangeLog.Name = "linkChangeLog";
-            linkChangeLog.Size = new Size(426, 15);
-            linkChangeLog.TabIndex = 2;
+            linkChangeLog.Size = new Size(432, 15);
+            linkChangeLog.TabIndex = 3;
             linkChangeLog.TabStop = true;
             linkChangeLog.Text = "Show Change&Log";
             linkChangeLog.Visible = false;
@@ -86,7 +87,7 @@
             // 
             btnUpdateNow.AutoSize = true;
             btnUpdateNow.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            btnUpdateNow.Location = new Point(242, 8);
+            btnUpdateNow.Location = new Point(248, 8);
             btnUpdateNow.MinimumSize = new Size(100, 0);
             btnUpdateNow.Name = "btnUpdateNow";
             btnUpdateNow.Size = new Size(100, 25);
@@ -100,7 +101,7 @@
             // 
             linkDirectDownload.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
             linkDirectDownload.AutoSize = true;
-            linkDirectDownload.Location = new Point(348, 5);
+            linkDirectDownload.Location = new Point(354, 5);
             linkDirectDownload.Name = "linkDirectDownload";
             linkDirectDownload.Size = new Size(95, 31);
             linkDirectDownload.TabIndex = 1;
@@ -116,24 +117,38 @@
             tlpnlContent.ColumnStyles.Add(new ColumnStyle());
             tlpnlContent.Controls.Add(UpdateLabel, 0, 0);
             tlpnlContent.Controls.Add(progressBar1, 0, 1);
-            tlpnlContent.Controls.Add(linkChangeLog, 0, 2);
+            tlpnlContent.Controls.Add(linkRequiredNetRuntime, 0, 3);
+            tlpnlContent.Controls.Add(linkChangeLog, 0, 4);
             tlpnlContent.Dock = DockStyle.Fill;
             tlpnlContent.Location = new Point(12, 12);
             tlpnlContent.Margin = new Padding(0);
             tlpnlContent.Name = "tlpnlContent";
-            tlpnlContent.RowCount = 4;
+            tlpnlContent.RowCount = 6;
             tlpnlContent.RowStyles.Add(new RowStyle());
+            tlpnlContent.RowStyles.Add(new RowStyle());
+            tlpnlContent.RowStyles.Add(new RowStyle(SizeType.Absolute, 8F));
             tlpnlContent.RowStyles.Add(new RowStyle());
             tlpnlContent.RowStyles.Add(new RowStyle());
             tlpnlContent.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            tlpnlContent.Size = new Size(432, 49);
+            tlpnlContent.Size = new Size(438, 67);
             tlpnlContent.TabIndex = 3;
+            // 
+            // linkRequiredNetRuntime
+            // 
+            linkRequiredNetRuntime.AutoSize = true;
+            linkRequiredNetRuntime.Dock = DockStyle.Fill;
+            linkRequiredNetRuntime.LinkArea = new LinkArea(0, 0);
+            linkRequiredNetRuntime.Location = new Point(3, 49);
+            linkRequiredNetRuntime.Name = "linkRequiredNetRuntime";
+            linkRequiredNetRuntime.Size = new Size(432, 15);
+            linkRequiredNetRuntime.TabIndex = 2;
+            linkRequiredNetRuntime.Text = "Required: .NET {0} Desktop Runtime {1} or later";
             // 
             // FormUpdates
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(456, 114);
+            ClientSize = new Size(462, 132);
             FormBorderStyle = FormBorderStyle.FixedToolWindow;
             MaximizeBox = false;
             MinimizeBox = false;
@@ -141,9 +156,6 @@
             StartPosition = FormStartPosition.CenterParent;
             Text = "Check for update";
             MainPanel.ResumeLayout(false);
-            MainPanel.PerformLayout();
-            ControlsPanel.ResumeLayout(false);
-            ControlsPanel.PerformLayout();
             tlpnlContent.ResumeLayout(false);
             tlpnlContent.PerformLayout();
             ResumeLayout(false);
@@ -158,5 +170,6 @@
         private Button btnUpdateNow;
         private LinkLabel linkDirectDownload;
         private TableLayoutPanel tlpnlContent;
+        private LinkLabel linkRequiredNetRuntime;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -143,6 +143,7 @@
             linkRequiredNetRuntime.Size = new Size(432, 15);
             linkRequiredNetRuntime.TabIndex = 2;
             linkRequiredNetRuntime.Text = "Required: .NET {0} Desktop Runtime {1} or later";
+            linkRequiredNetRuntime.LinkClicked += linkRequiredNetRuntime_LinkClicked;
             // 
             // FormUpdates
             // 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -20,9 +20,10 @@ public partial class FormUpdates : GitExtensionsDialog
     private IWin32Window? _ownerWindow;
     private Version _currentVersion;
     private bool _updateFound;
-    private string _updateUrl = "";
+    private string _netRuntimeDownloadUrl = string.Empty;
+    private string _updateUrl = string.Empty;
+    private string _newVersion = string.Empty;
     private Version? _requiredNetRuntimeVersion;
-    private string _newVersion = "";
 
     public FormUpdates(Version currentVersion)
         : base(commands: null, enablePositionRestore: false)
@@ -187,6 +188,8 @@ public partial class FormUpdates : GitExtensionsDialog
         int length = versionText2.Length;
         linkRequiredNetRuntime.LinkArea = new LinkArea(start, length);
 
+        _netRuntimeDownloadUrl = $@"https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-{requiredNetRuntimeVersion.ToString(3)}-windows-x64-installer";
+
         linkRequiredNetRuntime.Visible = true;
     }
 
@@ -209,13 +212,22 @@ public partial class FormUpdates : GitExtensionsDialog
                 }
 
                 break;
+
+            case LaunchType.NetRuntime:
+                if (!string.IsNullOrWhiteSpace(_netRuntimeDownloadUrl))
+                {
+                    OsShellUtil.OpenUrlInDefaultBrowser(_netRuntimeDownloadUrl);
+                }
+
+                break;
         }
     }
 
-    private void linkChangeLog_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-    {
-        LaunchUrl(LaunchType.ChangeLog);
-    }
+    private void linkChangeLog_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => LaunchUrl(LaunchType.ChangeLog);
+
+    private void linkDirectDownload_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => LaunchUrl(LaunchType.DirectDownload);
+
+    private void linkRequiredNetRuntime_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => LaunchUrl(LaunchType.NetRuntime);
 
     private void btnUpdateNow_Click(object sender, EventArgs e)
     {
@@ -259,15 +271,11 @@ public partial class FormUpdates : GitExtensionsDialog
         });
     }
 
-    private void linkDirectDownload_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-    {
-        LaunchUrl(LaunchType.DirectDownload);
-    }
-
-    private enum LaunchType
+    internal enum LaunchType
     {
         ChangeLog,
-        DirectDownload
+        DirectDownload,
+        NetRuntime
     }
 
     internal TestAccessor GetTestAccessor() => new(this);
@@ -283,6 +291,10 @@ public partial class FormUpdates : GitExtensionsDialog
 
         public LinkLabel linkRequiredNetRuntime => _form.linkRequiredNetRuntime;
 
+        public string NetRuntimeDownloadUrl => _form._netRuntimeDownloadUrl;
+
         public void DisplayNetRuntimeLink(string format, Version requiredNetRuntimeVersion) => _form.DisplayNetRuntimeLink(format, requiredNetRuntimeVersion);
+
+        public void LaunchUrl(LaunchType launchType) => _form.LaunchUrl(launchType);
     }
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -183,7 +183,8 @@ public partial class FormUpdates : GitExtensionsDialog
 
         string versionText1 = requiredNetRuntimeVersion.ToString(fieldCount: 2);
         string versionText2 = requiredNetRuntimeVersion.ToString(fieldCount: 3);
-        linkRequiredNetRuntime.Text = string.Format(format, versionText1, versionText2);
+        string versionText3 = requiredNetRuntimeVersion.ToString(fieldCount: 1);
+        linkRequiredNetRuntime.Text = string.Format(format, versionText1, versionText2, versionText3);
 
         int start = linkRequiredNetRuntime.Text.IndexOf(versionText2, StringComparison.Ordinal);
         int length = versionText2.Length;

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Net;
+using System.Runtime.InteropServices;
 using Git.hub;
 using GitCommands;
 using ResourceManager;
@@ -180,15 +181,15 @@ public partial class FormUpdates : GitExtensionsDialog
             return;
         }
 
-        string versionText1 = requiredNetRuntimeVersion.ToString(2);
-        string versionText2 = requiredNetRuntimeVersion.ToString(3);
+        string versionText1 = requiredNetRuntimeVersion.ToString(fieldCount: 2);
+        string versionText2 = requiredNetRuntimeVersion.ToString(fieldCount: 3);
         linkRequiredNetRuntime.Text = string.Format(format, versionText1, versionText2);
 
         int start = linkRequiredNetRuntime.Text.IndexOf(versionText2, StringComparison.Ordinal);
         int length = versionText2.Length;
         linkRequiredNetRuntime.LinkArea = new LinkArea(start, length);
 
-        _netRuntimeDownloadUrl = $@"https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-{requiredNetRuntimeVersion.ToString(3)}-windows-x64-installer";
+        _netRuntimeDownloadUrl = $@"https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch={RuntimeInformation.OSArchitecture}&rid=win-{RuntimeInformation.OSArchitecture}&apphost_version={requiredNetRuntimeVersion.ToString(fieldCount: 3)}&gui=true";
 
         linkRequiredNetRuntime.Visible = true;
     }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -7636,7 +7636,7 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <target />
       </trans-unit>
       <trans-unit id="linkRequiredNetRuntime.Text">
-        <source>Required: .NET {0} Desktop Runtime {1} or later</source>
+        <source>Required: .NET {0} Desktop Runtime {1} or later {2}.x</source>
         <target />
       </trans-unit>
     </body>

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -7635,6 +7635,10 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <source>&amp;Direct Download</source>
         <target />
       </trans-unit>
+      <trans-unit id="linkRequiredNetRuntime.Text">
+        <source>Required: .NET {0} Desktop Runtime {1} or later</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="FormVerify" source-language="en">

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
@@ -94,15 +94,15 @@ public class FormUpdatesTests
     {
         yield return new TestCaseData(
             new Version(8, 10, 134),
-            "https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-8.10.134-windows-x64-installer");
+            "https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=X64&rid=win-X64&apphost_version=8.10.134&gui=true");
 
         yield return new TestCaseData(
             new Version(10, 0, 2),
-            "https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-10.0.2-windows-x64-installer");
+            "https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=X64&rid=win-X64&apphost_version=10.0.2&gui=true");
 
         yield return new TestCaseData(
             new Version(7, 11, 10),
-            "https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-7.11.10-windows-x64-installer");
+            "https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=X64&rid=win-X64&apphost_version=7.11.10&gui=true");
     }
 
     private void RunFormTest(Action<FormUpdates> testDriver)

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
@@ -35,7 +35,7 @@ public class FormUpdatesTests
             {
                 FormUpdates.TestAccessor accessor = form.GetTestAccessor();
 
-                accessor.DisplayNetRuntimeLink("Required: .NET {0} Desktop Runtime {1} or later", requiredNetRuntimeVersion: null);
+                accessor.DisplayNetRuntimeLink("Required: .NET {0} Desktop Runtime {1} or later {2}.x", requiredNetRuntimeVersion: null);
                 accessor.linkRequiredNetRuntime.Visible.Should().BeFalse();
             });
     }
@@ -60,20 +60,20 @@ public class FormUpdatesTests
     {
         yield return new TestCaseData(
             new Version(8, 10, 134),
-            "Required: .NET {0} Desktop Runtime {1} or later",
-            "Required: .NET 8.10 Desktop Runtime 8.10.134 or later",
+            "Required: .NET {0} Desktop Runtime {1} or later {2}.x",
+            "Required: .NET 8.10 Desktop Runtime 8.10.134 or later 8.x",
             new LinkArea(36, 8));
 
         yield return new TestCaseData(
             new Version(10, 0, 2),
-            "Требуется: .NET {0} Desktop Runtime {1} или более поздняя версия",
-            "Требуется: .NET 10.0 Desktop Runtime 10.0.2 или более поздняя версия",
+            "Требуется: .NET {0} Desktop Runtime {1} или более поздняя версия {2}.x",
+            "Требуется: .NET 10.0 Desktop Runtime 10.0.2 или более поздняя версия 10.x",
             new LinkArea(37, 6));
 
         yield return new TestCaseData(
             new Version(7, 11, 10),
-            "Erforderlich: .NET {0} Desktop Runtime {1} oder höher",
-            "Erforderlich: .NET 7.11 Desktop Runtime 7.11.10 oder höher",
+            "Erforderlich: .NET {0} Desktop Runtime {1} oder höher {2}.x",
+            "Erforderlich: .NET 7.11 Desktop Runtime 7.11.10 oder höher 7.x",
             new LinkArea(40, 7));
     }
 
@@ -84,7 +84,7 @@ public class FormUpdatesTests
             form =>
             {
                 FormUpdates.TestAccessor accessor = form.GetTestAccessor();
-                accessor.DisplayNetRuntimeLink("Required: .NET {0} Desktop Runtime {1} or later", runtimeVersion);
+                accessor.DisplayNetRuntimeLink("Required: .NET {0} Desktop Runtime {1} or later {2}.x", runtimeVersion);
 
                 accessor.NetRuntimeDownloadUrl.Should().Be(expectedUrl);
             });

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
@@ -1,0 +1,100 @@
+﻿using CommonTestUtils;
+using FluentAssertions;
+using GitUI;
+using GitUI.CommandsDialogs.BrowseDialog;
+
+namespace GitExtensions.UITests.CommandsDialogs;
+
+[Apartment(ApartmentState.STA)]
+public class FormUpdatesTests
+{
+    // Created once for the fixture
+    private ReferenceRepository _referenceRepository;
+
+    // Created once for each test
+    private GitUICommands _commands;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ReferenceRepository.ResetRepo(ref _referenceRepository);
+        _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _referenceRepository.Dispose();
+    }
+
+    [Test]
+    public void Should_hide_NET_runtime_link_if_no_required_version()
+    {
+        RunFormTest(
+            form =>
+            {
+                FormUpdates.TestAccessor accessor = form.GetTestAccessor();
+
+                accessor.DisplayNetRuntimeLink("Required: .NET {0} Desktop Runtime {1} or later", requiredNetRuntimeVersion: null);
+                accessor.linkRequiredNetRuntime.Visible.Should().BeFalse();
+            });
+    }
+
+    [TestCaseSource(nameof(NetRuntimeLinkTestCases))]
+    public void Should_correctly_link_NET_runtime(Version runtimeVersion, string format, string expectedText, LinkArea expectedLinkArea)
+    {
+        RunFormTest(
+            form =>
+            {
+                FormUpdates.TestAccessor accessor = form.GetTestAccessor();
+
+                accessor.DisplayNetRuntimeLink(format, runtimeVersion);
+
+                accessor.linkRequiredNetRuntime.Visible.Should().BeTrue();
+                accessor.linkRequiredNetRuntime.Text.Should().Be(expectedText);
+                accessor.linkRequiredNetRuntime.LinkArea.Should().Be(expectedLinkArea);
+            });
+    }
+
+    private static IEnumerable<TestCaseData> NetRuntimeLinkTestCases()
+    {
+        yield return new TestCaseData(
+            new Version(8, 10, 134),
+            "Required: .NET {0} Desktop Runtime {1} or later",
+            "Required: .NET 8.10 Desktop Runtime 8.10.134 or later",
+            new LinkArea(36, 8));
+
+        yield return new TestCaseData(
+            new Version(10, 0, 2),
+            "Требуется: .NET {0} Desktop Runtime {1} или более поздняя версия",
+            "Требуется: .NET 10.0 Desktop Runtime 10.0.2 или более поздняя версия",
+            new LinkArea(37, 6));
+
+        yield return new TestCaseData(
+            new Version(7, 11, 10),
+            "Erforderlich: .NET {0} Desktop Runtime {1} oder höher",
+            "Erforderlich: .NET 7.11 Desktop Runtime 7.11.10 oder höher",
+            new LinkArea(40, 7));
+    }
+
+    private void RunFormTest(Action<FormUpdates> testDriver)
+    {
+        RunFormTest(
+            form =>
+            {
+                testDriver(form);
+                return Task.CompletedTask;
+            });
+    }
+
+    private void RunFormTest(Func<FormUpdates, Task> testDriverAsync)
+    {
+        UITest.RunForm(
+            () =>
+            {
+                using FormUpdates form = new(new Version(4, 2, 0));
+                form.ShowDialog(owner: null);
+            },
+            testDriverAsync);
+    }
+}

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
@@ -40,8 +40,8 @@ public class FormUpdatesTests
             });
     }
 
-    [TestCaseSource(nameof(NetRuntimeLinkTestCases))]
-    public void Should_correctly_link_NET_runtime(Version runtimeVersion, string format, string expectedText, LinkArea expectedLinkArea)
+    [TestCaseSource(nameof(NetRuntimeLinkTextTestCases))]
+    public void Should_NET_runtime_link_text_be_correct(Version runtimeVersion, string format, string expectedText, LinkArea expectedLinkArea)
     {
         RunFormTest(
             form =>
@@ -56,7 +56,7 @@ public class FormUpdatesTests
             });
     }
 
-    private static IEnumerable<TestCaseData> NetRuntimeLinkTestCases()
+    private static IEnumerable<TestCaseData> NetRuntimeLinkTextTestCases()
     {
         yield return new TestCaseData(
             new Version(8, 10, 134),
@@ -75,6 +75,34 @@ public class FormUpdatesTests
             "Erforderlich: .NET {0} Desktop Runtime {1} oder höher",
             "Erforderlich: .NET 7.11 Desktop Runtime 7.11.10 oder höher",
             new LinkArea(40, 7));
+    }
+
+    [TestCaseSource(nameof(NetRuntimeLinkTestCases))]
+    public void Should_NET_runtime_link_url_be_correct(Version runtimeVersion, string expectedUrl)
+    {
+        RunFormTest(
+            form =>
+            {
+                FormUpdates.TestAccessor accessor = form.GetTestAccessor();
+                accessor.DisplayNetRuntimeLink("Required: .NET {0} Desktop Runtime {1} or later", runtimeVersion);
+
+                accessor.NetRuntimeDownloadUrl.Should().Be(expectedUrl);
+            });
+    }
+
+    private static IEnumerable<TestCaseData> NetRuntimeLinkTestCases()
+    {
+        yield return new TestCaseData(
+            new Version(8, 10, 134),
+            "https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-8.10.134-windows-x64-installer");
+
+        yield return new TestCaseData(
+            new Version(10, 0, 2),
+            "https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-10.0.2-windows-x64-installer");
+
+        yield return new TestCaseData(
+            new Version(7, 11, 10),
+            "https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-desktop-7.11.10-windows-x64-installer");
     }
 
     private void RunFormTest(Action<FormUpdates> testDriver)

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/BrowseDialog/ReleaseVersionTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/BrowseDialog/ReleaseVersionTests.cs
@@ -5,7 +5,7 @@ using GitUI.CommandsDialogs.BrowseDialog;
 namespace GitUITests.CommandsDialogs.BrowseDialog
 {
     [TestFixture]
-    public class FormUpdateFixture
+    public class ReleaseVersionTests
     {
         private static string GetReleasesConfigFileText()
         {
@@ -31,7 +31,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
                 new Version(2, 49),
                 new Version(2, 50)
             };
-            updates.Select(rv => rv.Version).Should().Equal(expectedVersions);
+            updates.Select(rv => rv.ApplicationVersion).Should().Equal(expectedVersions);
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
             {
                 new Version(2, 48)
             };
-            updates.Select(rv => rv.Version).Should().Equal(expectedVersions);
+            updates.Select(rv => rv.ApplicationVersion).Should().Equal(expectedVersions);
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
             IEnumerable<ReleaseVersion> availableVersions = ReleaseVersion.Parse(GetReleasesConfigFileText());
 
             IEnumerable<ReleaseVersion> updates = ReleaseVersion.GetNewerVersions(currentVersion, false, availableVersions);
-            updates.Select(rv => rv.Version).Should().BeEmpty();
+            updates.Select(rv => rv.ApplicationVersion).Should().BeEmpty();
         }
     }
 }


### PR DESCRIPTION
Resolves #12205


## Proposed changes

- Read required .NET desktop runtime version from https://github.com/gitextensions/gitextensions/blob/configdata/GitExtensions.releases. If the version is found it is shown in the dialog, otherwise the text is hidden. 
- Some QOL improvements.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/3f8a307e-6761-4528-8d47-bb76b3034047)


### After

![image](https://github.com/user-attachments/assets/ad4760fb-65f1-4f93-83b8-503e7483d3e3)

## Test methodology <!-- How did you ensure quality? -->

Tested manually.

- A test config is currently available at https://github.com/gitextensions/gitextensions/blob/configdata_test/GitExtensions.releases.
- Local version is set to 4.2.0, so the updater can detect a newer version

```diff
diff --git a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
index 832a36f79..4be587fb5 100644
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -27,7 +27,7 @@ public partial class FormUpdates : GitExtensionsDialog
     public FormUpdates(Version currentVersion)
         : base(commands: null, enablePositionRestore: false)
     {
-        CurrentVersion = currentVersion;
+        _currentVersion = new Version(4, 2, 0); // currentVersion;
 
         InitializeComponent();
         InitializeComplete();
@@ -70,7 +70,7 @@ private void SearchForUpdates()
             Client github = new();
             Repository gitExtRepo = github.getRepository("gitextensions", "gitextensions");
 
-            GitHubReference configData = gitExtRepo?.GetRef("heads/configdata");
+            GitHubReference configData = gitExtRepo?.GetRef("heads/configdata_test");
 
             GitHubTree tree = configData?.GetTree();
             if (tree is null)
```

![image](https://github.com/user-attachments/assets/8b9f387b-fe3c-40dc-a699-8d3203d22397)
![image](https://github.com/user-attachments/assets/e352d4d3-9a3d-4dbf-87b4-6feae2e172e8)
![image](https://github.com/user-attachments/assets/a7d8c46c-0207-411e-ac02-07578a913907)


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
