### PR TITLE
fix(message editor): Disable URL detection

### DIFF
--- a/src/app/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -51,6 +51,7 @@
             TextBox.AcceptsTab = true;
             TextBox.BorderStyle = BorderStyle.None;
             TextBox.ContextMenuStrip = SpellCheckContextMenu;
+            TextBox.DetectUrls = false;
             TextBox.Dock = DockStyle.Fill;
             TextBox.Location = new Point(0, 0);
             TextBox.Margin = new Padding(0);


### PR DESCRIPTION
Fixes #12340

## Proposed changes

`EditNetSpell`: Disable `TextBox.DetectUrls` in general.
It is not used: None of the four usages has a `LinkClicked` handler.

![image](https://github.com/user-attachments/assets/e60caca0-8e41-4855-bfc3-e6fe9a1c4180)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/85d7a2ad-57b3-4779-b051-bcdfa8afc814)

### After

![image](https://github.com/user-attachments/assets/db50c7b1-5c8c-4a4c-a299-3379eb93888c)
![image](https://github.com/user-attachments/assets/31ae4c08-1aa6-432d-915a-79bcc791d5ca)

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).