### PR TITLE
Fix FormRemotes color label size

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -233,13 +233,13 @@ namespace GitUI.CommandsDialogs
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
-            tblpnlMgtDetails.Controls.Add(flpnlRemoteColors, 1, 2);
             tblpnlMgtDetails.Controls.Add(label2, 0, 0);
             tblpnlMgtDetails.Controls.Add(Url, 1, 0);
             tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 0);
             tblpnlMgtDetails.Controls.Add(label1, 0, 1);
             tblpnlMgtDetails.Controls.Add(RemoteName, 1, 1);
             tblpnlMgtDetails.Controls.Add(lblRemoteColor, 0, 2);
+            tblpnlMgtDetails.Controls.Add(flpnlRemoteColors, 1, 2);
             tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 3);
             tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 4);
             tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 4);
@@ -257,6 +257,7 @@ namespace GitUI.CommandsDialogs
             // 
             // label2
             // 
+            label2.AutoSize = true;
             label2.Dock = DockStyle.Fill;
             label2.Location = new Point(3, 0);
             label2.MinimumSize = new Size(100, 0);
@@ -292,6 +293,7 @@ namespace GitUI.CommandsDialogs
             // 
             // label1
             // 
+            label1.AutoSize = true;
             label1.Dock = DockStyle.Fill;
             label1.Location = new Point(3, 31);
             label1.Name = "label1";
@@ -312,6 +314,7 @@ namespace GitUI.CommandsDialogs
             // 
             // lblRemoteColor
             // 
+            lblRemoteColor.AutoSize = true;
             lblRemoteColor.Dock = DockStyle.Fill;
             lblRemoteColor.Location = new Point(3, 60);
             lblRemoteColor.Name = "lblRemoteColor";
@@ -336,6 +339,7 @@ namespace GitUI.CommandsDialogs
             // 
             // labelPushUrl
             // 
+            labelPushUrl.AutoSize = true;
             labelPushUrl.Dock = DockStyle.Fill;
             labelPushUrl.Location = new Point(3, 116);
             labelPushUrl.Name = "labelPushUrl";

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -193,6 +193,7 @@ namespace GitUI.CommandsDialogs
             btnRemoteColorReset.Text = "Default color";
             btnRemoteColorReset.UseVisualStyleBackColor = false;
             btnRemoteColorReset.Click += btnRemoteColorReset_Click;
+            btnRemoteColorReset.Visible = false;
             // 
             // flpnlRemoteManagement
             // 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -110,11 +110,8 @@ Inactive remote is completely invisible to git.");
             // Persist the text of the buttons to be able to restore it whenever the color is reset
             btnRemoteColor.Tag = btnRemoteColor.Text;
 
-            // Set the minimum height of the color button to be the same as the reset button
-            btnRemoteColor.MinimumSize = new Size(DpiUtil.Scale(60), btnRemoteColorReset.Height);
-
-            // Prevent btnRemoteColorReset from blinking out soon after form loads
-            btnRemoteColorReset.Visible = false;
+            // Set the minimum height of the color button after initialization
+            btnRemoteColor.MinimumSize = new Size(DpiUtil.Scale(60), btnRemoteColor.Height);
 
             // remove text from 'new' and 'delete' buttons because now they are represented by icons
             New.Text = string.Empty;

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -113,6 +113,9 @@ Inactive remote is completely invisible to git.");
             // Set the minimum height of the color button to be the same as the reset button
             btnRemoteColor.MinimumSize = new Size(DpiUtil.Scale(60), btnRemoteColorReset.Height);
 
+            // Prevent btnRemoteColorReset from blinking out soon after form loads
+            btnRemoteColorReset.Visible = false;
+
             // remove text from 'new' and 'delete' buttons because now they are represented by icons
             New.Text = string.Empty;
             Delete.Text = string.Empty;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12303

## Proposed changes

- `AutoSize = true` for labels
- Prevent `btnRemoteColorReset` from blinking out part of a second after being shown

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

At 200%
![image](https://github.com/user-attachments/assets/74784118-c3ca-4628-8b52-14003452cd24)


### After

At 200%
![image](https://github.com/user-attachments/assets/62e76d54-d59b-489a-aaef-bfef6ea492f6)

At 100%
![image](https://github.com/user-attachments/assets/84d5d941-c469-4ba0-84b6-38e00b35cbb3)


## Test methodology <!-- How did you ensure quality? -->

- Manully at 100% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
