### PR TITLE
Add more keyboard mnemonics

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
@@ -83,7 +83,6 @@
             folderBrowserButton.Name = "folderBrowserButton";
             folderBrowserButton.Size = new Size(135, 25);
             folderBrowserButton.TabIndex = 4;
-            folderBrowserButton.Text = "&Browse...";
             folderBrowserButton.UseVisualStyleBackColor = true;
             folderBrowserButton.Click += folderBrowserButton_Click;
             // 

--- a/src/app/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -208,7 +208,7 @@
             brachLabel.Name = "brachLabel";
             brachLabel.Size = new Size(47, 32);
             brachLabel.TabIndex = 8;
-            brachLabel.Text = "&Branch:";
+            brachLabel.Text = "Br&anch:";
             brachLabel.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_Branches

--- a/src/app/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -327,6 +327,7 @@
             folderBrowserButton1.PathShowingControl = comboBoxPullSource;
             folderBrowserButton1.Size = new Size(0, 0);
             folderBrowserButton1.TabIndex = 5;
+            folderBrowserButton1.Text = "Bro&wse...";
             // 
             // GroupMergeOptions
             // 

--- a/src/app/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -327,7 +327,6 @@
             folderBrowserButton1.PathShowingControl = comboBoxPullSource;
             folderBrowserButton1.Size = new Size(0, 0);
             folderBrowserButton1.TabIndex = 5;
-            folderBrowserButton1.Text = "Bro&wse...";
             // 
             // GroupMergeOptions
             // 

