### PR TITLE
fix(AutoCompletion): No need for StreamReader

### DIFF
--- a/src/app/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/src/app/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -115,8 +115,7 @@ namespace GitUI.AutoCompletion
                 return File.ReadLines(path);
             }
 
-            using StreamReader sr = new(AutoCompleteRegexes.Default);
-            return sr.ReadToEnd().Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
+            return AutoCompleteRegexes.Default.Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private static Dictionary<string, Regex> ParseRegexes()


### PR DESCRIPTION
Fixup for #12244

## Proposed changes

- `ReadOrInitializeAutoCompleteRegexes`: No need for `StreamReader` when using `AutoCompleteRegexes.Default`
  <br>`StreamReader` interpreted the regexes as filename 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).