### PR TITLE
Bring back deselect-file behavior from before TreeView

### DIFF
--- a/src/app/GitUI/UserControls/MultiSelectTreeView.cs
+++ b/src/app/GitUI/UserControls/MultiSelectTreeView.cs
@@ -174,10 +174,27 @@ public class MultiSelectTreeView : NativeTreeView
         if (e.Button != MouseButtons.Left
 
             // or other modifier keys than for selection manipulation
-            || (modifierKeys | Keys.Control | Keys.Shift) != (Keys.Control | Keys.Shift)
+            || (modifierKeys | Keys.Control | Keys.Shift) != (Keys.Control | Keys.Shift))
+        {
+            _mouseClickHandled = false;
+            base.OnMouseDown(e);
+            return;
+        }
 
-            // or no node clicked
-            || HitTest(e.Location).Node is not TreeNode newFocusedNode
+        TreeViewHitTestInfo hitTestInfo = HitTest(e.Location);
+        if (// empty area clicked
+            hitTestInfo.Location == TreeViewHitTestLocations.None
+
+            // and no modifiers active
+            && modifierKeys == Keys.None)
+        {
+            ClearSelection();
+            _mouseClickHandled = true;
+            return;
+        }
+
+        if (// no node clicked
+            hitTestInfo.Node is not TreeNode newFocusedNode
 
             // or starting drag operation
             || (_selectedNodes.Contains(newFocusedNode) && modifierKeys == Keys.None && !ShallHandleRootIconClick(e.X, newFocusedNode, modifierKeys)))
@@ -264,6 +281,13 @@ public class MultiSelectTreeView : NativeTreeView
 
             FocusedNode = newFocusedNode;
             _toBeFocusedNode = newFocusedNode;
+        }
+
+        void ClearSelection()
+        {
+            SelectedNode = null;
+            FocusedNode = null;
+            SelectedNodesChanged?.Invoke(this, e);
         }
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

For the longest time (maybe even since the beginning of GE time) it was possible to de-select active FileStatusList item by clicking on an empty area.
This is especially beneficial when one wants to reduce distractions of the diff view and focus on the changes to pick next file to view. This is a sort of "context clearing" between diff switching.
TreeView doesn't de-select an item when clicking an empty area, this is a UX change that feels rigid and strict compared to what used to be. While it is possible to deselect an active item by ctrl+click'ing it, it is much more taxing than clicking **_any_** empty space bellow the items.

Granted current behavior has a benefit of focusing the `TreeView` while clicking on an empty area bellow its items without loosing a focus of the current item although with this PR it is still possible to achieve that while ctrl+clicking the empty area bellow the items.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Before the TreeView

https://github.com/user-attachments/assets/6780f4fc-b356-4605-b78a-3ceba00bb06e

Current `master`

https://github.com/user-attachments/assets/1322b3a4-bc67-4f43-b7bc-4dd590fb9569


<!-- TODO -->

### After

Here I've tried to imitate how I view diffs. It's not very natural but shows the idea of deselecting to "clear the context/distraction" to ease focusing on the next file

https://github.com/user-attachments/assets/88386370-e86c-467c-9334-dbd186a2a8dc

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
