### PR TITLE
feat(FormCommit): Add hidden setting for word wrap in message editor

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -488,6 +488,8 @@ namespace GitCommands
             set => DetailedSettingsPath.SetEnum("CommitInfoPosition", value);
         }
 
+        public static ISetting<bool> MessageEditorWordWrap => Setting.Create(DetailedSettingsPath, nameof(MessageEditorWordWrap), false);
+
         public static bool ShowSplitViewLayout
         {
             get => DetailedSettingsPath.GetBool("ShowSplitViewLayout", true);

--- a/src/app/GitUI/SpellChecker/EditNetSpell.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.cs
@@ -68,7 +68,14 @@ namespace GitUI.SpellChecker
 
             _wordAtCursorExtractor = new WordAtCursorExtractor();
 
-            _ = new TextBoxSilencer(TextBox);
+            if (AppSettings.MessageEditorWordWrap.Value)
+            {
+                TextBox.WordWrap = true;
+            }
+            else
+            {
+                _ = new TextBoxSilencer(TextBox);
+            }
         }
 
         public override string Text

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -198,6 +198,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.UseDiffViewerForBlame)], false, false, true);
                 yield return (properties[nameof(AppSettings.ShowGpgInformation)], true, false, true);
 
+                yield return (properties[nameof(AppSettings.MessageEditorWordWrap)], false, isNotNullable, isISetting);
                 yield return (properties[nameof(AppSettings.ShowSplitViewLayout)], true, false, false);
                 yield return (properties[nameof(AppSettings.ProvideAutocompletion)], true, false, false);
                 yield return (properties[nameof(AppSettings.TruncatePathMethod)], TruncatePathMethod.None, false, false);


### PR DESCRIPTION
Fixes #12263

## Proposed changes

Add hidden setting for enabling word wrap in `EditNetSpell`.
Can be enabled by adding the following section to your `%APPDATA%\GitExtensions\GitExtensions\GitExtensions.settings` file:
```
  <item>
    <key>
      <string>Detailed.MessageEditorWordWrap</string>
    </key>
    <value>
      <string>True</string>
    </value>
  </item>
```

Then `TextBoxSilencer` (which avoids "ding" sounds) cannot be activated because it conflicts with word wrap.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/437ef5b6-a117-4c09-8597-12400b292d64)

### After

![image](https://github.com/user-attachments/assets/93fcb502-8adc-40fa-a06e-ea794a672190)

## Test methodology <!-- How did you ensure quality? -->

- manual

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).