### PR TITLE
Initialize color picker with remote's color

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -5,8 +5,10 @@ using GitCommands.UserRepositoryHistory;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Infrastructure;
 using GitUI.Properties;
+using GitUI.Theming;
 using GitUI.UserControls;
 using Microsoft;
 using ResourceManager;
@@ -379,7 +381,7 @@ Inactive remote is completely invisible to git.");
         private void btnRemoteColor_Click(object sender, EventArgs e)
         {
             colorDialog.Color = btnRemoteColor.BackColor == Color.Transparent
-                ? Color.Black
+                ? AppColor.RemoteBranch.GetThemeColor()
                 : btnRemoteColor.BackColor;
 
             if (colorDialog.ShowDialog() == DialogResult.OK)

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -378,6 +378,10 @@ Inactive remote is completely invisible to git.");
 
         private void btnRemoteColor_Click(object sender, EventArgs e)
         {
+            colorDialog.Color = btnRemoteColor.BackColor == Color.Transparent
+                ? Color.Black
+                : btnRemoteColor.BackColor;
+
             if (colorDialog.ShowDialog() == DialogResult.OK)
             {
                 SetRemoteColor(colorDialog.Color);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- When editing selected color it's often the case that the color itself is fine but should be darker/lighter thus it's desired that previously selected value would be reflected in a color picker when attempting to update the color

### Before

![image](https://github.com/user-attachments/assets/51438e22-dcc5-44ce-94f5-39c9e4605c02)

### After

![image](https://github.com/user-attachments/assets/93e03501-45ff-4a39-b4e4-4013fa9f2f30)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
