### PR TITLE
feat(diff viewer): Set caret to first change line

### DIFF
--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -901,6 +901,10 @@ namespace GitUI.Editor
                     {
                         internalFileViewer.GoToNextChange(NumberOfContextLines);
                     }
+                    else
+                    {
+                        internalFileViewer.GoToNextChange(NumberOfContextLines, keepFirstVisibleLine: true);
+                    }
 
                     TextLoaded?.Invoke(this, null);
                     return Task.CompletedTask;

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -424,7 +424,7 @@ namespace GitUI.Editor
         /// For range-diff, it is the next block of commit summary header.
         /// </summary>
         /// <param name="contextLines">Number of context lines, to include header for new diff.</param>
-        public void GoToNextChange(int contextLines)
+        public void GoToNextChange(int contextLines, bool keepFirstVisibleLine = false)
         {
             // Skip the file header
             bool hasDiffHeader = _textHighlightService is (PatchHighlightService or CombinedDiffHighlightService);
@@ -439,8 +439,12 @@ namespace GitUI.Editor
                 {
                     if (emptyLineCheck)
                     {
-                        // Include the header with the (possible) function summary line
-                        FirstVisibleLine = Math.Max(line - contextLines - 1, 0);
+                        if (!keepFirstVisibleLine)
+                        {
+                            // Include the header with the (possible) function summary line
+                            FirstVisibleLine = Math.Max(line - contextLines - 1, 0);
+                        }
+
                         LineAtCaret = line;
                         return;
                     }


### PR DESCRIPTION
## Proposed changes

`FileViewer`: Set caret to first change line
in order to open editor, VS, etc. at a meaningful line but not view line off.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/9d86b02f-09a2-4ae0-b106-b026eccacf92)

### After

![image](https://github.com/user-attachments/assets/a5785f77-34f3-4d6f-bc42-3c993aae215a)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).