### PR TITLE
feat(FileStatusList): Display file icons for git-grep and if grouped by file extension

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.DelayedExpansion.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.DelayedExpansion.cs
@@ -1,0 +1,126 @@
+﻿#nullable enable
+
+using GitUI.UserControls;
+
+namespace GitUI;
+
+partial class FileStatusList
+{
+    private void ExpandAll(TreeNode? node)
+    {
+        if (node is null)
+        {
+            return;
+        }
+
+        RestoreChildrenOfFolderNodes(node.Items(), afterAction: () =>
+        {
+            node.ExpandAll();
+            node.EnsureVerticallyVisible();
+            if (node.TreeView is MultiSelectTreeView treeView)
+            {
+                treeView.FocusedNode = node;
+            }
+        });
+    }
+
+    private void FileStatusListView_BeforeExpand(object? sender, TreeViewCancelEventArgs e)
+    {
+        if (e.Node is TreeNode node)
+        {
+            RestoreChildrenOfFolderNodes([node], delayExpansion: true);
+        }
+    }
+
+    private static void ReplaceChildrenOfFolderNodesWithPlaceholder(IEnumerable<TreeNode> nodes)
+    {
+        foreach (TreeNode node in nodes)
+        {
+            if (node.Nodes.Count == 0)
+            {
+                continue;
+            }
+
+            TreeNode[] children = new TreeNode[node.Nodes.Count];
+            node.Nodes.CopyTo(children, index: 0);
+            TreeNode placeholder = new() { Tag = children };
+
+            node.Nodes.Clear();
+            node.Nodes.Add(placeholder);
+        }
+    }
+
+    /// <summary>
+    ///  Replaces possible placeholders with the actual children.
+    /// </summary>
+    /// <param name="nodes">The nodes which are prepared for expansion.</param>
+    /// <param name="afterAction">An optional action which is performed before exiting Begin/EndUpdate.</param>
+    /// <param name="delayExpansion">If <c>true</c>, the subchildren are replaced with placeholders.</param>
+    private void RestoreChildrenOfFolderNodes(IEnumerable<TreeNode> nodes, Action? afterAction = null, bool delayExpansion = false)
+    {
+        List<(TreeNode Parent, TreeNode[] Children)> nodesWithPlaceholder = GetNodesWithPlaceHolder(nodes);
+        if (nodesWithPlaceholder.Count == 0 && afterAction is null)
+        {
+            return;
+        }
+
+        try
+        {
+            FileStatusListView.BeforeExpand -= FileStatusListView_BeforeExpand;
+            FileStatusListView.BeginUpdate();
+
+            IEnumerable<TreeNode> children = RestoreAndGetAllChildren(nodesWithPlaceholder, delayExpansion);
+            LoadFileIcons(children, cancellationToken: default);
+
+            afterAction?.Invoke();
+        }
+        finally
+        {
+            FileStatusListView.EndUpdate();
+            FileStatusListView.BeforeExpand += FileStatusListView_BeforeExpand;
+        }
+
+        return;
+
+        static List<(TreeNode Parent, TreeNode[] Children)> GetNodesWithPlaceHolder(IEnumerable<TreeNode> nodes)
+        {
+            List<(TreeNode Parent, TreeNode[] Children)> nodesWithPlaceholder = [];
+            foreach (TreeNode node in nodes)
+            {
+                if (node.Nodes.Count == 1 && node.Nodes[0].Tag is TreeNode[] children)
+                {
+                    nodesWithPlaceholder.Add((node, children));
+                }
+            }
+
+            return nodesWithPlaceholder;
+        }
+
+        static IEnumerable<TreeNode> RestoreAndGetAllChildren(List<(TreeNode Parent, TreeNode[] Children)> nodesWithPlaceholder, bool delayExpansion)
+        {
+            foreach ((TreeNode parent, TreeNode[] children) in nodesWithPlaceholder)
+            {
+                RestoreChildren(parent, children, delayExpansion);
+
+                foreach (TreeNode child in children)
+                {
+                    foreach (TreeNode subchild in child.Items())
+                    {
+                        yield return subchild;
+                    }
+                }
+            }
+        }
+
+        static void RestoreChildren(TreeNode parent, TreeNode[] children, bool delayExpansion)
+        {
+            if (delayExpansion)
+            {
+                ReplaceChildrenOfFolderNodesWithPlaceholder(children);
+            }
+
+            parent.Nodes.Clear();
+            parent.Nodes.AddRange(children);
+        }
+    }
+}

--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -92,6 +92,7 @@ namespace GitUI
             FileStatusListView.ShowRootLines = false;
             FileStatusListView.Size = new Size(682, 439);
             FileStatusListView.TabIndex = 9;
+            FileStatusListView.BeforeExpand += FileStatusListView_BeforeExpand;
             FileStatusListView.DrawNode += FileStatusListView_DrawNode;
             FileStatusListView.DoubleClick += FileStatusListView_DoubleClick;
             FileStatusListView.KeyDown += FileStatusListView_KeyDown;

