### PR TITLE
fix(delete files): Avoid wrong popup and actually support deleting multiple files

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1369,6 +1369,7 @@ namespace GitCommands
             List<string> filesToCheckout = [];
             List<string> filesToReset = [];
             List<string> filesCannotCheckout = [];
+            HashSet<GitItemStatus> deletedItems = [];
             output = new();
             Lazy<List<GitItemStatus>> postUnstageStatus = new(() => GetAllChangedFilesWithSubmodulesStatus().ToList());
 
@@ -1383,10 +1384,12 @@ namespace GitCommands
                         if (File.Exists(path))
                         {
                             File.Delete(path);
+                            deletedItems.Add(item);
                         }
                         else if (Directory.Exists(path))
                         {
                             Directory.Delete(path, recursive: true);
+                            deletedItems.Add(item);
                         }
                     }
                     catch (IOException)
@@ -1400,7 +1403,7 @@ namespace GitCommands
 
                 if (resetId == ObjectId.IndexId)
                 {
-                    if (!postUnstageStatus.Value.Any(i => i.Name == item.Name))
+                    if (deletedItems.Contains(item) || !postUnstageStatus.Value.Any(i => i.Name == item.Name))
                     {
                         // Already removed (for instance new file)
                         continue;

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -509,9 +509,9 @@ namespace GitUI.CommandsDialogs
 
         private void ResetSelectedItemsTo(bool resetToParent, bool resetAndDelete)
         {
-            IReadOnlyList<FileStatusItem> selectedItems = DiffFiles.SelectedItems.ToList();
+            FileStatusItem[] selectedItems = [.. DiffFiles.SelectedItems];
 
-            if (!selectedItems.Any())
+            if (selectedItems.Length == 0)
             {
                 return;
             }
@@ -526,8 +526,9 @@ namespace GitUI.CommandsDialogs
                         continue;
                     }
 
-                    IReadOnlyList<GitItemStatus> resetItems = (resetToParent ? selectedItems.Items()
-                        : selectedItems.Items().Select(item => item.InvertStatus())).ToList();
+                    GitItemStatus[] resetItems = [.. resetToParent
+                        ? selectedItems.Items()
+                        : selectedItems.Items().Select(item => item.InvertStatus())];
                     Module.ResetChanges(id, resetItems, resetAndDelete: resetAndDelete, _fullPathResolver, out StringBuilder output, progressAction: null);
 
                     if (output.Length > 0)
@@ -1248,8 +1249,8 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                FileStatusItem selected = DiffFiles.SelectedItem;
-                if (selected is null || !selected.SecondRevision.IsArtificial ||
+                FileStatusItem[] selected = [.. DiffFiles.SelectedItems];
+                if (selected.Length == 0 || !selected[0].SecondRevision.IsArtificial ||
                     MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo,
                         MessageBoxIcon.Warning) !=
                     DialogResult.Yes)
@@ -1261,7 +1262,7 @@ namespace GitUI.CommandsDialogs
 
                 try
                 {
-                    DeleteFromFilesystem(DiffFiles.SelectedItems);
+                    DeleteFromFilesystem(selected);
                 }
                 finally
                 {
@@ -1457,7 +1458,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResetSelectedItemsWithConfirmation(bool resetToParent)
         {
-            IEnumerable<FileStatusItem> items = DiffFiles.SelectedItems;
+            FileStatusItem[] items = [.. DiffFiles.SelectedItems];
 
             // The "new" state could change when resetting, allow user to tick the checkbox.
             // If there are only changed files, it is safe to disable the checkboc (also for restting to selected).


### PR DESCRIPTION
Fixes #11391

## Proposed changes

GitModule:
- Do not rely on the (lazy) `postUnstageStatus` for deleted files, because they may be deleted after its evaluation

RevisionDiffControl:
- Evaluate `DiffFiles.SelectedItems` (plural) instead of `DiffFiles.SelectedItem` (singular) also when checking the validity in `DeleteSelectedFiles`
- Use arrays instead of lists in `ResetSelectedItemsTo` and `ResetSelectedItemsWithConfirmation`

### Before

error popup on reset multiple new files
no reaction on delete multiple files (with #12149)

### After

reset & delete multiple new files work silently

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).