### PR TITLE
Fix Stashes drop-down size calculation

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormStash.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.cs
@@ -291,7 +291,7 @@ namespace GitUI.CommandsDialogs
         private void ResizeStashesWidth()
         {
             const int spacingBetweenLabelAndComboBox = 5;
-            Stashes.Size = new Size(toolStrip1.Width - DpiUtil.Scale(spacingBetweenLabelAndComboBox) - showToolStripLabel.Width, Stashes.Size.Height);
+            Stashes.Width = toolStrip1.Width - DpiUtil.Scale(spacingBetweenLabelAndComboBox) - showToolStripLabel.Width;
         }
 
         private void StashedSelectedIndexChanged(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormStash.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.cs
@@ -291,7 +291,7 @@ namespace GitUI.CommandsDialogs
         private void ResizeStashesWidth()
         {
             const int spacingBetweenLabelAndComboBox = 5;
-            Stashes.Width = toolStrip1.Width - spacingBetweenLabelAndComboBox - showToolStripLabel.Width;
+            Stashes.Size = new Size(toolStrip1.Width - DpiUtil.Scale(spacingBetweenLabelAndComboBox) - showToolStripLabel.Width, Stashes.Size.Height);
         }
 
         private void StashedSelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12302

## Proposed changes

- Revert changes to `Stashes` drop-down size calculation introduced in #12149

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

At 200%
![image](https://github.com/user-attachments/assets/9ff022a4-71eb-4964-919d-25c03966df1a)

### After

At 200%
![image](https://github.com/user-attachments/assets/cd621632-6096-4cc6-8c12-39a69699d616)

At 100%
![image](https://github.com/user-attachments/assets/1a82174f-4f1d-483f-b523-3bcb430f3715)


## Test methodology <!-- How did you ensure quality? -->

- Manually at 100% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
