### PR TITLE
Allow customise colors of remotes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# Instructions for GitHub and VisualStudio Copilot
+### https://github.blog/changelog/2025-01-21-custom-repository-instructions-are-now-available-for-copilot-on-github-com-public-preview/
+
+
+## General
+
+* Make only high confidence suggestions when reviewing code changes.
+* Always use the latest version C#, currently C# 13 features.
+* Files must have CRLF line endings.
+
+## Formatting
+
+* Apply code-formatting style defined in `.editorconfig`.
+* Prefer file-scoped namespace declarations and single-line using directives.
+* Insert a newline before the opening curly brace of any code block (e.g., after `if`, `for`, `while`, `foreach`, `using`, `try`, etc.).
+* Ensure that the final return statement of a method is on its own line.
+* Use pattern matching and switch expressions wherever possible.
+* Use `nameof` instead of string literals when referring to member names.
+
+### **Variable Declarations:**  
+
+*  Never use `var` for primitive types. Use `var` only when the type is obvious from context. When in doubt, opt for an explicit type declaration.
+* Prefer simplified "new()" construct over to "new MyType()" where the type is already declared.
+  For example: "MyType t = new()" instead of "var t = new MyType()" or "MyType t = new MyType()".
+
+### Nullable Reference Types
+
+* Declare variables non-nullable, and check for `null` at entry points.
+* Always use `is null` or `is not null` instead of `== null` or `!= null`.
+* Trust the C# null annotations and don't add null checks when the type system says a value cannot be null.
+
+
+### Testing
+
+* We use NUnit SDK
+* Do not emit "Act", "Arrange" or "Assert" comments.
+* The test names must follow snake-casing in the suffix BUT keeping the methods under test intact.
+  For example, a test for a method "MyMethod" should be named as "MyMethod_should_return_expected".
+* Use NSubstitute for mocking.
+* Use FluentAssertions for assertions.

--- a/src/app/GitCommands/Config/SettingKeyString.cs
+++ b/src/app/GitCommands/Config/SettingKeyString.cs
@@ -17,6 +17,11 @@
         public static string CredentialHelper = "credential.helper";
 
         /// <summary>
+        /// "remote.{0}.color"
+        /// </summary>
+        public static string RemoteColor = "remote.{0}.color";
+
+        /// <summary>
         /// "remote.{0}.push"
         /// </summary>
         public static string RemotePush = "remote.{0}.push";

--- a/src/app/GitCommands/Remotes/ConfigFileRemote.cs
+++ b/src/app/GitCommands/Remotes/ConfigFileRemote.cs
@@ -5,6 +5,11 @@ namespace GitCommands.Remotes
     public class ConfigFileRemote
     {
         /// <summary>
+        /// Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemoteColor"/> key.
+        /// </summary>
+        public string? Color { get; set; }
+
+        /// <summary>
         /// Gets or sets value indicating whether the remote is enabled or not.
         /// If remote section is [remote branch] then it is considered enabled, if it is [-remote branch] then it is disabled.
         /// </summary>

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using GitExtensions.Extensibility.Configurations;
 using GitExtensions.Extensibility.Settings;
@@ -17,6 +18,19 @@ public interface IGitModule
     IReadOnlyList<IGitRef> GetRefs(RefsFilter getRef);
     IEnumerable<string> GetSettings(string setting);
     IEnumerable<INamedGitItem> GetTree(ObjectId? commitId, bool full);
+
+    /// <summary>
+    ///  Loads the user-defined colors for the remote branches specific for the current repository.
+    /// </summary>
+    /// <returns>
+    ///  The user-defined colors for the remote branches specific for the current repository.
+    /// </returns>
+    FrozenDictionary<string, Color> GetRemoteColors();
+
+    /// <summary>
+    /// Resets the colors of the remote to their default values.
+    /// </summary>
+    void ResetRemoteColors();
 
     /// <summary>
     /// Removes the registered remote by running <c>git remote rm</c> command.

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1688,6 +1688,9 @@ namespace GitUI.CommandsDialogs
 
             repoObjectsTree.ClearTrees();
 
+            // Reset branch colors whenever we open a new repository
+            e.GitModule.ResetRemoteColors();
+
             UICommands = UICommands.WithGitModule(e.GitModule);
             if (Module.IsValidGitWorkingDir())
             {

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -140,11 +140,11 @@ namespace GitUI.CommandsDialogs
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 110F));
-            tblpnlMgtDetails.Controls.Add(label1, 0, 0);
-            tblpnlMgtDetails.Controls.Add(RemoteName, 1, 0);
-            tblpnlMgtDetails.Controls.Add(label2, 0, 1);
-            tblpnlMgtDetails.Controls.Add(Url, 1, 1);
-            tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 1);
+            tblpnlMgtDetails.Controls.Add(label2, 0, 0);
+            tblpnlMgtDetails.Controls.Add(Url, 1, 0);
+            tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 0);
+            tblpnlMgtDetails.Controls.Add(label1, 0, 1);
+            tblpnlMgtDetails.Controls.Add(RemoteName, 1, 1);
             tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 2);
             tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 3);
             tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 3);
@@ -166,7 +166,7 @@ namespace GitUI.CommandsDialogs
             label1.MinimumSize = new Size(100, 0);
             label1.Name = "label1";
             label1.Size = new Size(100, 29);
-            label1.TabIndex = 0;
+            label1.TabIndex = 3;
             label1.Text = "Name";
             label1.TextAlign = ContentAlignment.MiddleLeft;
             // 
@@ -176,7 +176,7 @@ namespace GitUI.CommandsDialogs
             RemoteName.Location = new Point(109, 3);
             RemoteName.Name = "RemoteName";
             RemoteName.Size = new Size(248, 23);
-            RemoteName.TabIndex = 1;
+            RemoteName.TabIndex = 4;
             RemoteName.TextChanged += RemoteName_TextChanged;
             RemoteName.Enter += RemoteName_Enter;
             // 
@@ -186,7 +186,7 @@ namespace GitUI.CommandsDialogs
             label2.Location = new Point(3, 29);
             label2.Name = "label2";
             label2.Size = new Size(100, 31);
-            label2.TabIndex = 2;
+            label2.TabIndex = 0;
             label2.Text = "Url";
             label2.TextAlign = ContentAlignment.MiddleLeft;
             // 
@@ -199,7 +199,7 @@ namespace GitUI.CommandsDialogs
             Url.Location = new Point(109, 33);
             Url.Name = "Url";
             Url.Size = new Size(248, 23);
-            Url.TabIndex = 3;
+            Url.TabIndex = 1;
             Url.Enter += Url_Enter;
             // 
             // folderBrowserButtonUrl
@@ -212,7 +212,7 @@ namespace GitUI.CommandsDialogs
             folderBrowserButtonUrl.Name = "folderBrowserButtonUrl";
             folderBrowserButtonUrl.PathShowingControl = Url;
             folderBrowserButtonUrl.Size = new Size(104, 25);
-            folderBrowserButtonUrl.TabIndex = 4;
+            folderBrowserButtonUrl.TabIndex = 2;
             // 
             // checkBoxSepPushUrl
             // 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Windows.Forms;
