### PR TITLE
fix: catch plugin settings load exceptions

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -1,4 +1,5 @@
-﻿using GitExtensions.Extensibility.Plugins;
+﻿using GitExtensions.Extensibility;
+using GitExtensions.Extensibility.Plugins;
 using GitExtensions.Extensibility.Settings;
 using Microsoft;
 
@@ -28,7 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
             }
             catch (Exception ex)
             {
-                throw new Exception($"Cannot load settings for plugin {_gitPlugin?.Name ?? "unknown"}", ex);
+                throw new ExternalOperationException(command: $"Cannot load settings for plugin {_gitPlugin?.Name ?? "unknown"}", innerException: ex);
             }
         }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -17,11 +17,18 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
         private void CreateSettingsControls()
         {
-            IEnumerable<ISetting> settings = GetSettings();
-
-            foreach (ISetting setting in settings)
+            try
             {
-                AddSettingControl(setting.CreateControlBinding());
+                IEnumerable<ISetting> settings = GetSettings();
+
+                foreach (ISetting setting in settings)
+                {
+                    AddSettingControl(setting.CreateControlBinding());
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Cannot load settings for plugin {_gitPlugin?.Name ?? "unknown"}", ex);
             }
         }
 


### PR DESCRIPTION
Some info to debug #12212 etc
The most common NBug after Windows update issues and Git reporting errors.

## Proposed changes

The exception does not even contain the plugin that fails right now.
More info can be added?

## Test methodology <!-- How did you ensure quality? -->

Added throw to see the message appeared.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
