### PR TITLE
Checkout "other" branch after reset

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1029,6 +1029,12 @@ namespace GitCommands
             set => SetEnum("checkoutbranchaction", value);
         }
 
+        public static bool CheckoutOtherBranchAfterReset
+        {
+            get => GetBool("checkoutotherbranchafterreset", true);
+            set => SetBool("checkoutotherbranchafterreset", value);
+        }
+
         public static bool UseDefaultCheckoutBranchAction
         {
             get => GetBool("UseDefaultCheckoutBranchAction", false);

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1029,11 +1029,7 @@ namespace GitCommands
             set => SetEnum("checkoutbranchaction", value);
         }
 
-        public static bool CheckoutOtherBranchAfterReset
-        {
-            get => GetBool("checkoutotherbranchafterreset", true);
-            set => SetBool("checkoutotherbranchafterreset", value);
-        }
+        public static ISetting<bool> CheckoutOtherBranchAfterReset { get; } = Setting.Create(DialogSettingsPath, nameof(CheckoutOtherBranchAfterReset), defaultValue: true);
 
         public static bool UseDefaultCheckoutBranchAction
         {

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
@@ -31,14 +31,15 @@
             BranchInfo = new Label();
             Ok = new Button();
             Cancel = new Button();
-            commitSummaryUserControl = new UserControls.CommitSummaryUserControl();
+            commitSummaryUserControl = new GitUI.UserControls.CommitSummaryUserControl();
             ForceReset = new CheckBox();
             pictureBox1 = new PictureBox();
-            labelResetBranchWarning = new Label();
+            lblResetBranchWarning = new Label();
             Branches = new ComboBox();
             tableLayoutPanel1 = new TableLayoutPanel();
             flowLayoutPanel1 = new FlowLayoutPanel();
             tlpnlWarning = new TableLayoutPanel();
+            cbxCheckoutBranch = new CheckBox();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             tableLayoutPanel1.SuspendLayout();
             flowLayoutPanel1.SuspendLayout();
@@ -49,19 +50,19 @@
             // 
             BranchInfo.AutoSize = true;
             BranchInfo.Dock = DockStyle.Fill;
-            BranchInfo.Location = new Point(6, 39);
+            BranchInfo.Location = new Point(6, 47);
             BranchInfo.Name = "BranchInfo";
-            BranchInfo.Size = new Size(509, 13);
+            BranchInfo.Size = new Size(517, 15);
             BranchInfo.TabIndex = 1;
             BranchInfo.Text = "Reset local &branch:";
             // 
             // Ok
             // 
             Ok.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            Ok.Location = new Point(320, 3);
+            Ok.Location = new Point(328, 3);
             Ok.Name = "Ok";
             Ok.Size = new Size(91, 25);
-            Ok.TabIndex = 4;
+            Ok.TabIndex = 0;
             Ok.Text = "OK";
             Ok.UseVisualStyleBackColor = true;
             Ok.Click += Ok_Click;
@@ -70,10 +71,10 @@
             // 
             Cancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
             Cancel.DialogResult = DialogResult.Cancel;
-            Cancel.Location = new Point(417, 3);
+            Cancel.Location = new Point(425, 3);
             Cancel.Name = "Cancel";
             Cancel.Size = new Size(91, 25);
-            Cancel.TabIndex = 5;
+            Cancel.TabIndex = 1;
             Cancel.Text = "Cancel";
             Cancel.UseVisualStyleBackColor = true;
             Cancel.Click += Cancel_Click;
@@ -83,23 +84,23 @@
             commitSummaryUserControl.AutoSize = true;
             commitSummaryUserControl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             commitSummaryUserControl.Dock = DockStyle.Fill;
-            commitSummaryUserControl.Location = new Point(4, 80);
+            commitSummaryUserControl.Location = new Point(4, 92);
             commitSummaryUserControl.Margin = new Padding(1);
             commitSummaryUserControl.MinimumSize = new Size(493, 150);
             commitSummaryUserControl.Name = "commitSummaryUserControl";
             commitSummaryUserControl.Revision = null;
-            commitSummaryUserControl.Size = new Size(513, 150);
-            commitSummaryUserControl.TabIndex = 0;
+            commitSummaryUserControl.Size = new Size(521, 150);
+            commitSummaryUserControl.TabIndex = 3;
             commitSummaryUserControl.TabStop = false;
             // 
             // ForceReset
             // 
             ForceReset.AutoSize = true;
             ForceReset.Dock = DockStyle.Fill;
-            ForceReset.Location = new Point(6, 234);
+            ForceReset.Location = new Point(6, 271);
             ForceReset.Name = "ForceReset";
-            ForceReset.Size = new Size(509, 17);
-            ForceReset.TabIndex = 3;
+            ForceReset.Size = new Size(517, 19);
+            ForceReset.TabIndex = 5;
             ForceReset.Text = "&Force reset for a non-fast-forward reset";
             ForceReset.UseVisualStyleBackColor = true;
             ForceReset.CheckedChanged += Validate;
@@ -111,34 +112,34 @@
             pictureBox1.InitialImage = Properties.Images.Warning;
             pictureBox1.Location = new Point(3, 3);
             pictureBox1.Name = "pictureBox1";
-            pictureBox1.Size = new Size(16, 16);
+            pictureBox1.Size = new Size(16, 24);
             pictureBox1.SizeMode = PictureBoxSizeMode.AutoSize;
             pictureBox1.TabIndex = 11;
             pictureBox1.TabStop = false;
             // 
-            // labelResetBranchWarning
+            // lblResetBranchWarning
             // 
-            labelResetBranchWarning.ForeColor = SystemColors.WindowText;
-            labelResetBranchWarning.Location = new Point(25, 0);
-            labelResetBranchWarning.Name = "labelResetBranchWarning";
-            labelResetBranchWarning.Size = new Size(250, 20);
-            labelResetBranchWarning.TabIndex = 0;
-            labelResetBranchWarning.Text = "You can only reset a branch safely if there is a direct path from it to selected " +
-    "revision.\r\nForcing a branch to reset if it has not been merged might leave some " +
-    "commits unreachable.";
+            lblResetBranchWarning.AutoSize = true;
+            lblResetBranchWarning.Dock = DockStyle.Fill;
+            lblResetBranchWarning.ForeColor = SystemColors.WindowText;
+            lblResetBranchWarning.Location = new Point(25, 0);
+            lblResetBranchWarning.Name = "lblResetBranchWarning";
+            lblResetBranchWarning.Size = new Size(491, 30);
+            lblResetBranchWarning.TabIndex = 0;
+            lblResetBranchWarning.Text = "You can only reset a branch safely if there is a direct path from it to selected revision.\r\nForcing a branch to reset if it has not been merged might leave some commits unreachable.";
             // 
             // Branches
             // 
             Branches.Dock = DockStyle.Fill;
-            Branches.Location = new Point(11, 55);
+            Branches.Location = new Point(11, 65);
             Branches.Margin = new Padding(8, 3, 8, 3);
             Branches.Name = "Branches";
-            Branches.Size = new Size(499, 21);
+            Branches.Size = new Size(507, 23);
             Branches.TabIndex = 2;
-            Branches.KeyUp += Branches_KeyUp;
-            Branches.Enter += Validate;
             Branches.DropDownClosed += Validate;
             Branches.TextChanged += Validate;
+            Branches.Enter += Validate;
+            Branches.KeyUp += Branches_KeyUp;
             // 
             // tableLayoutPanel1
             // 
@@ -148,16 +149,17 @@
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanel1.Controls.Add(BranchInfo, 0, 2);
             tableLayoutPanel1.Controls.Add(Branches, 0, 3);
-            tableLayoutPanel1.Controls.Add(ForceReset, 0, 5);
+            tableLayoutPanel1.Controls.Add(ForceReset, 0, 6);
             tableLayoutPanel1.Controls.Add(commitSummaryUserControl, 0, 4);
-            tableLayoutPanel1.Controls.Add(flowLayoutPanel1, 0, 6);
+            tableLayoutPanel1.Controls.Add(flowLayoutPanel1, 0, 7);
             tableLayoutPanel1.Controls.Add(tlpnlWarning, 0, 0);
+            tableLayoutPanel1.Controls.Add(cbxCheckoutBranch, 0, 5);
             tableLayoutPanel1.Dock = DockStyle.Top;
             tableLayoutPanel1.Location = new Point(8, 8);
             tableLayoutPanel1.Margin = new Padding(2);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.Padding = new Padding(3);
-            tableLayoutPanel1.RowCount = 7;
+            tableLayoutPanel1.RowCount = 8;
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
             tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 10F));
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
@@ -165,9 +167,9 @@
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel1.Size = new Size(519, 292);
-            tableLayoutPanel1.TabIndex = 12;
+            tableLayoutPanel1.RowStyles.Add(new RowStyle());
+            tableLayoutPanel1.Size = new Size(519, 331);
+            tableLayoutPanel1.TabIndex = 0;
             // 
             // flowLayoutPanel1
             // 