+
 namespace GitUI.CommandsDialogs
 {
     partial class FormRemotes
@@ -30,27 +32,31 @@ namespace GitUI.CommandsDialogs
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            ListViewGroup listViewGroup2 = new ListViewGroup("ListViewGroup", HorizontalAlignment.Left);
+            FlowLayoutPanel flowLayoutPanelSsh;
+            ListViewGroup listViewGroup1 = new ListViewGroup("ListViewGroup", HorizontalAlignment.Left);
+            TestConnection = new Button();
+            LoadSSHKey = new Button();
+            flpnlRemoteColors = new FlowLayoutPanel();
+            btnRemoteColor = new Button();
+            btnRemoteColorReset = new Button();
             flpnlRemoteManagement = new TableLayoutPanel();
             pnlMgtDetails = new Panel();
             tblpnlMgtDetails = new TableLayoutPanel();
+            label2 = new Label();
+            Url = new GitUI.UserControls.CaseSensitiveComboBox();
+            folderBrowserButtonUrl = new GitUI.UserControls.FolderBrowserButton();
             label1 = new Label();
             RemoteName = new TextBox();
-            label2 = new Label();
-            Url = new UserControls.CaseSensitiveComboBox();
-            folderBrowserButtonUrl = new UserControls.FolderBrowserButton();
+            lblRemoteColor = new Label();
             checkBoxSepPushUrl = new CheckBox();
             labelPushUrl = new Label();
-            comboBoxPushUrl = new UserControls.CaseSensitiveComboBox();
-            folderBrowserButtonPushUrl = new UserControls.FolderBrowserButton();
+            comboBoxPushUrl = new GitUI.UserControls.CaseSensitiveComboBox();
+            folderBrowserButtonPushUrl = new GitUI.UserControls.FolderBrowserButton();
             pnlMgtPuttySsh = new Panel();
             tableLayoutPanel1 = new TableLayoutPanel();
             label3 = new Label();
             PuttySshKey = new TextBox();
             SshBrowse = new Button();
-            flowLayoutPanel3 = new FlowLayoutPanel();
-            TestConnection = new Button();
-            LoadSSHKey = new Button();
             lblMgtPuttyPanelHeader = new Label();
             lblHeaderLine2 = new Label();
             flowLayoutPanel2 = new FlowLayoutPanel();
@@ -64,7 +70,7 @@ namespace GitUI.CommandsDialogs
             tabControl1 = new TabControl();
             tabPage1 = new TabPage();
             panel1 = new Panel();
-            Remotes = new UserControls.NativeListView();
+            Remotes = new GitUI.UserControls.NativeListView();
             columnHeader1 = new ColumnHeader();
             tabPage2 = new TabPage();
             tableLayoutPanel2 = new TableLayoutPanel();
@@ -81,12 +87,15 @@ namespace GitUI.CommandsDialogs
             RemoteCombo = new DataGridViewTextBoxColumn();
             MergeWith = new DataGridViewTextBoxColumn();
             toolTip1 = new ToolTip(components);
+            colorDialog = new ColorDialog();
+            flowLayoutPanelSsh = new FlowLayoutPanel();
+            flowLayoutPanelSsh.SuspendLayout();
+            flpnlRemoteColors.SuspendLayout();
             flpnlRemoteManagement.SuspendLayout();
             pnlMgtDetails.SuspendLayout();
             tblpnlMgtDetails.SuspendLayout();
             pnlMgtPuttySsh.SuspendLayout();
             tableLayoutPanel1.SuspendLayout();
-            flowLayoutPanel3.SuspendLayout();
             flowLayoutPanel2.SuspendLayout();
             pnlManagementContainer.SuspendLayout();
             gbMgtPanel.SuspendLayout();
@@ -99,6 +108,91 @@ namespace GitUI.CommandsDialogs
             panelDetails.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)RemoteBranches).BeginInit();
             SuspendLayout();
+            // 
+            // flowLayoutPanelSsh
+            // 
+            flowLayoutPanelSsh.AutoSize = true;
+            flowLayoutPanelSsh.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel1.SetColumnSpan(flowLayoutPanelSsh, 2);
+            flowLayoutPanelSsh.Controls.Add(TestConnection);
+            flowLayoutPanelSsh.Controls.Add(LoadSSHKey);
+            flowLayoutPanelSsh.Dock = DockStyle.Fill;
+            flowLayoutPanelSsh.FlowDirection = FlowDirection.RightToLeft;
+            flowLayoutPanelSsh.Location = new Point(106, 31);
+            flowLayoutPanelSsh.Margin = new Padding(0);
+            flowLayoutPanelSsh.Name = "flowLayoutPanelSsh";
+            flowLayoutPanelSsh.Size = new Size(364, 31);
+            flowLayoutPanelSsh.TabIndex = 3;
+            // 
+            // TestConnection
+            // 
+            TestConnection.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            TestConnection.AutoSize = true;
+            TestConnection.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            TestConnection.Image = Properties.Images.Putty;
+            TestConnection.ImageAlign = ContentAlignment.MiddleLeft;
+            TestConnection.Location = new Point(201, 3);
+            TestConnection.MinimumSize = new Size(160, 25);
+            TestConnection.Name = "TestConnection";
+            TestConnection.Size = new Size(160, 25);
+            TestConnection.TabIndex = 4;
+            TestConnection.Text = "Test connection";
+            TestConnection.UseVisualStyleBackColor = true;
+            TestConnection.Click += TestConnectionClick;
+            // 
+            // LoadSSHKey
+            // 
+            LoadSSHKey.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            LoadSSHKey.AutoSize = true;
+            LoadSSHKey.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            LoadSSHKey.Image = Properties.Images.Putty;
+            LoadSSHKey.ImageAlign = ContentAlignment.MiddleLeft;
+            LoadSSHKey.Location = new Point(35, 3);
+            LoadSSHKey.MinimumSize = new Size(160, 25);
+            LoadSSHKey.Name = "LoadSSHKey";
+            LoadSSHKey.Size = new Size(160, 25);
+            LoadSSHKey.TabIndex = 3;
+            LoadSSHKey.Text = "Load SSH key";
+            LoadSSHKey.UseVisualStyleBackColor = true;
+            LoadSSHKey.Click += LoadSshKeyClick;
+            // 
+            // flpnlRemoteColors
+            // 
+            flpnlRemoteColors.AutoSize = true;
+            flpnlRemoteColors.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tblpnlMgtDetails.SetColumnSpan(flpnlRemoteColors, 2);
+            flpnlRemoteColors.Controls.Add(btnRemoteColor);
+            flpnlRemoteColors.Controls.Add(btnRemoteColorReset);
+            flpnlRemoteColors.Dock = DockStyle.Fill;
+            flpnlRemoteColors.Location = new Point(106, 60);
+            flpnlRemoteColors.Margin = new Padding(0);
+            flpnlRemoteColors.Name = "flpnlRemoteColors";
+            flpnlRemoteColors.Size = new Size(364, 31);
+            flpnlRemoteColors.TabIndex = 6;
+            // 
+            // btnRemoteColor
+            // 
+            btnRemoteColor.AutoSize = true;
+            btnRemoteColor.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            btnRemoteColor.Location = new Point(3, 3);
+            btnRemoteColor.Name = "btnRemoteColor";
+            btnRemoteColor.Size = new Size(63, 25);
+            btnRemoteColor.TabIndex = 7;
+            btnRemoteColor.Text = "Set color";
+            btnRemoteColor.UseVisualStyleBackColor = false;
+            btnRemoteColor.Click += btnRemoteColor_Click;
+            // 
+            // btnRemoteColorReset
+            // 
+            btnRemoteColorReset.AutoSize = true;
+            btnRemoteColorReset.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            btnRemoteColorReset.Location = new Point(72, 3);
+            btnRemoteColorReset.Name = "btnRemoteColorReset";
+            btnRemoteColorReset.Size = new Size(85, 25);
+            btnRemoteColorReset.TabIndex = 8;
+            btnRemoteColorReset.Text = "Default color";
+            btnRemoteColorReset.UseVisualStyleBackColor = false;
+            btnRemoteColorReset.Click += btnRemoteColorReset_Click;
             // 
             // flpnlRemoteManagement
             // 
@@ -116,74 +210,56 @@ namespace GitUI.CommandsDialogs
             flpnlRemoteManagement.RowStyles.Add(new RowStyle());
             flpnlRemoteManagement.RowStyles.Add(new RowStyle());
             flpnlRemoteManagement.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            flpnlRemoteManagement.Size = new Size(514, 278);
+            flpnlRemoteManagement.Size = new Size(514, 309);
             flpnlRemoteManagement.TabIndex = 0;
             // 
             // pnlMgtDetails
             // 
             pnlMgtDetails.AutoSize = true;
+            pnlMgtDetails.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             pnlMgtDetails.Controls.Add(tblpnlMgtDetails);
             pnlMgtDetails.Dock = DockStyle.Top;
             pnlMgtDetails.Location = new Point(3, 3);
             pnlMgtDetails.Name = "pnlMgtDetails";
             pnlMgtDetails.Padding = new Padding(0, 0, 0, 8);