--- a/src/app/GitUI/UserControls/FileStatusList.FileIcons.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.FileIcons.cs
@@ -1,0 +1,113 @@
+﻿#nullable enable
+
+using GitUI.UserControls;
+
+namespace GitUI;
+
+partial class FileStatusList
+{
+    private void LoadFileIcons(IEnumerable<TreeNode> nodes, CancellationToken cancellationToken)
+    {
+        Dictionary<string, MissingIcon> missingIconsByExtension = FindMissingIcons(nodes);
+        if (missingIconsByExtension.Count > 0 && Module?.WorkingDir is string workingDir)
+        {
+            ThreadHelper.FileAndForget(() => LoadFileIconsAsync(missingIconsByExtension, fileName => _iconProvider.Get(workingDir, fileName), _imageListData.ImageList.ImageSize, FileStatusListView, cancellationToken));
+        }
+
+        return;
+
+        static async Task LoadFileIconsAsync(Dictionary<string, MissingIcon> missingIconsByExtension, Func<string, Icon?> loadFileIcon, Size size, Control control, CancellationToken cancellationToken)
+        {
+            List<Image> icons = new(capacity: missingIconsByExtension.Count);
+            foreach (KeyValuePair<string, MissingIcon> missingIcon in missingIconsByExtension)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                missingIcon.Value.RelativeImageIndex = icons.Count;
+                icons.Add(loadFileIcon(missingIcon.Value.ExampleFileName) is Icon icon
+                    ? Scale(icon.ToBitmap(), _imageListData.IconSize, size, offsetY: 0)
+                    : _imageListData.DefaultFileImage);
+            }
+
+            await control.SwitchToMainThreadAsync(cancellationToken);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            int imageIndexOffset = _imageListData.ImageList.Images.Count;
+            _imageListData.ImageList.Images.AddRange([.. icons]);
+            foreach (KeyValuePair<string, MissingIcon> missingIcon in missingIconsByExtension)
+            {
+                _imageListData.StateImageIndexMap[missingIcon.Key] = missingIcon.Value.RelativeImageIndex + imageIndexOffset;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            int delayCounter = 0;
+            foreach (KeyValuePair<string, MissingIcon> missingIcon in missingIconsByExtension)
+            {
+                int imageIndex = missingIcon.Value.RelativeImageIndex + imageIndexOffset;
+                foreach (TreeNode node in missingIcon.Value.Nodes)
+                {
+                    node.ImageIndex = imageIndex;
+                    node.SelectedImageIndex = imageIndex;
+
+                    if (++delayCounter >= 100)
+                    {
+                        delayCounter = 0;
+                        await Task.Delay(millisecondsDelay: 1, cancellationToken);
+                    }
+                }
+            }
+
+            control.Invalidate();
+        }
+
+        static Dictionary<string, MissingIcon> FindMissingIcons(IEnumerable<TreeNode> nodes)
+        {
+            Dictionary<string, MissingIcon> missingIconsByExtension = [];
+
+            int defaultFileImageIndex = _imageListData.StateImageIndexMap[nameof(ImageListData.DefaultFileImage)];
+            foreach (TreeNode node in nodes)
+            {
+                if (node.ImageIndex != defaultFileImageIndex)
+                {
+                    continue;
+                }
+
+                TreeNode fileNode = node.Tag is GroupKey
+                    ? node.Items().First(node => node.Nodes.Count == 0)
+                    : node;
+                if (fileNode.Tag is not FileStatusItem fileStatusItem)
+                {
+                    continue;
+                }
+
+                string fileName = fileStatusItem.Item.Name;
+                string extension = Path.GetExtension(fileName);
+                if (_imageListData.StateImageIndexMap.TryGetValue(extension, out int imageIndex))
+                {
+                    node.ImageIndex = imageIndex;
+                    node.SelectedImageIndex = imageIndex;
+                }
+                else if (missingIconsByExtension.TryGetValue(extension, out MissingIcon? entry))
+                {
+                    entry.Nodes.Add(node);
+                }
+                else
+                {
+                    missingIconsByExtension[extension] = new MissingIcon(fileName, [node]);
+                }
+            }
+
+            return missingIconsByExtension;
+        }
+    }
+}

--- a/src/app/GitUI/UserControls/FileStatusList.MissingIcon.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.MissingIcon.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+
+namespace GitUI;
+
+partial class FileStatusList
+{
+    private sealed class MissingIcon(string exampleFileName, List<TreeNode> nodes)
+    {
+        public string ExampleFileName { get; } = exampleFileName;
+        public List<TreeNode> Nodes { get; } = nodes;
+        public int RelativeImageIndex { get; set; } = -1;
+    }
+}

--- a/src/app/GitUI/UserControls/FileStatusList.TreeContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.TreeContextMenu.cs
@@ -54,7 +54,7 @@ partial class FileStatusList
     {
         foreach (TreeNode node in FileStatusListView.SelectedNodes)
         {
-            node.ExpandAll();
+            ExpandAll(node);
         }
     }
 
@@ -63,7 +63,7 @@ partial class FileStatusList
         HashSet<TreeNode> selectedItems = [];
         foreach (TreeNode node in FileStatusListView.SelectedNodes)
         {
-            node.ExpandAll();
+            ExpandAll(node);
             foreach (TreeNode leaf in node.Items().Where(node => node.Tag is FileStatusItem))
             {
                 selectedItems.Add(leaf);

--- a/src/app/GitUI/UserControls/MultiSelectTreeView.cs
+++ b/src/app/GitUI/UserControls/MultiSelectTreeView.cs
@@ -37,6 +37,11 @@ public class MultiSelectTreeView : NativeTreeView
 
                 if (value is not null)
                 {
+                    if (value.TreeView is null)
+                    {
+                        this.ExpandTopDownTo(value);
+                    }
+
                     if (!_mouseClickHandled)
                     {
                         value.EnsureVerticallyVisible();


### PR DESCRIPTION
## Proposed changes

FileStatusList:
- Display file icons for git-grep and if grouped by file extension
- Add git-grep subfolder content on expand

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/8ed3330d-1521-48c7-9a90-92d309c44504)

### After

![image](https://github.com/user-attachments/assets/a26df015-b815-49f8-8e91-d4464de226f0)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).