--- a/src/app/GitUI/CommandsDialogs/FormPull.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPull.cs
@@ -21,8 +21,9 @@ namespace GitUI.CommandsDialogs
     public sealed partial class FormPull : GitExtensionsDialog
     {
         #region Mnemonics
-        // Available: BIJKQVXYZ
+        // Available: IJKQVXYZ
         // A Fetch all tags
+        // B Browse...
         // C Stash changes
         // D Prune remote branches and tags
         // E Rebase

--- a/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -309,7 +309,7 @@
             labelFrom.Name = "labelFrom";
             labelFrom.Size = new Size(79, 13);
             labelFrom.TabIndex = 0;
-            labelFrom.Text = "Br&anch to push";
+            labelFrom.Text = "&Branch to push";
             // 
             // TagTab
             // 
@@ -511,6 +511,7 @@
             folderBrowserButton1.PathShowingControl = PushDestination;
             folderBrowserButton1.Size = new Size(0, 0);
             folderBrowserButton1.TabIndex = 5;
+            folderBrowserButton1.Text = "Bro&wse...";
             // 
             // Pull
             // 

--- a/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -309,7 +309,7 @@
             labelFrom.Name = "labelFrom";
             labelFrom.Size = new Size(79, 13);
             labelFrom.TabIndex = 0;
-            labelFrom.Text = "&Branch to push";
+            labelFrom.Text = "Br&anch to push";
             // 
             // TagTab
             // 
@@ -511,7 +511,6 @@
             folderBrowserButton1.PathShowingControl = PushDestination;
             folderBrowserButton1.Size = new Size(0, 0);
             folderBrowserButton1.TabIndex = 5;
-            folderBrowserButton1.Text = "Bro&wse...";
             // 
             // Pull
             // 

--- a/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -440,7 +440,7 @@
             LoadSSHKey.Name = "LoadSSHKey";
             LoadSSHKey.Size = new Size(137, 25);
             LoadSSHKey.TabIndex = 3;
-            LoadSSHKey.Text = "Load SSH key";
+            LoadSSHKey.Text = "&Load SSH key";
             LoadSSHKey.UseVisualStyleBackColor = true;
             LoadSSHKey.Click += LoadSshKeyClick;
             // 
@@ -511,6 +511,7 @@
             folderBrowserButton1.PathShowingControl = PushDestination;
             folderBrowserButton1.Size = new Size(0, 0);
             folderBrowserButton1.TabIndex = 5;
+            folderBrowserButton1.Text = "Bro&wse...";
             // 
             // Pull
             // 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -291,7 +291,6 @@ namespace GitUI.CommandsDialogs
             folderBrowserButtonUrl.PathShowingControl = Url;
             folderBrowserButtonUrl.Size = new Size(104, 25);
             folderBrowserButtonUrl.TabIndex = 2;
-            folderBrowserButtonUrl.Text = "&Browse...";
             // 
             // label1
             // 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -178,7 +178,7 @@ namespace GitUI.CommandsDialogs
             btnRemoteColor.Name = "btnRemoteColor";
             btnRemoteColor.Size = new Size(63, 25);
             btnRemoteColor.TabIndex = 7;
-            btnRemoteColor.Text = "Set color";
+            btnRemoteColor.Text = "Set &color";
             btnRemoteColor.UseVisualStyleBackColor = false;
             btnRemoteColor.Click += btnRemoteColor_Click;
             // 
@@ -675,7 +675,7 @@ namespace GitUI.CommandsDialogs
             label4.Name = "label4";
             label4.Size = new Size(108, 15);
             label4.TabIndex = 0;
-            label4.Text = "L&ocal branch name";
+            label4.Text = "&Local branch name";
             // 
             // label5
             // 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs
             TestConnection.Name = "TestConnection";
             TestConnection.Size = new Size(160, 25);
             TestConnection.TabIndex = 4;
-            TestConnection.Text = "Test connection";
+            TestConnection.Text = "&Test connection";
             TestConnection.UseVisualStyleBackColor = true;
             TestConnection.Click += TestConnectionClick;
             // 
@@ -152,7 +152,7 @@ namespace GitUI.CommandsDialogs
             LoadSSHKey.Name = "LoadSSHKey";
             LoadSSHKey.Size = new Size(160, 25);
             LoadSSHKey.TabIndex = 3;
-            LoadSSHKey.Text = "Load SSH key";
+            LoadSSHKey.Text = "&Load SSH key";
             LoadSSHKey.UseVisualStyleBackColor = true;
             LoadSSHKey.Click += LoadSshKeyClick;
             // 
@@ -265,7 +265,7 @@ namespace GitUI.CommandsDialogs
             label2.Name = "label2";
             label2.Size = new Size(100, 31);
             label2.TabIndex = 0;
-            label2.Text = "Url";
+            label2.Text = "&Url";
             label2.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // Url
@@ -291,6 +291,7 @@ namespace GitUI.CommandsDialogs
             folderBrowserButtonUrl.PathShowingControl = Url;
             folderBrowserButtonUrl.Size = new Size(104, 25);
             folderBrowserButtonUrl.TabIndex = 2;
+            folderBrowserButtonUrl.Text = "&Browse...";
             // 
             // label1
             // 
@@ -300,7 +301,7 @@ namespace GitUI.CommandsDialogs
             label1.Name = "label1";
             label1.Size = new Size(100, 29);
             label1.TabIndex = 3;
-            label1.Text = "Name";
+            label1.Text = "&Name";
             label1.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // RemoteName
@@ -334,7 +335,7 @@ namespace GitUI.CommandsDialogs
             checkBoxSepPushUrl.Padding = new Padding(24, 0, 0, 0);
             checkBoxSepPushUrl.Size = new Size(354, 19);
             checkBoxSepPushUrl.TabIndex = 9;
-            checkBoxSepPushUrl.Text = "Separate Push Url";
+            checkBoxSepPushUrl.Text = "Sep&arate Push Url";
             checkBoxSepPushUrl.UseVisualStyleBackColor = true;
             checkBoxSepPushUrl.CheckedChanged += checkBoxSepPushUrl_CheckedChanged;
             // 
@@ -346,7 +347,7 @@ namespace GitUI.CommandsDialogs
             labelPushUrl.Name = "labelPushUrl";
             labelPushUrl.Size = new Size(100, 31);
             labelPushUrl.TabIndex = 10;
-            labelPushUrl.Text = "Push Url";
+            labelPushUrl.Text = "&Push Url";
             labelPushUrl.TextAlign = ContentAlignment.MiddleLeft;
             labelPushUrl.Visible = false;
             // 
@@ -374,6 +375,7 @@ namespace GitUI.CommandsDialogs
             folderBrowserButtonPushUrl.PathShowingControl = comboBoxPushUrl;
             folderBrowserButtonPushUrl.Size = new Size(104, 25);
             folderBrowserButtonPushUrl.TabIndex = 12;
+            folderBrowserButtonPushUrl.Text = "Bro&wse...";
             folderBrowserButtonPushUrl.Visible = false;
             // 
             // pnlMgtPuttySsh
@@ -421,7 +423,7 @@ namespace GitUI.CommandsDialogs
             label3.Name = "label3";
             label3.Size = new Size(100, 31);
             label3.TabIndex = 0;
-            label3.Text = "Private key file";
+            label3.Text = "Private &key file";
             label3.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // PuttySshKey
@@ -444,7 +446,7 @@ namespace GitUI.CommandsDialogs
             SshBrowse.Name = "SshBrowse";
             SshBrowse.Size = new Size(104, 25);
             SshBrowse.TabIndex = 2;
-            SshBrowse.Text = " Browse...";
+            SshBrowse.Text = "Brows&e...";
             SshBrowse.TextImageRelation = TextImageRelation.ImageBeforeText;
             SshBrowse.UseVisualStyleBackColor = true;
             SshBrowse.Click += SshBrowseClick;
@@ -489,7 +491,7 @@ namespace GitUI.CommandsDialogs
             Save.Name = "Save";
             Save.Size = new Size(130, 25);
             Save.TabIndex = 0;
-            Save.Text = "Save changes";
+            Save.Text = "&Save changes";
             Save.UseVisualStyleBackColor = true;
             Save.Click += SaveClick;
             // 
@@ -673,7 +675,7 @@ namespace GitUI.CommandsDialogs
             label4.Name = "label4";
             label4.Size = new Size(108, 15);
             label4.TabIndex = 0;
-            label4.Text = "Local branch name";
+            label4.Text = "L&ocal branch name";
             // 
             // label5
             // 
@@ -682,7 +684,7 @@ namespace GitUI.CommandsDialogs
             label5.Name = "label5";
             label5.Size = new Size(104, 15);
             label5.TabIndex = 1;
-            label5.Text = "Remote repository";
+            label5.Text = "&Remote repository";
             // 
             // label6
             // 
@@ -691,7 +693,7 @@ namespace GitUI.CommandsDialogs
             label6.Name = "label6";
             label6.Size = new Size(108, 15);
             label6.TabIndex = 2;
-            label6.Text = "Default merge with";
+            label6.Text = "&Default merge with";
             // 
             // DefaultMergeWithCombo
             // 
@@ -732,7 +734,7 @@ namespace GitUI.CommandsDialogs
             SaveDefaultPushPull.Name = "SaveDefaultPushPull";
             SaveDefaultPushPull.Size = new Size(130, 25);
             SaveDefaultPushPull.TabIndex = 3;
-            SaveDefaultPushPull.Text = "Save changes";
+            SaveDefaultPushPull.Text = "&Save changes";
             SaveDefaultPushPull.TextImageRelation = TextImageRelation.ImageBeforeText;
             SaveDefaultPushPull.UseVisualStyleBackColor = true;
             SaveDefaultPushPull.Click += SaveDefaultPushPullClick;

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -63,10 +63,10 @@ namespace GitUI.CommandsDialogs
             new("Select ssh key file");
 
         private readonly TranslationString _labelUrlAsFetch =
-            new("Fetch Url");
+            new("Fetch &Url");
 
         private readonly TranslationString _labelUrlAsFetchPush =
-            new("Url");
+            new("&Url");
 
         private readonly TranslationString _gbMgtPanelHeaderNew =
             new("Create New Remote");

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.Designer.cs
@@ -68,7 +68,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             createDirTB = new TextBox();
             createDirectoryLbl = new Label();
             label1 = new Label();
-            browseForCloneToDirbtn = new Button();
+            browseForCloneToDirbtn = new UserControls.FolderBrowserButton();
             destinationTB = new TextBox();
             depthUpDown = new NumericUpDown();
             flowLayoutPanel1 = new FlowLayoutPanel();
@@ -518,10 +518,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // 
             browseForCloneToDirbtn.Location = new Point(310, 32);
             browseForCloneToDirbtn.Name = "browseForCloneToDirbtn";
+            browseForCloneToDirbtn.PathShowingControl = createDirTB;
             browseForCloneToDirbtn.Size = new Size(102, 23);
             browseForCloneToDirbtn.TabIndex = 2;
-            browseForCloneToDirbtn.Text = "Browse...";
-            browseForCloneToDirbtn.UseVisualStyleBackColor = true;
             browseForCloneToDirbtn.Click += _browseForCloneToDirbtn_Click;
             // 
             // destinationTB
@@ -616,7 +615,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private TextBox createDirTB;
         private Label createDirectoryLbl;
         private Label label1;
-        private Button browseForCloneToDirbtn;
+        private UserControls.FolderBrowserButton browseForCloneToDirbtn;
         private TextBox destinationTB;
         private FlowLayoutPanel flowLayoutPanel1;
         private Label cloneInfoText;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.Designer.cs
@@ -66,7 +66,6 @@
             otherHomeBrowse.PathShowingControl = otherHomeDir;
             otherHomeBrowse.Size = new Size(130, 25);
             otherHomeBrowse.TabIndex = 5;
-            otherHomeBrowse.Text = "&Browse...";
             // 
             // otherHomeDir
             // 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.Designer.cs
@@ -66,6 +66,7 @@
             otherHomeBrowse.PathShowingControl = otherHomeDir;
             otherHomeBrowse.Size = new Size(130, 25);
             otherHomeBrowse.TabIndex = 5;
+            otherHomeBrowse.Text = "&Browse...";
             // 
             // otherHomeDir
             // 
@@ -84,7 +85,7 @@
             otherHome.Size = new Size(53, 17);
             otherHome.TabIndex = 3;
             otherHome.TabStop = true;
-            otherHome.Text = "Other";
+            otherHome.Text = "&Other";
             otherHome.UseVisualStyleBackColor = true;
             // 
             // userprofileHome
@@ -95,7 +96,7 @@
             userprofileHome.Size = new Size(157, 17);
             userprofileHome.TabIndex = 2;
             userprofileHome.TabStop = true;
-            userprofileHome.Text = "Set HOME to USERPROFILE";
+            userprofileHome.Text = "&Set HOME to USERPROFILE";
             userprofileHome.UseVisualStyleBackColor = true;
             // 
             // defaultHome
@@ -106,7 +107,7 @@
             defaultHome.Size = new Size(129, 17);
             defaultHome.TabIndex = 1;
             defaultHome.TabStop = true;
-            defaultHome.Text = "Use default for HOME";
+            defaultHome.Text = "&Use default for HOME";
             defaultHome.UseVisualStyleBackColor = true;
             // 
             // label51

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.Designer.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.Designer.cs
@@ -283,7 +283,7 @@ namespace GitUI.LeftPanel
             mnuBtnPruneAllBranchesFromARemote.Image = Properties.Images.PullFetchPrune;
             mnuBtnPruneAllBranchesFromARemote.Name = "mnuBtnPruneAllBranchesFromARemote";
             mnuBtnPruneAllBranchesFromARemote.Size = new Size(266, 26);
-            mnuBtnPruneAllBranchesFromARemote.Text = "Fetch and prune";
+            mnuBtnPruneAllBranchesFromARemote.Text = "Fetch and &prune";
             // 
             // mnuBtnOpenRemoteUrlInBrowser
             // 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -5018,7 +5018,7 @@ Do you want Git Extensions to help locate the correct folder?</source>
         <target />
       </trans-unit>
       <trans-unit id="defaultHome.Text">
-        <source>Use default for HOME</source>
+        <source>&amp;Use default for HOME</source>
         <target />
       </trans-unit>
       <trans-unit id="groupBox8.Text">
@@ -5036,15 +5036,15 @@ Change the default behaviour only if you experience problems.</source>
         <target />
       </trans-unit>
       <trans-unit id="otherHome.Text">
-        <source>Other</source>
+        <source>&amp;Other</source>
         <target />
       </trans-unit>
       <trans-unit id="otherHomeBrowse.Text">
-        <source>Browse...</source>
+        <source>&amp;Browse...</source>
         <target />
       </trans-unit>
       <trans-unit id="userprofileHome.Text">
-        <source>Set HOME to USERPROFILE</source>
+        <source>&amp;Set HOME to USERPROFILE</source>
         <target />
       </trans-unit>
     </body>

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2164,18 +2164,6 @@ Suitable for some config files modified locally.</source>
       </trans-unit>
     </body>
   </file>
-  <file datatype="plaintext" original="FolderBrowserButton" source-language="en">
-    <body>
-      <trans-unit id="$this.Text">
-        <source>Browse...</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="buttonBrowse.Text">
-        <source>Browse...</source>
-        <target />
-      </trans-unit>
-    </body>
-  </file>
   <file datatype="plaintext" original="ForkAndCloneForm" source-language="en">
     <body>
       <trans-unit id="$this.Text">
@@ -4504,10 +4492,6 @@ You can unset the template:
         <source>Create the new worktree</source>
         <target />
       </trans-unit>
-      <trans-unit id="folderBrowserButton1.Text">
-        <source>Browse...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="groupBoxWhatToCheckout.Text">
         <source>What to checkout: </source>
         <target />
@@ -5379,10 +5363,6 @@ packages/</source>
     <body>
       <trans-unit id="$this.Text">
         <source>Create new repository</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="Browse.Text">
-        <source>Browse...</source>
         <target />
       </trans-unit>
       <trans-unit id="Central.Text">

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -5023,10 +5023,6 @@ Change the default behaviour only if you experience problems.</source>
         <source>&amp;Other</source>
         <target />
       </trans-unit>
-      <trans-unit id="otherHomeBrowse.Text">
-        <source>&amp;Browse...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="userprofileHome.Text">
         <source>&amp;Set HOME to USERPROFILE</source>
         <target />
@@ -5645,10 +5641,6 @@ command "git help shortlog"</source>
       </trans-unit>
       <trans-unit id="_warningOpenFailed.Text">
         <source>The selected directory is not a valid git repository.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="folderBrowserButton.Text">
-        <source>&amp;Browse...</source>
         <target />
       </trans-unit>
       <trans-unit id="folderGoUpButton.toolTip1">
@@ -6730,10 +6722,6 @@ Value has been reset to empty value.</source>
       </trans-unit>
       <trans-unit id="folderBrowserButtonPushUrl.Text">
         <source>Bro&amp;wse...</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="folderBrowserButtonUrl.Text">
-        <source>&amp;Browse...</source>
         <target />
       </trans-unit>
       <trans-unit id="gbMgtPanel.Text">

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2164,6 +2164,14 @@ Suitable for some config files modified locally.</source>
       </trans-unit>
     </body>
   </file>
+  <file datatype="plaintext" original="FolderBrowserButton" source-language="en">
+    <body>
+      <trans-unit id="buttonBrowse.Text">
+        <source>&amp;Browse...</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="ForkAndCloneForm" source-language="en">
     <body>
       <trans-unit id="$this.Text">

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2166,6 +2166,10 @@ Suitable for some config files modified locally.</source>
   </file>
   <file datatype="plaintext" original="FolderBrowserButton" source-language="en">
     <body>
+      <trans-unit id="$this.Text">
+        <source>Browse...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="buttonBrowse.Text">
         <source>Browse...</source>
         <target />
@@ -4500,6 +4504,10 @@ You can unset the template:
         <source>Create the new worktree</source>
         <target />
       </trans-unit>
+      <trans-unit id="folderBrowserButton1.Text">
+        <source>Browse...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="groupBoxWhatToCheckout.Text">
         <source>What to checkout: </source>
         <target />
@@ -5031,6 +5039,10 @@ Change the default behaviour only if you experience problems.</source>
         <source>Other</source>
         <target />
       </trans-unit>
+      <trans-unit id="otherHomeBrowse.Text">
+        <source>Browse...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="userprofileHome.Text">
         <source>Set HOME to USERPROFILE</source>
         <target />
@@ -5367,6 +5379,10 @@ packages/</source>
     <body>
       <trans-unit id="$this.Text">
         <source>Create new repository</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Browse.Text">
+        <source>Browse...</source>
         <target />
       </trans-unit>
       <trans-unit id="Central.Text">
@@ -5898,6 +5914,10 @@ This will initialize and update all submodules recursive.</source>
         <source>Please select a source directory</source>
         <target />
       </trans-unit>
+      <trans-unit id="folderBrowserButton1.Text">
+        <source>Bro&amp;wse...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="lblLocalBranch.Text">
         <source>&amp;Local branch</source>
         <target />
@@ -5951,7 +5971,7 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="LoadSSHKey.Text">
-        <source>Load SSH key</source>
+        <source>&amp;Load SSH key</source>
         <target />
       </trans-unit>
       <trans-unit id="LocalColumn.HeaderText">
@@ -6126,6 +6146,10 @@ Would you like to do it now?</source>
       </trans-unit>
       <trans-unit id="ckForceWithLease.Text">
         <source>&amp;Force with lease</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="folderBrowserButton1.Text">
+        <source>Bro&amp;wse...</source>
         <target />
       </trans-unit>
       <trans-unit id="groupBox2.Text">
@@ -6594,7 +6618,7 @@ Do you want to register the host's fingerprint and restart the process?</source>
         <target />
       </trans-unit>
       <trans-unit id="LoadSSHKey.Text">
-        <source>Load SSH key</source>
+        <source>&amp;Load SSH key</source>
         <target />
       </trans-unit>
       <trans-unit id="MergeWith.HeaderText">
@@ -6610,19 +6634,19 @@ Do you want to register the host's fingerprint and restart the process?</source>
         <target />
       </trans-unit>
       <trans-unit id="Save.Text">
-        <source>Save changes</source>
+        <source>&amp;Save changes</source>
         <target />
       </trans-unit>
       <trans-unit id="SaveDefaultPushPull.Text">
-        <source>Save changes</source>
+        <source>&amp;Save changes</source>
         <target />
       </trans-unit>
       <trans-unit id="SshBrowse.Text">
-        <source> Browse...</source>
+        <source>Brows&amp;e...</source>
         <target />
       </trans-unit>
       <trans-unit id="TestConnection.Text">
-        <source>Test connection</source>
+        <source>&amp;Test connection</source>
         <target />
       </trans-unit>
       <trans-unit id="_btnDeleteTooltip.Text">
@@ -6663,11 +6687,11 @@ Inactive remote is completely invisible to git.</source>
         <target />
       </trans-unit>
       <trans-unit id="_labelUrlAsFetch.Text">
-        <source>Fetch Url</source>
+        <source>Fetch &amp;Url</source>
         <target />
       </trans-unit>
       <trans-unit id="_labelUrlAsFetchPush.Text">
-        <source>Url</source>
+        <source>&amp;Url</source>
         <target />
       </trans-unit>
       <trans-unit id="_lvgDisabledHeader.Text">
@@ -6721,7 +6745,15 @@ Value has been reset to empty value.</source>
         <target />
       </trans-unit>
       <trans-unit id="checkBoxSepPushUrl.Text">
-        <source>Separate Push Url</source>
+        <source>Sep&amp;arate Push Url</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="folderBrowserButtonPushUrl.Text">
+        <source>Bro&amp;wse...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="folderBrowserButtonUrl.Text">
+        <source>&amp;Browse...</source>
         <target />
       </trans-unit>
       <trans-unit id="gbMgtPanel.Text">
@@ -6729,31 +6761,31 @@ Value has been reset to empty value.</source>
         <target />
       </trans-unit>
       <trans-unit id="label1.Text">
-        <source>Name</source>
+        <source>&amp;Name</source>
         <target />
       </trans-unit>
       <trans-unit id="label2.Text">
-        <source>Url</source>
+        <source>&amp;Url</source>
         <target />
       </trans-unit>
       <trans-unit id="label3.Text">
-        <source>Private key file</source>
+        <source>Private &amp;key file</source>
         <target />
       </trans-unit>
       <trans-unit id="label4.Text">
-        <source>Local branch name</source>
+        <source>L&amp;ocal branch name</source>
         <target />
       </trans-unit>
       <trans-unit id="label5.Text">
-        <source>Remote repository</source>
+        <source>&amp;Remote repository</source>
         <target />
       </trans-unit>
       <trans-unit id="label6.Text">
-        <source>Default merge with</source>
+        <source>&amp;Default merge with</source>
         <target />
       </trans-unit>
       <trans-unit id="labelPushUrl.Text">
-        <source>Push Url</source>
+        <source>&amp;Push Url</source>
         <target />
       </trans-unit>
       <trans-unit id="lblMgtPuttyPanelHeader.Text">
@@ -8845,7 +8877,7 @@ Reset the filter via View &gt; Show all branches.</source>
         <target />
       </trans-unit>
       <trans-unit id="mnuBtnPruneAllBranchesFromARemote.Text">
-        <source>Fetch and prune</source>
+        <source>Fetch and &amp;prune</source>
         <target />
       </trans-unit>
       <trans-unit id="mnuBtnPruneAllRemotes.Text">

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6733,7 +6733,7 @@ Value has been reset to empty value.</source>
         <target />
       </trans-unit>
       <trans-unit id="btnRemoteColor.Text">
-        <source>Set color</source>
+        <source>Set &amp;color</source>
         <target />
       </trans-unit>
       <trans-unit id="btnRemoteColorReset.Text">
@@ -6773,7 +6773,7 @@ Value has been reset to empty value.</source>
         <target />
       </trans-unit>
       <trans-unit id="label4.Text">
-        <source>L&amp;ocal branch name</source>
+        <source>&amp;Local branch name</source>
         <target />
       </trans-unit>
       <trans-unit id="label5.Text">

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6120,6 +6120,10 @@ Would you like to do it now?</source>
         <source>&amp;Force with lease</source>
         <target />
       </trans-unit>
+      <trans-unit id="folderBrowserButton1.Text">
+        <source>Bro&amp;wse...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="groupBox2.Text">
         <source>Push to</source>
         <target />
@@ -6133,7 +6137,7 @@ Would you like to do it now?</source>
         <target />
       </trans-unit>
       <trans-unit id="labelFrom.Text">
-        <source>Br&amp;anch to push</source>
+        <source>&amp;Branch to push</source>
         <target />
       </trans-unit>
       <trans-unit id="labelTo.Text">

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2232,10 +2232,6 @@ You can not push unless you are a collaborator. {2}</source>
 You will have push access. {2}</source>
         <target />
       </trans-unit>
-      <trans-unit id="browseForCloneToDirbtn.Text">
-        <source>Browse...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="cloneBtn.Text">
         <source>Clone</source>
         <target />
@@ -3865,7 +3861,7 @@ Do you want to open the new repository "{0}" now?</source>
         <target />
       </trans-unit>
       <trans-unit id="brachLabel.Text">
-        <source>&amp;Branch:</source>
+        <source>Br&amp;anch:</source>
         <target />
       </trans-unit>
       <trans-unit id="cbDownloadFullHistory.Text">
@@ -5886,10 +5882,6 @@ This will initialize and update all submodules recursive.</source>
         <source>Please select a source directory</source>
         <target />
       </trans-unit>
-      <trans-unit id="folderBrowserButton1.Text">
-        <source>Bro&amp;wse...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="lblLocalBranch.Text">
         <source>&amp;Local branch</source>
         <target />
@@ -6120,10 +6112,6 @@ Would you like to do it now?</source>
         <source>&amp;Force with lease</source>
         <target />
       </trans-unit>
-      <trans-unit id="folderBrowserButton1.Text">
-        <source>Bro&amp;wse...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="groupBox2.Text">
         <source>Push to</source>
         <target />
@@ -6137,7 +6125,7 @@ Would you like to do it now?</source>
         <target />
       </trans-unit>
       <trans-unit id="labelFrom.Text">
-        <source>&amp;Branch to push</source>
+        <source>Br&amp;anch to push</source>
         <target />
       </trans-unit>
       <trans-unit id="labelTo.Text">

--- a/src/app/GitUI/UserControls/FolderBrowserButton.Designer.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.Designer.cs
@@ -43,7 +43,7 @@
             _NO_TRANSLATE_buttonBrowse.Name = "_NO_TRANSLATE_buttonBrowse";
             _NO_TRANSLATE_buttonBrowse.Size = new Size(100, 25);
             _NO_TRANSLATE_buttonBrowse.TabIndex = 5;
-            _NO_TRANSLATE_buttonBrowse.Text = "Browse...";
+            _NO_TRANSLATE_buttonBrowse.Text = "&Browse...";
             _NO_TRANSLATE_buttonBrowse.UseVisualStyleBackColor = true;
             _NO_TRANSLATE_buttonBrowse.Click += buttonBrowse_Click;
             // 

--- a/src/app/GitUI/UserControls/FolderBrowserButton.Designer.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.Designer.cs
@@ -28,29 +28,29 @@
         /// </summary>
         private void InitializeComponent()
         {
-            _NO_TRANSLATE_buttonBrowse = new Button();
+            buttonBrowse = new Button();
             SuspendLayout();
             // 
-            // _NO_TRANSLATE_buttonBrowse
+            // buttonBrowse
             // 
-            _NO_TRANSLATE_buttonBrowse.AutoSize = true;
-            _NO_TRANSLATE_buttonBrowse.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            _NO_TRANSLATE_buttonBrowse.Dock = DockStyle.Fill;
-            _NO_TRANSLATE_buttonBrowse.Image = Properties.Images.BrowseFileExplorer;
-            _NO_TRANSLATE_buttonBrowse.ImageAlign = ContentAlignment.MiddleLeft;
-            _NO_TRANSLATE_buttonBrowse.Location = new Point(0, 0);
-            _NO_TRANSLATE_buttonBrowse.MinimumSize = new Size(100, 25);
-            _NO_TRANSLATE_buttonBrowse.Name = "_NO_TRANSLATE_buttonBrowse";
-            _NO_TRANSLATE_buttonBrowse.Size = new Size(100, 25);
-            _NO_TRANSLATE_buttonBrowse.TabIndex = 5;
-            _NO_TRANSLATE_buttonBrowse.Text = "&Browse...";
-            _NO_TRANSLATE_buttonBrowse.UseVisualStyleBackColor = true;
-            _NO_TRANSLATE_buttonBrowse.Click += buttonBrowse_Click;
+            buttonBrowse.AutoSize = true;
+            buttonBrowse.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            buttonBrowse.Dock = DockStyle.Fill;
+            buttonBrowse.Image = Properties.Images.BrowseFileExplorer;
+            buttonBrowse.ImageAlign = ContentAlignment.MiddleLeft;
+            buttonBrowse.Location = new Point(0, 0);
+            buttonBrowse.MinimumSize = new Size(100, 25);
+            buttonBrowse.Name = "buttonBrowse";
+            buttonBrowse.Size = new Size(100, 25);
+            buttonBrowse.TabIndex = 5;
+            buttonBrowse.Text = "&Browse...";
+            buttonBrowse.UseVisualStyleBackColor = true;
+            buttonBrowse.Click += buttonBrowse_Click;
             // 
             // FolderBrowserButton
             // 
             AutoScaleMode = AutoScaleMode.Inherit;
-            Controls.Add(_NO_TRANSLATE_buttonBrowse);
+            Controls.Add(buttonBrowse);
             Name = "FolderBrowserButton";
             Size = new Size(100, 25);
             ResumeLayout(false);
@@ -60,6 +60,6 @@
 
         #endregion
 
-        private Button _NO_TRANSLATE_buttonBrowse;
+        private Button buttonBrowse;
     }
 }

