### PR TITLE
fix(RevisionGraph): Correctly handle partly visible initial revision

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/Rendering/GraphCache.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/Rendering/GraphCache.cs
@@ -31,7 +31,7 @@ internal sealed class GraphCache
     internal void AdjustCapacity(int capacity)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
-        Capacity = capacity;
+        Capacity = Math.Max(Capacity, capacity);
     }
 
     internal void Allocate(int width, int height)


### PR DESCRIPTION
Fixes graph glitch after scrolling a partly visible bottom line into view

## Proposed changes

- `GraphCache`: Do not shrink `Capacity` in order to not make `Count` invalid f.i.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/29fddc10-fa34-447f-abfe-a1901fa9901b)

![image](https://github.com/user-attachments/assets/da40fc05-c20c-49ce-be5d-b4b0c0c00883)

### After

![image](https://github.com/user-attachments/assets/61eb6471-2f2e-460c-84a3-cdc7116b636b)

## Test methodology <!-- How did you ensure quality? -->

- manual

### Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).