### PR TITLE
doc: update wiki links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,10 @@ existing or closely related issue before creating a new one. Be sure to include 
 in your search.
 
 If an open issue already exists, read through the discussion. If you can add something helpful, do so.
-Add a 👍 if you'd like to see it prioritised. Subscribe to the issue for updates.
+Add a 👍 if you'd like to see it prioritized. Subscribe to the issue for updates.
 
 If a closed issue already exists and the issue was addressed, you may like to try one of the
-[CI builds](https://github.com/gitextensions/gitextensions/wiki/CI-Builds).
+[CI builds](https://github.com/gitextensions/gitextensions/wiki/Canary-Builds).
 
 If no issue exists, create one. Complete the template, and add any further information that
 could be relevant such as steps to reproduce, stack traces, screenshots, git/OS version, etc.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Have a question? Come and talk to us: [![Gitter](https://badges.gitter.im/Join%2
 
 <a href="#backers" alt="sponsors on Open Collective"><img src="https://opencollective.com/gitextensions/backers/badge.svg" /></a> <a href="#sponsors" alt="Sponsors on Open Collective"><img src="https://opencollective.com/gitextensions/sponsors/badge.svg" /></a>
 
-### Next Version ([build instructions](https://github.com/gitextensions/gitextensions/wiki/How-To%3A-build-instructions))
+### Next Version ([build instructions](https://github.com/gitextensions/gitextensions/wiki/Build-instructions))
 
 <table>
   <tr>
@@ -56,9 +56,9 @@ Have a question? Come and talk to us: [![Gitter](https://badges.gitter.im/Join%2
   </tr>
 </table>
 
-### Older versions 
+### Older versions
 
-See [build instructions](https://github.com/gitextensions/gitextensions/wiki/How-To%3A-build-instructions)
+See [build instructions](https://github.com/gitextensions/gitextensions/wiki/Build-instructions)
 
 
 ## Downloads

--- a/setup/installer/README.md
+++ b/setup/installer/README.md
@@ -1,4 +1,4 @@
 Building installers for Git Extensions
 ======================================
 
-See the [wiki](https://github.com/gitextensions/gitextensions/wiki/How-To:-build-instructions).
+See the [wiki](https://github.com/gitextensions/gitextensions/wiki/Build-instructions).

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -614,7 +614,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void GcmDetectedFix_Click(object sender, EventArgs e)
         {
-            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/How-To:-fix-GitCredentialWinStore-missing");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Fix-GitCredentialWinStore-missing");
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Fix broken links to the GE wiki.
Some were older, some were recently updated.

The link to ChecklistSettingsPage.cs should be removed in a follow up.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
