### PR TITLE
feat: mark current line in editor

### DIFF
--- a/src/app/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/src/app/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -57,8 +57,10 @@ public class DiffViewerLineNumberControl : AbstractMargin
 
         int fontHeight = textArea.TextView.FontHeight;
         ICSharpCode.TextEditor.Document.HighlightColor lineNumberPainterColor = textArea.Document.HighlightingStrategy.GetColorFor("LineNumbers");
+        ICSharpCode.TextEditor.Document.HighlightColor lineNumberCurrentPainterColor = textArea.Document.HighlightingStrategy.GetColorFor("LineNumberSelected");
         Brush fillBrush = textArea.Enabled ? BrushRegistry.GetBrush(lineNumberPainterColor.BackgroundColor) : SystemBrushes.InactiveBorder;
         Brush drawBrush = BrushRegistry.GetBrush(lineNumberPainterColor.Color);
+        Brush currentLineBrush = BrushRegistry.GetBrush(lineNumberCurrentPainterColor.Color);
 
         for (int y = 0; y < ((DrawingPosition.Height + textArea.TextView.VisibleLineDrawingRemainder) / fontHeight) + 1; ++y)
         {
@@ -108,19 +110,24 @@ public class DiffViewerLineNumberControl : AbstractMargin
                 g.FillRectangle(brush, new Rectangle(leftWidth, backgroundRectangle.Top, rightWidth, backgroundRectangle.Height));
             }
 
+            bool isCurrentLine = curLine == textArea.Caret.Line && MarkSelectedLine;
+            Brush lineBrush = isCurrentLine ? currentLineBrush : drawBrush;
+            Font font = isCurrentLine
+                ? lineNumberCurrentPainterColor.GetFont(TextEditorProperties.FontContainer)
+                : lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer);
             if (diffLine.LeftLineNumber != DiffLineInfo.NotApplicableLineNum)
             {
                 g.DrawString(diffLine.LeftLineNumber.ToString(),
-                    lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
-                    drawBrush,
+                    font,
+                    lineBrush,
                     new Point(_textHorizontalMargin, backgroundRectangle.Top));
             }
 
             if (diffLine.RightLineNumber != DiffLineInfo.NotApplicableLineNum)
             {
                 g.DrawString(diffLine.RightLineNumber.ToString(),
-                    lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
-                    drawBrush,
+                    font,
+                    lineBrush,
                     new Point(leftWidth, backgroundRectangle.Top));
             }
         }
@@ -138,6 +145,8 @@ public class DiffViewerLineNumberControl : AbstractMargin
         _diffLines = _empty;
         MaxLineNumber = 0;
     }
+
+    public override bool IsVisible => _visible;
 
     public void SetVisibility(bool visible)
     {

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -517,6 +517,11 @@ namespace GitUI.Editor
             internalFileViewer.ClearHighlighting();
         }
 
+        internal void DontMarkGutterSelectedLine()
+        {
+            internalFileViewer.DontMarkGutterSelectedLine();
+        }
+
         public string GetText() => internalFileViewer.GetText();
 
         /// <summary>

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -81,11 +81,29 @@ namespace GitUI.Editor
             TextEditor.ActiveTextAreaControl.TextEditorProperties.EnableFolding = false;
             _lineNumbersControl = new DiffViewerLineNumberControl(TextEditor.ActiveTextAreaControl.TextArea);
             VRulerPosition = AppSettings.DiffVerticalRulerPosition;
+            TextEditor.ActiveTextAreaControl.Caret.PositionChanged += GutterSelectedLineChanged;
+        }
+
+        public void DontMarkGutterSelectedLine()
+        {
+            TextEditor.ActiveTextAreaControl.Caret.PositionChanged -= GutterSelectedLineChanged;
+            TextEditor.ActiveTextAreaControl.TextArea.GutterMargin.MarkSelectedLine = false;
         }
 
         public void SetContinuousScrollManager(ContinuousScrollEventManager continuousScrollEventManager)
         {
             _continuousScrollEventManager = continuousScrollEventManager;
+        }
+
+        internal void GutterSelectedLineChanged(object sender, EventArgs e)
+        {
+            GutterSelectedLineChanged(TextEditor.ActiveTextAreaControl.Caret.Line);
+        }
+
+        internal void GutterSelectedLineChanged(int lineNo)
+        {
+            _lineNumbersControl.SelectedLineChanged(lineNo);
+            TextEditor.ActiveTextAreaControl.TextArea.GutterMargin.SelectedLineChanged(lineNo);
         }
 
         private void SelectionManagerSelectionChanged(object sender, EventArgs e)