-            pnlMgtDetails.Size = new Size(508, 138);
+            pnlMgtDetails.Size = new Size(508, 169);
             pnlMgtDetails.TabIndex = 0;
             pnlMgtDetails.Text = "Details";
             // 
             // tblpnlMgtDetails
             // 
-            tblpnlMgtDetails.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             tblpnlMgtDetails.AutoSize = true;
             tblpnlMgtDetails.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            tblpnlMgtDetails.ColumnCount = 3;
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
-            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 110F));
+            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
+            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
+            tblpnlMgtDetails.Controls.Add(flpnlRemoteColors, 1, 2);
             tblpnlMgtDetails.Controls.Add(label2, 0, 0);
             tblpnlMgtDetails.Controls.Add(Url, 1, 0);
             tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 0);
             tblpnlMgtDetails.Controls.Add(label1, 0, 1);
             tblpnlMgtDetails.Controls.Add(RemoteName, 1, 1);
-            tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 2);
-            tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 3);
-            tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 3);
-            tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 3);
+            tblpnlMgtDetails.Controls.Add(lblRemoteColor, 0, 2);
+            tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 3);
+            tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 4);
+            tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 4);
+            tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 4);
             tblpnlMgtDetails.Location = new Point(16, 11);
             tblpnlMgtDetails.Name = "tblpnlMgtDetails";
-            tblpnlMgtDetails.RowCount = 4;
+            tblpnlMgtDetails.RowCount = 5;
             tblpnlMgtDetails.RowStyles.Add(new RowStyle());
             tblpnlMgtDetails.RowStyles.Add(new RowStyle());
             tblpnlMgtDetails.RowStyles.Add(new RowStyle());
             tblpnlMgtDetails.RowStyles.Add(new RowStyle());
-            tblpnlMgtDetails.Size = new Size(470, 116);
+            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
+            tblpnlMgtDetails.Size = new Size(470, 147);
             tblpnlMgtDetails.TabIndex = 11;
