### PR TITLE
fix(BlameControl): Avoid negative number of spaces

### DIFF
--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -467,7 +467,7 @@ namespace GitUI.Blame
                 authorLineBuilder.Append(line.Commit.FileName);
             }
 
-            authorLineBuilder.Append(' ', lineLength - authorLineBuilder.Length).AppendLine();
+            authorLineBuilder.Append(' ', Math.Max(0, lineLength - authorLineBuilder.Length)).AppendLine();
 
             return authorLineBuilder.ToString();
         }

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -119,6 +119,17 @@ namespace GitUITests.UserControls
         }
 
         [Test]
+        public void BuildAuthorLine_DoNotPadIfNotNeeded()
+        {
+            StringBuilder line = new();
+
+            _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, 5, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
+                "fileName.txt", true, false, false, false);
+
+            line.ToString().Should().StartWith("author1");
+        }
+
+        [Test]
         public void BuildBlameContents_WithDateAndTime()
         {
             bool originalValue = AppSettings.BlameShowAuthorTime;


### PR DESCRIPTION
Fixes #12242

## Proposed changes

- BlameControl: Avoid negative number of spaces appended to author line (in case length estimation was too low)

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).