@@ -285,6 +303,7 @@ namespace GitUI.Editor
             // important to set after the text was changed
             // otherwise the may be rendering artifacts as noted in #5568
             TextEditor.ShowLineNumbers = ShowLineNumbers ?? !hasLineNumberControl;
+            GutterSelectedLineChanged(-1);
             if (ShowLineNumbers.HasValue && !ShowLineNumbers.Value)
             {
                 Padding = new Padding(DpiUtil.Scale(5), Padding.Top, Padding.Right, Padding.Bottom);

--- a/src/app/GitUI/Theming/ThemeModule.cs
+++ b/src/app/GitUI/Theming/ThemeModule.cs
@@ -31,6 +31,8 @@ namespace GitUI.Theming
                 new HighlightColor(SystemColors.WindowText, AppColor.EditorBackground.GetThemeColor(), bold: false, italic: false, adaptable: false));
             strategy.SetColorFor("LineNumbers",
                 new HighlightColor(SystemColors.GrayText, AppColor.LineNumberBackground.GetThemeColor(), bold: false, italic: false, adaptable: false));
+            strategy.SetColorFor("LineNumberSelected",
+                new HighlightColor(SystemColors.WindowText, AppColor.LineNumberBackground.GetThemeColor(), bold: true, italic: false, adaptable: false));
             if (Application.IsDarkModeEnabled)
             {
                 strategy.SetColorFor("EOLMarkers",

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -70,6 +70,7 @@ namespace GitUI.Blame
             BlameAuthor.SelectedLineChanged += SelectedLineChanged;
             BlameAuthor.RequestDiffView += ActiveTextAreaControlDoubleClick;
             BlameAuthor.EscapePressed += () => EscapePressed?.Invoke();
+            BlameAuthor.DontMarkGutterSelectedLine();
 
             BlameFile.IsReadOnly = true;
             BlameFile.VScrollPositionChanged += BlameFile_VScrollPositionChanged;


### PR DESCRIPTION
Depends on https://github.com/gitextensions/ICSharpCode.TextEditor/pull/51

## Proposed changes

Use WindowsText color to mark the line for the caret/cursor line, keeping gray text for others.
Especially in dark mode, the cursor can be hard to see, also when marking. This makes it easier to se the cursor line.

This is implemented for all editors with some kind of cursors, including read-only.
The kind of exception is Blame control where the left (author) part may have a line number panel (better to hide it).

Note: I implemented and discarded the left line no following the right (with the cursor), but it is no real improvement, the left lineno is not following info in the author panel anyway.
(Before that I implemented that clicking in author panel controlled the cursor, which was just annoying.
In the same way, it is just confusing to have the author lineno marked independent, the left line has no meaning, you cannot even copy marked text, just the more relevant options in the dropdown.)
(Also, the invalidation of the lineno is not necessary when cursor changes in the diff from header -> header, just makes this more complicated.)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before
Just all the same line no.

### After

![image](https://github.com/user-attachments/assets/a598eb86-45fe-4caa-b4ce-37d3c95e21c2)

![image](https://github.com/user-attachments/assets/713a15a3-1648-4b39-848e-063c26af4711)

![image](https://github.com/user-attachments/assets/bc4beb59-e08d-4336-9313-e69b703fa7fc)

![image](https://github.com/user-attachments/assets/011a31d6-e768-47fc-8d3a-e3ef2a941296)

![image](https://github.com/user-attachments/assets/1a9b39f3-d22b-42b0-bfb0-d360447ed87c)

![image](https://github.com/user-attachments/assets/42dabee1-9aa3-4998-be24-01213df09228)

First version, not bold

![image](https://github.com/user-attachments/assets/11bd1bed-4533-4b6c-8abb-d3f60d2a0453)

![image](https://github.com/user-attachments/assets/0b357713-4a28-438b-ad41-8d312815d689)

![image](https://github.com/user-attachments/assets/94c8a2b6-e869-48fd-b554-63cf9778f6b5)

![image](https://github.com/user-attachments/assets/119e7a9f-ae3a-4ff8-808e-9236f697995c)

![image](https://github.com/user-attachments/assets/c126a745-2123-43dd-989b-0377f8bd3a92)

![image](https://github.com/user-attachments/assets/e35a3ef4-92d1-42b6-ad12-1762e5ce9538)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
