### PR TITLE
fix(tests): Serialize execution; Load and create default settings file

### DIFF
--- a/src/app/GitCommands/Settings/SettingsCache.cs
+++ b/src/app/GitCommands/Settings/SettingsCache.cs
@@ -57,7 +57,7 @@ namespace GitCommands
             LockedAction(SaveImpl);
         }
 
-        private void Load()
+        public void Load()
         {
             LockedAction(() =>
                 {

--- a/tests/CommonTestUtils/TestAppSettingsAttribute.cs
+++ b/tests/CommonTestUtils/TestAppSettingsAttribute.cs
@@ -7,10 +7,14 @@ namespace CommonTestUtils
     [AttributeUsage(AttributeTargets.Assembly)]
     public sealed class TestAppSettingsAttribute : Attribute, ITestAction
     {
+        private readonly Semaphore _semaphore = new(initialCount: 1, maximumCount: 1, "GitExtensionsTestAssemblySerializer");
+
         public ActionTargets Targets => ActionTargets.Suite;
 
         public void BeforeTest(ITest test)
         {
+            _semaphore.WaitOne();
+
             File.Delete(AppSettings.SettingsContainer.SettingsCache.SettingsFilePath);
             AppSettings.SettingsContainer.SettingsCache.Load();
 
@@ -24,6 +28,8 @@ namespace CommonTestUtils
         public void AfterTest(ITest test)
         {
             AppSettings.SettingsContainer.SettingsCache.Dispose();
+
+            _semaphore.Release();
         }
     }
 }

--- a/tests/CommonTestUtils/TestAppSettingsAttribute.cs
+++ b/tests/CommonTestUtils/TestAppSettingsAttribute.cs
@@ -12,9 +12,13 @@ namespace CommonTestUtils
         public void BeforeTest(ITest test)
         {
             File.Delete(AppSettings.SettingsContainer.SettingsCache.SettingsFilePath);
+            AppSettings.SettingsContainer.SettingsCache.Load();
 
             AppSettings.CheckForUpdates = false;
             AppSettings.ShowAvailableDiffTools = false;
+
+            // Create the settings file so that the SettingsCache does not think it should reload the file again and again
+            AppSettings.SettingsContainer.SettingsCache.Save();
         }
 
         public void AfterTest(ITest test)


### PR DESCRIPTION
Fixes #12252

## Proposed changes

`TestAppSettingsAttribute`:
- Serialize execution of test assembly by means of a named `Semaphore`
- Actually load & create a default `AppSettings` file

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- run tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).