-            // 
-            // label1
-            // 
-            label1.Dock = DockStyle.Fill;
-            label1.Location = new Point(3, 0);
-            label1.MinimumSize = new Size(100, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(100, 29);
-            label1.TabIndex = 3;
-            label1.Text = "Name";
-            label1.TextAlign = ContentAlignment.MiddleLeft;
-            // 
-            // RemoteName
-            // 
-            RemoteName.Dock = DockStyle.Fill;
-            RemoteName.Location = new Point(109, 3);
-            RemoteName.Name = "RemoteName";
-            RemoteName.Size = new Size(248, 23);
-            RemoteName.TabIndex = 4;
-            RemoteName.TextChanged += RemoteName_TextChanged;
-            RemoteName.Enter += RemoteName_Enter;
             // 
             // label2
             // 
             label2.Dock = DockStyle.Fill;
-            label2.Location = new Point(3, 29);
+            label2.Location = new Point(3, 0);
+            label2.MinimumSize = new Size(100, 0);
             label2.Name = "label2";
             label2.Size = new Size(100, 31);
             label2.TabIndex = 0;
@@ -196,7 +272,7 @@ namespace GitUI.CommandsDialogs
             Url.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
             Url.AutoCompleteSource = AutoCompleteSource.ListItems;
             Url.FormattingEnabled = true;
-            Url.Location = new Point(109, 33);
+            Url.Location = new Point(109, 4);
             Url.Name = "Url";
             Url.Size = new Size(248, 23);
             Url.TabIndex = 1;
@@ -207,23 +283,53 @@ namespace GitUI.CommandsDialogs
             folderBrowserButtonUrl.AutoSize = true;
             folderBrowserButtonUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             folderBrowserButtonUrl.Dock = DockStyle.Fill;
-            folderBrowserButtonUrl.Location = new Point(363, 32);
+            folderBrowserButtonUrl.Location = new Point(363, 3);
             folderBrowserButtonUrl.MinimumSize = new Size(104, 25);
             folderBrowserButtonUrl.Name = "folderBrowserButtonUrl";
             folderBrowserButtonUrl.PathShowingControl = Url;
             folderBrowserButtonUrl.Size = new Size(104, 25);
             folderBrowserButtonUrl.TabIndex = 2;
             // 
+            // label1
+            // 
+            label1.Dock = DockStyle.Fill;
+            label1.Location = new Point(3, 31);
+            label1.Name = "label1";
+            label1.Size = new Size(100, 29);
+            label1.TabIndex = 3;
+            label1.Text = "Name";
+            label1.TextAlign = ContentAlignment.MiddleLeft;
+            // 
+            // RemoteName
+            // 
+            RemoteName.Dock = DockStyle.Fill;
+            RemoteName.Location = new Point(109, 34);
+            RemoteName.Name = "RemoteName";
+            RemoteName.Size = new Size(248, 23);
+            RemoteName.TabIndex = 4;
+            RemoteName.TextChanged += RemoteName_TextChanged;
+            RemoteName.Enter += RemoteName_Enter;
+            // 
+            // lblRemoteColor
+            // 
+            lblRemoteColor.Dock = DockStyle.Fill;
+            lblRemoteColor.Location = new Point(3, 60);
+            lblRemoteColor.Name = "lblRemoteColor";
+            lblRemoteColor.Size = new Size(100, 31);
+            lblRemoteColor.TabIndex = 5;
+            lblRemoteColor.Text = "Color";
+            lblRemoteColor.TextAlign = ContentAlignment.MiddleLeft;
+            // 
             // checkBoxSepPushUrl
             // 
             checkBoxSepPushUrl.AutoSize = true;
             tblpnlMgtDetails.SetColumnSpan(checkBoxSepPushUrl, 2);
             checkBoxSepPushUrl.Dock = DockStyle.Fill;
-            checkBoxSepPushUrl.Location = new Point(3, 63);
+            checkBoxSepPushUrl.Location = new Point(3, 94);
             checkBoxSepPushUrl.Name = "checkBoxSepPushUrl";
             checkBoxSepPushUrl.Padding = new Padding(24, 0, 0, 0);
             checkBoxSepPushUrl.Size = new Size(354, 19);
-            checkBoxSepPushUrl.TabIndex = 5;
+            checkBoxSepPushUrl.TabIndex = 9;
             checkBoxSepPushUrl.Text = "Separate Push Url";
             checkBoxSepPushUrl.UseVisualStyleBackColor = true;
             checkBoxSepPushUrl.CheckedChanged += checkBoxSepPushUrl_CheckedChanged;
@@ -231,10 +337,10 @@ namespace GitUI.CommandsDialogs
             // labelPushUrl
             // 
             labelPushUrl.Dock = DockStyle.Fill;
-            labelPushUrl.Location = new Point(3, 85);
+            labelPushUrl.Location = new Point(3, 116);
             labelPushUrl.Name = "labelPushUrl";
             labelPushUrl.Size = new Size(100, 31);
-            labelPushUrl.TabIndex = 6;
+            labelPushUrl.TabIndex = 10;
             labelPushUrl.Text = "Push Url";
             labelPushUrl.TextAlign = ContentAlignment.MiddleLeft;
             labelPushUrl.Visible = false;
@@ -245,10 +351,10 @@ namespace GitUI.CommandsDialogs
             comboBoxPushUrl.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
             comboBoxPushUrl.AutoCompleteSource = AutoCompleteSource.ListItems;
             comboBoxPushUrl.FormattingEnabled = true;
-            comboBoxPushUrl.Location = new Point(109, 89);
+            comboBoxPushUrl.Location = new Point(109, 120);
             comboBoxPushUrl.Name = "comboBoxPushUrl";
             comboBoxPushUrl.Size = new Size(248, 23);
-            comboBoxPushUrl.TabIndex = 7;
+            comboBoxPushUrl.TabIndex = 11;
             comboBoxPushUrl.Visible = false;
             comboBoxPushUrl.Enter += ComboBoxPushUrl_Enter;
             // 
@@ -257,12 +363,12 @@ namespace GitUI.CommandsDialogs
             folderBrowserButtonPushUrl.AutoSize = true;
             folderBrowserButtonPushUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             folderBrowserButtonPushUrl.Dock = DockStyle.Fill;
-            folderBrowserButtonPushUrl.Location = new Point(363, 88);
+            folderBrowserButtonPushUrl.Location = new Point(363, 119);
             folderBrowserButtonPushUrl.MinimumSize = new Size(104, 25);
             folderBrowserButtonPushUrl.Name = "folderBrowserButtonPushUrl";
             folderBrowserButtonPushUrl.PathShowingControl = comboBoxPushUrl;
             folderBrowserButtonPushUrl.Size = new Size(104, 25);
-            folderBrowserButtonPushUrl.TabIndex = 8;
+            folderBrowserButtonPushUrl.TabIndex = 12;
             folderBrowserButtonPushUrl.Visible = false;
             // 
             // pnlMgtPuttySsh
@@ -273,7 +379,7 @@ namespace GitUI.CommandsDialogs
             pnlMgtPuttySsh.Controls.Add(lblMgtPuttyPanelHeader);
             pnlMgtPuttySsh.Controls.Add(lblHeaderLine2);
             pnlMgtPuttySsh.Dock = DockStyle.Top;
-            pnlMgtPuttySsh.Location = new Point(3, 147);
+            pnlMgtPuttySsh.Location = new Point(3, 178);
             pnlMgtPuttySsh.Name = "pnlMgtPuttySsh";
             pnlMgtPuttySsh.Padding = new Padding(0, 0, 0, 8);
             pnlMgtPuttySsh.Size = new Size(508, 91);
@@ -292,7 +398,7 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel1.Controls.Add(label3, 0, 0);
             tableLayoutPanel1.Controls.Add(PuttySshKey, 1, 0);
             tableLayoutPanel1.Controls.Add(SshBrowse, 2, 0);
-            tableLayoutPanel1.Controls.Add(flowLayoutPanel3, 1, 1);
+            tableLayoutPanel1.Controls.Add(flowLayoutPanelSsh, 1, 1);
             tableLayoutPanel1.Location = new Point(16, 18);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.RowCount = 2;
@@ -338,59 +444,12 @@ namespace GitUI.CommandsDialogs
             SshBrowse.UseVisualStyleBackColor = true;
             SshBrowse.Click += SshBrowseClick;
             // 
-            // flowLayoutPanel3
-            // 
-            flowLayoutPanel3.AutoSize = true;
-            flowLayoutPanel3.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            tableLayoutPanel1.SetColumnSpan(flowLayoutPanel3, 2);
-            flowLayoutPanel3.Controls.Add(TestConnection);
-            flowLayoutPanel3.Controls.Add(LoadSSHKey);
-            flowLayoutPanel3.Dock = DockStyle.Fill;
-            flowLayoutPanel3.FlowDirection = FlowDirection.RightToLeft;
-            flowLayoutPanel3.Location = new Point(106, 31);
-            flowLayoutPanel3.Margin = new Padding(0);
-            flowLayoutPanel3.Name = "flowLayoutPanel3";
-            flowLayoutPanel3.Size = new Size(364, 31);
-            flowLayoutPanel3.TabIndex = 3;
-            // 
-            // TestConnection
-            // 
-            TestConnection.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            TestConnection.AutoSize = true;
-            TestConnection.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            TestConnection.Image = Properties.Images.Putty;
-            TestConnection.ImageAlign = ContentAlignment.MiddleLeft;
-            TestConnection.Location = new Point(201, 3);
-            TestConnection.MinimumSize = new Size(160, 25);
-            TestConnection.Name = "TestConnection";
-            TestConnection.Size = new Size(160, 25);
-            TestConnection.TabIndex = 1;
-            TestConnection.Text = "Test connection";
-            TestConnection.UseVisualStyleBackColor = true;
-            TestConnection.Click += TestConnectionClick;
-            // 
-            // LoadSSHKey
-            // 
-            LoadSSHKey.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            LoadSSHKey.AutoSize = true;
-            LoadSSHKey.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            LoadSSHKey.Image = Properties.Images.Putty;
-            LoadSSHKey.ImageAlign = ContentAlignment.MiddleLeft;
-            LoadSSHKey.Location = new Point(35, 3);
-            LoadSSHKey.MinimumSize = new Size(160, 25);
-            LoadSSHKey.Name = "LoadSSHKey";
-            LoadSSHKey.Size = new Size(160, 25);
-            LoadSSHKey.TabIndex = 0;
-            LoadSSHKey.Text = "Load SSH key";
-            LoadSSHKey.UseVisualStyleBackColor = true;
-            LoadSSHKey.Click += LoadSshKeyClick;
-            // 
             // lblMgtPuttyPanelHeader
             // 
             lblMgtPuttyPanelHeader.AutoSize = true;
             lblMgtPuttyPanelHeader.Location = new Point(8, 0);
             lblMgtPuttyPanelHeader.Name = "lblMgtPuttyPanelHeader";
-            lblMgtPuttyPanelHeader.Size = new Size(64, 15);
+            lblMgtPuttyPanelHeader.Size = new Size(66, 15);
             lblMgtPuttyPanelHeader.TabIndex = 0;
             lblMgtPuttyPanelHeader.Text = "PuTTY SSH";
             // 
@@ -410,7 +469,7 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel2.Controls.Add(Save);
             flowLayoutPanel2.Dock = DockStyle.Top;
             flowLayoutPanel2.FlowDirection = FlowDirection.RightToLeft;
-            flowLayoutPanel2.Location = new Point(3, 244);
+            flowLayoutPanel2.Location = new Point(3, 275);
             flowLayoutPanel2.Name = "flowLayoutPanel2";
             flowLayoutPanel2.Padding = new Padding(0, 0, 20, 0);
             flowLayoutPanel2.Size = new Size(508, 31);
@@ -436,7 +495,7 @@ namespace GitUI.CommandsDialogs
             pnlManagementContainer.Location = new Point(197, 3);
             pnlManagementContainer.Name = "pnlManagementContainer";
             pnlManagementContainer.Padding = new Padding(8, 4, 8, 8);
-            pnlManagementContainer.Size = new Size(536, 297);
+            pnlManagementContainer.Size = new Size(536, 327);
             pnlManagementContainer.TabIndex = 0;
             // 
             // gbMgtPanel
@@ -447,7 +506,7 @@ namespace GitUI.CommandsDialogs
             gbMgtPanel.Dock = DockStyle.Top;
             gbMgtPanel.Location = new Point(8, 4);
             gbMgtPanel.Name = "gbMgtPanel";
-            gbMgtPanel.Size = new Size(520, 300);
+            gbMgtPanel.Size = new Size(520, 331);
             gbMgtPanel.TabIndex = 0;
             gbMgtPanel.TabStop = false;
             gbMgtPanel.Text = "Create New Remote";
@@ -464,7 +523,7 @@ namespace GitUI.CommandsDialogs
             panelButtons.Margin = new Padding(8);
             panelButtons.Name = "panelButtons";
             panelButtons.Padding = new Padding(4, 0, 0, 0);
-            panelButtons.Size = new Size(36, 281);
+            panelButtons.Size = new Size(36, 311);
             panelButtons.TabIndex = 1;
             // 
             // New
@@ -508,7 +567,7 @@ namespace GitUI.CommandsDialogs
             tabControl1.Location = new Point(0, 0);
             tabControl1.Name = "tabControl1";
             tabControl1.SelectedIndex = 0;
-            tabControl1.Size = new Size(744, 331);
+            tabControl1.Size = new Size(744, 361);
             tabControl1.TabIndex = 0;
             // 
             // tabPage1
@@ -518,7 +577,7 @@ namespace GitUI.CommandsDialogs
             tabPage1.Location = new Point(4, 24);
             tabPage1.Name = "tabPage1";
             tabPage1.Padding = new Padding(3);
-            tabPage1.Size = new Size(736, 303);
+            tabPage1.Size = new Size(736, 333);
             tabPage1.TabIndex = 0;
             tabPage1.Text = "Remote repositories";
             tabPage1.UseVisualStyleBackColor = true;
@@ -531,7 +590,7 @@ namespace GitUI.CommandsDialogs
             panel1.Location = new Point(3, 3);
             panel1.Name = "panel1";
             panel1.Padding = new Padding(8);
-            panel1.Size = new Size(194, 297);
+            panel1.Size = new Size(194, 327);
             panel1.TabIndex = 0;
             // 
             // Remotes
@@ -540,15 +599,15 @@ namespace GitUI.CommandsDialogs
             Remotes.Columns.AddRange(new ColumnHeader[] { columnHeader1 });
             Remotes.Dock = DockStyle.Fill;
             Remotes.FullRowSelect = true;
-            listViewGroup2.Header = "ListViewGroup";
-            listViewGroup2.Name = "listViewGroup1";
-            Remotes.Groups.AddRange(new ListViewGroup[] { listViewGroup2 });
+            listViewGroup1.Header = "ListViewGroup";
+            listViewGroup1.Name = "listViewGroup1";
+            Remotes.Groups.AddRange(new ListViewGroup[] { listViewGroup1 });
             Remotes.HeaderStyle = ColumnHeaderStyle.None;
             Remotes.LabelWrap = false;
             Remotes.Location = new Point(8, 8);
             Remotes.MultiSelect = false;
             Remotes.Name = "Remotes";
-            Remotes.Size = new Size(142, 281);
+            Remotes.Size = new Size(142, 311);
             Remotes.TabIndex = 1;
             Remotes.TileSize = new Size(136, 18);
             Remotes.UseCompatibleStateImageBehavior = false;
@@ -566,7 +625,7 @@ namespace GitUI.CommandsDialogs
             tabPage2.Location = new Point(4, 24);
             tabPage2.Name = "tabPage2";
             tabPage2.Padding = new Padding(3);
-            tabPage2.Size = new Size(736, 303);
+            tabPage2.Size = new Size(736, 333);
             tabPage2.TabIndex = 1;
             tabPage2.Text = "Default pull behavior (fetch & merge)";
             tabPage2.UseVisualStyleBackColor = true;
@@ -584,7 +643,7 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             tableLayoutPanel2.RowStyles.Add(new RowStyle());
             tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel2.Size = new Size(730, 297);
+            tableLayoutPanel2.Size = new Size(730, 327);
             tableLayoutPanel2.TabIndex = 12;
             // 
             // panelDetails
@@ -597,7 +656,7 @@ namespace GitUI.CommandsDialogs
             panelDetails.Controls.Add(RemoteRepositoryCombo);
             panelDetails.Controls.Add(LocalBranchNameEdit);
             panelDetails.Controls.Add(SaveDefaultPushPull);
-            panelDetails.Location = new Point(3, 173);
+            panelDetails.Location = new Point(3, 203);
             panelDetails.Name = "panelDetails";
             panelDetails.Size = new Size(724, 121);
             panelDetails.TabIndex = 0;
@@ -691,7 +750,7 @@ namespace GitUI.CommandsDialogs
             RemoteBranches.ReadOnly = true;
             RemoteBranches.RowHeadersVisible = false;
             RemoteBranches.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-            RemoteBranches.Size = new Size(724, 164);
+            RemoteBranches.Size = new Size(724, 194);
             RemoteBranches.TabIndex = 0;
             RemoteBranches.DataError += RemoteBranchesDataError;
             // 
@@ -713,19 +772,28 @@ namespace GitUI.CommandsDialogs
             MergeWith.Name = "MergeWith";
             MergeWith.ReadOnly = true;
             // 
+            // colorDialog
+            // 
+            colorDialog.AnyColor = true;
+            colorDialog.FullOpen = true;
+            // 
             // FormRemotes
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(744, 331);
+            ClientSize = new Size(744, 361);
             Controls.Add(tabControl1);
             MaximizeBox = false;
             MinimizeBox = false;
-            MinimumSize = new Size(760, 370);
+            MinimumSize = new Size(760, 400);
             Name = "FormRemotes";
             SizeGripStyle = SizeGripStyle.Show;
             StartPosition = FormStartPosition.CenterParent;
             Text = "Remote repositories";
+            flowLayoutPanelSsh.ResumeLayout(false);
+            flowLayoutPanelSsh.PerformLayout();
+            flpnlRemoteColors.ResumeLayout(false);
+            flpnlRemoteColors.PerformLayout();
             flpnlRemoteManagement.ResumeLayout(false);
             flpnlRemoteManagement.PerformLayout();
             pnlMgtDetails.ResumeLayout(false);
@@ -736,8 +804,6 @@ namespace GitUI.CommandsDialogs
             pnlMgtPuttySsh.PerformLayout();
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
-            flowLayoutPanel3.ResumeLayout(false);
-            flowLayoutPanel3.PerformLayout();
             flowLayoutPanel2.ResumeLayout(false);
             pnlManagementContainer.ResumeLayout(false);
             pnlManagementContainer.PerformLayout();
@@ -796,7 +862,6 @@ namespace GitUI.CommandsDialogs
         private TableLayoutPanel flpnlRemoteManagement;
         private FlowLayoutPanel flowLayoutPanel2;
         private TableLayoutPanel tableLayoutPanel1;
-        private FlowLayoutPanel flowLayoutPanel3;
         private Label lblHeaderLine2;
         private Panel pnlMgtDetails;
         private TableLayoutPanel tblpnlMgtDetails;
@@ -808,5 +873,10 @@ namespace GitUI.CommandsDialogs
         private Button btnToggleState;
         private ColumnHeader columnHeader1;
         private Panel panelDetails;
+        private Label lblRemoteColor;
+        private Button btnRemoteColor;
+        private ColorDialog colorDialog;
+        private Button btnRemoteColorReset;
+        private FlowLayoutPanel flpnlRemoteColors;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -105,6 +105,14 @@ Inactive remote is completely invisible to git.");
             InitializeComponent();
             InitializeComplete();
 
+            btnRemoteColor.BackColor = Color.Transparent;
+
+            // Persist the text of the buttons to be able to restore it whenever the color is reset
+            btnRemoteColor.Tag = btnRemoteColor.Text;
+
+            // Set the minimum height of the color button to be the same as the reset button
+            btnRemoteColor.MinimumSize = new Size(DpiUtil.Scale(60), btnRemoteColorReset.Height);
+
             // remove text from 'new' and 'delete' buttons because now they are represented by icons
             New.Text = string.Empty;
             Delete.Text = string.Empty;
@@ -309,6 +317,27 @@ Inactive remote is completely invisible to git.");
             }
         }
 
