### PR TITLE
fix(LeftSplitContainer): Workaround shift on load

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2283,6 +2283,19 @@ namespace GitUI.CommandsDialogs
             }
 
             LeftSplitContainer.Panel2Collapsed = !AppSettings.OutputHistoryPanelVisible.Value;
+
+            // Account for shift by 2px as for RevisionsSplitContainer
+            if (!LeftSplitContainer.Panel2Collapsed && LeftSplitContainer.FixedPanel == FixedPanel.Panel2)
+            {
+                try
+                {
+                    LeftSplitContainer.SplitterDistance += 2;
+                }
+                catch (Exception)
+                {
+                    // Catching because bad value can raise an exception
+                }
+            }
         }
 
         private void CommandsToolStripMenuItem_DropDownOpening(object sender, EventArgs e)


### PR DESCRIPTION
## Proposed changes

- `LeftSplitContainer.Panel2` (Output panel): Account for shift by 2px as for `RevisionsSplitContainer`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

![image](https://github.com/user-attachments/assets/99305a50-e279-4536-b29d-2dcfd1f66f12)

## Test methodology <!-- How did you ensure quality? -->

- manual with different scaling

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).