### PR TITLE
feat(git config): Add credential.helper and "reuse recorded resolution of conflicted merges"

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
@@ -34,6 +34,8 @@
             checkBoxRebaseAutosquash = new CheckBox();
             checkBoxUpdateRefs = new CheckBox();
             checkboxMergeAutoStash = new CheckBox();
+            checkBoxReReReEnabled = new CheckBox();
+            checkBoxReReReAutoUpdate = new CheckBox();
             SuspendLayout();
             // 
             // checkBoxRebaseAutostash
@@ -102,10 +104,34 @@
             checkboxMergeAutoStash.ThreeState = true;
             checkboxMergeAutoStash.UseVisualStyleBackColor = true;
             // 
+            // checkBoxReReReEnabled
+            // 
+            checkBoxReReReEnabled.AutoSize = true;
+            checkBoxReReReEnabled.Location = new Point(19, 164);
+            checkBoxReReReEnabled.Name = "checkBoxReReReEnabled";
+            checkBoxReReReEnabled.Size = new Size(275, 19);
+            checkBoxReReReEnabled.TabIndex = 7;
+            checkBoxReReReEnabled.Text = "Reuse recorded resolution of conflicted merges";
+            checkBoxReReReEnabled.ThreeState = true;
+            checkBoxReReReEnabled.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxReReReAutoUpdate
+            // 
+            checkBoxReReReAutoUpdate.AutoSize = true;
+            checkBoxReReReAutoUpdate.Location = new Point(19, 189);
+            checkBoxReReReAutoUpdate.Name = "checkBoxReReReAutoUpdate";
+            checkBoxReReReAutoUpdate.Size = new Size(350, 19);
+            checkBoxReReReAutoUpdate.TabIndex = 8;
+            checkBoxReReReAutoUpdate.Text = "Automatically apply recorded resolution of conflicted merges";
+            checkBoxReReReAutoUpdate.ThreeState = true;
+            checkBoxReReReAutoUpdate.UseVisualStyleBackColor = true;
+            // 
             // GitConfigAdvancedSettingsPage
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
+            Controls.Add(checkBoxReReReAutoUpdate);
+            Controls.Add(checkBoxReReReEnabled);
             Controls.Add(checkboxMergeAutoStash);
             Controls.Add(checkBoxRebaseAutostash);
             Controls.Add(checkBoxFetchPrune);
@@ -127,5 +153,7 @@
         private CheckBox checkBoxRebaseAutosquash;
         private CheckBox checkBoxUpdateRefs;
         private CheckBox checkboxMergeAutoStash;
+        private CheckBox checkBoxReReReEnabled;
+        private CheckBox checkBoxReReReAutoUpdate;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -23,7 +23,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 new("merge.autostash", checkboxMergeAutoStash),
                 new("rebase.autostash", checkBoxRebaseAutostash),
                 new("rebase.autosquash", checkBoxRebaseAutosquash),
-                new("rebase.updaterefs", checkBoxUpdateRefs)
+                new("rebase.updaterefs", checkBoxUpdateRefs),
+                new("rerere.enabled", checkBoxReReReEnabled),
+                new("rerere.autoupdate", checkBoxReReReAutoUpdate),
             ];
 
             checkBoxUpdateRefs.Visible = GitVersion.Current.SupportUpdateRefs;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -66,6 +66,8 @@
             lblMergeToolCommand = new Label();
             lblMergeToolPath = new Label();
             lblMergeTool = new Label();
+            lblCredentialHelper = new Label();
+            cbxCredentialHelper = new ComboBox();
             InvalidGitPathGlobal.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(pictureBox1)).BeginInit();
             groupBoxLineEndings.SuspendLayout();
@@ -426,38 +428,41 @@
             tableLayoutPanelGitConfig.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanelGitConfig.Controls.Add(label3, 0, 0);
             tableLayoutPanelGitConfig.Controls.Add(GlobalUserName, 1, 0);
+            tableLayoutPanelGitConfig.Controls.Add(InvalidGitPathGlobal, 2, 0);
             tableLayoutPanelGitConfig.Controls.Add(label4, 0, 1);
             tableLayoutPanelGitConfig.Controls.Add(GlobalUserEmail, 1, 1);
