### PR TITLE
fix(FileViewer): Avoid crash on animated image file

### DIFF
--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Drawing.Imaging;
 using System.Text;
 using System.Text.RegularExpressions;
 using GitCommands;
@@ -1200,6 +1201,18 @@ namespace GitUI.Editor
                                     string text = getFileText();
                                     DisplayAsHexDump(_cannotViewImage.Text, fileName, text, openWithDifftool);
                                     return;
+                                }
+
+                                if (image.FrameDimensionsList.Length > 0)
+                                {
+                                    FrameDimension frameDimension = new(image.FrameDimensionsList[0]);
+                                    if (image.GetFrameCount(frameDimension) > 1)
+                                    {
+                                        image.SelectActiveFrame(frameDimension, 0);
+                                        Bitmap firstFrame = new(image);
+                                        image.Dispose();
+                                        image = firstFrame;
+                                    }
                                 }
 
                                 ResetView(ViewMode.Image, fileName, item);


### PR DESCRIPTION
Fixes #12269

## Proposed changes

FileViewer: Render only the first frame of an animated image in order to avoid exception in `PictureBox.WndProc` 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

first frame, then red frame and cross

### After

first frame

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).