### PR TITLE
feat(rename file/folder): Add to context menu

### DIFF
--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -404,6 +404,15 @@ namespace GitCommands.Git
             };
         }
 
+        public static ArgumentString Move(string oldName, string newName)
+        {
+            return new GitArgumentBuilder("mv")
+            {
+                oldName.Quote(),
+                newName.Quote()
+            };
+        }
+
         /// <summary>
         ///  Creates a <c>git push</c> command using the specified parameters.</summary>
         /// <param name="remote">The remote repository that is the destination of the push operation.</param>

--- a/src/app/GitCommands/StringExtensions.cs
+++ b/src/app/GitCommands/StringExtensions.cs
@@ -13,6 +13,13 @@ namespace System
         // NOTE ordinal string comparison is the default as most string comparison in GE is against static ASCII output from git.exe
 
         /// <summary>
+        /// Returns <paramref name="str"/> without the mnemonic marker "&amp;".
+        /// </summary>
+        [Pure]
+        public static string RemoveMnemonicMarker(this string? str)
+            => str?.Replace("&", "");
+
+        /// <summary>
         /// Returns <paramref name="str"/> without <paramref name="prefix"/>.
         /// If <paramref name="prefix"/> is not found, <paramref name="str"/> is returned unchanged.
         /// </summary>

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -14,6 +14,7 @@ namespace GitUI.CommandsDialogs
         bool ShouldShowMenuEditWorkingDirectoryFile(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuOpenRevision(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuDeleteFile(ContextMenuSelectionInfo selectionInfo);
+        bool ShouldShowMenuMove(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowResetFileMenus(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuFileHistory(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuSaveAs(ContextMenuSelectionInfo selectionInfo);
@@ -159,6 +160,12 @@ namespace GitUI.CommandsDialogs
         public bool ShouldShowMenuDeleteFile(ContextMenuSelectionInfo selectionInfo)
         {
             return selectionInfo.AllFilesOrUntrackedDirectoriesExist && (selectionInfo.SelectedRevision?.IsArtificial ?? false);
+        }
+
+        public bool ShouldShowMenuMove(ContextMenuSelectionInfo selectionInfo)
+        {
+            return (selectionInfo.SelectedGitItemCount == 1 && selectionInfo.IsAnyTracked && !selectionInfo.IsAnySubmodule)
+                || selectionInfo.SelectedFolder is not null;
         }
 
         public bool ShouldShowMenuOpenRevision(ContextMenuSelectionInfo selectionInfo)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1565,6 +1565,10 @@ Git will never check if the file has changed that will improve status check perf
         <source>&lt;multiple&gt;</source>
         <target />
       </trans-unit>
+      <trans-unit id="_newName.Text">
+        <source>New name</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_resetSelectedChangesText.Text">
         <source>Are you sure you want to reset all selected files to {0}?</source>
         <target />
@@ -1776,6 +1780,10 @@ Suitable for some config files modified locally.</source>
       </trans-unit>
       <trans-unit id="tsmiInteractiveAdd.Text">
         <source>Interactive add...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiMove.Text">
+        <source>Rena&amp;me / move</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiOpenFindInCommitFilesGitGrepDialog.Text">

--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -121,6 +121,7 @@ namespace GitUI
             tsmiEditWorkingDirectoryFile = new ToolStripMenuItem();
             tsmiOpenInVisualStudio = new ToolStripMenuItem();
             tsmiSaveAs = new ToolStripMenuItem();
+            tsmiMove = new ToolStripMenuItem();
             tsmiDeleteFile = new ToolStripMenuItem();
             sepFile = new ToolStripSeparator();
             tsmiCopyPaths = new GitUI.CommandsDialogs.Menus.CopyPathsToolStripMenuItem();
@@ -660,9 +661,9 @@ namespace GitUI
             // 
             // ItemContextMenu
             // 
-            ItemContextMenu.Items.AddRange(new ToolStripItem[] { tsmiUpdateSubmodule, tsmiResetSubmoduleChanges, tsmiStashSubmoduleChanges, tsmiCommitSubmoduleChanges, sepSubmodule, tsmiStageFile, tsmiUnstageFile, tsmiResetFileTo, tsmiResetChunkOfFile, tsmiInteractiveAdd, tsmiCherryPickChanges, sepGit, tsmiOpenWithDifftool, tsmiOpenWorkingDirectoryFile, tsmiOpenWorkingDirectoryFileWith, tsmiOpenRevisionFile, tsmiOpenRevisionFileWith, tsmiEditWorkingDirectoryFile, tsmiOpenInVisualStudio, tsmiSaveAs, tsmiDeleteFile, sepFile, tsmiCopyPaths, tsmiShowInFolder, sepBrowse, tsmiShowInFileTree, tsmiFilterFileInGrid, tsmiFileHistory, tsmiBlame, tsmiFindFile, tsmiOpenFindInCommitFilesGitGrepDialog, tsmiShowFindInCommitFilesGitGrep, sepIgnore, tsmiAddFileToGitIgnore, tsmiAddFileToGitInfoExclude, tsmiSkipWorktree, tsmiAssumeUnchanged, tsmiStopTracking, sepScripts, tsmiRunScript });
+            ItemContextMenu.Items.AddRange(new ToolStripItem[] { tsmiUpdateSubmodule, tsmiResetSubmoduleChanges, tsmiStashSubmoduleChanges, tsmiCommitSubmoduleChanges, sepSubmodule, tsmiStageFile, tsmiUnstageFile, tsmiResetFileTo, tsmiResetChunkOfFile, tsmiInteractiveAdd, tsmiCherryPickChanges, sepGit, tsmiOpenWithDifftool, tsmiOpenWorkingDirectoryFile, tsmiOpenWorkingDirectoryFileWith, tsmiOpenRevisionFile, tsmiOpenRevisionFileWith, tsmiEditWorkingDirectoryFile, tsmiOpenInVisualStudio, tsmiSaveAs, tsmiMove, tsmiDeleteFile, sepFile, tsmiCopyPaths, tsmiShowInFolder, sepBrowse, tsmiShowInFileTree, tsmiFilterFileInGrid, tsmiFileHistory, tsmiBlame, tsmiFindFile, tsmiOpenFindInCommitFilesGitGrepDialog, tsmiShowFindInCommitFilesGitGrep, sepIgnore, tsmiAddFileToGitIgnore, tsmiAddFileToGitInfoExclude, tsmiSkipWorktree, tsmiAssumeUnchanged, tsmiStopTracking, sepScripts, tsmiRunScript });
             ItemContextMenu.Name = "DiffContextMenu";
-            ItemContextMenu.Size = new Size(296, 788);
+            ItemContextMenu.Size = new Size(296, 832);
             ItemContextMenu.Opening += ItemContextMenu_Opening;
             // 
             // tsmiUpdateSubmodule
@@ -902,6 +903,14 @@ namespace GitUI
             tsmiSaveAs.Size = new Size(295, 22);
             tsmiSaveAs.Text = "S&ave selected as...";
             tsmiSaveAs.Click += SaveAs_Click;
+            // 
+            // tsmiMove
+            // 
+            tsmiMove.Image = Properties.Images.Renamed;
+            tsmiMove.Name = "tsmiMove";
+            tsmiMove.Size = new Size(295, 22);
+            tsmiMove.Text = "Rena&me / move";
+            tsmiMove.Click += Move_Click;
             // 
             // tsmiDeleteFile
             // 
@@ -1165,6 +1174,7 @@ namespace GitUI
         internal ToolStripMenuItem tsmiEditWorkingDirectoryFile;
         private ToolStripMenuItem tsmiOpenInVisualStudio;
         private ToolStripMenuItem tsmiSaveAs;
+        private ToolStripMenuItem tsmiMove;
         private ToolStripMenuItem tsmiDeleteFile;
         private ToolStripSeparator sepFile;
         private CommandsDialogs.Menus.CopyPathsToolStripMenuItem tsmiCopyPaths;


### PR DESCRIPTION
Fixes #671

## Proposed changes

`FileStatusList`: Add context menu item "Rename / move" for the command "git mv"

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/80648e15-f4b3-414d-9d20-fb2cb333cb7a)

### After

![image](https://github.com/user-attachments/assets/13222a79-fe2c-4bce-b02f-f0c6caba2b5d)

![image](https://github.com/user-attachments/assets/79656214-2a9e-4839-bdaa-77367b020841)

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).