--- a/src/app/GitUI/UserControls/FolderBrowserButton.Designer.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.Designer.cs
@@ -28,29 +28,29 @@
         /// </summary>
         private void InitializeComponent()
         {
-            buttonBrowse = new Button();
+            _NO_TRANSLATE_buttonBrowse = new Button();
             SuspendLayout();
             // 
-            // buttonBrowse
+            // _NO_TRANSLATE_buttonBrowse
             // 
-            buttonBrowse.AutoSize = true;
-            buttonBrowse.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            buttonBrowse.Dock = DockStyle.Fill;
-            buttonBrowse.Image = Properties.Images.BrowseFileExplorer;
-            buttonBrowse.ImageAlign = ContentAlignment.MiddleLeft;
-            buttonBrowse.Location = new Point(0, 0);
-            buttonBrowse.MinimumSize = new Size(100, 25);
-            buttonBrowse.Name = "buttonBrowse";
-            buttonBrowse.Size = new Size(100, 25);
-            buttonBrowse.TabIndex = 5;
-            buttonBrowse.Text = "Browse...";
-            buttonBrowse.UseVisualStyleBackColor = true;
-            buttonBrowse.Click += buttonBrowse_Click;
+            _NO_TRANSLATE_buttonBrowse.AutoSize = true;
+            _NO_TRANSLATE_buttonBrowse.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _NO_TRANSLATE_buttonBrowse.Dock = DockStyle.Fill;
+            _NO_TRANSLATE_buttonBrowse.Image = Properties.Images.BrowseFileExplorer;
+            _NO_TRANSLATE_buttonBrowse.ImageAlign = ContentAlignment.MiddleLeft;
+            _NO_TRANSLATE_buttonBrowse.Location = new Point(0, 0);
+            _NO_TRANSLATE_buttonBrowse.MinimumSize = new Size(100, 25);
+            _NO_TRANSLATE_buttonBrowse.Name = "_NO_TRANSLATE_buttonBrowse";
+            _NO_TRANSLATE_buttonBrowse.Size = new Size(100, 25);
+            _NO_TRANSLATE_buttonBrowse.TabIndex = 5;
+            _NO_TRANSLATE_buttonBrowse.Text = "Browse...";
+            _NO_TRANSLATE_buttonBrowse.UseVisualStyleBackColor = true;
+            _NO_TRANSLATE_buttonBrowse.Click += buttonBrowse_Click;
             // 
             // FolderBrowserButton
             // 
             AutoScaleMode = AutoScaleMode.Inherit;
-            Controls.Add(buttonBrowse);
+            Controls.Add(_NO_TRANSLATE_buttonBrowse);
             Name = "FolderBrowserButton";
             Size = new Size(100, 25);
             ResumeLayout(false);
@@ -60,6 +60,6 @@
 
         #endregion
 
-        private Button buttonBrowse;
+        private Button _NO_TRANSLATE_buttonBrowse;
     }
 }

