### PR TITLE
Mnemonics in Commit window right-click menus for files and submodules

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -228,14 +228,14 @@ namespace GitUI.CommandsDialogs
             tsmiResetUnstagedChanges.Image = Properties.Images.ResetWorkingDirChanges;
             tsmiResetUnstagedChanges.Name = "tsmiResetUnstagedChanges";
             tsmiResetUnstagedChanges.Size = new Size(232, 22);
-            tsmiResetUnstagedChanges.Text = "Reset file or directory changes";
+            tsmiResetUnstagedChanges.Text = "&Reset file or directory changes";
             tsmiResetUnstagedChanges.Click += ResetFilesClick;
             // 
             // resetPartOfFileToolStripMenuItem
             // 
             resetPartOfFileToolStripMenuItem.Name = "resetPartOfFileToolStripMenuItem";
             resetPartOfFileToolStripMenuItem.Size = new Size(232, 22);
-            resetPartOfFileToolStripMenuItem.Text = "Reset chunk of file";
+            resetPartOfFileToolStripMenuItem.Text = "Reset chunk of fi&le";
             resetPartOfFileToolStripMenuItem.Click += ResetPartOfFileToolStripMenuItemClick;
             // 
             // toolStripSeparator12
@@ -247,14 +247,14 @@ namespace GitUI.CommandsDialogs
             // 
             openToolStripMenuItem.Name = "openToolStripMenuItem";
             openToolStripMenuItem.Size = new Size(232, 22);
-            openToolStripMenuItem.Text = "Open";
+            openToolStripMenuItem.Text = "&Open";
             openToolStripMenuItem.Click += OpenToolStripMenuItemClick;
             // 
             // openWithToolStripMenuItem
             // 
             openWithToolStripMenuItem.Name = "openWithToolStripMenuItem";
             openWithToolStripMenuItem.Size = new Size(232, 22);
-            openWithToolStripMenuItem.Text = "Open with...";
+            openWithToolStripMenuItem.Text = "Open &with...";
             openWithToolStripMenuItem.Click += OpenWithToolStripMenuItemClick;
             // 
             // stageToolStripMenuItem
@@ -270,7 +270,7 @@ namespace GitUI.CommandsDialogs
             openWithDifftoolToolStripMenuItem.Image = Properties.Images.Diff;
             openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
             openWithDifftoolToolStripMenuItem.Size = new Size(232, 22);
-            openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
+            openWithDifftoolToolStripMenuItem.Text = "O&pen with difftool";
             openWithDifftoolToolStripMenuItem.Click += openWithDifftoolToolStripMenuItem_Click;
             // 
             // toolStripSeparator9
@@ -283,7 +283,7 @@ namespace GitUI.CommandsDialogs
             filenameToClipboardToolStripMenuItem.Image = Properties.Images.CopyToClipboard;
             filenameToClipboardToolStripMenuItem.Name = "filenameToClipboardToolStripMenuItem";
             filenameToClipboardToolStripMenuItem.Size = new Size(232, 22);
-            filenameToClipboardToolStripMenuItem.Text = "Copy full path";
+            filenameToClipboardToolStripMenuItem.Text = "&Copy full path";
             filenameToClipboardToolStripMenuItem.Click += FilenameToClipboardToolStripMenuItemClick;
             // 
             // openContainingFolderToolStripMenuItem
@@ -291,7 +291,7 @@ namespace GitUI.CommandsDialogs
             openContainingFolderToolStripMenuItem.Image = Properties.Images.BrowseFileExplorer;
             openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
             openContainingFolderToolStripMenuItem.Size = new Size(232, 22);
-            openContainingFolderToolStripMenuItem.Text = "Show in folder";
+            openContainingFolderToolStripMenuItem.Text = "Show in &folder";
             openContainingFolderToolStripMenuItem.Click += openContainingFolderToolStripMenuItem_Click;
             // 
             // toolStripSeparator8
@@ -304,7 +304,7 @@ namespace GitUI.CommandsDialogs
             viewFileHistoryToolStripItem.Image = Properties.Images.FileHistory;
             viewFileHistoryToolStripItem.Name = "viewFileHistoryToolStripItem";
             viewFileHistoryToolStripItem.Size = new Size(232, 22);
