### PR TITLE
fix: adjust settings check colors

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/OtherColors.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/OtherColors.cs
@@ -7,5 +7,8 @@
         public static readonly Color MergeConflictsColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
         public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
         public static readonly Color PanelMessageWarningColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
+        public static readonly Color BrightGreen = Color.FromArgb(128, 255, 128);
+        public static readonly Color BrightYellow = Color.FromArgb(255, 255, 128);
+        public static readonly Color BrightRed = Color.FromArgb(255, 128, 128);
     }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -579,7 +579,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// </summary>
         private static void RenderSettingSet(Button settingButton, Button settingFixButton, string text)
         {
-            settingButton.BackColor = Color.PaleGreen.AdaptBackColor();
+            settingButton.BackColor = OtherColors.BrightGreen;
             settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
             settingButton.Text = text;
             settingFixButton.Visible = false;
@@ -590,7 +590,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// </summary>
         private static void RenderSettingUnset(Button settingButton, Button settingFixButton, string text)
         {
-            settingButton.BackColor = Color.LavenderBlush.AdaptBackColor();
+            settingButton.BackColor = OtherColors.BrightRed;
             settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
             settingButton.Text = text;
             settingFixButton.Visible = true;
@@ -598,7 +598,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private static void RenderSettingNotRecommended(Button settingButton, Button settingFixButton, string text)
         {
-            settingButton.BackColor = Color.Coral.AdaptBackColor();
+            settingButton.BackColor = OtherColors.BrightYellow;
             settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
             settingButton.Text = text;
             settingFixButton.Visible = true;

--- a/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.HelperDialogs
+﻿using GitExtUtils.GitUI.Theming;
+
+namespace GitUI.HelperDialogs
 {
     partial class FormResetCurrentBranch
     {
@@ -91,7 +93,7 @@
             // Soft
             // 
             Soft.AutoSize = true;
-            Soft.BackColor = Color.FromArgb(((int)(((byte)(128)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
+            Soft.BackColor = OtherColors.BrightGreen;
             Soft.Checked = true;
             Soft.Dock = DockStyle.Fill;
             Soft.Location = new Point(3, 3);
@@ -105,7 +107,7 @@
             // Mixed
             // 
             Mixed.AutoSize = true;
-            Mixed.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
+            Mixed.BackColor = OtherColors.BrightYellow;
             Mixed.Dock = DockStyle.Fill;
             Mixed.Location = new Point(3, 45);
             Mixed.Name = "Mixed";
@@ -119,7 +121,7 @@
             // Keep
             // 
             Keep.AutoSize = true;
-            Keep.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
+            Keep.BackColor = OtherColors.BrightYellow;
             Keep.Dock = DockStyle.Fill;
             Keep.Location = new Point(3, 87);
             Keep.Name = "Keep";
@@ -133,7 +135,7 @@
             // Merge
             // 
             Merge.AutoSize = true;
-            Merge.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
+            Merge.BackColor = OtherColors.BrightYellow;
             Merge.Dock = DockStyle.Fill;
             Merge.Location = new Point(3, 129);
             Merge.Name = "Merge";
@@ -147,7 +149,7 @@
             // Hard
             // 
             Hard.AutoSize = true;
-            Hard.BackColor = Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(128)))));
+            Hard.BackColor = OtherColors.BrightRed;
             Hard.Dock = DockStyle.Fill;
             Hard.Location = new Point(3, 171);
             Hard.Name = "Hard";

--- a/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -31,16 +31,11 @@ namespace GitUI.HelperDialogs
             Revision = revision;
 
             InitializeComponent();
-            Soft.BackColor.AdaptBackColor();
             Soft.SetForeColorForBackColor();
-            Hard.BackColor.AdaptBackColor();
-            Hard.SetForeColorForBackColor();
-            Mixed.BackColor.AdaptBackColor();
             Mixed.SetForeColorForBackColor();
-            Merge.BackColor.AdaptBackColor();
-            Merge.SetForeColorForBackColor();
-            Keep.BackColor.AdaptBackColor();
-            Keep.SetForeColorForBackColor();
+            Keep.ForeColor = Mixed.ForeColor;
+            Merge.ForeColor = Mixed.ForeColor;
+            Hard.SetForeColorForBackColor();
             InitializeComplete();
 
             switch (resetType)


### PR DESCRIPTION
## Proposed changes

Use the same colors in the settings check as in reset branch. These colors also look OK in dark mode.

Use a common definition of the bright colors.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/a0a9a3af-d418-4436-be76-024fb3307ae8)

Unchanged
![image](https://github.com/user-attachments/assets/8f7a5b37-31d0-4794-80f2-bd518eb3f778)

### After

![image](https://github.com/user-attachments/assets/2e1622fd-6b1f-4ca5-aeea-2dab523d5d8b)

Good enough for me in dark mode (can be tuned to be slightly darker but better than adapting current colors, there are less colors to customize if that is done).

![image](https://github.com/user-attachments/assets/91358e4f-d724-4b1e-89f5-cd0c37a25bbe)

![image](https://github.com/user-attachments/assets/2d0d920a-4e4a-4cf0-abe2-96f9929a9b42)

As a reference, the adapted colors in dark mode

![image](https://github.com/user-attachments/assets/0bb84579-5cc7-4a19-a4e0-83b411196b0e)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
