### PR TITLE
fix(stage submodule): Get working in Diff tab again

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1742,7 +1742,7 @@ namespace GitCommands
                     {
                         foreach (GitItemStatus file in nonDeletedFiles)
                         {
-                            UpdateIndex(inputWriter, file.Name);
+                            UpdateIndex(inputWriter, file.Name.TrimEnd('/'));
                         }
                     },
                     SystemEncoding,


### PR DESCRIPTION
## Proposed changes

- `RevisionDiffControl.StageFiles`: Remove trailing '/' for submodules

### Before

nothing happens (git emits a warning, which is not shown)

### After

stage a submodule in Diff tab works

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).