-            viewFileHistoryToolStripItem.Text = "View file history";
+            viewFileHistoryToolStripItem.Text = "View file &history";
             viewFileHistoryToolStripItem.Click += ViewFileHistoryMenuItem_Click;
             // 
             // editFileToolStripMenuItem
@@ -312,7 +312,7 @@ namespace GitUI.CommandsDialogs
             editFileToolStripMenuItem.Image = Properties.Images.EditFile;
             editFileToolStripMenuItem.Name = "editFileToolStripMenuItem";
             editFileToolStripMenuItem.Size = new Size(232, 22);
-            editFileToolStripMenuItem.Text = "Edit file";
+            editFileToolStripMenuItem.Text = "&Edit file";
             editFileToolStripMenuItem.Click += editFileToolStripMenuItem_Click;
             //
             // deleteFileToolStripMenuItem
@@ -320,7 +320,7 @@ namespace GitUI.CommandsDialogs
             deleteFileToolStripMenuItem.Image = Properties.Images.DeleteFile;
             deleteFileToolStripMenuItem.Name = "deleteFileToolStripMenuItem";
             deleteFileToolStripMenuItem.Size = new Size(232, 22);
-            deleteFileToolStripMenuItem.Text = "Delete file";
+            deleteFileToolStripMenuItem.Text = "&Delete file";
             deleteFileToolStripMenuItem.Click += DeleteFileToolStripMenuItemClick;
             //
             // toolStripSeparator5
@@ -333,7 +333,7 @@ namespace GitUI.CommandsDialogs
             addFileToGitIgnoreToolStripMenuItem.Image = Properties.Images.AddToGitIgnore;
             addFileToGitIgnoreToolStripMenuItem.Name = "addFileToGitIgnoreToolStripMenuItem";
             addFileToGitIgnoreToolStripMenuItem.Size = new Size(232, 22);
-            addFileToGitIgnoreToolStripMenuItem.Text = "Add file to .gitignore";
+            addFileToGitIgnoreToolStripMenuItem.Text = "Add file to .&gitignore";
             addFileToGitIgnoreToolStripMenuItem.Click += AddFileToGitIgnoreToolStripMenuItemClick;
             // 
             // addFileToGitInfoExcludeLocallyToolStripMenuItem
@@ -341,14 +341,14 @@ namespace GitUI.CommandsDialogs
             addFileToGitInfoExcludeLocallyToolStripMenuItem.Image = Properties.Images.AddToGitIgnore;
             addFileToGitInfoExcludeLocallyToolStripMenuItem.Name = "addFileToGitInfoExcludeLocallyToolStripMenuItem";
             addFileToGitInfoExcludeLocallyToolStripMenuItem.Size = new Size(232, 22);
-            addFileToGitInfoExcludeLocallyToolStripMenuItem.Text = "Add file to .git/info/exclude";
+            addFileToGitInfoExcludeLocallyToolStripMenuItem.Text = "Add file to .git/info/e&xclude";
             addFileToGitInfoExcludeLocallyToolStripMenuItem.Click += AddFileToGitInfoExcludeToolStripMenuItemClick;
             // 
             // skipWorktreeToolStripMenuItem
             // 
             skipWorktreeToolStripMenuItem.Name = "skipWorktreeToolStripMenuItem";
             skipWorktreeToolStripMenuItem.Size = new Size(232, 22);
-            skipWorktreeToolStripMenuItem.Text = "Skip worktree";
+            skipWorktreeToolStripMenuItem.Text = "S&kip worktree";
             skipWorktreeToolStripMenuItem.Click += SkipWorktreeToolStripMenuItemClick;
             // 
             // doNotSkipWorktreeToolStripMenuItem
@@ -363,14 +363,14 @@ namespace GitUI.CommandsDialogs
             // 
             assumeUnchangedToolStripMenuItem.Name = "assumeUnchangedToolStripMenuItem";
             assumeUnchangedToolStripMenuItem.Size = new Size(232, 22);
-            assumeUnchangedToolStripMenuItem.Text = "Assume unchanged";
+            assumeUnchangedToolStripMenuItem.Text = "&Assume unchanged";
             assumeUnchangedToolStripMenuItem.Click += AssumeUnchangedToolStripMenuItemClick;
             // 
             // doNotAssumeUnchangedToolStripMenuItem
             // 
             doNotAssumeUnchangedToolStripMenuItem.Name = "doNotAssumeUnchangedToolStripMenuItem";
             doNotAssumeUnchangedToolStripMenuItem.Size = new Size(232, 22);