@@ -177,11 +179,11 @@
             flowLayoutPanel1.Controls.Add(Ok);
             flowLayoutPanel1.Dock = DockStyle.Fill;
             flowLayoutPanel1.FlowDirection = FlowDirection.RightToLeft;
-            flowLayoutPanel1.Location = new Point(5, 256);
+            flowLayoutPanel1.Location = new Point(5, 295);
             flowLayoutPanel1.Margin = new Padding(2);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
-            flowLayoutPanel1.Size = new Size(511, 31);
-            flowLayoutPanel1.TabIndex = 3;
+            flowLayoutPanel1.Size = new Size(519, 31);
+            flowLayoutPanel1.TabIndex = 6;
             // 
             // tlpnlWarning
             // 
@@ -191,15 +193,26 @@
             tlpnlWarning.ColumnStyles.Add(new ColumnStyle());
             tlpnlWarning.ColumnStyles.Add(new ColumnStyle());
             tlpnlWarning.Controls.Add(pictureBox1, 0, 0);
-            tlpnlWarning.Controls.Add(labelResetBranchWarning, 1, 0);
+            tlpnlWarning.Controls.Add(lblResetBranchWarning, 1, 0);
             tlpnlWarning.Dock = DockStyle.Fill;
             tlpnlWarning.Location = new Point(5, 5);
             tlpnlWarning.Margin = new Padding(2);
             tlpnlWarning.Name = "tlpnlWarning";
             tlpnlWarning.RowCount = 1;
             tlpnlWarning.RowStyles.Add(new RowStyle());