-            tableLayoutPanelGitConfig.Controls.Add(label6, 0, 2);
-            tableLayoutPanelGitConfig.Controls.Add(GlobalEditor, 1, 2);
-            tableLayoutPanelGitConfig.Controls.Add(lblMergeTool, 0, 3);
-            tableLayoutPanelGitConfig.Controls.Add(_NO_TRANSLATE_cboMergeTool, 1, 3);
-            tableLayoutPanelGitConfig.Controls.Add(lblMergeToolPath, 0, 4);
-            tableLayoutPanelGitConfig.Controls.Add(txtMergeToolPath, 1, 4);
-            tableLayoutPanelGitConfig.Controls.Add(btnMergeToolBrowse, 2, 4);
-            tableLayoutPanelGitConfig.Controls.Add(lblMergeToolCommand, 0, 5);
-            tableLayoutPanelGitConfig.Controls.Add(txtMergeToolCommand, 1, 5);
-            tableLayoutPanelGitConfig.Controls.Add(btnMergeToolCommandSuggest, 2, 5);
-            tableLayoutPanelGitConfig.Controls.Add(lblDiffTool, 0, 6);
-            tableLayoutPanelGitConfig.Controls.Add(_NO_TRANSLATE_cboDiffTool, 1, 6);
-            tableLayoutPanelGitConfig.Controls.Add(lblDiffToolPath, 0, 7);
-            tableLayoutPanelGitConfig.Controls.Add(txtDiffToolPath, 1, 7);
-            tableLayoutPanelGitConfig.Controls.Add(btnDiffToolBrowse, 2, 7);
-            tableLayoutPanelGitConfig.Controls.Add(lblDiffToolCommand, 0, 8);
-            tableLayoutPanelGitConfig.Controls.Add(txtDiffToolCommand, 1, 8);
-            tableLayoutPanelGitConfig.Controls.Add(btnDiffToolCommandSuggest, 2, 8);
-            tableLayoutPanelGitConfig.Controls.Add(lblCommitTemplatePath, 0, 9);
-            tableLayoutPanelGitConfig.Controls.Add(txtCommitTemplatePath, 1, 9);
-            tableLayoutPanelGitConfig.Controls.Add(btnCommitTemplateBrowse, 2, 9);
-            tableLayoutPanelGitConfig.Controls.Add(groupBoxLineEndings, 0, 10);
-            tableLayoutPanelGitConfig.Controls.Add(label60, 0, 11);
-            tableLayoutPanelGitConfig.Controls.Add(InvalidGitPathGlobal, 2, 0);
-            tableLayoutPanelGitConfig.Controls.Add(Global_FilesEncoding, 1, 11);
-            tableLayoutPanelGitConfig.Controls.Add(ConfigureEncoding, 2, 11);
+            tableLayoutPanelGitConfig.Controls.Add(lblCredentialHelper, 0, 2);
+            tableLayoutPanelGitConfig.Controls.Add(cbxCredentialHelper, 1, 2);
+            tableLayoutPanelGitConfig.Controls.Add(label6, 0, 3);
+            tableLayoutPanelGitConfig.Controls.Add(GlobalEditor, 1, 3);
+            tableLayoutPanelGitConfig.Controls.Add(lblMergeTool, 0, 4);
+            tableLayoutPanelGitConfig.Controls.Add(_NO_TRANSLATE_cboMergeTool, 1, 4);
+            tableLayoutPanelGitConfig.Controls.Add(lblMergeToolPath, 0, 5);
+            tableLayoutPanelGitConfig.Controls.Add(txtMergeToolPath, 1, 5);
+            tableLayoutPanelGitConfig.Controls.Add(btnMergeToolBrowse, 2, 5);
+            tableLayoutPanelGitConfig.Controls.Add(lblMergeToolCommand, 0, 6);
+            tableLayoutPanelGitConfig.Controls.Add(txtMergeToolCommand, 1, 6);
+            tableLayoutPanelGitConfig.Controls.Add(btnMergeToolCommandSuggest, 2, 6);
+            tableLayoutPanelGitConfig.Controls.Add(lblDiffTool, 0, 7);
+            tableLayoutPanelGitConfig.Controls.Add(_NO_TRANSLATE_cboDiffTool, 1, 7);
+            tableLayoutPanelGitConfig.Controls.Add(lblDiffToolPath, 0, 8);
+            tableLayoutPanelGitConfig.Controls.Add(txtDiffToolPath, 1, 8);
+            tableLayoutPanelGitConfig.Controls.Add(btnDiffToolBrowse, 2, 8);
+            tableLayoutPanelGitConfig.Controls.Add(lblDiffToolCommand, 0, 9);
+            tableLayoutPanelGitConfig.Controls.Add(txtDiffToolCommand, 1, 9);
+            tableLayoutPanelGitConfig.Controls.Add(btnDiffToolCommandSuggest, 2, 9);
+            tableLayoutPanelGitConfig.Controls.Add(lblCommitTemplatePath, 0, 10);
+            tableLayoutPanelGitConfig.Controls.Add(txtCommitTemplatePath, 1, 10);
+            tableLayoutPanelGitConfig.Controls.Add(btnCommitTemplateBrowse, 2, 10);
+            tableLayoutPanelGitConfig.Controls.Add(groupBoxLineEndings, 0, 11);
+            tableLayoutPanelGitConfig.Controls.Add(label60, 0, 12);
+            tableLayoutPanelGitConfig.Controls.Add(Global_FilesEncoding, 1, 12);
+            tableLayoutPanelGitConfig.Controls.Add(ConfigureEncoding, 2, 12);
             tableLayoutPanelGitConfig.Dock = DockStyle.Top;
             tableLayoutPanelGitConfig.Location = new Point(0, 0);
             tableLayoutPanelGitConfig.Name = "tableLayoutPanelGitConfig";