-            doNotAssumeUnchangedToolStripMenuItem.Text = "Do not assume unchanged";
+            doNotAssumeUnchangedToolStripMenuItem.Text = "Do not &assume unchanged";
             doNotAssumeUnchangedToolStripMenuItem.Visible = false;
             doNotAssumeUnchangedToolStripMenuItem.Click += DoNotAssumeUnchangedToolStripMenuItemClick;
             // 
@@ -378,7 +378,7 @@ namespace GitUI.CommandsDialogs
             //
             interactiveAddToolStripMenuItem.Name = "interactiveAddToolStripMenuItem";
             interactiveAddToolStripMenuItem.Size = new Size(232, 22);
-            interactiveAddToolStripMenuItem.Text = "Interactive Add";
+            interactiveAddToolStripMenuItem.Text = "&Interactive Add";
             interactiveAddToolStripMenuItem.Click += interactiveAddToolStripMenuItem_Click;
             //
             // toolStripSeparatorScript
@@ -432,7 +432,7 @@ namespace GitUI.CommandsDialogs
             stagedResetChanges.Image = Properties.Images.ResetWorkingDirChanges;
             stagedResetChanges.Name = "stagedResetChanges";
             stagedResetChanges.Size = new Size(232, 22);
-            stagedResetChanges.Text = "Reset file or directory changes";
+            stagedResetChanges.Text = "&Reset file or directory changes";
             stagedResetChanges.Click += ResetFilesClick;
             // 
             // stagedFileHistoryToolStripMenuItem6
@@ -440,7 +440,7 @@ namespace GitUI.CommandsDialogs
             stagedFileHistoryToolStripMenuItem6.Image = Properties.Images.FileHistory;
             stagedFileHistoryToolStripMenuItem6.Name = "stagedFileHistoryToolStripMenuItem6";
             stagedFileHistoryToolStripMenuItem6.Size = new Size(232, 22);
-            stagedFileHistoryToolStripMenuItem6.Text = "View file history";
+            stagedFileHistoryToolStripMenuItem6.Text = "View file &history";
             stagedFileHistoryToolStripMenuItem6.Click += ViewFileHistoryMenuItem_Click;
             //
             // stagedFileHistoryToolStripSeparator
@@ -457,14 +457,14 @@ namespace GitUI.CommandsDialogs
             // 
             stagedOpenToolStripMenuItem7.Name = "stagedOpenToolStripMenuItem7";
             stagedOpenToolStripMenuItem7.Size = new Size(232, 22);
-            stagedOpenToolStripMenuItem7.Text = "Open";
+            stagedOpenToolStripMenuItem7.Text = "&Open";
             stagedOpenToolStripMenuItem7.Click += OpenToolStripMenuItemClick;
             // 
             // stagedOpenWithToolStripMenuItem8
             // 
             stagedOpenWithToolStripMenuItem8.Name = "stagedOpenWithToolStripMenuItem8";
             stagedOpenWithToolStripMenuItem8.Size = new Size(232, 22);
-            stagedOpenWithToolStripMenuItem8.Text = "Open with...";
+            stagedOpenWithToolStripMenuItem8.Text = "Open &with...";
             stagedOpenWithToolStripMenuItem8.Click += OpenWithToolStripMenuItemClick;
             // 
             // stagedUnstageToolStripMenuItem
@@ -480,7 +480,7 @@ namespace GitUI.CommandsDialogs
             stagedOpenDifftoolToolStripMenuItem9.Image = Properties.Images.Diff;
             stagedOpenDifftoolToolStripMenuItem9.Name = "stagedOpenDifftoolToolStripMenuItem9";
             stagedOpenDifftoolToolStripMenuItem9.Size = new Size(232, 22);
-            stagedOpenDifftoolToolStripMenuItem9.Text = "Open with difftool";
+            stagedOpenDifftoolToolStripMenuItem9.Text = "O&pen with difftool";
             stagedOpenDifftoolToolStripMenuItem9.Click += stagedOpenDifftoolToolStripMenuItem9_Click;
             // 
             // stagedToolStripSeparator18
@@ -493,7 +493,7 @@ namespace GitUI.CommandsDialogs
             stagedCopyPathToolStripMenuItem14.Image = Properties.Images.CopyToClipboard;
             stagedCopyPathToolStripMenuItem14.Name = "stagedCopyPathToolStripMenuItem14";
             stagedCopyPathToolStripMenuItem14.Size = new Size(232, 22);