-            tlpnlWarning.Size = new Size(511, 22);
-            tlpnlWarning.TabIndex = 4;
+            tlpnlWarning.Size = new Size(519, 30);
+            tlpnlWarning.TabIndex = 0;
+            // 
+            // cbxCheckoutBranch
+            // 
+            cbxCheckoutBranch.AutoSize = true;
+            cbxCheckoutBranch.Dock = DockStyle.Fill;
+            cbxCheckoutBranch.Location = new Point(6, 246);
+            cbxCheckoutBranch.Name = "cbxCheckoutBranch";
+            cbxCheckoutBranch.Size = new Size(517, 19);
+            cbxCheckoutBranch.TabIndex = 4;
+            cbxCheckoutBranch.Text = "Chec&kout branch after reset";
+            cbxCheckoutBranch.UseVisualStyleBackColor = true;
             // 
             // FormResetAnotherBranch
             // 
@@ -237,10 +250,11 @@
         private UserControls.CommitSummaryUserControl commitSummaryUserControl;
         private CheckBox ForceReset;
         private PictureBox pictureBox1;
-        private Label labelResetBranchWarning;
+        private Label lblResetBranchWarning;
         private ComboBox Branches;
         private TableLayoutPanel tableLayoutPanel1;
         private FlowLayoutPanel flowLayoutPanel1;
         private TableLayoutPanel tlpnlWarning;
+        private CheckBox cbxCheckoutBranch;
     }
 }

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -29,9 +29,9 @@ namespace GitUI.HelperDialogs
             InitializeComponent();
 
             pictureBox1.Image = DpiUtil.Scale(pictureBox1.Image);
-            labelResetBranchWarning.AutoSize = true;
-            labelResetBranchWarning.Dock = DockStyle.Fill;
-            labelResetBranchWarning.SetForeColorForBackColor();
+            lblResetBranchWarning.AutoSize = true;
+            lblResetBranchWarning.Dock = DockStyle.Fill;
+            lblResetBranchWarning.SetForeColorForBackColor();
 
             Height = tableLayoutPanel1.Height + tableLayoutPanel1.Top;
             tableLayoutPanel1.Dock = DockStyle.Fill;
