### PR TITLE
Add ComboBoxWatermarkManager for control of ComboBox watermark text

### DIFF
--- a/src/app/GitUI/Editor/ComboBoxWatermarkManager.cs
+++ b/src/app/GitUI/Editor/ComboBoxWatermarkManager.cs
@@ -1,0 +1,185 @@
+namespace GitUI.Editor;
+
+/// <summary>
+///  Manages watermark text display for a ComboBox control.
+/// </summary>
+internal sealed class ComboBoxWatermarkManager : IDisposable
+{
+    private readonly ComboBox _comboBox;
+    private readonly string _watermarkText;
+    private Font _watermarkFont;
+    private readonly Color _watermarkColor = SystemColors.GrayText;
+    private Font _originalFont;
+    private Color _originalForeColor;
+    private bool _isWatermarkActive;
+    private bool _isDisposed;
+
+    /// <param name="comboBox">The ComboBox control to manage.</param>
+    /// <param name="watermarkText">The watermark text to display.</param>
+    public ComboBoxWatermarkManager(ComboBox comboBox, string watermarkText)
+    {
+        _comboBox = comboBox ?? throw new ArgumentNullException(nameof(comboBox));
+        _watermarkText = watermarkText ?? string.Empty;
+
+        _originalFont = _comboBox.Font;
+        _originalForeColor = _comboBox.ForeColor;
+        _watermarkFont = new Font(_originalFont, FontStyle.Italic);
+
+        if (string.IsNullOrEmpty(_comboBox.Text))
+        {
+            ShowWatermark();
+        }
+
+        _comboBox.Enter += ComboBox_Enter;
+        _comboBox.LostFocus += ComboBox_LostFocus;
+        _comboBox.TextChanged += ComboBox_TextChanged; // Handle programmatic changes or pasting
+        _comboBox.FontChanged += ComboBox_FontChanged; // Keep original font updated
+        _comboBox.ForeColorChanged += ComboBox_ForeColorChanged; // Keep original color updated
+    }
+
+    public string ComboBoxText
+    {
+        get
+        {
+            return _isWatermarkActive
+                ? string.Empty
+                : _comboBox.Text;
+        }
+    }
+
+    public bool WatermarkActive => _isWatermarkActive;
+
+    private void ComboBox_Enter(object sender, EventArgs e)
+    {
+        ActOpaqueToTextChanged(static wmm => wmm.HideWatermarkInternal(resetText: true));
+    }
+
+    private void ComboBox_LostFocus(object sender, EventArgs e)
+    {
+        if (string.IsNullOrEmpty(_comboBox.Text))
+        {
+            ActOpaqueToTextChanged(static wmm => wmm.ShowWatermark());
+        }
+    }
+
+    private void ComboBox_TextChanged(object sender, EventArgs e)
+    {
+        string comboBoxText = _comboBox.Text;
+
+        // If text changes while watermark is active (e.g., programmatically), hide watermark
+        if (_isWatermarkActive && comboBoxText != _watermarkText && comboBoxText != "")
+        {
+            ActOpaqueToTextChanged(static wmm => wmm.HideWatermarkInternal(resetText: false));
+        }
+        else if (!_isWatermarkActive && comboBoxText == "")
+        {
+            ActOpaqueToTextChanged(static wmm => wmm.ShowWatermark());
+        }
+    }
+
+    private void ComboBox_FontChanged(object sender, EventArgs e)
+    {
+        // If the font changes while the watermark is not active, update the original font.
+        if (!_isWatermarkActive && !_isDisposed && _comboBox.Font != _watermarkFont)
+        {
+            _originalFont = _comboBox.Font;
+
+            // Recreate watermark font based on new original font
+            _watermarkFont?.Dispose(); // Dispose previous watermark font if exists
+            _watermarkFont = new Font(_originalFont, FontStyle.Italic);
+        }
+    }
+
+    private void ComboBox_ForeColorChanged(object sender, EventArgs e)
+    {
+        // If the color changes while the watermark is not active, update the original color.
+        if (!_isWatermarkActive && !_isDisposed && _comboBox.ForeColor != _watermarkColor)
+        {
+            _originalForeColor = _comboBox.ForeColor;
+        }
+    }
+
+    /// <summary>
+    ///  Displays the watermark text in the ComboBox.
+    /// </summary>
+    public void ShowWatermark()
+    {
+        if (_isWatermarkActive || _isDisposed || _comboBox.Focused)
+        {
+            return;
+        }
+
+        _isWatermarkActive = true;
+        _comboBox.Font = _watermarkFont;
+        _comboBox.ForeColor = _watermarkColor;
+        _comboBox.Text = _watermarkText;
+    }
+
+    /// <summary>
+    ///  Hides the watermark text and restores the original appearance.
+    /// </summary>
+    public void HideWatermark()
+    {
+        HideWatermarkInternal(resetText: true);
+    }
+
+    private void HideWatermarkInternal(bool resetText)
+    {
+        if (!_isWatermarkActive || _isDisposed)
+        {
+            return;
+        }
+
+        _isWatermarkActive = false;
+
+        if (resetText)
+        {
+            _comboBox.Text = string.Empty;
+        }
+
+        _comboBox.Font = _originalFont;
+        _comboBox.ForeColor = _originalForeColor;
+    }
+
+    /// <summary>
+    ///  Releases the resources used by the <see cref="ComboBoxWatermarkManager"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _isDisposed = true;
+
+        _comboBox.Enter -= ComboBox_Enter;
+        _comboBox.LostFocus -= ComboBox_LostFocus;
+        _comboBox.TextChanged -= ComboBox_TextChanged;
+        _comboBox.FontChanged -= ComboBox_FontChanged;
+        _comboBox.ForeColorChanged -= ComboBox_ForeColorChanged;
+
+        _watermarkFont?.Dispose();
+
+        // Restore original state if watermark was active on dispose
+        if (_isWatermarkActive)
+        {
+            _comboBox.Text = string.Empty;
+            _comboBox.Font = _originalFont;
+            _comboBox.ForeColor = _originalForeColor;
+        }
+    }
+
+    private void ActOpaqueToTextChanged(Action<ComboBoxWatermarkManager> action)
+    {
+        // Temporarily unsubscribe to prevent recursion when ShowWatermark changes text
+        _comboBox.TextChanged -= ComboBox_TextChanged;
+        action(this);
+
+        // Re-subscribe if not disposed
+        if (!_isDisposed)
+        {
+            _comboBox.TextChanged += ComboBox_TextChanged;
+        }
+    }
+}