-            stagedCopyPathToolStripMenuItem14.Text = "Copy full path";
+            stagedCopyPathToolStripMenuItem14.Text = "&Copy full path";
             stagedCopyPathToolStripMenuItem14.Click += FilenameToClipboardToolStripMenuItemClick;
             // 
             // stagedOpenFolderToolStripMenuItem10
@@ -501,7 +501,7 @@ namespace GitUI.CommandsDialogs
             stagedOpenFolderToolStripMenuItem10.Image = Properties.Images.BrowseFileExplorer;
             stagedOpenFolderToolStripMenuItem10.Name = "stagedOpenFolderToolStripMenuItem10";
             stagedOpenFolderToolStripMenuItem10.Size = new Size(232, 22);
-            stagedOpenFolderToolStripMenuItem10.Text = "Show in folder";
+            stagedOpenFolderToolStripMenuItem10.Text = "Show in &folder";
             stagedOpenFolderToolStripMenuItem10.Click += openFolderToolStripMenuItem10_Click;
             // 
             // stagedEditFileToolStripMenuItem11
@@ -509,7 +509,7 @@ namespace GitUI.CommandsDialogs
             stagedEditFileToolStripMenuItem11.Image = Properties.Images.EditFile;
             stagedEditFileToolStripMenuItem11.Name = "stagedEditFileToolStripMenuItem11";
             stagedEditFileToolStripMenuItem11.Size = new Size(232, 22);
-            stagedEditFileToolStripMenuItem11.Text = "Edit file";
+            stagedEditFileToolStripMenuItem11.Text = "&Edit file";
             stagedEditFileToolStripMenuItem11.Click += editFileToolStripMenuItem_Click;
             // 
             // stagedToolStripSeparatorScript
@@ -547,7 +547,7 @@ namespace GitUI.CommandsDialogs
             commitSubmoduleChanges.Image = Properties.Images.RepoStateDirtySubmodules;
             commitSubmoduleChanges.Name = "commitSubmoduleChanges";
             commitSubmoduleChanges.Size = new Size(228, 22);
-            commitSubmoduleChanges.Text = "Commit submodule changes";
+            commitSubmoduleChanges.Text = "Co&mmit submodule changes";
             commitSubmoduleChanges.Click += commitSubmoduleChanges_Click;
             // 
             // resetSubmoduleChanges
@@ -555,7 +555,7 @@ namespace GitUI.CommandsDialogs
             resetSubmoduleChanges.Image = Properties.Images.ResetWorkingDirChanges;
             resetSubmoduleChanges.Name = "resetSubmoduleChanges";
             resetSubmoduleChanges.Size = new Size(228, 22);
-            resetSubmoduleChanges.Text = "Reset submodule changes";
+            resetSubmoduleChanges.Text = "&Reset submodule changes";
             resetSubmoduleChanges.Click += resetSubmoduleChanges_Click;
             // 
             // stashSubmoduleChangesToolStripMenuItem
@@ -563,7 +563,7 @@ namespace GitUI.CommandsDialogs
             stashSubmoduleChangesToolStripMenuItem.Image = Properties.Images.Stash;
             stashSubmoduleChangesToolStripMenuItem.Name = "stashSubmoduleChangesToolStripMenuItem";
             stashSubmoduleChangesToolStripMenuItem.Size = new Size(228, 22);
-            stashSubmoduleChangesToolStripMenuItem.Text = "Stash submodule changes";
+            stashSubmoduleChangesToolStripMenuItem.Text = "S&tash submodule changes";
             stashSubmoduleChangesToolStripMenuItem.Click += stashSubmoduleChangesToolStripMenuItem_Click;
             // 
             // updateSubmoduleMenuItem
@@ -572,7 +572,7 @@ namespace GitUI.CommandsDialogs
             updateSubmoduleMenuItem.Name = "updateSubmoduleMenuItem";
             updateSubmoduleMenuItem.Size = new Size(228, 22);
             updateSubmoduleMenuItem.Tag = "1";
-            updateSubmoduleMenuItem.Text = "Update submodule";
+            updateSubmoduleMenuItem.Text = "&Update submodule";
             updateSubmoduleMenuItem.Click += updateSubmoduleMenuItem_Click;
             // 
             // stageSubmoduleToolStripMenuItem
