### PR TITLE
fix(AppSettings): Reset git version after storing

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -335,7 +335,11 @@ namespace GitCommands
             }
             set
             {
-                GitVersion.ResetVersion();
+                if (GitCommandValue == value)
+                {
+                    return;
+                }
+
                 if (IsPortable())
                 {
                     SetString("gitcommand", value);
@@ -344,6 +348,8 @@ namespace GitCommands
                 {
                     WriteStringRegValue("gitcommand", value);
                 }
+
+                GitVersion.ResetVersion();
             }
         }
 


### PR DESCRIPTION
Fixes that AppSettings continues to use the version of the previous git executable

## Proposed changes

- fix(AppSettings): Reset git version **after** storing 
- perf(AppSettings): Run "git --version" only if a different git executable has been set

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).