--- a/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.Designer.cs
+++ b/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.Designer.cs
@@ -26,14 +26,12 @@ namespace GitUI
             chkMatchCase = new CheckBox();
             btnSearch = new Button();
             chkShowSearchBox = new CheckBox();
-            lblSearchCommitGitGrepWatermark = new Label();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
             SuspendLayout();
             // 
             // MainPanel
             // 
-            MainPanel.Controls.Add(lblSearchCommitGitGrepWatermark);
             MainPanel.Controls.Add(chkMatchCase);
             MainPanel.Controls.Add(chkMatchWholeWord);
             MainPanel.Controls.Add(txtOptions);
@@ -75,8 +73,6 @@ namespace GitUI
             cboFindInCommitFilesGitGrep.Name = "cboFindInCommitFilesGitGrep";
             cboFindInCommitFilesGitGrep.Size = new Size(323, 23);
             cboFindInCommitFilesGitGrep.TabIndex = 1;
-            cboFindInCommitFilesGitGrep.GotFocus += cboSearchCommitGitGrep_GotFocus;
-            cboFindInCommitFilesGitGrep.LostFocus += cboSearchCommitGitGrep_LostFocus;
             // 
             // txtOptions
             // 
@@ -136,19 +132,6 @@ namespace GitUI
             chkShowSearchBox.UseVisualStyleBackColor = true;
             chkShowSearchBox.CheckedChanged += chkShowSearchBox_CheckedChanged;
             // 