--- a/src/app/GitUI/UserControls/FolderBrowserButton.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.cs
@@ -23,8 +23,12 @@ namespace GitUI.UserControls
         /// </summary>
         public override string Text
         {
-            get => buttonBrowse.Text;
-            set => buttonBrowse.Text = value;
+            get => base.Text;
+            set
+            {
+                base.Text = value;
+                _NO_TRANSLATE_buttonBrowse.Text = value;
+            }
         }
 
         /// <summary>

--- a/src/app/GitUI/UserControls/FolderBrowserButton.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.cs
@@ -19,6 +19,15 @@ namespace GitUI.UserControls
         public Control? PathShowingControl { get; set; }
 
         /// <summary>
+        /// Specifies the text label of the button.
+        /// </summary>
+        public override string Text
+        {
+            get => buttonBrowse.Text;
+            set => buttonBrowse.Text = value;
+        }
+
+        /// <summary>
         /// Opens a a folder picker dialog with the path in "getter" preselected and
         /// if OK is returned uses "setter" to set the path.
         /// </summary>

--- a/src/app/GitUI/UserControls/FolderBrowserButton.cs
+++ b/src/app/GitUI/UserControls/FolderBrowserButton.cs
@@ -27,7 +27,7 @@ namespace GitUI.UserControls
             set
             {
                 base.Text = value;
-                _NO_TRANSLATE_buttonBrowse.Text = value;
+                buttonBrowse.Text = value;
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Hello! I’m back with more keyboard mnemonics:

* All elements in “Remote Repositories” dialog
* The “Fetch and Prune” command in the remote right-click menu
* “Load SSH key” in “Push” dialog

## Screenshots

![master](https://github.com/user-attachments/assets/e8a521cd-4ee7-4fd4-8bb8-fef27e26d7f3)

## Mnemonics added in “Remote Repositories”

```
E	Separate Push Url (checkbox; R tab)
F	Default merge with (textbox/dropdown; D tab)
K	Private key file (textbox; R tab)
L	Load SSH key (button; R tab)
L	Local branch name (textbox; D tab)
N	Name (textbox; R tab)
P	Push Url (textbox; R tab)
R	Remote repository (textbox/dropdown; D tab)
S	Save changes (button)
T	Test connection (button; R tab)
U	Url/Fetch Url (textbox; R tab)
```

## Contribution

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
