### PR TITLE
feat(CheckListSettingsPage): Improve display of git version

### DIFF
--- a/src/app/BugReporter/Info/GeneralInfo.cs
+++ b/src/app/BugReporter/Info/GeneralInfo.cs
@@ -31,7 +31,7 @@ namespace BugReporter.Info
 
             try
             {
-                GitVersion = GitCommands.GitVersion.Current?.ToString();
+                GitVersion = GitCommands.Git.GitVersion.Current?.ToString();
             }
             catch (Exception)
             {

--- a/src/app/BugReporter/UserEnvironmentInformation.cs
+++ b/src/app/BugReporter/UserEnvironmentInformation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text;
 using GitCommands;
+using GitCommands.Git;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 

--- a/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
+++ b/src/app/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands.Config;
+using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Configurations;
 

--- a/src/app/GitCommands/Git/Executable.cs
+++ b/src/app/GitCommands/Git/Executable.cs
@@ -12,7 +12,6 @@ namespace GitCommands
     {
         private readonly string _workingDir;
         private readonly Func<string> _fileNameProvider;
-        private readonly string _prefixArguments;
 
         public Executable(string fileName, string workingDir = "")
             : this(() => fileName, workingDir)
@@ -23,11 +22,12 @@ namespace GitCommands
         {
             _workingDir = workingDir;
             _fileNameProvider = fileNameProvider;
-            _prefixArguments = prefixArguments;
+            PrefixArguments = prefixArguments;
         }
 
         public string WorkingDir => _workingDir;
         public string Command => _fileNameProvider();
+        public string PrefixArguments { get; }
 
         public IProcess Start(ArgumentString arguments = default,
                               bool createWindow = false,
@@ -45,7 +45,7 @@ namespace GitCommands
 
             string fileName = _fileNameProvider();
 
-            return new ProcessWrapper(fileName, _prefixArguments, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute, throwOnErrorExit, cancellationToken);
+            return new ProcessWrapper(fileName, PrefixArguments, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute, throwOnErrorExit, cancellationToken);
         }
 
         public string GetWorkingDirectory() => _workingDir;

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -191,7 +191,7 @@ namespace GitCommands
         /// <summary>
         /// GitVersion for the default GitExecutable.
         /// </summary>
-        public IGitVersion GitVersion => GitCommands.GitVersion.CurrentVersion(GitExecutable, _wslDistro);
+        public IGitVersion GitVersion => GitCommands.GitVersion.CurrentVersion(GitExecutable);
 
         /// <inherit/>
         public IExecutable GitExecutable => _gitExecutable;

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -191,7 +191,7 @@ namespace GitCommands
         /// <summary>
         /// GitVersion for the default GitExecutable.
         /// </summary>
-        public IGitVersion GitVersion => GitCommands.GitVersion.CurrentVersion(GitExecutable);
+        public IGitVersion GitVersion => Git.GitVersion.CurrentVersion(GitExecutable);
 
         /// <inherit/>
         public IExecutable GitExecutable => _gitExecutable;
@@ -945,7 +945,7 @@ namespace GitCommands
         {
             // Use Windows Git if custom tool is selected as the list is native to the application.
             bool isWindowsGit = !string.IsNullOrWhiteSpace(customTool);
-            string gui = (isWindowsGit ? GitCommands.GitVersion.Current : GitVersion).SupportGuiMergeTool ? "--gui" : string.Empty;
+            string gui = (isWindowsGit ? Git.GitVersion.Current : GitVersion).SupportGuiMergeTool ? "--gui" : string.Empty;
             GitArgumentBuilder args = new("mergetool")
             {
                 { string.IsNullOrWhiteSpace(customTool), gui, $"--tool={customTool}" },

--- a/src/app/GitCommands/Git/GitVersion.cs
+++ b/src/app/GitCommands/Git/GitVersion.cs
@@ -3,187 +3,188 @@
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 
-namespace GitCommands
+namespace GitCommands;
+
+public class GitVersion : IComparable<GitVersion>, IGitVersion
 {
-    public class GitVersion : IComparable<GitVersion>, IGitVersion
+    private static readonly GitVersion v2_19_0 = new("2.19.0");
+    private static readonly GitVersion v2_20_0 = new("2.20.0");
+    private static readonly GitVersion v2_32_0 = new("2.32.0");
+    private static readonly GitVersion v2_35_0 = new("2.35.0");
+    private static readonly GitVersion v2_38_0 = new("2.38.0");
+
+    /// <summary>
+    /// The recommended Git version (normally latest official before a GE release).
+    /// This and later versions are green in the settings check.
+    /// </summary>
+    public static readonly GitVersion LastRecommendedVersion = new("2.46.0");
+
+    /// <summary>
+    /// The oldest version with reasonable reliable support in GE.
+    /// Older than this version is red in settings.
+    /// </summary>
+    public static readonly GitVersion LastSupportedVersion = new("2.25.0");
+
+    /// <summary>
+    /// The oldest Git version without known incompatibilities.
+    /// </summary>
+    public static readonly GitVersion LastVersionWithoutKnownLimitations = new("2.15.2");
+
+    private static readonly Dictionary<string, GitVersion> _current = [];
+
+    /// <summary>
+    /// GitVersion for the native ("Windows") Git
+    /// </summary>
+    public static IGitVersion Current => CurrentVersion();
+
+    /// <summary>
+    /// Gets the Git version for the <paramref name="gitExecutable"/>.
+    /// </summary>
+    /// <returns>A <see cref="GitVersion"/>.</returns>
+    public static IGitVersion CurrentVersion(IExecutable? gitExecutable = null)
     {
-        private static readonly GitVersion v2_19_0 = new("2.19.0");
-        private static readonly GitVersion v2_20_0 = new("2.20.0");
-        private static readonly GitVersion v2_32_0 = new("2.32.0");
-        private static readonly GitVersion v2_35_0 = new("2.35.0");
-        private static readonly GitVersion v2_38_0 = new("2.38.0");
-
-        /// <summary>
-        /// The recommended Git version (normally latest official before a GE release).
-        /// This and later versions are green in the settings check.
-        /// </summary>
-        public static readonly GitVersion LastRecommendedVersion = new("2.46.0");
-
-        /// <summary>
-        /// The oldest version with reasonable reliable support in GE.
-        /// Older than this version is red in settings.
-        /// </summary>
-        public static readonly GitVersion LastSupportedVersion = new("2.25.0");
-
-        /// <summary>
-        /// The oldest Git version without known incompatibilities.
-        /// </summary>
-        public static readonly GitVersion LastVersionWithoutKnownLimitations = new("2.15.2");
-
-        private static readonly Dictionary<string, GitVersion> _current = [];
-
-        /// <summary>
-        /// GitVersion for the native ("Windows") Git
-        /// </summary>
-        public static IGitVersion Current => CurrentVersion();
-
-        /// <summary>
-        /// Gets the Git version for the <paramref name="gitExecutable"/>.
-        /// </summary>
-        /// <returns>A <see cref="GitVersion"/>.</returns>
-        public static IGitVersion CurrentVersion(IExecutable? gitExecutable = null)
+        string gitIdentifiable = gitExecutable is null
+            ? AppSettings.GitCommand
+            : string.IsNullOrWhiteSpace(gitExecutable.PrefixArguments)
+                ? gitExecutable.Command
+                : $"{gitExecutable.Command} {gitExecutable.PrefixArguments}";
+        if (_current.TryGetValue(gitIdentifiable, out GitVersion? gitVersion) && !gitVersion.IsUnknown)
         {
-            string gitIdentifiable = gitExecutable is null
-                ? AppSettings.GitCommand
-                : string.IsNullOrWhiteSpace(gitExecutable.PrefixArguments)
-                    ? gitExecutable.Command
-                    : $"{gitExecutable.Command} {gitExecutable.PrefixArguments}";
-            if (!_current.TryGetValue(gitIdentifiable, out GitVersion? gitVersion) || gitVersion.IsUnknown)
-            {
-                gitExecutable ??= new Executable(gitIdentifiable);
-                string output = gitExecutable.GetOutput("--version");
-                gitVersion = new GitVersion(output);
-                _current[gitIdentifiable] = gitVersion;
-                if (gitVersion < LastVersionWithoutKnownLimitations)
-                {
-                    // Report the last supported version rather than the last version without known issues
-                    MessageBox.Show(null, $"{_current[gitIdentifiable]} is lower than {LastSupportedVersion}. Some commands can fail.", "Unsupported Git version", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-            }
-
             return gitVersion;
         }
 
-        public static void ResetVersion()
+        gitExecutable ??= new Executable(gitIdentifiable);
+        string output = gitExecutable.GetOutput("--version");
+        gitVersion = new GitVersion(output);
+        _current[gitIdentifiable] = gitVersion;
+        if (gitVersion < LastVersionWithoutKnownLimitations)
         {
-            _current.Clear();
+            // Report the last supported version rather than the last version without known issues
+            MessageBox.Show(null, $"{_current[gitIdentifiable]} is lower than {LastSupportedVersion}. Some commands can fail.", "Unsupported Git version", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
-        private readonly string _fullVersionMoniker;
-        private readonly int _a;
-        private readonly int _b;
-        private readonly int _c;
-        private readonly int _d;
+        return gitVersion;
+    }
 
-        public GitVersion(string? version)
+    public static void ResetVersion()
+    {
+        _current.Clear();
+    }
+
+    private readonly string _fullVersionMoniker;
+    private readonly int _a;
+    private readonly int _b;
+    private readonly int _c;
+    private readonly int _d;
+
+    public GitVersion(string? version)
+    {
+        _fullVersionMoniker = Fix();
+
+        IReadOnlyList<int> numbers = GetNumbers();
+        _a = Get(numbers, 0);
+        _b = Get(numbers, 1);
+        _c = Get(numbers, 2);
+        _d = Get(numbers, 3);
+
+        string Fix()
         {
-            _fullVersionMoniker = Fix();
-
-            IReadOnlyList<int> numbers = GetNumbers();
-            _a = Get(numbers, 0);
-            _b = Get(numbers, 1);
-            _c = Get(numbers, 2);
-            _d = Get(numbers, 3);
-
-            string Fix()
+            if (version is null)
             {
-                if (version is null)
-                {
-                    return "";
-                }
-
-                const string Prefix = "git version";
-
-                if (version.StartsWith(Prefix))
-                {
-                    return version[Prefix.Length..].Trim();
-                }
-
-                return version.Trim();
+                return "";
             }
 
-            IReadOnlyList<int> GetNumbers()
-            {
-                return ParseNumbers().ToList();
+            const string Prefix = "git version";
 
-                IEnumerable<int> ParseNumbers()
+            if (version.StartsWith(Prefix))
+            {
+                return version[Prefix.Length..].Trim();
+            }
+
+            return version.Trim();
+        }
+
+        IReadOnlyList<int> GetNumbers()
+        {
+            return ParseNumbers().ToList();
+
+            IEnumerable<int> ParseNumbers()
+            {
+                foreach (string number in _fullVersionMoniker.LazySplit('.'))
                 {
-                    foreach (string number in _fullVersionMoniker.LazySplit('.'))
+                    if (int.TryParse(number, out int value))
                     {
-                        if (int.TryParse(number, out int value))
-                        {
-                            yield return value;
-                        }
+                        yield return value;
                     }
                 }
             }
-
-            int Get(IReadOnlyList<int> values, int index)
-            {
-                return index < values.Count ? values[index] : 0;
-            }
         }
 
-        public bool SupportRebaseMerges => this >= v2_19_0;
-        public bool SupportGuiMergeTool => this >= v2_20_0;
-        public bool SupportRangeDiffTool => this >= v2_19_0;
-        public bool SupportStashStaged => this >= v2_35_0;
-        public bool SupportUpdateRefs => this >= v2_38_0;
-        public bool SupportRangeDiffPath => this >= v2_38_0;
-        public bool SupportAmendCommits => this >= v2_32_0;
-
-        public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
-
-        private static int Compare(GitVersion? left, GitVersion? right)
+        int Get(IReadOnlyList<int> values, int index)
         {
-            if (left is null && right is null)
-            {
-                return 0;
-            }
-
-            if (right is null)
-            {
-                return 1;
-            }
-
-            if (left is null)
-            {
-                return -1;
-            }
-
-            int compareA = left._a.CompareTo(right._a);
-            if (compareA != 0)
-            {
-                return compareA;
-            }
-
-            int compareB = left._b.CompareTo(right._b);
-            if (compareB != 0)
-            {
-                return compareB;
-            }
-
-            int compareC = left._c.CompareTo(right._c);
-            if (compareC != 0)
-            {
-                return compareC;
-            }
-
-            return left._d.CompareTo(right._d);
+            return index < values.Count ? values[index] : 0;
         }
+    }
 
-        public int CompareTo(GitVersion? other) => Compare(this, other);
+    public bool SupportRebaseMerges => this >= v2_19_0;
+    public bool SupportGuiMergeTool => this >= v2_20_0;
+    public bool SupportRangeDiffTool => this >= v2_19_0;
+    public bool SupportStashStaged => this >= v2_35_0;
+    public bool SupportUpdateRefs => this >= v2_38_0;
+    public bool SupportRangeDiffPath => this >= v2_38_0;
+    public bool SupportAmendCommits => this >= v2_32_0;
 
-        public int CompareTo(IGitVersion? other) => Compare(this, other as GitVersion);
+    public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 
-        public static bool operator >(GitVersion left, GitVersion right) => Compare(left, right) > 0;
-        public static bool operator <(GitVersion left, GitVersion right) => Compare(left, right) < 0;
-        public static bool operator >=(GitVersion left, GitVersion right) => Compare(left, right) >= 0;
-        public static bool operator <=(GitVersion left, GitVersion right) => Compare(left, right) <= 0;
-
-        public override string ToString()
+    private static int Compare(GitVersion? left, GitVersion? right)
+    {
+        if (left is null && right is null)
         {
-            return _fullVersionMoniker;
+            return 0;
         }
+
+        if (right is null)
+        {
+            return 1;
+        }
+
+        if (left is null)
+        {
+            return -1;
+        }
+
+        int compareA = left._a.CompareTo(right._a);
+        if (compareA != 0)
+        {
+            return compareA;
+        }
+
+        int compareB = left._b.CompareTo(right._b);
+        if (compareB != 0)
+        {
+            return compareB;
+        }
+
+        int compareC = left._c.CompareTo(right._c);
+        if (compareC != 0)
+        {
+            return compareC;
+        }
+
+        return left._d.CompareTo(right._d);
+    }
+
+    public int CompareTo(GitVersion? other) => Compare(this, other);
+
+    public int CompareTo(IGitVersion? other) => Compare(this, other as GitVersion);
+
+    public static bool operator >(GitVersion left, GitVersion right) => Compare(left, right) > 0;
+    public static bool operator <(GitVersion left, GitVersion right) => Compare(left, right) < 0;
+    public static bool operator >=(GitVersion left, GitVersion right) => Compare(left, right) >= 0;
+    public static bool operator <=(GitVersion left, GitVersion right) => Compare(left, right) <= 0;
+
+    public override string ToString()
+    {
+        return _fullVersionMoniker;
     }
 }

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using GitCommands.Git;
 using GitCommands.Settings;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;

--- a/src/app/GitExtensions.Extensibility/IExecutable.cs
+++ b/src/app/GitExtensions.Extensibility/IExecutable.cs
@@ -10,6 +10,7 @@ public interface IExecutable
 {
     public string WorkingDir { get; }
     public string Command { get; }
+    public string PrefixArguments { get; }
 
     /// <summary>
     /// Starts a process of this executable.

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using GitCommands;
 using GitCommands.Config;
+using GitCommands.Git;
 using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands;
+using GitCommands.Git;
 using GitCommands.Utils;
 using GitExtensions.Extensibility.Git;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -1,6 +1,7 @@
 ﻿using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
+using GitCommands.Git;
 using GitCommands.Utils;
 using GitExtensions.Extensibility.Translations;
 using GitExtUtils.GitUI.Theming;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -3,6 +3,7 @@ using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Git;
 using GitCommands.Utils;
+using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Translations;
 using GitExtUtils.GitUI.Theming;
 using GitUI.CommandsDialogs.SettingsDialog.ShellExtension;
@@ -423,19 +424,23 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return false;
             }
 
-            if (GitVersion.Current < GitVersion.LastSupportedVersion)
+            IGitVersion nativeGitVersion = GitVersion.Current;
+            IGitVersion usedGitVersion = ServiceProvider is IGitUICommands uiCommands && uiCommands.Module.IsValidGitWorkingDir() ? GitVersion.CurrentVersion(uiCommands.Module.GitExecutable) : nativeGitVersion;
+            string displayedVersion = nativeGitVersion == usedGitVersion ? $"{nativeGitVersion}" : $"{nativeGitVersion} / WSL {usedGitVersion}";
+
+            if (usedGitVersion < GitVersion.LastSupportedVersion)
             {
-                RenderSettingUnset(GitFound, GitFound_Fix, string.Format(_wrongGitVersion.Text, GitVersion.Current, GitVersion.LastRecommendedVersion));
+                RenderSettingUnset(GitFound, GitFound_Fix, string.Format(_wrongGitVersion.Text, displayedVersion, GitVersion.LastRecommendedVersion));
                 return false;
             }
 
-            if (GitVersion.Current < GitVersion.LastRecommendedVersion)
+            if (usedGitVersion < GitVersion.LastRecommendedVersion)
             {
-                RenderSettingNotRecommended(GitFound, GitFound_Fix, string.Format(_notRecommendedGitVersion.Text, GitVersion.Current, GitVersion.LastRecommendedVersion));
+                RenderSettingNotRecommended(GitFound, GitFound_Fix, string.Format(_notRecommendedGitVersion.Text, displayedVersion, GitVersion.LastRecommendedVersion));
                 return false;
             }
 
-            RenderSettingSet(GitFound, GitFound_Fix, string.Format(_gitVersionFound.Text, GitVersion.Current));
+            RenderSettingSet(GitFound, GitFound_Fix, string.Format(_gitVersionFound.Text, displayedVersion));
             return true;
         }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+﻿using GitCommands.Git;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using GitCommands;
+using GitCommands.Git;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 using GitExtUtils.GitUI.Theming;

--- a/src/app/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
+++ b/src/app/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands;
+using GitCommands.Git;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 

--- a/src/app/GitUI/UserEnvironmentInformation.cs
+++ b/src/app/GitUI/UserEnvironmentInformation.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using GitCommands;
+using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtUtils;
 using GitExtUtils.GitUI;

--- a/tests/CommonTestUtils/MockExecutable.cs
+++ b/tests/CommonTestUtils/MockExecutable.cs
@@ -15,6 +15,7 @@ namespace CommonTestUtils
 
         public string Command => "mock-git.exe";
         public string WorkingDir => ".";
+        public string PrefixArguments => "";
 
         public IDisposable StageOutput(string arguments, string output, int? exitCode = 0, string? error = null)
         {

--- a/tests/app/UnitTests/BugReporter.Tests/UserEnvironmentInformationTests.cs
+++ b/tests/app/UnitTests/BugReporter.Tests/UserEnvironmentInformationTests.cs
@@ -1,5 +1,5 @@
 ﻿using BugReporter;
-using GitCommands;
+using GitCommands.Git;
 
 namespace BugReporterTests
 {

--- a/tests/app/UnitTests/GitCommands.Tests/DiffMergeTools/DiffMergeToolConfigurationManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/DiffMergeTools/DiffMergeToolConfigurationManagerTests.cs
@@ -2,6 +2,7 @@
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
+using GitCommands.Git;
 using GitExtensions.Extensibility.Configurations;
 using NSubstitute;
 

--- a/tests/app/UnitTests/GitUI.Tests/UserEnvironmentInformationTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserEnvironmentInformationTests.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+﻿using GitCommands.Git;
 using GitUI;
 
 namespace GitUITests


### PR DESCRIPTION
Addresses https://github.com/gitextensions/gitextensions/pull/12185#issuecomment-2683482362

## Proposed changes

ChecklistSettingsPage:
- Check _used_ git version
- Display versions of used git (WSL) and of configured native git (if different)

GitVersion:
- Simplify by always identifying the `GitVersion` by means of `gitExecutable.Command + gitExecutable.PrefixArguments`
- Reduce dictionary lookups and handle exceptions
- Unindent namespace
- Exit early
- Apply code style

IExecutable:
- Add property `PrefixArguments`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/b5c0eb5b-46f3-429e-9f50-88ea1eaf4260)

### After

![image](https://github.com/user-attachments/assets/c859e9f3-396a-48fb-9e59-e50a33b7fe11)

## Test methodology <!-- How did you ensure quality? -->

- manual
- to be tested with real WSL, please

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).