### PR TITLE
refactor(LinkFactory.ExecuteLink): Use OsShellUtil

### DIFF
--- a/src/app/ResourceManager/LinkFactory.cs
+++ b/src/app/ResourceManager/LinkFactory.cs
@@ -1,6 +1,6 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility.Git;
 
@@ -112,12 +112,7 @@ namespace ResourceManager
                 return;
             }
 
-            using Process process = new()
-            {
-                EnableRaisingEvents = false,
-                StartInfo = { FileName = uri.AbsoluteUri, UseShellExecute = true },
-            };
-            process.Start();
+            OsShellUtil.OpenUrlInDefaultBrowser(uri.AbsoluteUri);
         }
 
         private static bool ParseInternalScheme(Uri? uri, [NotNullWhen(returnValue: true)] out CommandEventArgs? commandEventArgs)


### PR DESCRIPTION
Addresses https://github.com/gitextensions/gitextensions/discussions/12272#discussioncomment-12583313

## Proposed changes

- Use `OsShellUtil.OpenUrlInDefaultBrowser` wherever a URL is opened 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).