### PR TITLE
feat(WSL, dubious ownership): Improve first use of WSL repo

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -56,7 +56,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 command = $"{command[..windowsDriveIndex]}/mnt/{char.ToLower(command[windowsDriveIndex])}{command[(colonIndex + 1)..]}";
             }
 
-            return Regex.Replace(command, @"\$(LOCAL|REMOTE|BASE|MERGED)", @"$(wslpath -aw $&)");
+            return Regex.Replace(command, @"\$(LOCAL|REMOTE|BASE|MERGED)", @"$(wslpath -aw $&)").ToPosixPath();
         }
 
         protected override void Init(ISettingsPageHost pageHost)
@@ -67,7 +67,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             CommonLogic.FillEncodings(Global_FilesEncoding);
 
-            GlobalEditor.Items.AddRange(EditorHelper.GetEditors());
+            GlobalEditor.Items.AddRange([.. EditorHelper.GetEditors().Select(AdaptCommandIfWsl).WhereNotNull()]);
         }
 
         public static SettingsPageReference GetPageReference()

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -16,6 +16,8 @@ namespace GitUI.NBugReports
     {
         public const string DubiousOwnershipSecurityConfigString = "config --global --add safe.directory";
 
+        private static bool _isReportingDubiousOwnershipSecurity;
+
         private static Form? OwnerForm
             => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
 
@@ -269,6 +271,24 @@ namespace GitUI.NBugReports
         }
 
         private static void ReportDubiousOwnership(Exception exception)
+        {
+            if (_isReportingDubiousOwnershipSecurity)
+            {
+                return;
+            }
+
+            try
+            {
+                _isReportingDubiousOwnershipSecurity = true;
+                ReportDubiousOwnershipImpl(exception);
+            }
+            finally
+            {
+                _isReportingDubiousOwnershipSecurity = false;
+            }
+        }
+
+        private static void ReportDubiousOwnershipImpl(Exception exception)
         {
             string error = exception.Message;
             TaskDialogPage pageSecurity = new()

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -135,7 +135,7 @@ namespace GitUI.NBugReports
 
             if (externalOperationException?.InnerException?.Message?.Contains(DubiousOwnershipSecurityConfigString) is true)
             {
-                ReportDubiousOwnership(externalOperationException.InnerException);
+                ReportDubiousOwnership(externalOperationException);
                 return;
             }
 
@@ -270,7 +270,7 @@ namespace GitUI.NBugReports
             }
         }
 
-        private static void ReportDubiousOwnership(Exception exception)
+        private static void ReportDubiousOwnership(ExternalOperationException exception)
         {
             if (_isReportingDubiousOwnershipSecurity)
             {
@@ -288,9 +288,10 @@ namespace GitUI.NBugReports
             }
         }
 
-        private static void ReportDubiousOwnershipImpl(Exception exception)
+        private static void ReportDubiousOwnershipImpl(ExternalOperationException exception)
         {
-            string error = exception.Message;
+            ArgumentNullException.ThrowIfNull(exception.InnerException);
+            string error = exception.InnerException.Message;
             TaskDialogPage pageSecurity = new()
             {
                 Icon = TaskDialogIcon.Error,
@@ -302,13 +303,13 @@ namespace GitUI.NBugReports
             };
             int startIndex = error.IndexOf(DubiousOwnershipSecurityConfigString);
             string gitConfigTrustRepoCommand = ReplaceRepoPathQuotes(error[startIndex..].Trim());
-            string folderPath = error[(startIndex + DubiousOwnershipSecurityConfigString.Length + 1)..];
+            string folderPath = exception.WorkingDirectory ?? error[(startIndex + DubiousOwnershipSecurityConfigString.Length + 1)..];
 
             TaskDialogCommandLinkButton openExplorerButton = new(TranslatedStrings.GitDubiousOwnershipOpenRepositoryFolder, allowCloseDialog: false);
             openExplorerButton.Click += (_, _) => OsShellUtil.OpenWithFileExplorer(PathUtil.ToNativePath(folderPath));
             pageSecurity.Buttons.Add(openExplorerButton);
 
-            AddTrustRepoButton(TranslatedStrings.GitDubiousOwnershipTrustRepository, gitConfigTrustRepoCommand);
+            AddTrustRepoButton(TranslatedStrings.GitDubiousOwnershipTrustRepository, gitConfigTrustRepoCommand, exception.WorkingDirectory ?? ".");
 
             TaskDialogButton helpButton = TaskDialogButton.Help;
             helpButton.Click += (_, _) =>
@@ -335,7 +336,7 @@ namespace GitUI.NBugReports
 
             return;
 
-            void AddTrustRepoButton(string buttonText, string command)
+            void AddTrustRepoButton(string buttonText, string command, string workingDir)
             {
                 TaskDialogCommandLinkButton button = new(buttonText)
                 {
@@ -344,8 +345,8 @@ namespace GitUI.NBugReports
 
                 button.Click += (_, _) =>
                 {
-                    new GitModule(".").GitExecutable.Start(command);
-                    ShowGitRepo(OwnerForm, folderPath);
+                    new GitModule(workingDir).GitExecutable.Start(command).WaitForExit();
+                    ShowGitRepo(OwnerForm, workingDir);
                 };
 
                 pageSecurity.Buttons.Add(button);


### PR DESCRIPTION
## Proposed changes

- `GitConfigSettingsPage`: Adapt paths of suggested editor commands in case of WSL repo
- `BugReportInvoker.ReportDubiousOwnership`:
  - Do not popup twice at a time
  - Support WSL (use WSL git for WSL repo)
  - (Try to) open the newly trusted repo (instead of the Dashboard)

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/aa6d58f1-74b1-4c4b-9ab1-05ae6917fc93)

### After

![image](https://github.com/user-attachments/assets/28a3530a-c4be-420e-8ad9-1dd8bb2531d6)

## Test methodology <!-- How did you ensure quality? -->

- manually

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).