+        private void SetRemoteColor(Color color)
+        {
+            if (color == Color.Transparent)
+            {
+                btnRemoteColor.Text = (string)btnRemoteColor.Tag;
+                btnRemoteColor.BackColor = Color.Transparent;
+
+                btnRemoteColorReset.Visible = false;
+            }
+            else
+            {
+                if (btnRemoteColor.BackColor == Color.Transparent)
+                {
+                    btnRemoteColor.Text = string.Empty;
+                    btnRemoteColorReset.Visible = true;
+                }
+
+                btnRemoteColor.BackColor = color;
+            }
+        }
+
         private void application_Idle(object sender, EventArgs e)
         {
             // we need this event only once, so unwire
@@ -323,8 +352,15 @@ Inactive remote is completely invisible to git.");
 
             pnlMgtPuttySsh.Visible = GitSshHelpers.IsPlink;
 
+            if (!AppSettings.AlwaysShowAdvOpt)
+            {
+                lblRemoteColor.Visible = false;
+                flpnlRemoteColors.Visible = false;
+            }
+
             // if Putty SSH isn't enabled, reduce the minimum height of the form
             MinimumSize = new Size(MinimumSize.Width, pnlMgtPuttySsh.Visible ? MinimumSize.Height : MinimumSize.Height - pnlMgtPuttySsh.Height);
+            Height = MinimumSize.Height + DpiUtil.Scale(36);
 
             // adjust width of the labels if required
             // this may be necessary if the translated labels require more space than English versions
@@ -338,6 +374,19 @@ Inactive remote is completely invisible to git.");
 
             // load the data for the very first time
             Initialize(PreselectRemoteOnLoad, PreselectLocalOnLoad);
+        }
+
+        private void btnRemoteColor_Click(object sender, EventArgs e)
+        {
+            if (colorDialog.ShowDialog() == DialogResult.OK)
+            {
+                SetRemoteColor(colorDialog.Color);
+            }
+        }
+
+        private void btnRemoteColorReset_Click(object sender, EventArgs e)
+        {
+            SetRemoteColor(Color.Transparent);
         }
 
         private void btnToggleState_Click(object sender, EventArgs e)
