### PR TITLE
feat(ExitCode): Display larger values hexadecimal

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2277,7 +2277,7 @@ namespace GitCommands
                 cancellationToken: cancellationToken);
             if (!result.ExitedSuccessfully)
             {
-                return (Patch: null, ErrorMessage: $"{result.StandardError}{Environment.NewLine}Git command (exit code: {result.ExitCode}): {args}{Environment.NewLine}");
+                return (Patch: null, ErrorMessage: $"{result.StandardError}{Environment.NewLine}Git command (exit code: {result.ExitCodeDisplay}): {args}{Environment.NewLine}");
             }
 
             string patch = result.StandardOutput;

--- a/src/app/GitCommands/Logging/CommandLog.cs
+++ b/src/app/GitCommands/Logging/CommandLog.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using GitExtensions.Extensibility;
 using GitUI;
 
 namespace GitCommands.Logging
@@ -166,7 +167,7 @@ namespace GitCommands.Logging
                 s.Append("Started at:  ").AppendLine($"{StartedAt:O}");
                 s.Append("UI Thread?:  ").AppendLine($"{IsOnMainThread}");
                 s.Append("Duration:    ").AppendLine(Duration is not null ? $"{Duration.Value.TotalMilliseconds:0.###} ms" : "still running");
-                s.Append("Exit code:   ").AppendLine(ExitCode is not null ? $"{ExitCode}" : Exception is not null ? $"{Exception}" : "unknown");
+                s.Append("Exit code:   ").AppendLine(ExitCode is int exitCode ? ExecutionResult.FormatExitCode(exitCode) : Exception is not null ? $"{Exception}" : "unknown");
                 s.Append("Error:       ").AppendLine(Error is not null ? Error : "not captured");
                 s.Append("Call stack:  ").Append(CallStack is not null ? $"{Environment.NewLine}{CallStack}" : "not captured");
 

--- a/src/app/GitExtensions.Extensibility/ExecutionResult.cs
+++ b/src/app/GitExtensions.Extensibility/ExecutionResult.cs
@@ -27,7 +27,7 @@ public readonly struct ExecutionResult
 
     public string AllOutput => string.Concat(StandardOutput, Environment.NewLine, StandardError);
 
-    public static string FormatExitCode(int exitCode) => Math.Abs(exitCode) <= 128 ? $"{exitCode}" : $"{exitCode:X8} hex ({exitCode} dec)";
+    public static string FormatExitCode(int exitCode) => Math.Abs(exitCode) <= 128 ? $"{exitCode}" : 0x$"{exitCode:X8} ({exitCode} dec)";
 
     public void ThrowIfErrorExit(string? errorMessage = null)
     {

--- a/src/app/GitExtensions.Extensibility/ExecutionResult.cs
+++ b/src/app/GitExtensions.Extensibility/ExecutionResult.cs
@@ -21,13 +21,20 @@ public readonly struct ExecutionResult
         ExitCode = exitCode;
     }
 
+    /// <summary>
+    ///  Gets a verbose string with the <see cref="ExitCode"/> using <see cref="FormatExitCode"/>.
+    /// </summary>
     public string? ExitCodeDisplay => ExitCode is int exitCode ? FormatExitCode(exitCode) : "null";
 
     public bool ExitedSuccessfully => ExitCode == Success;
 
     public string AllOutput => string.Concat(StandardOutput, Environment.NewLine, StandardError);
 
