### PR TITLE
Feature/worktree fixes

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -214,3 +214,4 @@ YYYY/MM/DD, github id, Full name, email
 2024/09/26, georg138, Georg Siebke, github(at)georgsiebke.de
 2024/10/21, chkoddi,Chandar,chkoddi@live.com
 2024/11/05, anhtrvn, Anh Tran, anhtran18202(at)gmail.com
+2025/04/19, borzag, Boris Zagar, boris.zagar(at)gmail.com

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1016,6 +1016,8 @@ namespace GitUI.CommandsDialogs
                     applyPatchToolStripMenuItem.Enabled = !bareRepository;
                 }
 
+                manageWorktreeToolStripMenuItem.ShortcutKeys = Keys.ControlKey | Keys.Alt | Keys.W;
+
                 stashChangesToolStripMenuItem.Enabled = !bareRepository;
                 stashStagedToolStripMenuItem.Visible = Module.GitVersion.SupportStashStaged;
 
@@ -1129,6 +1131,7 @@ namespace GitUI.CommandsDialogs
             pullToolStripMenuItem1.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.PullOrFetch);
             pushToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Push);
             rebaseToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Rebase);
+            manageWorktreeToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ManageWorkTrees);
 
             fileToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
             helpToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
@@ -1961,9 +1964,10 @@ namespace GitUI.CommandsDialogs
             OpenCommitsWithDifftool = 35,
             ToggleBetweenArtificialAndHeadCommits = 36,
             GoToChild = 37,
-            GoToParent = 38
+            GoToParent = 38,
 
             /* deprecated: RotateApplicationIcon = 14, */
+            ManageWorkTrees = 50,
         }
 
         private void AddNotes()
@@ -2093,6 +2097,7 @@ namespace GitUI.CommandsDialogs
                 case Command.MergeBranches: UICommands.StartMergeBranchDialog(this, null); break;
                 case Command.CreateTag: UICommands.StartCreateTagDialog(this, RevisionGrid.LatestSelectedRevision); break;
                 case Command.Rebase: rebaseToolStripMenuItem.PerformClick(); break;
+                case Command.ManageWorkTrees: manageWorktreeToolStripMenuItem.PerformClick(); break;
                 default: return base.ExecuteCommand(cmd);
             }
 

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1016,8 +1016,6 @@ namespace GitUI.CommandsDialogs
                     applyPatchToolStripMenuItem.Enabled = !bareRepository;
                 }
 
-                manageWorktreeToolStripMenuItem.ShortcutKeys = Keys.ControlKey | Keys.Alt | Keys.W;
-
                 stashChangesToolStripMenuItem.Enabled = !bareRepository;
                 stashStagedToolStripMenuItem.Visible = Module.GitVersion.SupportStashStaged;
 
@@ -1918,6 +1916,7 @@ namespace GitUI.CommandsDialogs
 
             // REPOSITORY menu
             CloseRepository = 15,
+            ManageWorkTrees = 49,
 
             // COMMANDS menu
             Commit = 7,
@@ -1967,7 +1966,6 @@ namespace GitUI.CommandsDialogs
             GoToParent = 38,
 
             /* deprecated: RotateApplicationIcon = 14, */
-            ManageWorkTrees = 50,
         }
 
         private void AddNotes()

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
@@ -146,6 +146,8 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             Worktrees.Size = new Size(674, 265);
             Worktrees.TabIndex = 2;
             Worktrees.SelectionChanged += Worktrees_SelectionChanged;
+            Worktrees.CellDoubleClick += WorktreesOnCellDoubleClick;
+            Worktrees.KeyDown += Worktrees_KeyDown;
             // 
             // Path
             // 

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
@@ -213,6 +213,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             // 
             // FormManageWorktree
             // 
+            AcceptButton = buttonOpenSelectedWorktree;
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(697, 361);

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -189,7 +189,25 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void buttonOpenSelectedWorktree_Click(object sender, EventArgs e)
         {
-            if (!CanActOnSelectedWorkspace(out WorkTree workTree))
+            OpenSelectedWorktree();
+        }
+
+        private void WorktreesOnCellDoubleClick(object? sender, DataGridViewCellEventArgs e)
+        {
+            OpenSelectedWorktree();
+        }
+
+        private void Worktrees_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                OpenSelectedWorktree();
+            }
+        }
+
+        private void OpenSelectedWorktree()
+        {
+            if (!CanActOnSelectedWorkspace(out WorkTree? workTree))
             {
                 return;
             }

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -35,6 +35,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
             Worktrees.Columns[3].DefaultCellStyle.Font = AppSettings.MonospaceFont;
             Worktrees.Columns[3].DefaultCellStyle.WrapMode = DataGridViewTriState.True;
+            Worktrees.Select();
 
             InitializeComplete();
         }

