### PR TITLE
feat(blame): better usage of gutter width

### DIFF
--- a/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -144,7 +144,7 @@ namespace GitUITests.UserControls
             {
                 AppSettings.BlameShowAuthorTime = true;
 
-                (string gutter, string content, List<GitUI.Editor.GitBlameEntry> _) = _blameControl.GetTestAccessor().BuildBlameContents("fileName.txt");
+                (string gutter, string content, List<GitUI.Editor.GitBlameEntry> _, int _) = _blameControl.GetTestAccessor().BuildBlameContents("fileName.txt");
 
                 content.Should().Be($"line1{Environment.NewLine}line2{Environment.NewLine}line3{Environment.NewLine}line4{Environment.NewLine}");
                 string[] gutterLines = gutter.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
@@ -173,7 +173,7 @@ namespace GitUITests.UserControls
                 AppSettings.BlameShowAuthorTime = false;
 
                 // When
-                (string gutter, string content, List<GitUI.Editor.GitBlameEntry> _) = _blameControl.GetTestAccessor().BuildBlameContents("fileName.txt");
+                (string gutter, string content, List<GitUI.Editor.GitBlameEntry> _, int _) = _blameControl.GetTestAccessor().BuildBlameContents("fileName.txt");
 
                 // Then
                 content.Should().Be($"line1{Environment.NewLine}line2{Environment.NewLine}line3{Environment.NewLine}line4{Environment.NewLine}");


### PR DESCRIPTION
by reducing width of splitter if less data is displayed in the gutter

Should prevent #12249 & #12225

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/f210300e-f985-43d5-aea1-45022eb12d2d)


### After

![image](https://github.com/user-attachments/assets/6ecacd1c-e11a-42a8-acb6-afa017319352)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