@@ -392,6 +441,12 @@ Inactive remote is completely invisible to git.");
             string remotePushUrl = comboBoxPushUrl.Text.Trim();
             bool creatingNew = _selectedRemote is null;
 
+            string? color = null;
+            if (btnRemoteColor.BackColor != Color.Transparent)
+            {
+                color = ColorTranslator.ToHtml(btnRemoteColor.BackColor);
+            }
+
             try
             {
                 // disable the control while saving
@@ -415,7 +470,8 @@ Inactive remote is completely invisible to git.");
                                                        remote,
                                                        remoteUrl,
                                                        checkBoxSepPushUrl.Checked ? remotePushUrl : null,
-                                                       PuttySshKey.Text);
+                                                       PuttySshKey.Text,
+                                                       color);
 
                 if (!string.IsNullOrEmpty(result.UserMessage))
                 {
@@ -424,6 +480,9 @@ Inactive remote is completely invisible to git.");
                 }
                 else
                 {
+                    // This will cause the module's remotes colors to reload
+                    Module.ResetRemoteColors();
+
                     ThreadHelper.JoinableTaskFactory.Run(async () =>
                     {
                         IList<Repository> repositoryHistory = await RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync();
@@ -658,6 +717,15 @@ Inactive remote is completely invisible to git.");
             BindBtnToggleState(_selectedRemote.Disabled);
             btnToggleState.Visible = true;
             flpnlRemoteManagement.Enabled = !_selectedRemote.Disabled;
+
+            if (string.IsNullOrWhiteSpace(_selectedRemote.Color))
+            {
+                SetRemoteColor(Color.Transparent);
+            }
+            else
+            {
+                SetRemoteColor(ColorTranslator.FromHtml(_selectedRemote.Color));
+            }
         }
 
         private void checkBoxSepPushUrl_CheckedChanged(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.resx
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.resx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
@@ -117,8 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="flowLayoutPanelSsh.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>132, 17</value>
   </metadata>
   <metadata name="BranchName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -129,16 +132,7 @@
   <metadata name="MergeWith.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="BranchName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="RemoteCombo.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="MergeWith.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="colorDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6624,6 +6624,14 @@ Value has been reset to empty value.</source>
         <source>Private key (*.ppk)</source>
         <target />
       </trans-unit>
+      <trans-unit id="btnRemoteColor.Text">
+        <source>Set color</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="btnRemoteColorReset.Text">
+        <source>Default color</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnToggleState.toolTip1">
         <source>Enable or disable the selected remote</source>
         <target />
@@ -6666,6 +6674,10 @@ Value has been reset to empty value.</source>
       </trans-unit>
       <trans-unit id="lblMgtPuttyPanelHeader.Text">
         <source>PuTTY SSH</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblRemoteColor.Text">
+        <source>Color</source>
         <target />
       </trans-unit>
       <trans-unit id="pnlMgtDetails.Text">

--- a/src/app/GitUI/UserControls/RevisionGrid/CellStyle.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/CellStyle.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.UserControls.RevisionGrid
+﻿using System.Collections.Frozen;
+
+namespace GitUI.UserControls.RevisionGrid
 {
     internal readonly struct CellStyle
     {
@@ -8,8 +10,9 @@
         public readonly Font NormalFont;
         public readonly Font BoldFont;
         public readonly Font MonospaceFont;
+        public readonly FrozenDictionary<string, Color> RemoteColors;
 
-        public CellStyle(Brush backBrush, Color foreColor, Color commitBodyForeColor, Font normalFont, Font boldFont, Font monospaceFont)
+        public CellStyle(Brush backBrush, Color foreColor, Color commitBodyForeColor, Font normalFont, Font boldFont, Font monospaceFont, FrozenDictionary<string, Color> remoteColors)
         {
             BackBrush = backBrush;
             ForeColor = foreColor;
@@ -17,6 +20,7 @@
             NormalFont = normalFont;
             BoldFont = boldFont;
             MonospaceFont = monospaceFont;
+            RemoteColors = remoteColors;
         }
     }
 }

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -360,7 +360,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 }
             }
 
-            Color headColor = RevisionGridRefRenderer.GetHeadColor(gitRef);
+            if (!style.RemoteColors.TryGetValue(gitRef.Remote, out Color headColor))
+            {
+                headColor = RevisionGridRefRenderer.GetHeadColor(gitRef);
+            }
 
             RefArrowType arrowType = gitRef.IsSelected
                 ? RefArrowType.Filled

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System.Collections.Frozen;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -227,6 +228,8 @@ namespace GitUI.UserControls.RevisionGrid
             }
         }
 
+        internal FrozenDictionary<string, Color> RemoteColors { get; set; }
+
         internal void AddColumn(ColumnProvider columnProvider)
         {
             _columnProviders.Add(columnProvider);
@@ -317,7 +320,7 @@ namespace GitUI.UserControls.RevisionGrid
                 bool isNonRelativeGray = _revisionGraphDrawNonRelativesTextGray && !RowIsRelative(e.RowIndex);
                 Color foreColor = GetForeground(_isSelected, _isFocused, isNonRelativeGray);
                 Color commitBodyForeColor = GetCommitBodyForeground(_isSelected, isNonRelativeGray);
-                _cellStyle = new(backBrush, foreColor, commitBodyForeColor, _normalFont, _boldFont, _monospaceFont);
+                _cellStyle = new(backBrush, foreColor, commitBodyForeColor, _normalFont, _boldFont, _monospaceFont, RemoteColors);
             }
 
             if (_cellStyle is null)

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -902,6 +902,8 @@ namespace GitUI
                       ? Module.GetSelectedBranch(emptyIfDetached: true)
                       : "");
 
