### PR TITLE
feat: Add DebugHelpers.Trace[If]

### DIFF
--- a/src/app/GitExtensions.Extensibility/DebugHelpers.cs
+++ b/src/app/GitExtensions.Extensibility/DebugHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace GitExtensions.Extensibility;
 
@@ -37,6 +38,22 @@ public static class DebugHelpers
         }
     }
 #pragma warning restore CS8763 // A method marked [DoesNotReturn] should not return.
+
+    [Conditional("DEBUG")]
+    public static void Trace(string message, [CallerMemberName] string caller = "")
+    {
+        const char noBreakSpace = '\u00a0';
+        Debug.WriteLine($"{caller}:{noBreakSpace}{message}");
+    }
+
+    [Conditional("DEBUG")]
+    public static void TraceIf(bool condition, string message, [CallerMemberName] string caller = "")
+    {
+        if (condition)
+        {
+            Trace(message, caller);
+        }
+    }
 
     private static bool IsTestRunning
         => Application.ExecutablePath.EndsWith("testhost.exe");

--- a/src/app/GitExtensions.Extensibility/DebugHelpers.cs
+++ b/src/app/GitExtensions.Extensibility/DebugHelpers.cs
@@ -42,6 +42,7 @@ public static class DebugHelpers
     [Conditional("DEBUG")]
     public static void Trace(string message, [CallerMemberName] string caller = "")
     {
+        // colon and noBreakSpace are used to detect such messages in order to show them in the Output History
         const char noBreakSpace = '\u00a0';
         Debug.WriteLine($"{caller}:{noBreakSpace}{message}");
     }

--- a/src/app/GitUI/ServiceContainerRegistry.cs
+++ b/src/app/GitUI/ServiceContainerRegistry.cs
@@ -21,9 +21,10 @@ public static class ServiceContainerRegistry
         serviceContainer.GetRequiredService<ISubscribableTraceListener>().TraceReceived += (in string message) =>
         {
             // In release builds, all Trace.Write* output is recorded.
-            // In debug builds, forward only exceptions but not all the noisy Debug.Write* output.
+            // In debug builds, forward only exceptions and DebugHelper.Trace messages but not all the noisy Debug.Write* output.
 #if DEBUG
-            if (message.Contains("Exception"))
+            const char noBreakSpace = '\u00a0';
+            if (message.Contains("Exception") || message.Contains($":{noBreakSpace}"))
 #endif
             {
                 outputHistoryModel.RecordHistory(message);


### PR DESCRIPTION
## Proposed changes

- Add `DebugHelpers.Trace` and `.TraceIf` with the name of the calling method prepended to the traced message
- Show such output in the Output History tab / panel, too

Benefit: Ease debugging. Short identical/similar code lines can be added in order to trace function calls and current values.

## Screenshots

### Before

N/A

### After

![image](https://github.com/user-attachments/assets/f01a2d46-da18-4128-a00d-c8c42448e41b)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).