@@ -39,6 +39,9 @@ namespace GitUI.HelperDialogs
             ActiveControl = Branches;
 
             InitializeComplete();
+
+            cbxCheckoutBranch.Checked = AppSettings.CheckoutOtherBranchAfterReset;
+            cbxCheckoutBranch.CheckedChanged += (s, e) => AppSettings.CheckoutOtherBranchAfterReset = cbxCheckoutBranch.Checked;
 
             Ok.Enabled = false;
         }
@@ -105,6 +108,11 @@ namespace GitUI.HelperDialogs
             bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {
+                if (cbxCheckoutBranch.Checked)
+                {
+                    UICommands.StartCheckoutBranch(this, gitRefToReset.Name);
+                }
+
                 UICommands.RepoChangedNotifier.Notify();
                 Close();
             }

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -40,8 +40,8 @@ namespace GitUI.HelperDialogs
 
             InitializeComplete();
 
-            cbxCheckoutBranch.Checked = AppSettings.CheckoutOtherBranchAfterReset;
-            cbxCheckoutBranch.CheckedChanged += (s, e) => AppSettings.CheckoutOtherBranchAfterReset = cbxCheckoutBranch.Checked;
+            cbxCheckoutBranch.Checked = AppSettings.CheckoutOtherBranchAfterReset.Value;
+            cbxCheckoutBranch.CheckedChanged += (s, e) => AppSettings.CheckoutOtherBranchAfterReset.Value = cbxCheckoutBranch.Checked;
 
             Ok.Enabled = false;
         }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6844,7 +6844,11 @@ Value has been reset to empty value.</source>
         <source>The entered value '{0}' is not the name of an existing local branch.</source>
         <target />
       </trans-unit>
-      <trans-unit id="labelResetBranchWarning.Text">
+      <trans-unit id="cbxCheckoutBranch.Text">
+        <source>Chec&amp;kout branch after reset</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblResetBranchWarning.Text">
         <source>You can only reset a branch safely if there is a direct path from it to selected revision.
 Forcing a branch to reset if it has not been merged might leave some commits unreachable.</source>
         <target />

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -249,7 +249,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.AutoStash)], false, false, false);
                 yield return (properties[nameof(AppSettings.RebaseAutoStash)], false, false, false);
                 yield return (properties[nameof(AppSettings.CheckoutBranchAction)], LocalChangesAction.DontChange, false, false);
-                yield return (properties[nameof(AppSettings.CheckoutOtherBranchAfterReset)], true, false, true);
+                yield return (properties[nameof(AppSettings.CheckoutOtherBranchAfterReset)], true, isNotNullable, isISetting);
                 yield return (properties[nameof(AppSettings.UseDefaultCheckoutBranchAction)], false, false, false);
                 yield return (properties[nameof(AppSettings.DontShowHelpImages)], false, false, false);
                 yield return (properties[nameof(AppSettings.AlwaysShowAdvOpt)], false, false, false);

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -249,6 +249,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.AutoStash)], false, false, false);
                 yield return (properties[nameof(AppSettings.RebaseAutoStash)], false, false, false);
                 yield return (properties[nameof(AppSettings.CheckoutBranchAction)], LocalChangesAction.DontChange, false, false);
+                yield return (properties[nameof(AppSettings.CheckoutOtherBranchAfterReset)], true, false, true);
                 yield return (properties[nameof(AppSettings.UseDefaultCheckoutBranchAction)], false, false, false);
                 yield return (properties[nameof(AppSettings.DontShowHelpImages)], false, false, false);
                 yield return (properties[nameof(AppSettings.AlwaysShowAdvOpt)], false, false, false);


### PR DESCRIPTION

## Proposed changes

I constantly finding myself continue on the wrong branch after resetting another branch to the ~current~ desired commit. This change allows starting automatically the branch checkout sequence
The checkbox is set (and the flow is enabled) by default; can be opt-ed out by unchecking the checkbox. The user choice is remembered.

I didn't want to force checkout, as it's possible to end up in a situation where a user has pending changes, and those could get lost. This way, the user can make a conscious decision to proceed or not.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://github.com/user-attachments/assets/3ca05efb-7336-4bc1-b064-f006b836a432)

### After

![image](https://github.com/user-attachments/assets/1dae5375-3533-4c59-9b40-1015b5fc3241)



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