+            _gridView.RemoteColors = Module.GetRemoteColors();
+
             // Revision info is read in three parallel steps:
             // 1. Read current commit, refs, prepare grid etc.
             // 2. Read stashes (if enabled).

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests_Remotes.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests_Remotes.cs
@@ -1,0 +1,282 @@
+﻿using System.Collections.Frozen;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Config;
+using GitCommands.Remotes;
+using GitCommands.Settings;
+using GitUI;
+using NSubstitute;
+
+namespace GitCommandsTests;
+
+partial class GitModuleTests
+{
+    [Test]
+    public void AddRemote()
+    {
+        const string name = "foo";
+        const string path = "a\\b\\c";
+        const string output = "bar";
+
+        using (_executable.StageOutput($"remote add \"{name}\" \"{path.ToPosixPath()}\"", output))
+        {
+            Assert.AreEqual(output, _gitModule.AddRemote(name, path));
+        }
+
+        Assert.AreEqual("Please enter a name.", _gitModule.AddRemote("", path));
+        Assert.AreEqual("Please enter a name.", _gitModule.AddRemote(null, path));
+    }
+
+    [Test]
+    public void RemoveRemote()
+    {
+        const string remoteName = "foo";
+        const string output = "bar";
+
+        using (_executable.StageOutput($"remote rm \"{remoteName}\"", output))
+        {
+            Assert.AreEqual(output, _gitModule.RemoveRemote(remoteName));
+        }
+    }
+
+    [Test]
+    public void RenameRemote()
+    {
+        const string oldName = "foo";
+        const string newName = "far";
+        const string output = "bar";
+
+        using (_executable.StageOutput($"remote rename \"{oldName}\" \"{newName}\"", output))
+        {
+            Assert.AreEqual(output, _gitModule.RenameRemote(oldName, newName));
+        }
+    }
+
+    [TestCase("ignorenopush\tgit@github.com:drewnoakes/gitextensions.git (fetch)")]
+    [TestCase("ignorenopull\tgit@github.com:drewnoakes/gitextensions.git (push)")]
+    public async Task GetRemotes_should_throw_if_not_pairs(string line)
+    {
+        using (_executable.StageOutput("remote -v", line))
+        {
+            await AssertEx.ThrowsAsync<Exception>(async () => await _gitModule.GetRemotesAsync());
+        }
+    }
+
+    [Test]
+    public void GetRemotes_should_parse_correctly_configured_remotes()
+    {
+        ThreadHelper.JoinableTaskFactory.Run(async () =>
+        {
+            string[] lines =
+            [
+                "RussKie\tgit://github.com/RussKie/gitextensions.git (fetch)",
+                "RussKie\tgit://github.com/RussKie/gitextensions.git (push)",
+                "origin\tgit@github.com:drewnoakes/gitextensions.git (fetch)",
+                "origin\tgit@github.com:drewnoakes/gitextensions.git (push)",
+                "upstream\tgit@github.com:gitextensions/gitextensions.git (fetch)",
+                "upstream\tgit@github.com:gitextensions/gitextensions.git (push)",
+                "asymmetrical\thttps://github.com/gitextensions/fetch.git (fetch)",
+                "asymmetrical\thttps://github.com/gitextensions/push.git (push)",
+                "with-space\tc:\\Bare Repo (fetch)",
+                "with-space\tc:\\Bare Repo (push)",
+
+                // A remote may have multiple push URLs, but only a single fetch URL
+                "multi\tgit@github.com:drewnoakes/gitextensions.git (fetch)",
+                "multi\tgit@github.com:drewnoakes/gitextensions.git (push)",
+                "multi\tgit@gitlab.com:drewnoakes/gitextensions.git (push)",
+
+                "ignoreunknown\tgit@github.com:drewnoakes/gitextensions.git (unknownType)",
+                "ignorenotab git@github.com:drewnoakes/gitextensions.git (fetch)",
+                "ignoremissingtype\tgit@gitlab.com:drewnoakes/gitextensions.git",
+                "git@gitlab.com:drewnoakes/gitextensions.git",
+
+                "with_option\thttps://github.com/flannelhead/jsmn-stream.git (fetch) [blob:none]",
+                "with_option\thttps://github.com/flannelhead/jsmn-stream.git (push) [ignored]"
+            ];
+
+            using (_executable.StageOutput("remote -v", string.Join("\n", lines)))
+            {
+                IReadOnlyList<GitExtensions.Extensibility.Git.Remote> remotes = await _gitModule.GetRemotesAsync();
+
+                Assert.AreEqual(7, remotes.Count);
+
+                Assert.AreEqual("RussKie", remotes[0].Name);
+                Assert.AreEqual("git://github.com/RussKie/gitextensions.git", remotes[0].FetchUrl);
+                Assert.AreEqual(1, remotes[0].PushUrls.Count);
+                Assert.AreEqual("git://github.com/RussKie/gitextensions.git", remotes[0].PushUrls[0]);
+
+                Assert.AreEqual("origin", remotes[1].Name);
+                Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[1].FetchUrl);
+                Assert.AreEqual(1, remotes[1].PushUrls.Count);
+                Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[1].PushUrls[0]);
+
+                Assert.AreEqual("upstream", remotes[2].Name);
+                Assert.AreEqual("git@github.com:gitextensions/gitextensions.git", remotes[2].FetchUrl);
+                Assert.AreEqual(1, remotes[2].PushUrls.Count);
+                Assert.AreEqual("git@github.com:gitextensions/gitextensions.git", remotes[2].PushUrls[0]);
+
+                Assert.AreEqual("asymmetrical", remotes[3].Name);
+                Assert.AreEqual("https://github.com/gitextensions/fetch.git", remotes[3].FetchUrl);
+                Assert.AreEqual(1, remotes[3].PushUrls.Count);
+                Assert.AreEqual("https://github.com/gitextensions/push.git", remotes[3].PushUrls[0]);
+
+                Assert.AreEqual("with-space", remotes[4].Name);
+                Assert.AreEqual("c:/Bare Repo", remotes[4].FetchUrl);
+                Assert.AreEqual(1, remotes[4].PushUrls.Count);
+                Assert.AreEqual("c:/Bare Repo", remotes[4].PushUrls[0]);
+
+                Assert.AreEqual("multi", remotes[5].Name);
+                Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[5].FetchUrl);
+                Assert.AreEqual(2, remotes[5].PushUrls.Count);
+                Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[5].PushUrls[0]);
+                Assert.AreEqual("git@gitlab.com:drewnoakes/gitextensions.git", remotes[5].PushUrls[1]);
+
+                Assert.AreEqual("with_option", remotes[6].Name);
+                Assert.AreEqual("https://github.com/flannelhead/jsmn-stream.git", remotes[6].FetchUrl);
+                Assert.AreEqual(1, remotes[6].PushUrls.Count);
+                Assert.AreEqual("https://github.com/flannelhead/jsmn-stream.git", remotes[6].PushUrls[0]);
+            }
+        });
+    }
+
+    [Test]
+    public void GetRemoteNames()
+    {
+        string[] lines = new[] { "RussKie", "origin", "upstream", "asymmetrical", "with-space" };
+
+        using (_executable.StageOutput("remote", string.Join("\n", lines)))
+        {
+            IReadOnlyList<string> remotes = _gitModule.GetRemoteNames();
+
+            Assert.AreEqual(lines, remotes);
+        }
+    }
+
+    [Test]
+    public void GetRemoteColors_should_return_saved_colors()
+    {
+        using GitModuleTestHelper moduleTestHelper = new();
+        GitModule gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
+
+        string remote = "fork";
+        gitModule.LocalConfigFile.SetValue(GetSettingKey(SettingKeyString.RemoteColor, remote), "#cccccc");
+
+        static string GetSettingKey(string settingKey, string remoteName) => string.Format(settingKey, remoteName);
+
+        // Mock IGitModule.GetRemoteNames() call
+        using (_executable.StageOutput("remote", "origin\nfork"))
+        {
+            FrozenDictionary<string, Color> colors = gitModule.GetRemoteColors();
+
+            colors.Should().NotBeNull();
+            colors.Count.Should().Be(1);
+            colors[remote].Should().Be(Color.FromArgb(204, 204, 204));
+        }
+    }
+
+    [Test]
+    public void GetRemoteColors_should_return_cached_colors()
+    {
+        using GitModuleTestHelper moduleTestHelper = new();
+        GitModule gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
+
+        string remote = "fork";
+        gitModule.LocalConfigFile.SetValue(GetSettingKey(SettingKeyString.RemoteColor, remote), "#cccccc");
+
+        static string GetSettingKey(string settingKey, string remoteName) => string.Format(settingKey, remoteName);
+
+        // Mock IGitModule.GetRemoteNames() call
+        using (_executable.StageOutput("remote", "origin\nfork"))
+        {
+            FrozenDictionary<string, Color> colors = gitModule.GetRemoteColors();
+
+            colors.Should().NotBeNull();
+            colors.Count.Should().Be(1);
+            colors.Should().ContainKey(remote);
+            colors[remote].Should().Be(Color.FromArgb(204, 204, 204));
+
+            // "Color" another remote
+            gitModule.LocalConfigFile.SetValue(GetSettingKey(SettingKeyString.RemoteColor, remoteName: "origin"), "#efefef");
+
+            // Call again to check if cached colors are returned
+            FrozenDictionary<string, Color> colors1 = gitModule.GetRemoteColors();
+
+            colors1.Should().NotBeNull();
+            colors1.Count.Should().Be(1);
+            colors1[remote].Should().Be(Color.FromArgb(204, 204, 204));
+        }
+    }
+
+    [Test]
+    public void GetRemoteColors_should_reload_colors_after_reset()
+    {
+        using GitModuleTestHelper moduleTestHelper = new();
+        GitModule gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
+
+        string remote = "fork";
+        gitModule.LocalConfigFile.SetValue(GetSettingKey(SettingKeyString.RemoteColor, remote), "#cccccc");
+
+        static string GetSettingKey(string settingKey, string remoteName) => string.Format(settingKey, remoteName);
+
+        // Mock IGitModule.GetRemoteNames() call
+        using (_executable.StageOutput("remote", "origin\nfork"))
+        {
+            FrozenDictionary<string, Color> colors = gitModule.GetRemoteColors();
+
+            colors.Should().NotBeNull();
+            colors.Count.Should().Be(1);
+            colors[remote].Should().Be(Color.FromArgb(204, 204, 204));
+
+            // "Color" another remote
+            gitModule.LocalConfigFile.SetValue(GetSettingKey(SettingKeyString.RemoteColor, remoteName: "origin"), "#efefef");
+
+            // Call again to check if cached colors are returned
+            FrozenDictionary<string, Color> colors1 = gitModule.GetRemoteColors();
+            colors1.Should().NotBeNull();
+            colors1.Count.Should().Be(1);
+
+            // Reset the colors
+            gitModule.ResetRemoteColors();
+            gitModule.GetTestAccessor().RemoteColors.Should().BeNull();
+        }
+
+        // Mock IGitModule.GetRemoteNames() call
+        using (_executable.StageOutput("remote", "origin\nfork"))
+        {
+            // Reload the colors
+            FrozenDictionary<string, Color> colors2 = gitModule.GetRemoteColors();
+
+            colors2.Should().NotBeNull();
+            colors2.Count.Should().Be(2);
+            colors2[remote].Should().Be(Color.FromArgb(204, 204, 204)); // "#cccccc"
+            colors2["origin"].Should().Be(Color.FromArgb(239, 239, 239)); // "#efefef"
+        }
+    }
+
+    [Test]
+    public void ResetRemoteColors_should_clear_cached_colors()
+    {
+        using GitModuleTestHelper moduleTestHelper = new();
+        GitModule gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
+
+        string remote = "fork";
+        gitModule.LocalConfigFile.SetValue(GetSettingKey(SettingKeyString.RemoteColor, remote), "#cccccc");
+
+        static string GetSettingKey(string settingKey, string remoteName) => string.Format(settingKey, remoteName);
+
+        // Mock IGitModule.GetRemoteNames() call
+        using (_executable.StageOutput("remote", "origin\nfork"))
+        {
+            FrozenDictionary<string, Color> colors = gitModule.GetRemoteColors();
+
+            colors.Should().NotBeNull();
+            colors.Count.Should().Be(1);
+            gitModule.GetTestAccessor().RemoteColors.Count.Should().Be(1);
+
+            gitModule.ResetRemoteColors();
+
+            gitModule.GetTestAccessor().RemoteColors.Should().BeNull();
+        }
+    }
+}