-    public static string FormatExitCode(int exitCode) => Math.Abs(exitCode) <= 128 ? $"{exitCode}" : 0x$"{exitCode:X8} ({exitCode} dec)";
+    /// <summary>
+    ///  Returns a verbose string of an <paramref name="exitCode"/>.
+    ///  Absolute values from 128 are presented as hexadecimal and decimal numbers.
+    /// </summary>
+    public static string FormatExitCode(int exitCode) => Math.Abs(exitCode) <= 128 ? $"{exitCode}" : $"0x{exitCode:X8} ({exitCode} dec)";
 
     public void ThrowIfErrorExit(string? errorMessage = null)
     {

--- a/src/app/GitExtensions.Extensibility/ExecutionResult.cs
+++ b/src/app/GitExtensions.Extensibility/ExecutionResult.cs
@@ -27,7 +27,7 @@ public readonly struct ExecutionResult
 
     public string AllOutput => string.Concat(StandardOutput, Environment.NewLine, StandardError);
 
-    public static string FormatExitCode(int exitCode) => Math.Abs(exitCode) <= 128 ? $"{exitCode}" : $"{exitCode:x8} hex ({exitCode} dec)";
+    public static string FormatExitCode(int exitCode) => Math.Abs(exitCode) <= 128 ? $"{exitCode}" : $"{exitCode:X8} hex ({exitCode} dec)";
 
     public void ThrowIfErrorExit(string? errorMessage = null)
     {

--- a/src/app/GitExtensions.Extensibility/ExecutionResult.cs
+++ b/src/app/GitExtensions.Extensibility/ExecutionResult.cs
@@ -21,9 +21,13 @@ public readonly struct ExecutionResult
         ExitCode = exitCode;
     }
 
+    public string? ExitCodeDisplay => ExitCode is int exitCode ? FormatExitCode(exitCode) : "null";
+
     public bool ExitedSuccessfully => ExitCode == Success;
 
     public string AllOutput => string.Concat(StandardOutput, Environment.NewLine, StandardError);
+
+    public static string FormatExitCode(int exitCode) => Math.Abs(exitCode) <= 128 ? $"{exitCode}" : $"{exitCode:x8} hex ({exitCode} dec)";
 
     public void ThrowIfErrorExit(string? errorMessage = null)
     {

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -86,7 +86,7 @@ namespace GitUI
 
                 if (!result.ExitedSuccessfully)
                 {
-                    string output = $"{result.StandardError}{Environment.NewLine}Git output (exit code: {result.ExitCode}): {Environment.NewLine}{result.StandardOutput}";
+                    string output = $"{result.StandardError}{Environment.NewLine}Git output (exit code: {result.ExitCodeDisplay}): {Environment.NewLine}{result.StandardOutput}";
                     await fileViewer.ViewTextAsync(item?.Item?.Name, text: output);
                     return;
                 }
@@ -116,7 +116,7 @@ namespace GitUI
 
                 if (!result.ExitedSuccessfully)
                 {
-                    string output = $"{result.StandardError}{Environment.NewLine}Git command (exit code: {result.ExitCode}): {result}{Environment.NewLine}";
+                    string output = $"{result.StandardError}{Environment.NewLine}Git command (exit code: {result.ExitCodeDisplay}): {result}{Environment.NewLine}";
                     await fileViewer.ViewTextAsync(item?.Item?.Name, text: output);
                     return;
                 }
@@ -172,7 +172,7 @@ namespace GitUI
 
                 if (!result.ExitedSuccessfully)
                 {
-                    string output = $"Git command exit code: {result}{Environment.NewLine}{result.StandardError}";
+                    string output = $"Git command exit code: {result.ExitCodeDisplay}{Environment.NewLine}{result.StandardError}";
                     await fileViewer.ViewTextAsync(item?.Item?.Name, text: output);
                     return;
                 }

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -58,7 +58,10 @@ namespace GitUI.NBugReports
             if (exception is ExternalOperationException externalOperationException)
             {
                 // Exit code: <n>
-                AppendIfNotEmpty(externalOperationException.ExitCode.ToString(), TranslatedStrings.ExitCode);
+                if (externalOperationException.ExitCode is int exitCode)
+                {
+                    AppendIfNotEmpty(ExecutionResult.FormatExitCode(exitCode), TranslatedStrings.ExitCode);
+                }
 
                 // Command: <command>
                 AppendIfNotEmpty(externalOperationException.Command, TranslatedStrings.Command);


### PR DESCRIPTION
## Proposed changes

Display larger `ExitCode` values (beyond +/-128) as hexadecimal number (in addition to decimal) in
- BugReporterInvoker
- GitCommandLog
- GetSingleDifftoolAsync & ViewChangesAsync on error

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/5f27a7a6-e949-45bb-aa70-4e7ac6ddcc4b)   ![image](https://github.com/user-attachments/assets/358f09ed-ee9c-453b-9e45-7d59930f38b6)

### After

![image](https://github.com/user-attachments/assets/8477ab4e-ee09-4e97-a2b5-05b3ac90467b)   ![image](https://github.com/user-attachments/assets/73de2855-00a2-4df2-8311-dc3c18e69c91)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).