@@ -594,7 +594,7 @@ namespace GitUI.CommandsDialogs
             viewHistoryMenuItem.Image = Properties.Images.FileHistory;
             viewHistoryMenuItem.Name = "viewHistoryMenuItem";
             viewHistoryMenuItem.Size = new Size(228, 22);
-            viewHistoryMenuItem.Text = "View history";
+            viewHistoryMenuItem.Text = "View &history";
             viewHistoryMenuItem.Click += ViewFileHistoryMenuItem_Click;
             //
             // toolStripSeparator15
@@ -612,7 +612,7 @@ namespace GitUI.CommandsDialogs
             openFolderMenuItem.Image = Properties.Images.BrowseFileExplorer;
             openFolderMenuItem.Name = "openFolderMenuItem";
             openFolderMenuItem.Size = new Size(228, 22);
-            openFolderMenuItem.Text = "Show in folder";
+            openFolderMenuItem.Text = "Show in &folder";
             openFolderMenuItem.Click += OpenToolStripMenuItemClick;
             // 
             // copyFolderNameMenuItem
@@ -620,7 +620,7 @@ namespace GitUI.CommandsDialogs
             copyFolderNameMenuItem.Image = Properties.Images.CopyToClipboard;
             copyFolderNameMenuItem.Name = "copyFolderNameMenuItem";
             copyFolderNameMenuItem.Size = new Size(228, 22);
-            copyFolderNameMenuItem.Text = "Copy folder name";
+            copyFolderNameMenuItem.Text = "&Copy folder name";
             copyFolderNameMenuItem.Click += FilenameToClipboardToolStripMenuItemClick;
             // 
             // gitItemStatusBindingSource
@@ -1524,7 +1524,7 @@ namespace GitUI.CommandsDialogs
             stopTrackingThisFileToolStripMenuItem.Image = Properties.Images.StopTrackingFile;
             stopTrackingThisFileToolStripMenuItem.Name = "stopTrackingThisFileToolStripMenuItem";
             stopTrackingThisFileToolStripMenuItem.Size = new Size(428, 38);
-            stopTrackingThisFileToolStripMenuItem.Text = "Stop tracking this file";
+            stopTrackingThisFileToolStripMenuItem.Text = "Stop &tracking this file";
             stopTrackingThisFileToolStripMenuItem.Click += stopTrackingThisFileToolStripMenuItem_Click;
             //
             // FormCommit

--- a/src/app/GitUI/TranslatedStrings.cs
+++ b/src/app/GitUI/TranslatedStrings.cs
@@ -73,7 +73,7 @@ namespace GitUI
         private readonly TranslationString _directoryIsNotAValidRepository = new("The selected item is not a valid git repository.");
 
         private readonly TranslationString _sortBy = new("&Sort by");
-        private readonly TranslationString _sortGroupBy = new("&Sort and group by");
+        private readonly TranslationString _sortGroupBy = new("Sort and group &by");
         private readonly TranslationString _sortOrder = new("&Sort order");
 
         private readonly TranslationString _diffSelectedWithRememberedFile = new("&Diff with \"{0}\"");

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1540,7 +1540,7 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
         <target />
       </trans-unit>
       <trans-unit id="_sortByContextMenu.Text">
-        <source>&amp;Sort and group by</source>
+        <source>Sort and group &amp;by</source>
         <target />
       </trans-unit>
       <trans-unit id="btnAsTree.ToolTipText">
@@ -3993,15 +3993,15 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="addFileToGitIgnoreToolStripMenuItem.Text">
-        <source>Add file to .gitignore</source>
+        <source>Add file to .&amp;gitignore</source>
         <target />
       </trans-unit>
       <trans-unit id="addFileToGitInfoExcludeLocallyToolStripMenuItem.Text">
-        <source>Add file to .git/info/exclude</source>
+        <source>Add file to .git/info/e&amp;xclude</source>
         <target />
       </trans-unit>
       <trans-unit id="assumeUnchangedToolStripMenuItem.Text">
-        <source>Assume unchanged</source>
+        <source>&amp;Assume unchanged</source>
         <target />
       </trans-unit>
       <trans-unit id="branchNameLabel.Text">
