### PR TITLE
fix(tests): Add missing Dispose calls to test teardown

### DIFF
--- a/tests/CommonTestUtils/TestAppSettingsAttribute.cs
+++ b/tests/CommonTestUtils/TestAppSettingsAttribute.cs
@@ -19,6 +19,7 @@ namespace CommonTestUtils
 
         public void AfterTest(ITest test)
         {
+            AppSettings.SettingsContainer.SettingsCache.Dispose();
         }
     }
 }

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRebaseTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRebaseTests.cs
@@ -18,6 +18,12 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }
 
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
         [Test]
         public void Interactive_check_enables_autosquash()
         {

--- a/tests/app/IntegrationTests/UI.IntegrationTests/GitCommands/GitModuleTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/GitCommands/GitModuleTests.cs
@@ -19,6 +19,12 @@ namespace GitCommandsTests
             Console.WriteLine("Repo path: " + _gitModule.WorkingDir);
         }
 
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _refRepo.Dispose();
+        }
+
         [Test]
         public void GetCommitCount_Should_manage_ambiguous_argument()
         {

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -92,6 +92,12 @@ namespace GitUITests.UserControls
             _blameControl.Dispose();
         }
 
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
         [TestCase(true, true, true, true, "author1 - 3/22/2010 - fileName.txt")]
         [TestCase(true, true, true, false, "3/22/2010 - author1 - fileName.txt")]
         [TestCase(false, true, true, false, "author1 - fileName.txt")]


### PR DESCRIPTION
## Proposed changes

- Dispose all `ReferenceRepository` instances
  in `OneTimeTearDown`: better late than never (i.e. but does not resolve #12238)
  otherwise, not all temp repos are deleted
- Dispose `AppSettings` cache on teardown of entire test suite

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).