### PR TITLE
Fix file list regex watermark label overflow

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -150,7 +150,7 @@ namespace GitUI
             FilterWatermarkLabel.ForeColor = SystemColors.GrayText;
             FilterWatermarkLabel.Location = new Point(0, 48);
             FilterWatermarkLabel.Name = "FilterWatermarkLabel";
-            FilterWatermarkLabel.Padding = new Padding(2, 3, 2, 2);
+            FilterWatermarkLabel.Padding = new Padding(2, 3, 2, 0);
             FilterWatermarkLabel.Size = new Size(210, 20);
             FilterWatermarkLabel.TabIndex = 6;
             FilterWatermarkLabel.Text = "Filter files using a regular expression...";


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes -

## Proposed changes

- Fix overflowing label at higher DPIs

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

At 200%
![image](https://github.com/user-attachments/assets/407dee47-fe2d-433d-b042-cb9e5149db4b)

### After

At 200%
![image](https://github.com/user-attachments/assets/4f31508d-0854-472b-b299-5003df6c6a75)

At 100%
![image](https://github.com/user-attachments/assets/1fd7e88b-7afd-4668-9e56-b80feeacde66)

## Test methodology <!-- How did you ensure quality? -->

- Manually at 100% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