@@ -4045,7 +4045,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="commitSubmoduleChanges.Text">
-        <source>Commit submodule changes</source>
+        <source>Co&amp;mmit submodule changes</source>
         <target />
       </trans-unit>
       <trans-unit id="commitTemplatesToolStripMenuItem.Text">
@@ -4057,7 +4057,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="copyFolderNameMenuItem.Text">
-        <source>Copy folder name</source>
+        <source>&amp;Copy folder name</source>
         <target />
       </trans-unit>
       <trans-unit id="createBranchToolStripButton.Text">
@@ -4073,11 +4073,11 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="deleteFileToolStripMenuItem.Text">
-        <source>Delete file</source>
+        <source>&amp;Delete file</source>
         <target />
       </trans-unit>
       <trans-unit id="doNotAssumeUnchangedToolStripMenuItem.Text">
-        <source>Do not assume unchanged</source>
+        <source>Do not &amp;assume unchanged</source>
         <target />
       </trans-unit>
       <trans-unit id="doNotSkipWorktreeToolStripMenuItem.Text">
@@ -4085,7 +4085,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="editFileToolStripMenuItem.Text">
-        <source>Edit file</source>
+        <source>&amp;Edit file</source>
         <target />
       </trans-unit>
       <trans-unit id="editGitIgnoreToolStripMenuItem.Text">
@@ -4097,7 +4097,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="filenameToClipboardToolStripMenuItem.Text">
-        <source>Copy full path</source>
+        <source>&amp;Copy full path</source>
         <target />
       </trans-unit>
       <trans-unit id="generateListOfChangesInSubmodulesChangesToolStripMenuItem.Text">
@@ -4105,7 +4105,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="interactiveAddToolStripMenuItem.Text">
-        <source>Interactive Add</source>
+        <source>&amp;Interactive Add</source>
         <target />
       </trans-unit>
       <trans-unit id="modifyCommitMessageButton.Text">
@@ -4117,23 +4117,23 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Show in folder</source>
+        <source>Show in &amp;folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openFolderMenuItem.Text">
-        <source>Show in folder</source>
+        <source>Show in &amp;folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openToolStripMenuItem.Text">
-        <source>Open</source>
+        <source>&amp;Open</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
-        <source>Open with difftool</source>
+        <source>O&amp;pen with difftool</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithToolStripMenuItem.Text">
-        <source>Open with...</source>
+        <source>Open &amp;with...</source>
         <target />
       </trans-unit>
       <trans-unit id="refreshDialogOnFormFocusToolStripMenuItem.Text">
@@ -4145,11 +4145,11 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="resetPartOfFileToolStripMenuItem.Text">
-        <source>Reset chunk of file</source>
+        <source>Reset chunk of fi&amp;le</source>
         <target />
       </trans-unit>
       <trans-unit id="resetSubmoduleChanges.Text">
-        <source>Reset submodule changes</source>
+        <source>&amp;Reset submodule changes</source>
         <target />
       </trans-unit>
       <trans-unit id="runScriptToolStripMenuItem.Text">
@@ -4181,39 +4181,39 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="skipWorktreeToolStripMenuItem.Text">
-        <source>Skip worktree</source>
+        <source>S&amp;kip worktree</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedCopyPathToolStripMenuItem14.Text">
-        <source>Copy full path</source>
+        <source>&amp;Copy full path</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedEditFileToolStripMenuItem11.Text">
-        <source>Edit file</source>
+        <source>&amp;Edit file</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedFileHistoryToolStripMenuItem6.Text">
-        <source>View file history</source>
+        <source>View file &amp;history</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedOpenDifftoolToolStripMenuItem9.Text">
-        <source>Open with difftool</source>
+        <source>O&amp;pen with difftool</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedOpenFolderToolStripMenuItem10.Text">
-        <source>Show in folder</source>
+        <source>Show in &amp;folder</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedOpenToolStripMenuItem7.Text">
-        <source>Open</source>
+        <source>&amp;Open</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedOpenWithToolStripMenuItem8.Text">
-        <source>Open with...</source>
+        <source>Open &amp;with...</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedResetChanges.Text">
-        <source>Reset file or directory changes</source>
+        <source>&amp;Reset file or directory changes</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedRunScriptToolStripMenuItem.Text">
@@ -4221,11 +4221,11 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="stashSubmoduleChangesToolStripMenuItem.Text">
-        <source>Stash submodule changes</source>
+        <source>S&amp;tash submodule changes</source>
         <target />
       </trans-unit>
       <trans-unit id="stopTrackingThisFileToolStripMenuItem.Text">
