### PR TITLE
fix: jumplist ignore \\wsl$\

### DIFF
--- a/src/app/GitUI/WindowsJumpListManager.cs
+++ b/src/app/GitUI/WindowsJumpListManager.cs
@@ -107,7 +107,7 @@ namespace GitUI
 
                 // sanitise
                 StringBuilder sb = new(repositoryDescription);
-                sb.Replace(@":\", "_");
+                sb.Replace(@"\\wsl$\", "").Replace(@":\", "_");
                 foreach (char c in Path.GetInvalidFileNameChars())
                 {
                     sb.Replace(c, '_');

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.MarkInlineGap.verified.txt
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.MarkInlineGap.verified.txt
@@ -2,33 +2,33 @@
   {
     Item1: [
       {
-        Offset: 388,
+        Offset: 396,
         Length: 106
       },
       {
-        Offset: 707,
+        Offset: 718,
         Length: 104
       },
       {
-        Offset: 812,
+        Offset: 824,
         Length: 1
       }
     ],
     Item2: [
       {
-        Offset: 967,
+        Offset: 984,
         Length: 106
       },
       {
-        Offset: 1074,
+        Offset: 1092,
         Length: 1
       },
       {
-        Offset: 1147,
+        Offset: 1167,
         Length: 1
       },
       {
-        Offset: 1149,
+        Offset: 1170,
         Length: 104
       }
     ]
@@ -36,13 +36,13 @@
   {
     Item1: [
       {
-        Offset: 1580,
+        Offset: 1609,
         Length: 10
       }
     ],
     Item2: [
       {
-        Offset: 1591,
+        Offset: 1621,
         Length: 1
       }
     ]
@@ -50,13 +50,13 @@
   {
     Item1: [
       {
-        Offset: 1621,
+        Offset: 1653,
         Length: 25
       }
     ],
     Item2: [
       {
-        Offset: 1647,
+        Offset: 1680,
         Length: 1
       }
     ]

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.MarkInlineGap.verified.txt
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.MarkInlineGap.verified.txt
@@ -2,33 +2,33 @@
   {
     Item1: [
       {
-        Offset: 396,
+        Offset: 388,
         Length: 106
       },
       {
-        Offset: 718,
+        Offset: 707,
         Length: 104
       },
       {
-        Offset: 824,
+        Offset: 812,
         Length: 1
       }
     ],
     Item2: [
       {
-        Offset: 984,
+        Offset: 967,
         Length: 106
       },
       {
-        Offset: 1092,
+        Offset: 1074,
         Length: 1
       },
       {
-        Offset: 1167,
+        Offset: 1147,
         Length: 1
       },
       {
-        Offset: 1170,
+        Offset: 1149,
         Length: 104
       }
     ]
@@ -36,13 +36,13 @@
   {
     Item1: [
       {
-        Offset: 1609,
+        Offset: 1580,
         Length: 10
       }
     ],
     Item2: [
       {
-        Offset: 1621,
+        Offset: 1591,
         Length: 1
       }
     ]
@@ -50,13 +50,13 @@
   {
     Item1: [
       {
-        Offset: 1653,
+        Offset: 1621,
         Length: 25
       }
     ],
     Item2: [
       {
-        Offset: 1680,
+        Offset: 1647,
         Length: 1
       }
     ]


### PR DESCRIPTION
## Proposed changes

Remove the redundant __wsl$_ in the unique path, to maybe get something interesting in the path
I considered hardcoding Ubuntu too, but there are other distros...

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

![image](https://github.com/user-attachments/assets/be7a60d1-9aa5-4246-8abd-f93d9a0f2be0)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
