### PR TITLE
fix(FileStatusList): status for renamed in branch diffs

### DIFF
--- a/src/app/GitCommands/Git/GitItemStatusNameEqualityComparer.cs
+++ b/src/app/GitCommands/Git/GitItemStatusNameEqualityComparer.cs
@@ -3,18 +3,32 @@
 namespace GitCommands.Git
 {
     /// <summary>
-    /// Compares the file names/>.
+    /// Compares the file names
     /// </summary>
     public class GitItemStatusNameEqualityComparer : EqualityComparer<GitItemStatus?>
     {
         public override bool Equals(GitItemStatus? x, GitItemStatus? y)
         {
-            return x?.Name == y?.Name;
+            if (x is null && y is null)
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return x.Name == y.Name
+                || (!string.IsNullOrWhiteSpace(x.OldName) && x.OldName == y.Name)
+                || (!string.IsNullOrWhiteSpace(y.OldName) && x.Name == y.OldName)
+                || (!string.IsNullOrWhiteSpace(x.OldName) && !string.IsNullOrWhiteSpace(y.OldName) && x.OldName == y.OldName);
         }
 
         public override int GetHashCode(GitItemStatus? obj)
         {
-            return obj?.Name?.GetHashCode() ?? 0;
+            // as renamed is an "or", hash cannot be used to compare
+            return 0;
         }
     }
 }

--- a/src/app/GitCommands/Git/GitItemStatusNameEqualityComparer.cs
+++ b/src/app/GitCommands/Git/GitItemStatusNameEqualityComparer.cs
@@ -3,7 +3,7 @@
 namespace GitCommands.Git
 {
     /// <summary>
-    /// Compares the file names
+    /// Compares the file names.
     /// </summary>
     public class GitItemStatusNameEqualityComparer : EqualityComparer<GitItemStatus?>
     {

--- a/src/app/GitExtensions.Extensibility/Git/GitItemStatus.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitItemStatus.cs
@@ -312,11 +312,11 @@ public sealed class GitItemStatus
 
         if (IsRenamed)
         {
-            str.Append("Renamed\n   ").Append(OldName).Append("\nto\n   ").Append(Name);
+            str.Append("Renamed\n   ").Append(OldName).Append("\n to\n   ").Append(Name);
         }
         else if (IsCopied)
         {
-            str.Append("Copied\n   ").Append(OldName).Append("\nto\n   ").Append(Name);
+            str.Append("Copied\n   ").Append(OldName).Append("\n to\n   ").Append(Name);
         }
         else
         {

--- a/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -229,9 +229,11 @@ namespace GitUI
             IReadOnlyList<GitItemStatus> allBaseToA = module.GetDiffFilesWithSubmodulesStatus(baseRevId, firstRev.ObjectId, firstRev.FirstParentId, cancellationToken);
 
             GitItemStatusNameEqualityComparer comparer = new();
-            List<GitItemStatus> sameBaseToAandB = allBaseToB.Intersect(allBaseToA, comparer).Except(allAToB, comparer).ToList();
-            List<GitItemStatus> onlyA = allBaseToA.Except(allBaseToB, comparer).ToList();
-            List<GitItemStatus> onlyB = allBaseToB.Except(allBaseToA, comparer).ToList();
+            List<GitItemStatus> sameBaseToAandB = [.. allBaseToB
+                .Intersect(allBaseToA, comparer)
+                .Except(allAToB.Where(i => !((i.IsRenamed || i.IsCopied) && i.RenameCopyPercentage == "100")), comparer)];
+            List<GitItemStatus> onlyA = [.. allBaseToA.Except(allBaseToB, comparer)];
+            List<GitItemStatus> onlyB = [.. allBaseToB.Except(allBaseToA, comparer)];
 
             foreach (IReadOnlyList<GitItemStatus> l in new[] { allAToB, allBaseToB, allBaseToA })
             {
@@ -246,9 +248,9 @@ namespace GitUI
                 // Always show where the change is done
                 // This means that if a file is added in A it is shown as removed in the A->B diff,
                 // but marked with A
-                return sameBaseToAandB.Any(i => i.Name == f.Name) ? DiffBranchStatus.SameChange
-                    : onlyA.Any(i => i.Name == f.Name) ? DiffBranchStatus.OnlyAChange
-                    : onlyB.Any(i => i.Name == f.Name) ? DiffBranchStatus.OnlyBChange
+                return sameBaseToAandB.Any(i => comparer.Equals(i, f)) ? DiffBranchStatus.SameChange
+                    : onlyA.Any(i => comparer.Equals(i, f)) ? DiffBranchStatus.OnlyAChange
+                    : onlyB.Any(i => comparer.Equals(i, f)) ? DiffBranchStatus.OnlyBChange
                     : DiffBranchStatus.UnequalChange;
             }
 

--- a/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -229,11 +229,10 @@ namespace GitUI
             IReadOnlyList<GitItemStatus> allBaseToA = module.GetDiffFilesWithSubmodulesStatus(baseRevId, firstRev.ObjectId, firstRev.FirstParentId, cancellationToken);
 
             GitItemStatusNameEqualityComparer comparer = new();
-            List<GitItemStatus> sameBaseToAandB = [.. allBaseToB
-                .Intersect(allBaseToA, comparer)
-                .Except(allAToB.Where(i => !((i.IsRenamed || i.IsCopied) && i.RenameCopyPercentage == "100")), comparer)];
-            List<GitItemStatus> onlyA = [.. allBaseToA.Except(allBaseToB, comparer)];
-            List<GitItemStatus> onlyB = [.. allBaseToB.Except(allBaseToA, comparer)];
+            GitItemStatus[] allAToBExceptExactRenameCopy = [.. allAToB.Where(i => !((i.IsRenamed || i.IsCopied) && i.RenameCopyPercentage == "100"))];
+            GitItemStatus[] sameBaseToAandB = [.. allBaseToB.Intersect(allBaseToA, comparer).Except(allAToBExceptExactRenameCopy, comparer)];
+            GitItemStatus[] onlyA = [.. allBaseToA.Except(allBaseToB, comparer)];
+            GitItemStatus[] onlyB = [.. allBaseToB.Except(allBaseToA, comparer)];
 
             foreach (IReadOnlyList<GitItemStatus> l in new[] { allAToB, allBaseToB, allBaseToA })
             {


### PR DESCRIPTION
## Proposed changes

When comparing status for branches, the status compared to BASE is shown as Unequal/Same/A/B.
For renamed and copied files, the old name was not used when comparing, so status was not set correctly.

## Screenshots <!-- Remove this section if PR does not change UI -->

Comparing 8863b8b46fc42b416f7493eaad35138e8c80ce41 with my private branch tmp/test-modified
 
### Before

![image](https://github.com/user-attachments/assets/3f98648a-e327-439d-a99f-e2e81972a11e)

### After

Note that the status A-B is not always the same as BASE-A/B

![image](https://github.com/user-attachments/assets/80b284e3-c622-4af1-8de4-7306f46c13ea)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
