### PR TITLE
feat(file tree): Provide git-grep

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -456,7 +456,7 @@ namespace GitUI.CommandsDialogs
 
             await DiffText.ViewChangesAsync(DiffFiles.SelectedItem,
                 line: line,
-                forceFileView: IsFileTreeMode,
+                forceFileView: IsFileTreeMode && !DiffFiles.FindInCommitFilesGitGrepActive,
                 openWithDiffTool: IsFileTreeMode ? null : DiffFiles.tsmiDiffFirstToSelected.PerformClick,
                 additionalCommandInfo: (DiffFiles.SelectedItem?.Item?.IsRangeDiff is true) && Module.GitVersion.SupportRangeDiffPath ? _pathFilter() : "",
                 cancellationToken: _viewChangesSequence.Next());

--- a/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
@@ -172,7 +172,7 @@ partial class FileStatusList
         tsmiShowInFileTree.Visible = true;
         tsmiFilterFileInGrid.Visible = true;
 
-        if (CanUseFindInCommitFilesGitGrep && !_isFileTreeMode)
+        if (CanUseFindInCommitFilesGitGrep)
         {
             tsmiOpenFindInCommitFilesGitGrepDialog.Visible = true;
             tsmiShowFindInCommitFilesGitGrep.Visible = true;

--- a/src/app/GitUI/UserControls/MultiSelectTreeView.cs
+++ b/src/app/GitUI/UserControls/MultiSelectTreeView.cs
@@ -102,7 +102,7 @@ public class MultiSelectTreeView : NativeTreeView
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public HashSet<TreeNode> SelectedNodes => _selectedNodes;
+    public IReadOnlySet<TreeNode> SelectedNodes => _selectedNodes;
 
     public void SetSelectedNodes(HashSet<TreeNode> selectedNodes, TreeNode? focusedNode)
     {


### PR DESCRIPTION
Requested in https://github.com/gitextensions/gitextensions/pull/12312#issuecomment-2816865516

## Proposed changes

- Enable git-grep for file-tree, too

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/21b0649c-c42a-48ad-b4f6-349ed01fd370)

### After

![image](https://github.com/user-attachments/assets/00a685ba-6245-4a64-b3f6-c16cb2be4e40)   ![image](https://github.com/user-attachments/assets/ee4a9b8c-ebbf-4806-b3eb-7d09a0ddc450)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).