### PR TITLE
build: Embed AutoCompleteRegexes as raw string literal

### DIFF
--- a/src/app/GitExtensions/GitExtensions.csproj
+++ b/src/app/GitExtensions/GitExtensions.csproj
@@ -44,9 +44,4 @@
     <ProjectReference Include="..\ResourceManager\ResourceManager.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Remove="AutoCompleteRegexes.txt" />
-    <EmbeddedResource Include="AutoCompleteRegexes.txt" />
-  </ItemGroup>
-
 </Project>

--- a/src/app/GitUI/AutoCompletion/AutoCompleteRegexes.cs
+++ b/src/app/GitUI/AutoCompletion/AutoCompleteRegexes.cs
@@ -1,4 +1,9 @@
-﻿.asm = ^([\w]+):
+﻿namespace GitUI.AutoCompletion;
+
+internal static class AutoCompleteRegexes
+{
+    internal const string Default = """
+.asm = ^([\w]+):
 .au3, .auh = Func\s+([\w]+)|\$([\w]+)
 .bas, .frm, .cls = ^\s*(?:(?:Public (?:Default )?|Private )?(?:Sub|Function|Property Get|Property Set|Property Let) ?)(\w+)\(|^Attribute VB_Name = "(\w+)"
 .bat = ^\:(\w+)|^set\s+(\w+)
@@ -18,3 +23,5 @@
 .sd = ^\s*(?:procedure|function)\s+(\w+)
 .vb, .vb6 = (?:class|function|sub)\s+(\w+)(?:\s*(?:[\(\']|$))
 .xaml = \sname\s*=\s*\"(\w+)\"
+""";
+}

--- a/src/app/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/src/app/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Git;
@@ -116,22 +115,7 @@ namespace GitUI.AutoCompletion
                 return File.ReadLines(path);
             }
 
-            Assembly entryAssembly = Assembly.GetEntryAssembly();
-
-            if (entryAssembly is null)
-            {
-                // This will be null during integration tests, for example
-                return Enumerable.Empty<string>();
-            }
-
-            Stream? s = entryAssembly.GetManifestResourceStream("GitExtensions.AutoCompleteRegexes.txt");
-
-            if (s is null)
-            {
-                throw new NotImplementedException("Please add AutoCompleteRegexes.txt file into .csproj");
-            }
-
-            using StreamReader sr = new(s);
+            using StreamReader sr = new(AutoCompleteRegexes.Default);
             return sr.ReadToEnd().Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/UI.IntegrationTests.csproj
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/UI.IntegrationTests.csproj
@@ -14,11 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="AutoCompleteRegexes.txt" />
-    <EmbeddedResource Include="..\..\..\..\src\app\GitExtensions\AutoCompleteRegexes.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="MEF\MockGenericBuildServerSettingsUserControl.Designer.cs">
       <SubType>UserControl</SubType>
     </Compile>


### PR DESCRIPTION
Fixes #12226

## Proposed changes

- Embed default `AutoCompleteRegexes.txt` as raw string literal instead of as resource file in order to be able to use them in tests, too

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).