-            tableLayoutPanelGitConfig.RowCount = 13;
+            tableLayoutPanelGitConfig.RowCount = 14;
+            tableLayoutPanelGitConfig.RowStyles.Add(new RowStyle());
             tableLayoutPanelGitConfig.RowStyles.Add(new RowStyle());
             tableLayoutPanelGitConfig.RowStyles.Add(new RowStyle());
             tableLayoutPanelGitConfig.RowStyles.Add(new RowStyle());
@@ -483,6 +488,22 @@
             ConfigureEncoding.Text = "Configure";
             ConfigureEncoding.UseVisualStyleBackColor = true;
             ConfigureEncoding.Click += ConfigureEncoding_Click;
+            // 
+            // lblCredentialHelper
+            // 
+            lblCredentialHelper.Anchor = AnchorStyles.Left;
+            lblCredentialHelper.AutoSize = true;
+            lblCredentialHelper.Location = new Point(3, 59);
+            lblCredentialHelper.Name = "lblCredentialHelper";
+            lblCredentialHelper.Size = new Size(34, 13);
+            lblCredentialHelper.Text = "Credential helper";
+            // 
+            // cbxCredentialHelper
+            // 
+            cbxCredentialHelper.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            cbxCredentialHelper.Location = new Point(129, 55);
+            cbxCredentialHelper.Name = "cbxCredentialHelper";
+            cbxCredentialHelper.Size = new Size(902, 21);
             // 
             // GitConfigSettingsPage
             // 
@@ -545,5 +566,7 @@
         private Label lblMergeToolCommand;
         private Label lblMergeToolPath;
         private Label lblMergeTool;
+        private Label lblCredentialHelper;
+        private ComboBox cbxCredentialHelper;
     }
 }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -8064,6 +8064,14 @@ Context menu for additional operations</source>
         <source>Rebase local branch when pulling (instead of merge)</source>
         <target />
       </trans-unit>
+      <trans-unit id="checkBoxReReReAutoUpdate.Text">
+        <source>Automatically apply recorded resolution of conflicted merges</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="checkBoxReReReEnabled.Text">
+        <source>Reuse recorded resolution of conflicted merges</source>
+        <target />
+      </trans-unit>
       <trans-unit id="checkBoxRebaseAutosquash.Text">
         <source>Automatically squash commits when doing an interactive rebase</source>
         <target />

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -8191,6 +8191,10 @@ global settings.
         <source>Path to commit template</source>
         <target />
       </trans-unit>
+      <trans-unit id="lblCredentialHelper.Text">
+        <source>Credential helper</source>
+        <target />
+      </trans-unit>
       <trans-unit id="lblDiffTool.Text">
         <source>Difftool</source>
         <target />


### PR DESCRIPTION
## Proposed changes

- Add `credential.helper` to git config settings page (with matching suggestions from git folder) (https://git-scm.com/docs/git-config#Documentation/git-config.txt-credentialhelper)
- Add `rerere.enabled` and `rerere.autoupdate` to advanced git settings page (https://git-scm.com/docs/git-config#Documentation/git-config.txt-rerereautoUpdate)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/f5ccc0e3-04b6-41a6-b2d1-608b9cf8352f)

![image](https://github.com/user-attachments/assets/265cba73-82d5-4df1-8fae-536d04c3dba9)

### After

![image](https://github.com/user-attachments/assets/87180fbb-596d-4c2c-a800-297606306d58)

![image](https://github.com/user-attachments/assets/073da9fa-1dd1-4e47-9a4a-749224a3b47e)

![image](https://github.com/user-attachments/assets/d8ae2d51-a3a4-47c2-9e1e-3c536470aa18)

## Test methodology <!-- How did you ensure quality? -->

- manually

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).