### PR TITLE
fix(FileViewer): Actually go to first change

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -767,8 +767,7 @@ namespace GitUI.CommandsDialogs
 
         private void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
         {
-            int? line = DiffText.Visible ? DiffText.CurrentFileLine : BlameControl.CurrentFileLine;
-            ShowSelectedFile(ensureNoSwitchToFilter: true, line);
+            ShowSelectedFile(ensureNoSwitchToFilter: true);
         }
 
         private void DiffText_PatchApplied(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -767,7 +767,8 @@ namespace GitUI.CommandsDialogs
 
         private void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
         {
-            ShowSelectedFile(ensureNoSwitchToFilter: true);
+            int? line = DiffText.Visible ? DiffText.CurrentFileLine : BlameControl.CurrentFileLine;
+            ShowSelectedFile(ensureNoSwitchToFilter: true, line);
         }
 
         private void DiffText_PatchApplied(object sender, EventArgs e)

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -902,13 +902,9 @@ namespace GitUI.Editor
                     {
                         GoToLine(line.Value);
                     }
-                    else if (viewMode == ViewMode.Grep && ShowEntireFile)
-                    {
-                        internalFileViewer.GoToNextChange(NumberOfContextLines);
-                    }
                     else
                     {
-                        internalFileViewer.GoToNextChange(NumberOfContextLines, keepFirstVisibleLine: true);
+                        internalFileViewer.GoToFirstChange(NumberOfContextLines);
                     }
 
                     TextLoaded?.Invoke(this, null);

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -897,12 +897,12 @@ namespace GitUI.Editor
                 () =>
                 {
                     ResetView(viewMode, fileName, item: item, text: text);
-                    internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring, contentIdentification: fileName);
+                    bool positionSet = internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring, contentIdentification: fileName);
                     if (line is not null)
                     {
                         GoToLine(line.Value);
                     }
-                    else
+                    else if (!positionSet)
                     {
                         internalFileViewer.GoToFirstChange(NumberOfContextLines);
                     }

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -313,7 +313,7 @@ namespace GitUI.Editor
             TextEditor.Refresh();
 
             // Restore position if contentIdentification matches the capture
-            bool positionSet = _currentViewPositionCache.Restore(contentIdentification) && LineAtCaret != 0;
+            bool positionSet = _currentViewPositionCache.Restore(contentIdentification) && LineAtCaret > FirstLineAfterHeader;
 
             if (_shouldScrollToBottom || _shouldScrollToTop)
             {
@@ -441,6 +441,15 @@ namespace GitUI.Editor
         private bool IsSearchMatch(int indexInText)
             => _textHighlightService.IsSearchMatch(_lineNumbersControl, indexInText);
 
+        private int FirstLineAfterHeader
+        {
+            get
+            {
+                bool hasDiffHeader = _textHighlightService is (PatchHighlightService or CombinedDiffHighlightService);
+                return hasDiffHeader ? 5 : 0;
+            }
+        }
+
         /// <summary>
         /// Go to the first change.
         /// For normal diffs, this is the first diff.
@@ -465,8 +474,7 @@ namespace GitUI.Editor
         private void GoToNextChange(int contextLines, bool fromTop)
         {
             // Skip the file header
-            bool hasDiffHeader = _textHighlightService is (PatchHighlightService or CombinedDiffHighlightService);
-            int firstValidIndex = hasDiffHeader ? 4 : 0;
+            int firstValidIndex = FirstLineAfterHeader;
             int startIndex = fromTop ? firstValidIndex : Math.Max(firstValidIndex, LineAtCaret);
             int totalNumberOfLines = TotalNumberOfLines;
 

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -313,7 +313,7 @@ namespace GitUI.Editor
             TextEditor.Refresh();
 
             // Restore position if contentIdentification matches the capture
-            bool positionSet = _currentViewPositionCache.Restore(contentIdentification);
+            bool positionSet = _currentViewPositionCache.Restore(contentIdentification) && LineAtCaret != 0;
 
             if (_shouldScrollToBottom || _shouldScrollToTop)
             {

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -254,7 +254,8 @@ namespace GitUI.Editor
         /// <param name="text">The text to set in the editor.</param>
         /// <param name="openWithDifftool">The command to open the difftool.</param>
         /// <param name="viewMode">the view viewMode in the file viewer, the kind of info shown</param>
-        public void SetText(string text, Action? openWithDifftool, ViewMode viewMode, bool useGitColoring, string? contentIdentification)
+        /// <returns><see langword="true"/> if a position was set.</returns>
+        public bool SetText(string text, Action? openWithDifftool, ViewMode viewMode, bool useGitColoring, string? contentIdentification)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -312,7 +313,7 @@ namespace GitUI.Editor
             TextEditor.Refresh();
 
             // Restore position if contentIdentification matches the capture
-            _currentViewPositionCache.Restore(contentIdentification);
+            bool positionSet = _currentViewPositionCache.Restore(contentIdentification);
 
             if (_shouldScrollToBottom || _shouldScrollToTop)
             {
@@ -320,11 +321,14 @@ namespace GitUI.Editor
                 if (scrollBar.Visible)
                 {
                     scrollBar.Value = _shouldScrollToTop ? 0 : Math.Max(0, scrollBar.Maximum - scrollBar.Height - _bottomBlankHeight);
+                    positionSet = true;
                 }
 
                 _shouldScrollToTop = false;
                 _shouldScrollToBottom = false;
             }
+
+            return positionSet;
         }
 
         protected override void OnPaintBackground(PaintEventArgs e)
@@ -893,18 +897,18 @@ namespace GitUI.Editor
                 }
             }
 
-            public void Restore(string? contentIdentification)
+            public bool Restore(string? contentIdentification)
             {
                 _currentIdentification = contentIdentification;
                 if (_viewer.TotalNumberOfLines <= 1 || string.IsNullOrEmpty(contentIdentification) || string.IsNullOrEmpty(_currentIdentification))
                 {
-                    return;
+                    return false;
                 }
 
                 bool sameIdentification = contentIdentification == _capturedIdentification;
                 if (!sameIdentification)
                 {
-                    return;
+                    return false;
                 }
 
                 ViewPosition viewPosition = _currentViewPosition;
@@ -933,6 +937,8 @@ namespace GitUI.Editor
                         _viewer.FirstVisibleLine = viewPosition.FirstVisibleLine;
                     }
                 }
+
+                return true;
             }
 
             /// <summary>


### PR DESCRIPTION
Fixes regression by #12317

## Proposed changes

- `FileViewer`: Actually go to first change if no line number is passed
- `RevisionDiffControl`: Keep line number when switching extra diff arguments

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

### Before

1. move to next change on every toggle of "Show entire file"
2. second git-grep match selected if first was in first line

### After

1. stay at current change
2. first git-grep match selected

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).