-            // lblSearchCommitGitGrepWatermark
-            // 
-            lblSearchCommitGitGrepWatermark.AutoSize = true;
-            lblSearchCommitGitGrepWatermark.BackColor = SystemColors.Window;
-            lblSearchCommitGitGrepWatermark.ForeColor = SystemColors.GrayText;
-            lblSearchCommitGitGrepWatermark.Location = new Point(93, 8);
-            lblSearchCommitGitGrepWatermark.Name = "lblSearchCommitGitGrepWatermark";
-            lblSearchCommitGitGrepWatermark.Padding = new Padding(2);
-            lblSearchCommitGitGrepWatermark.Size = new Size(162, 19);
-            lblSearchCommitGitGrepWatermark.TabIndex = 3;
-            lblSearchCommitGitGrepWatermark.Text = "git-grep regular expression...";
-            lblSearchCommitGitGrepWatermark.Click += lblSearchCommitGitGrepWatermark_Click;
-            // 
             // FormFindInCommitFilesGitGrep
             // 
             AcceptButton = btnSearch;
@@ -175,7 +158,6 @@ namespace GitUI
 
         #endregion
 
-        private Label lblSearchCommitGitGrepWatermark;
         private Label label1;
         private Label lblOptions;
         private ComboBox cboFindInCommitFilesGitGrep;

--- a/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
+++ b/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
@@ -1,10 +1,15 @@
 ﻿using GitCommands;
 using GitExtensions.Extensibility.Git;
