### PR TITLE
fix(FileSettingsCache): The last change must win!

### DIFF
--- a/src/app/GitCommands/Settings/FileSettingsCache.cs
+++ b/src/app/GitCommands/Settings/FileSettingsCache.cs
@@ -209,7 +209,7 @@ namespace GitCommands.Settings
                 FileChanged();
             }
 
-            return !_lastFileRead.HasValue || _lastFileModificationDate > _lastFileRead.Value;
+            return !_lastFileRead.HasValue || (_lastFileModificationDate > _lastFileRead.Value && !(_lastModificationDate.HasValue && _lastModificationDate >= _lastFileModificationDate));
         }
 
         protected override void SettingsChanged()


### PR DESCRIPTION
## Proposed changes

If there are concurrent changes to the settings file (on disk vs. in app), the last action shall win.
That's why additionally check in `FileSettingsCache.NeedRefresh` whether the app has newer modifications in memory.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).