### PR TITLE
fix: Address NU1510 warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
   <ItemGroup>
     <!-- Solution dependencies -->
     <PackageVersion Include="AdysTech.CredentialManager" Version="2.3.0" />
-    <PackageVersion Include="Atlassian.SDK" Version="13.0.0" />
     <PackageVersion Include="AppInsights.WindowsDesktop" Version="2.18.1" />
+    <PackageVersion Include="Atlassian.SDK" Version="13.0.0" />
     <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
     <PackageVersion Include="ConEmu.Core" Version="23.07.24" />
     <PackageVersion Include="EnvDTE" Version="17.0.32112.339" />
@@ -12,25 +12,23 @@
     <PackageVersion Include="GitInfo" Version="2.2.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.27.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
-    <PackageVersion Include="StrongOf" Version="1.2.4" />
-    <PackageVersion Include="System.ComponentModel.Composition" Version="6.0.0" /> <!-- Required by GitExtensions.PluginManager -->
-    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NString" Version="2.1.1" />
     <PackageVersion Include="RestSharp" Version="106.12.0" />
     <PackageVersion Include="SmartFormat" Version="3.0.0" />
+    <PackageVersion Include="StrongOf" Version="1.2.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" /> <!-- Required by GitExtensions.Plugins.AutoCompileSubmodules -->
+    <PackageVersion Include="System.ComponentModel.Composition" Version="6.0.0" /> <!-- Required by GitExtensions.PluginManager -->
     <PackageVersion Include="System.IO.Abstractions" Version="19.2.18" />
-    <PackageVersion Include="System.Reactive" Version="5.0.0" />
-    <PackageVersion Include="System.Reactive.Linq" Version="5.0.0" />
     <PackageVersion Include="System.Reactive.Interfaces" Version="5.0.0" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" /> <!-- Required by GitExtensions.Plugins.AutoCompileSubmodules -->
+    <PackageVersion Include="System.Reactive.Linq" Version="5.0.0" />
+    <PackageVersion Include="System.Reactive" Version="5.0.0" />
 
     <!-- Analyzers -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.23364.2" PrivateAssets="all" />
@@ -50,7 +48,6 @@
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="19.2.18" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" /> <!-- CVE-2019-0820, see https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
     <PackageVersion Include="Verify.NUnit" Version="20.3.0" />
     <PackageVersion Include="YamlDotNet" Version="11.2.1" />
 

--- a/src/plugins/AutoCompileSubmodules/GitExtensions.Plugins.AutoCompileSubmodules.csproj
+++ b/src/plugins/AutoCompileSubmodules/GitExtensions.Plugins.AutoCompileSubmodules.csproj
@@ -5,11 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" />
-    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\app\GitExtUtils\GitExtUtils.csproj">
       <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
       <Private>false</Private>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -11,9 +11,4 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- CVE-2019-0820, see https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
-    <PackageReference Include="System.Text.RegularExpressions" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Proposed changes

error NU1510: Warning As Error: PackageReference X.Y.Z will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.

related to https://github.com/gitextensions/gitextensions/pull/12111#issuecomment-2709403043
separated

By @RussKie (I just try to keep  #12111 with changes only affecting dark mode to keep it reviewable)

## Test methodology <!-- How did you ensure quality? -->

Build

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
