### PR TITLE
Add instructions asking for higher scaling screenshots

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Fixes #
 - 
 - 
 
-## Screenshots <!-- Remove this section if PR does not change UI -->
+## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->
 
 ### Before
 


### PR DESCRIPTION
It's understandable that there may be (are!) dialogs, form elements which are broken under higher DPI / scaling, that were developed long ago. But for this to keep happening recently is mildly put _unfortunate_.

This is a bug that triggered this PR https://github.com/gitextensions/gitextensions/issues/12302 but there's also this https://github.com/gitextensions/gitextensions/issues/12303 (although the screenshots seem to be made at higher DPI although under a different theme)

## Proposed changes

- Add instructions to PR template to include higher scaling factors

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