-        <source>Stop tracking this file</source>
+        <source>Stop &amp;tracking this file</source>
         <target />
       </trans-unit>
       <trans-unit id="toolAuthorLabelItem.Text">
@@ -4253,19 +4253,19 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="tsmiResetUnstagedChanges.Text">
-        <source>Reset file or directory changes</source>
+        <source>&amp;Reset file or directory changes</source>
         <target />
       </trans-unit>
       <trans-unit id="updateSubmoduleMenuItem.Text">
-        <source>Update submodule</source>
+        <source>&amp;Update submodule</source>
         <target />
       </trans-unit>
       <trans-unit id="viewFileHistoryToolStripItem.Text">
-        <source>View file history</source>
+        <source>View file &amp;history</source>
         <target />
       </trans-unit>
       <trans-unit id="viewHistoryMenuItem.Text">
-        <source>View history</source>
+        <source>View &amp;history</source>
         <target />
       </trans-unit>
       <trans-unit id="workingToolStripMenuItem.Text">
@@ -10539,7 +10539,7 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_disableMenuItem.Text">
-        <source>Disable this dropdown</source>
+        <source>&amp;Disable this dropdown</source>
         <target />
       </trans-unit>
       <trans-unit id="_dontShowAgain.Text">
@@ -10949,7 +10949,7 @@ the last selected commit.</source>
         <target />
       </trans-unit>
       <trans-unit id="_sortGroupBy.Text">
-        <source>&amp;Sort and group by</source>
+        <source>Sort and group &amp;by</source>
         <target />
       </trans-unit>
       <trans-unit id="_sortOrder.Text">

--- a/src/app/ResourceManager/TranslatedStrings.cs
+++ b/src/app/ResourceManager/TranslatedStrings.cs
@@ -47,7 +47,7 @@ Yes, I allow telemetry!");
         private readonly TranslationString _generalGitConfigExceptionMessage = new("Failed to read \"{0}\" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and it must be closed.{1}{1}Please correct this issue and re-open Git Extensions.");
         private readonly TranslationString _generalGitConfigExceptionCaption = new("Repository Configuration Error");
 
-        private readonly TranslationString _disableMenuItem = new("Disable this dropdown");
+        private readonly TranslationString _disableMenuItem = new("&Disable this dropdown");
 
         // public only because of FormTranslate
         public TranslatedStrings()


### PR DESCRIPTION
## Proposed changes

Added keyboard mnemonics to some of the right-click menus in the Commit window.

## Screenshots

![image](https://github.com/user-attachments/assets/138a238d-11c0-418a-ad15-255f6b89b6d1)

## Notes

* To prevent a conflict, I changed the mnemonic for “Sort by” to Y, but the same translatable string is used in another place, so I split it into two to keep the S mnemonic on the one I didn’t change.
* I tried to stage a submodule to get a look at the menu for a staged submodule, but it wouldn’t stage (it just stayed unstaged). I don’t use submodules and I don’t know how they work, so I didn’t pursue that any further.

### Alphabetic list of new mnemonics
```
mnemonic
│  unstaged files
│  │staged files
│  ││unstaged submodules
│  │││
│  │││
↓  ↓↓↓
A  ✓     Assume unchanged / Do not assume unchanged
C    ✓   Copy folder name
C  ✓✓    Copy full path
D  ✓     Delete file
E  ✓✓    Edit file
F  ✓✓✓   Show in folder
G  ✓     Add file to .gitignore
H  ✓✓✓   View history/View file history
I  ✓     Interactive Add
K  ✓     Skip worktree
L  ✓     Reset chunk of file
M    ✓   Commit submodule changes
O    ✓   Open with Git Extensions
O  ✓✓    Open
P  ✓✓    Open with difftool
R    ✓   Reset submodule changes
R  ✓     Reset file or directory changes
S  ✓ ✓   Stage
T    ✓   Stash submodule changes
T  ✓     Stop tracking this file
U    ✓   Update submodule
U   ✓    Unstage
V  ✓✓    Open in Visual Studio
W  ✓✓    Open with...
X  ✓     Add file to .git/info/exclude
Y  ✓✓✓   Sort by...
```

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
