### PR TITLE
Fix Find button scaling in git-grep dialog

### DIFF
--- a/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.Designer.cs
+++ b/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.Designer.cs
@@ -113,8 +113,10 @@ namespace GitUI
             // 
             btnSearch.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
             btnSearch.AutoSize = true;
+            btnSearch.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnSearch.DialogResult = DialogResult.Cancel;
             btnSearch.Location = new Point(337, 8);
+            btnSearch.MinimumSize = new Size(75, 25);
             btnSearch.Name = "btnSearch";
             btnSearch.Size = new Size(75, 25);
             btnSearch.TabIndex = 7;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12310

## Proposed changes

- Fix Find button scaling
- Fix watermark placement

### Before

At 200%
![image](https://github.com/user-attachments/assets/ba724314-49c3-4834-9484-271e17b54bb1)

At 100%
![image](https://github.com/user-attachments/assets/4c714fab-564f-468c-8ac4-417941b0b6da)

### After

At 200%
![image](https://github.com/user-attachments/assets/68e4460b-bc39-4c0d-9c1d-7e2094b1e0ac)

At 150%
![image](https://github.com/user-attachments/assets/77b2aa47-26e0-45e8-ab89-948a377c1169)

At 100%
![image](https://github.com/user-attachments/assets/62ecffe0-2fa6-4e7a-86ba-ccd8ec886f30)

## Test methodology <!-- How did you ensure quality? -->

- Manually at 100% 150% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