+using GitUI.Editor;
+using ResourceManager;
 
 namespace GitUI;
 
 internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
 {
+    private readonly TranslationString _watermarkText = new("git-grep regular expression...");
+    private readonly ComboBoxWatermarkManager _cboFindInCommitFilesGitGrepWatermark;
+
     private bool _hasLoaded = false;
 
     /// <summary>
@@ -23,14 +28,14 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
         InitializeComponent();
         InitializeComplete();
 
-        lblSearchCommitGitGrepWatermark.Font = new Font(lblSearchCommitGitGrepWatermark.Font, FontStyle.Italic);
+        _cboFindInCommitFilesGitGrepWatermark = new ComboBoxWatermarkManager(cboFindInCommitFilesGitGrep, _watermarkText.Text);
 
         ShowInTaskbar = false;
     }
 
     public string? GitGrepExpressionText
     {
-        get => cboFindInCommitFilesGitGrep.Text;
+        get => _cboFindInCommitFilesGitGrepWatermark.ComboBoxText;
         set
         {
             if (value is not null)
@@ -50,7 +55,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
     public void SetSearchItems(ComboBox.ObjectCollection items)
     {
         cboFindInCommitFilesGitGrep.BeginUpdate();
-        string search = cboFindInCommitFilesGitGrep.Text;
+        string search = _cboFindInCommitFilesGitGrepWatermark.ComboBoxText;
         int selectionStart = cboFindInCommitFilesGitGrep.SelectionStart;
         int selectionLength = cboFindInCommitFilesGitGrep.SelectionLength;
 
@@ -91,6 +96,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
         if (disposing)
         {
             components?.Dispose();
+            _cboFindInCommitFilesGitGrepWatermark?.Dispose();
         }
 
         base.Dispose(disposing);
@@ -119,28 +125,9 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
     private void Search()
         => FilesGitGrepLocator?.Invoke(GitGrepExpressionText, 0);
 
-    private void SetSearchWatermarkLabelVisibility()
-    {
-        lblSearchCommitGitGrepWatermark.Visible = cboFindInCommitFilesGitGrep.Visible && !cboFindInCommitFilesGitGrep.Focused && string.IsNullOrEmpty(cboFindInCommitFilesGitGrep.Text);
-        if (lblSearchCommitGitGrepWatermark.Visible)
-        {
-            lblSearchCommitGitGrepWatermark.BringToFront();
-        }
-    }
-
     private void btnSearch_Click(object sender, EventArgs e)
     {
         Search();
-    }
-
-    private void cboSearchCommitGitGrep_GotFocus(object sender, EventArgs e)
-    {
-        SetSearchWatermarkLabelVisibility();
-    }
-
-    private void cboSearchCommitGitGrep_LostFocus(object sender, EventArgs e)
-    {
-        SetSearchWatermarkLabelVisibility();
     }
 
     private void chkMatchCase_CheckedChanged(object sender, EventArgs e)
@@ -162,11 +149,6 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
         }
 
         FindInCommitFilesGitGrepToggle?.Invoke(chkShowSearchBox.Checked);
-    }
-
-    private void lblSearchCommitGitGrepWatermark_Click(object sender, EventArgs e)
-    {
-        cboFindInCommitFilesGitGrep.Focus();
     }
 
     private void txtOptions_TextChanged(object sender, EventArgs e)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1515,10 +1515,6 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
         <source>RegEx</source>
         <target />
       </trans-unit>
-      <trans-unit id="FilterWatermarkLabel.Text">
-        <source>Filter files using a regular expression...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="LoadingFiles.Text">
         <source>Loading data...</source>
         <target />
@@ -1531,6 +1527,10 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
         <source>Tell git to not check the status of this file for performance benefits.
 Use this feature when a file is big and never change.
 Git will never check if the file has changed that will improve status check performance.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_cboFindInCommitFilesGitGrepWatermarkText.Text">
+        <source>Find in commit files using git-grep regular expression...</source>
         <target />
       </trans-unit>
       <trans-unit id="_collapseAll.Text">
@@ -1555,6 +1555,10 @@ Git will never check if the file has changed that will improve status check perf
       </trans-unit>
       <trans-unit id="_expandAll.Text">
         <source>E&amp;xpand all</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_filterComboBoxWatermarkText.Text">
+        <source>Filter files using a regular expression...</source>
         <target />
       </trans-unit>
       <trans-unit id="_firstRevision.Text">
@@ -1654,12 +1658,12 @@ Suitable for some config files modified locally.</source>
         <source>Show files with different changes</source>
         <target />
       </trans-unit>
-      <trans-unit id="columnHeader.Text">
-        <source>Files</source>
+      <trans-unit id="cboFindInCommitFilesGitGrep.Text">
+        <source>Find in commit files using git-grep regular expression...</source>
         <target />
       </trans-unit>
-      <trans-unit id="lblFindInCommitFilesGitGrepWatermark.Text">
-        <source>Find in commit files using git-grep regular expression...</source>
+      <trans-unit id="columnHeader.Text">
+        <source>Files</source>
         <target />
       </trans-unit>
       <trans-unit id="tmsiEditLocallyIgnoredFiles.Text">
@@ -4937,6 +4941,10 @@ If you are not sure just close this window.</source>
         <source>Find in commit files using git-grep</source>
         <target />
       </trans-unit>
+      <trans-unit id="_watermarkText.Text">
+        <source>git-grep regular expression...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnSearch.Text">
         <source>&amp;Find</source>
         <target />
@@ -4959,10 +4967,6 @@ If you are not sure just close this window.</source>
       </trans-unit>
       <trans-unit id="lblOptions.Text">
         <source>&amp;Options:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="lblSearchCommitGitGrepWatermark.Text">
-        <source>git-grep regular expression...</source>
         <target />
       </trans-unit>
     </body>

--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -38,12 +38,10 @@ namespace GitUI
             NoFiles = new Label();
             LoadingFiles = new Label();
             _NO_TRANSLATE_FilterComboBox = new ComboBox();
-            FilterWatermarkLabel = new Label();
             FilterToolTip = new ToolTip(components);
             lblSplitter = new Label();
             DeleteFilterButton = new Label();
             cboFindInCommitFilesGitGrep = new ComboBox();
-            lblFindInCommitFilesGitGrepWatermark = new Label();
             DeleteSearchButton = new Label();
             Toolbar = new ToolStripEx();
             btnCollapseGroups = new ToolStripButton();
@@ -206,22 +204,7 @@ namespace GitUI
             _NO_TRANSLATE_FilterComboBox.SelectedIndexChanged += FilterComboBox_SelectedIndexChanged;
             _NO_TRANSLATE_FilterComboBox.TextUpdate += FilterComboBox_TextUpdate;
             _NO_TRANSLATE_FilterComboBox.SizeChanged += FilterComboBox_SizeChanged;
-            _NO_TRANSLATE_FilterComboBox.GotFocus += FilterComboBox_GotFocus;
-            _NO_TRANSLATE_FilterComboBox.LostFocus += FilterComboBox_LostFocus;
             _NO_TRANSLATE_FilterComboBox.MouseEnter += FilterComboBox_MouseEnter;
-            // 
-            // FilterWatermarkLabel
-            // 
-            FilterWatermarkLabel.AutoSize = true;
-            FilterWatermarkLabel.BackColor = SystemColors.Window;
-            FilterWatermarkLabel.ForeColor = SystemColors.GrayText;
-            FilterWatermarkLabel.Location = new Point(0, 48);
-            FilterWatermarkLabel.Name = "FilterWatermarkLabel";
-            FilterWatermarkLabel.Padding = new Padding(2, 3, 2, 0);
-            FilterWatermarkLabel.Size = new Size(210, 18);
-            FilterWatermarkLabel.TabIndex = 6;
-            FilterWatermarkLabel.Text = "Filter files using a regular expression...";
-            FilterWatermarkLabel.Click += FilterWatermarkLabel_Click;
             // 
             // FilterToolTip
             // 
@@ -267,21 +250,6 @@ namespace GitUI
             cboFindInCommitFilesGitGrep.SelectedIndexChanged += cboFindInCommitFilesGitGrep_SelectedIndexChanged;
             cboFindInCommitFilesGitGrep.TextUpdate += cboFindInCommitFilesGitGrep_TextUpdate;
             cboFindInCommitFilesGitGrep.SizeChanged += cboFindInCommitFilesGitGrep_SizeChanged;
-            cboFindInCommitFilesGitGrep.GotFocus += cboFindInCommitFilesGitGrep_GotFocus;
-            cboFindInCommitFilesGitGrep.LostFocus += cboFindInCommitFilesGitGrep_LostFocus;
-            // 
-            // lblFindInCommitFilesGitGrepWatermark
-            // 
-            lblFindInCommitFilesGitGrepWatermark.AutoSize = true;
-            lblFindInCommitFilesGitGrepWatermark.BackColor = SystemColors.Window;
-            lblFindInCommitFilesGitGrepWatermark.ForeColor = SystemColors.GrayText;
-            lblFindInCommitFilesGitGrepWatermark.Location = new Point(0, 25);
-            lblFindInCommitFilesGitGrepWatermark.Name = "lblFindInCommitFilesGitGrepWatermark";
-            lblFindInCommitFilesGitGrepWatermark.Padding = new Padding(2, 3, 2, 2);
-            lblFindInCommitFilesGitGrepWatermark.Size = new Size(302, 20);
-            lblFindInCommitFilesGitGrepWatermark.TabIndex = 3;
-            lblFindInCommitFilesGitGrepWatermark.Text = "Find in commit files using git-grep regular expression...";
-            lblFindInCommitFilesGitGrepWatermark.Click += lblFindInCommitFilesGitGrepWatermark_Click;
             // 
             // DeleteSearchButton
             // 
@@ -1058,9 +1026,7 @@ namespace GitUI
             ContextMenuStrip = ItemContextMenu;
             Controls.Add(LoadingFiles);
             Controls.Add(NoFiles);
-            Controls.Add(lblFindInCommitFilesGitGrepWatermark);
             Controls.Add(DeleteSearchButton);
-            Controls.Add(FilterWatermarkLabel);
             Controls.Add(DeleteFilterButton);
             Controls.Add(cboFindInCommitFilesGitGrep);
             Controls.Add(FileStatusListView);
@@ -1084,12 +1050,10 @@ namespace GitUI
         private Label LoadingFiles;
         private ColumnHeader columnHeader;
         private ComboBox _NO_TRANSLATE_FilterComboBox;
-        private Label FilterWatermarkLabel;
         private ToolTip FilterToolTip;
         private Label lblSplitter;
         private Label DeleteFilterButton;
         private ComboBox cboFindInCommitFilesGitGrep;
-        private Label lblFindInCommitFilesGitGrepWatermark;
         private Label DeleteSearchButton;
         private ToolStripEx Toolbar;
         private ToolStripButton btnCollapseGroups;

--- a/tests/app/UnitTests/GitUI.Tests/ComboBoxWatermarkManagerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ComboBoxWatermarkManagerTests.cs
@@ -1,0 +1,374 @@
+﻿using FluentAssertions;
+using GitUI.Editor;
+
+namespace GitUITests;
+
+[TestFixture]
+[Apartment(ApartmentState.STA)]
+public class ComboBoxWatermarkManagerTests
+{
+    private const string Watermark = "Enter text here...";
+    private Form _form = null!;
+    private ComboBox _comboBox1 = null!;
+    private ComboBox _comboBox2 = null!; // For focus change tests
+    private TextBox _textBox = null!; // For focus change tests and for initial focus
+    private ComboBoxWatermarkManager _manager1 = null!;
+    private ComboBoxWatermarkManager _manager2 = null!;
+    private Font _originalFont = null!;
+    private Color _originalForeColor;
+    private Font _watermarkFont = null!;
+    private Color _watermarkColor;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _form = new Form();
+        _comboBox1 = new ComboBox { Parent = _form, Name = "ComboBox1" };
+        _comboBox2 = new ComboBox { Parent = _form, Name = "ComboBox2", Left = _comboBox1.Right + 10 };
+        _textBox = new TextBox { Parent = _form, Name = "TextBox", Top = _comboBox1.Bottom + 10 };
+
+        // Store initial styles before manager potentially changes them
+        _originalFont = (Font)_comboBox1.Font.Clone();
+        _originalForeColor = _comboBox1.ForeColor;
+        _watermarkFont = new Font(_originalFont, FontStyle.Italic);
+        _watermarkColor = SystemColors.GrayText;
+
+        _form.Show();
+
+        // Initialize managers AFTER showing the form and storing original styles
+        _manager1 = new ComboBoxWatermarkManager(_comboBox1, Watermark);
+        _manager2 = new ComboBoxWatermarkManager(_comboBox2, "Another watermark");
+
+        _textBox.Focus();
+
+        Application.DoEvents();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _manager1.Dispose();
+        _manager2.Dispose();
+
+        _comboBox1.Dispose();
+        _comboBox2.Dispose();
+        _form.Dispose();
+        _watermarkFont.Dispose();
+    }
+
+    [Test]
+    public void Constructor_should_show_watermark_when_combobox_is_empty()
+    {
+        // Assert
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+    }
+
+    [Test]
+    public void Constructor_should_not_show_watermark_when_combobox_has_text()
+    {
+        // Arrange
+        using Form form = new();
+        using ComboBox comboBox = new() { Parent = form, Text = "Initial Text" };
+        form.Show();
+
+        // Act
+        using ComboBoxWatermarkManager manager = new(comboBox, Watermark);
+
+        // Assert
+        AssertWatermarkInactive(comboBox, manager, "Initial Text");
+    }
+
+    [Test]
+    public void Got_focus_should_hide_watermark()
+    {
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+
+        // Act
+        _comboBox1.Focus();
+        Application.DoEvents();
+
+        // Assert
+        AssertWatermarkInactive(_comboBox1, _manager1, string.Empty);
+    }
+
+    [Test]
+    public void Lost_focus_should_show_watermark_when_text_is_empty()
+    {
+        // Arrange
+        _comboBox1.Focus(); // Hide watermark
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, string.Empty);
+
+        // Act
+        _textBox.Focus(); // Change focus to another control
+        Application.DoEvents();
+
+        // Assert
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+    }
+
+    [Test]
+    public void Lost_focus_should_not_show_watermark_when_text_is_not_empty()
+    {
+        // Arrange
+        _comboBox1.Focus(); // Hide watermark
+        Application.DoEvents();
+        _comboBox1.Text = "User Text";
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, "User Text");
+
+        // Act
+        _textBox.Focus(); // Change focus
+        Application.DoEvents();
+
+        // Assert
+        AssertWatermarkInactive(_comboBox1, _manager1, "User Text");
+    }
+
+    [Test]
+    public void Text_changed_to_empty_should_show_watermark_when_not_focused()
+    {
+        // Arrange
+        _comboBox1.Focus();
+        Application.DoEvents();
+        _comboBox1.Text = "Some Text";
+        Application.DoEvents();
+        _textBox.Focus(); // Lose focus
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, "Some Text");
+
+        // Act
+        _comboBox1.Text = ""; // Programmatically clear text while not focused
+        Application.DoEvents();
+
+        // Assert
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+    }
+
+    [Test]
+    public void Text_changed_to_non_empty_should_hide_watermark_when_watermark_active_and_not_focused()
+    {
+        // Arrange
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+
+        // Act
+        _comboBox1.Text = "Programmatic Text"; // Set text while watermark is active
+        Application.DoEvents();
+
+        // Assert
+        AssertWatermarkInactive(_comboBox1, _manager1, "Programmatic Text");
+    }
+
+    [Test]
+    public void Text_changed_to_non_empty_should_hide_watermark_when_watermark_active_and_focused()
+    {
+        // Arrange
+        _comboBox1.Focus(); // Regain focus, watermark hides, text becomes ""
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, "");
+
+        // Act
+        // Simulate typing - setting text while focused and previously empty
+        _comboBox1.Text = "User Typing";
+        Application.DoEvents();
+
+        // Assert
+        AssertWatermarkInactive(_comboBox1, _manager1, "User Typing");
+    }
+
+    [Test]
+    public void Text_changed_to_watermark_text_should_not_hide_watermark()
+    {
+        // Arrange (Watermark is active initially)
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+
+        // Act
+        // Programmatically set text to the exact watermark string
+        // Let's test setting it while focused, then losing focus.
+        _comboBox1.Focus();
+        Application.DoEvents(); // Hides watermark
+        _comboBox1.Text = Watermark; // Set text to watermark value
+        Application.DoEvents();
+        _textBox.Focus(); // Lose focus
+        Application.DoEvents();
+
+        // Assert
+        // Even though the text *is* the watermark string, because it was explicitly set,
+        // it should NOT be treated as a watermark.
+        AssertWatermarkInactive(_comboBox1, _manager1, Watermark);
+    }
+
+    [Test]
+    public void Text_set_programmatically_to_null_should_show_watermark_when_not_focused()
+    {
+        // Arrange
+        _comboBox1.Text = "Some Text";
+        Application.DoEvents();
+        _textBox.Focus(); // Lose focus
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, "Some Text");
+
+        // Act
+        _comboBox1.Text = null; // Programmatically set text to null while not focused
+        Application.DoEvents();
+
+        // Assert
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+    }
+
+    [Test]
+    public void Font_changed_should_update_original_font_when_watermark_inactive()
+    {
+        // Arrange
+        _comboBox1.Focus(); // Hide watermark
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, string.Empty);
+
+        // Act
+        using Font newFont = new("Arial", 12);
+        _comboBox1.Font = newFont;
+        Application.DoEvents();
+
+        // Assert manager picked up the change
+        // Lose focus to trigger potential watermark application with the *new* original font
+        _textBox.Focus();
+        Application.DoEvents(); // Should show watermark
+        Font expectedWatermarkFont = new(newFont, FontStyle.Italic);
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark, expectedWatermarkFont);
+
+        _comboBox1.Focus(); // Hide watermark again
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, string.Empty, newFont);
+    }
+
+    [Test]
+    public void Forecolor_changed_should_update_original_color_when_watermark_inactive()
+    {
+        // Arrange
+        _comboBox1.Focus(); // Hide watermark
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, string.Empty);
+
+        // Act
+        Color newColor = Color.Blue;
+        _comboBox1.ForeColor = newColor;
+        Application.DoEvents();
+
+        // Assert manager picked up the change
+        // Lose focus to trigger potential watermark application with the *new* original color
+        _textBox.Focus();
+        Application.DoEvents(); // Should show watermark
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+        _comboBox1.ForeColor.Should().Be(_watermarkColor); // Watermark color is fixed
+
+        // Set text programatically to show it with the *new* original color
+        _comboBox1.Text = "Some Text";
+        Application.DoEvents(); // Should show watermark
+        AssertWatermarkInactive(_comboBox1, _manager1, "Some Text", foreColor: newColor);
+    }
+
+    [Test]
+    public void Dispose_should_unsubscribe_events_and_restore_state_if_watermark_active()
+    {
+        // Arrange
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+
+        // Act
+        _manager1.Dispose();
+
+        // Assert: State should be restored to original (empty text)
+        _comboBox1.Text.Should().BeEmpty();
+        _comboBox1.Font.Should().Be(_originalFont);
+        _comboBox1.ForeColor.Should().Be(_originalForeColor);
+
+        // Assert: Events should no longer trigger manager logic
+        _comboBox1.Focus();
+        Application.DoEvents();
+        _comboBox1.Text = "After Dispose";
+        Application.DoEvents();
+        _comboBox1.Text = "";
+        Application.DoEvents();
+        _textBox.Focus(); // Lose focus
+        Application.DoEvents();
+
+        // State should remain as set, watermark logic is detached
+        _comboBox1.Text.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Dispose_should_unsubscribe_events_and_keep_state_if_watermark_inactive()
+    {
+        // Arrange
+        _comboBox1.Focus();
+        Application.DoEvents();
+        _comboBox1.Text = "User Text";
+        Application.DoEvents();
+        AssertWatermarkInactive(_comboBox1, _manager1, "User Text");
+
+        // Act
+        _manager1.Dispose();
+
+        // Assert: State should remain as it was
+        _comboBox1.Text.Should().Be("User Text");
+        _comboBox1.Font.Should().Be(_originalFont);
+        _comboBox1.ForeColor.Should().Be(_originalForeColor);
+    }
+
+    [Test]
+    public void Focus_change_between_two_managed_comboboxes()
+    {
+        // Arrange (Both start with watermark)
+        AssertWatermarkActive(_comboBox1, _manager1, Watermark);
+        AssertWatermarkActive(_comboBox2, _manager2, "Another watermark");
+
+        // Act 1: Focus ComboBox1
+        _comboBox1.Focus();
+        Application.DoEvents();
+
+        // Assert 1: CB1 watermark hidden, CB2 unchanged
+        AssertWatermarkInactive(_comboBox1, _manager1, string.Empty);
+        AssertWatermarkActive(_comboBox2, _manager2, "Another watermark");
+
+        // Act 2: Enter text in ComboBox1
+        _comboBox1.Text = "Text in CB1";
+        Application.DoEvents();
+
+        // Assert 2: CB1 has text, CB2 unchanged
+        AssertWatermarkInactive(_comboBox1, _manager1, "Text in CB1");
+        AssertWatermarkActive(_comboBox2, _manager2, "Another watermark");
+
+        // Act 3: Focus ComboBox2
+        _comboBox2.Focus();
+        Application.DoEvents();
+
+        // Assert 3: CB1 keeps text (lost focus), CB2 watermark hidden
+        AssertWatermarkInactive(_comboBox1, _manager1, "Text in CB1");
+        AssertWatermarkInactive(_comboBox2, _manager2, string.Empty);
+
+        // Act 4: Focus back to ComboBox1 (leaving CB2 empty)
+        _comboBox1.Focus();
+        Application.DoEvents();
+
+        // Assert 4: CB1 keeps text and focus, CB2 shows watermark (lost focus while empty)
+        AssertWatermarkInactive(_comboBox1, _manager1, "Text in CB1");
+        AssertWatermarkActive(_comboBox2, _manager2, "Another watermark");
+    }
+
+    private void AssertWatermarkActive(ComboBox comboBox, ComboBoxWatermarkManager manager, string expectedWatermark, Font? font = null)
+    {
+        manager.WatermarkActive.Should().BeTrue();
+        comboBox.Text.Should().Be(expectedWatermark);
+        comboBox.Font.Should().Be(font ?? _watermarkFont); // Assumes watermark font is italic version of original
+        comboBox.ForeColor.Should().Be(_watermarkColor);
+        manager.ComboBoxText.Should().BeEmpty();
+    }
+
+    private void AssertWatermarkInactive(ComboBox comboBox, ComboBoxWatermarkManager manager, string expectedText, Font? font = null, Color? foreColor = null)
+    {
+        manager.WatermarkActive.Should().BeFalse();
+        comboBox.Text.Should().Be(expectedText);
+        comboBox.Font.Should().Be(font ?? _originalFont);
+        comboBox.ForeColor.Should().Be(foreColor ?? _originalForeColor);
+        manager.ComboBoxText.Should().Be(expectedText);
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Create a generic solution for ComboBox watermarks
  - Add `ComboBoxWatermarkManager` which through event handling will manage watermark state
- Convert three instances of manual ComboBox watermark management in `FormFindInCommitFilesGitGrep` and `FileStatusList`

This PR is a follow-up to this comment https://github.com/gitextensions/gitextensions/pull/12311#discussion_r2041211460

### After

![image](https://github.com/user-attachments/assets/91f5b337-cf64-4bae-a285-39e27a4c8bab)

## Test methodology <!-- How did you ensure quality? -->

- Added tests
- Manually for ~1 month

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