--- a/src/app/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/src/app/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -249,6 +249,7 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.GoToParent, Keys.Control | Keys.P),
                     Hk(FormBrowse.Command.GoToSubmodule, Keys.None),
                     Hk(FormBrowse.Command.GoToSuperproject, Keys.None),
+                    Hk(FormBrowse.Command.ManageWorkTrees, Keys.Control | Keys.Alt | Keys.W),
                     Hk(FormBrowse.Command.MergeBranches, Keys.Control | Keys.M),
                     Hk(FormBrowse.Command.OpenAsTempFile, OpenAsTempFileHotkey),
                     Hk(FormBrowse.Command.OpenAsTempFileWith, OpenAsTempFileWithHotkey),
@@ -269,8 +270,7 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.StashPop, Keys.Control | Keys.Alt | Keys.Down),
                     Hk(FormBrowse.Command.StashStaged, Keys.Control | Keys.Shift | Keys.Alt | Keys.Up),
                     Hk(FormBrowse.Command.ToggleBetweenArtificialAndHeadCommits, Keys.Control | Keys.OemBackslash),
-                    Hk(FormBrowse.Command.ToggleLeftPanel, Keys.Control | Keys.Alt | Keys.C),
-                    Hk(FormBrowse.Command.ManageWorkTrees, Keys.Control | Keys.Alt | Keys.W)),
+                    Hk(FormBrowse.Command.ToggleLeftPanel, Keys.Control | Keys.Alt | Keys.C)),
                 new HotkeySettings(
                     RepoObjectsTree.HotkeySettingsName,
                     Hk(RepoObjectsTree.Command.Delete, Keys.Delete),

--- a/src/app/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/src/app/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -269,7 +269,8 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.StashPop, Keys.Control | Keys.Alt | Keys.Down),
                     Hk(FormBrowse.Command.StashStaged, Keys.Control | Keys.Shift | Keys.Alt | Keys.Up),
                     Hk(FormBrowse.Command.ToggleBetweenArtificialAndHeadCommits, Keys.Control | Keys.OemBackslash),
-                    Hk(FormBrowse.Command.ToggleLeftPanel, Keys.Control | Keys.Alt | Keys.C)),
+                    Hk(FormBrowse.Command.ToggleLeftPanel, Keys.Control | Keys.Alt | Keys.C),
+                    Hk(FormBrowse.Command.ManageWorkTrees, Keys.Control | Keys.Alt | Keys.W)),
                 new HotkeySettings(
                     RepoObjectsTree.HotkeySettingsName,
                     Hk(RepoObjectsTree.Command.Delete, Keys.Delete),


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12322

## Proposed changes
See issue #12322 for details and more screenshots about the changes.
- Adds shortcut `Ctrl+Alt+W` key to open Repository->Manage Worktrees
- Adds possibility to change the shortcut in settings->Hotkeys->Browse->Manageworktrees.
- Sets the Worktrees datagrid focused when opening the Manage Worktrees form, so that it accepts navigating by up/down arrows immediately without having to focus it first.
- Enables enter key as default to open the selected worktree.
- Enables double click to open selected worktree.
- Supports optional question dialog to open selected worktree, as originally implemented, for all implemented events/eventhandlers.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before
![image](https://github.com/user-attachments/assets/8530bb61-b1e1-4d32-bb00-6bd3230aa631)
![image](https://github.com/user-attachments/assets/f3e95ba6-bbfd-4365-b710-84d72dd72845)

### After
![image](https://github.com/user-attachments/assets/bbeffa1a-8cf6-42e8-b34f-65af0dbd8d0b)
![image](https://github.com/user-attachments/assets/ba26c955-cf65-4a53-b388-899774cda28c)

## Test methodology <!-- How did you ensure quality? -->
- Tested by running the app manually and seeing that the fixed issues worked.

## Merge strategy
I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
