### PR TITLE
fixup! fix(FindAndReplaceForm): Cancel multi-file search

### DIFF
--- a/tests/app/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
@@ -198,6 +198,7 @@ namespace GitUITests.Editor
             }
 
             Arrange(texts[0], searchPhrase, scanRegion: scanRegion, fileLoader: FileLoader);
+            _findAndReplaceForm.Show();
 
             foreach (TextRange expectedRange in expectedRanges)
             {


### PR DESCRIPTION
Fixes #12383 tests

## Proposed changes

- Test `FindNextAsync_should_iterate_over_files` must show the form

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).