--- a/tests/app/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
@@ -111,11 +111,11 @@ namespace GitCommandsTests.Remote
         [Test]
         public void SaveRemote_should_throw_if_remoteName_is_null_or_empty()
         {
-            ((Action)(() => _remotesManager.SaveRemote(null, null, "b", "c", "d"))).Should().Throw<ArgumentNullException>()
+            ((Action)(() => _remotesManager.SaveRemote(null, null, "b", "c", "d", "e"))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null. (Parameter 'remoteName')");
-            ((Action)(() => _remotesManager.SaveRemote(null, "", "b", "c", "d"))).Should().Throw<ArgumentNullException>()
+            ((Action)(() => _remotesManager.SaveRemote(null, "", "b", "c", "d", "e"))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null. (Parameter 'remoteName')");
-            ((Action)(() => _remotesManager.SaveRemote(null, "  ", "b", "c", "d"))).Should().Throw<ArgumentNullException>()
+            ((Action)(() => _remotesManager.SaveRemote(null, "  ", "b", "c", "d", "e"))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null. (Parameter 'remoteName')");
         }
 
@@ -127,7 +127,7 @@ namespace GitCommandsTests.Remote
             const string output = "";
             _module.AddRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, null, null);
+            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, null, null, null);
 
             result.UserMessage.Should().Be(output);
             result.ShouldUpdateRemote.Should().BeTrue();
@@ -141,16 +141,18 @@ namespace GitCommandsTests.Remote
             const string remoteUrl = "b";
             const string remotePushUrl = "c";
             const string remotePuttySshKey = "";
+            const string remoteColor = "";
             const string output = "";
             _module.AddRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, remotePushUrl, remotePuttySshKey);
+            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, remotePushUrl, remotePuttySshKey, remoteColor);
 
             result.UserMessage.Should().Be(output);
             result.ShouldUpdateRemote.Should().BeTrue();
             _module.Received(1).SetSetting(string.Format(SettingKeyString.RemoteUrl, remoteName), remoteUrl);
             _module.Received(1).SetSetting(string.Format(SettingKeyString.RemotePushUrl, remoteName), remotePushUrl);
             _module.Received(1).UnsetSetting(string.Format(SettingKeyString.RemotePuttySshKey, remoteName));
+            _module.Received(1).UnsetSetting(string.Format(SettingKeyString.RemoteColor, remoteName));
         }
 
         [Test]
@@ -162,7 +164,7 @@ namespace GitCommandsTests.Remote
             ConfigFileRemote gitRemote = new() { Name = "old", Url = remoteUrl };
             _module.RenameRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null);
+            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null, null);
 
             result.UserMessage.Should().Be(output);
             result.ShouldUpdateRemote.Should().BeFalse();
@@ -178,22 +180,23 @@ namespace GitCommandsTests.Remote
             ConfigFileRemote gitRemote = new() { Name = "old", Url = "old" };
             _module.RenameRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null);
+            ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null, null);
 
             result.UserMessage.Should().Be(output);
             result.ShouldUpdateRemote.Should().BeTrue();
             _module.Received(1).RenameRemote(gitRemote.Name, remoteName);
         }
 
-        [TestCase(null, null, null)]
-        [TestCase("a", null, null)]
-        [TestCase("a", "b", null)]
-        [TestCase("a", "b", "c")]
-        public void SaveRemote_should_update_settings(string remoteUrl, string remotePushUrl, string remotePuttySshKey)
+        [TestCase(null, null, null, null)]
+        [TestCase("a", null, null, null)]
+        [TestCase("a", "b", null, null)]
+        [TestCase("a", "b", "c", null)]
+        [TestCase("a", "b", "c", "d")]
+        public void SaveRemote_should_update_settings(string? remoteUrl, string? remotePushUrl, string? remotePuttySshKey, string? remoteColor)
         {
             ConfigFileRemote remote = new() { Name = "bla", Url = remoteUrl };
 
-            _remotesManager.SaveRemote(remote, remote.Name, remoteUrl, remotePushUrl, remotePuttySshKey);
+            _remotesManager.SaveRemote(remote, remote.Name, remoteUrl, remotePushUrl, remotePuttySshKey, remoteColor);
 
             void Ensure(string setting, string value)
             {


### PR DESCRIPTION
I generally work in repos where maintainers tend to use main trunks instead of own forks, which makes repos very busy. Those repos also tend to have several remotes, which often make finding the right branch a daunting task. 
Colouring the remotes makes finding the right remote easier.


## Proposed changes

- Allow customise colors of remotes
- Reorder name and URL rows in FormRemotes dialog

**Key points:**

- The color settings are persisted in \<repo>/.gitconfig, where "remote" information is stored.
- If/whenever the app's color theme is changed, the remotes' colours must be changed manually. No automatic colour adjustment is planned.
- The feature belongs to the "advanced" feature set, and it is only available when "Show advanced option" is enabled.
    ![image](https://github.com/user-attachments/assets/a2948918-02e5-4f00-88f8-76f4ff4b45ce)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://github.com/user-attachments/assets/741a9c19-b93c-4d28-8b08-a75143a1192a)


### After

If the color is not set, then only "Set color" button is available:
![image](https://github.com/user-attachments/assets/474e7096-3cbb-473a-9d95-731ce27c88a9)

Once a color for a remote is set, then there is an additional button to reset:
![image](https://github.com/user-attachments/assets/0c5f11b9-4502-459a-82e3-74320905725c)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- I can look into adding some automated tests if there are no pushback on the implementation.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
