### PR TITLE
fix(FindAndReplaceForm): Make multi-file search cancelable

### DIFF
--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -176,6 +176,11 @@ namespace GitUI
                 else if (isMultiFileSearch)
                 {
                     range = null;
+                    if (!Visible)
+                    {
+                        return range;
+                    }
+
                     if (currentItem is not null && startItem is null)
                     {
                         startItem = currentItem;


### PR DESCRIPTION
Fixes #12380

## Proposed changes

`FindAndReplaceForm`: Cancel multi-file search if the form has been closed
(`btnCancel_Click` just closes the form.)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).