### PR TITLE
fix(WSL): Make "edit commit" & "reword commit" work

### DIFF
--- a/src/app/GitCommands/Utils/WslUtil.cs
+++ b/src/app/GitCommands/Utils/WslUtil.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+namespace GitCommands.Utils;
+
+public static class WslUtil
+{
+    /// <summary>
+    /// Tells Windows to forward <paramref name="envVarNames"/> to WSL by means of also setting WSLENV
+    /// if <paramref name="workingDir"/> is a WSL path.
+    /// </summary>
+    /// <param name="envVariables">The current set of environment variables to be adapted.</param>
+    /// <param name="workingDir">The path of the affected repo in order to check whether it is WSL.</param>
+    /// <param name="envVarNames">A list of environment variables to be forwarded to WSL.</param>
+    public static void ForwardEnvironmentVariableToWsl(this Dictionary<string, string> envVariables, string workingDir, params string[] envVarNames)
+    {
+        if (!PathUtil.IsWslPath(workingDir))
+        {
+            return;
+        }
+
+        const string envVarNameWslEnvVarControl = "WSLENV";
+        const char separator = ':';
+        string wslEnvControlValue = string.Join(separator, envVarNames);
+        if (envVariables.Remove(envVarNameWslEnvVarControl, out string? existingWslEnvValue))
+        {
+            wslEnvControlValue = $"{existingWslEnvValue}{separator}{wslEnvControlValue}";
+        }
+
+        envVariables.Add(envVarNameWslEnvVarControl, wslEnvControlValue);
+    }
+}

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -3158,15 +3158,18 @@ namespace GitUI
             const string envVarNameGitSequenceEditor = "GIT_SEQUENCE_EDITOR";
             formProcess.ProcessEnvVariables.Add(envVarNameGitSequenceEditor, string.Format("sed -i -re '0,/pick/s//{0}/'", command));
 
-            const string envVarNameWslEnvControl = "WSLENV";
-            string wslEnvControlValue = envVarNameGitSequenceEditor;
-            if (Environment.GetEnvironmentVariable(envVarNameWslEnvControl) is string existingWslEnvValue)
+            // Tell Windows to forward GIT_SEQUENCE_EDITOR to WSL by means of also setting WSLENV (regardless of whether it is a WSL repo or not)
             {
-                wslEnvControlValue = $"{existingWslEnvValue}:{wslEnvControlValue}";
-            }
+                const string envVarNameWslEnvControl = "WSLENV";
+                string wslEnvControlValue = envVarNameGitSequenceEditor;
+                if (Environment.GetEnvironmentVariable(envVarNameWslEnvControl) is string existingWslEnvValue)
+                {
+                    wslEnvControlValue = $"{existingWslEnvValue}:{wslEnvControlValue}";
+                }
 
-            formProcess.ProcessEnvVariables.Remove(envVarNameWslEnvControl);
-            formProcess.ProcessEnvVariables.Add(envVarNameWslEnvControl, wslEnvControlValue);
+                formProcess.ProcessEnvVariables.Remove(envVarNameWslEnvControl);
+                formProcess.ProcessEnvVariables.Add(envVarNameWslEnvControl, wslEnvControlValue);
+            }
 
             formProcess.ShowDialog(ParentForm);
             PerformRefreshRevisions();

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -8,6 +8,7 @@ using System.Runtime.ExceptionServices;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
+using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Translations;
@@ -3157,20 +3158,7 @@ namespace GitUI
 
             const string envVarNameGitSequenceEditor = "GIT_SEQUENCE_EDITOR";
             formProcess.ProcessEnvVariables.Add(envVarNameGitSequenceEditor, string.Format("sed -i -re '0,/pick/s//{0}/'", command));
-
-            // Tell Windows to forward GIT_SEQUENCE_EDITOR to WSL by means of also setting WSLENV
-            if (PathUtil.IsWslPath(Module.WorkingDir))
-            {
-                const string envVarNameWslEnvControl = "WSLENV";
-                string wslEnvControlValue = envVarNameGitSequenceEditor;
-                if (Environment.GetEnvironmentVariable(envVarNameWslEnvControl) is string existingWslEnvValue)
-                {
-                    wslEnvControlValue = $"{existingWslEnvValue}:{wslEnvControlValue}";
-                }
-
-                formProcess.ProcessEnvVariables.Remove(envVarNameWslEnvControl);
-                formProcess.ProcessEnvVariables.Add(envVarNameWslEnvControl, wslEnvControlValue);
-            }
+            formProcess.ProcessEnvVariables.ForwardEnvironmentVariableToWsl(Module.WorkingDir, envVarNameGitSequenceEditor);
 
             formProcess.ShowDialog(ParentForm);
             PerformRefreshRevisions();

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -3158,7 +3158,8 @@ namespace GitUI
             const string envVarNameGitSequenceEditor = "GIT_SEQUENCE_EDITOR";
             formProcess.ProcessEnvVariables.Add(envVarNameGitSequenceEditor, string.Format("sed -i -re '0,/pick/s//{0}/'", command));
 
-            // Tell Windows to forward GIT_SEQUENCE_EDITOR to WSL by means of also setting WSLENV (regardless of whether it is a WSL repo or not)
+            // Tell Windows to forward GIT_SEQUENCE_EDITOR to WSL by means of also setting WSLENV
+            if (PathUtil.IsWslPath(Module.WorkingDir))
             {
                 const string envVarNameWslEnvControl = "WSLENV";
                 string wslEnvControlValue = envVarNameGitSequenceEditor;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -3154,7 +3154,20 @@ namespace GitUI
             });
 
             using FormProcess formProcess = new(UICommands, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true);
-            formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", string.Format("sed -i -re '0,/pick/s//{0}/'", command));
+
+            const string envVarNameGitSequenceEditor = "GIT_SEQUENCE_EDITOR";
+            formProcess.ProcessEnvVariables.Add(envVarNameGitSequenceEditor, string.Format("sed -i -re '0,/pick/s//{0}/'", command));
+
+            const string envVarNameWslEnvControl = "WSLENV";
+            string wslEnvControlValue = envVarNameGitSequenceEditor;
+            if (Environment.GetEnvironmentVariable(envVarNameWslEnvControl) is string existingWslEnvValue)
+            {
+                wslEnvControlValue = $"{existingWslEnvValue}:{wslEnvControlValue}";
+            }
+
+            formProcess.ProcessEnvVariables.Remove(envVarNameWslEnvControl);
+            formProcess.ProcessEnvVariables.Add(envVarNameWslEnvControl, wslEnvControlValue);
+
             formProcess.ShowDialog(ParentForm);
             PerformRefreshRevisions();
         }


### PR DESCRIPTION
## Proposed changes

- `LaunchRebase`: Forward env var `GIT_SEQUENCE_EDITOR` to WSL in order to make "edit / reword commit" work
  by setting env var `WSLENV`, which controls which env vars are synchronized between Windows and WSL

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

editor pops up with `git-rebase-todo` file

### After

works as expected without the need to edit `git-rebase-todo`

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).