### PR TITLE
fix(GitRef): Do not remove too much when removing prefix

### DIFF
--- a/src/app/GitCommands/Git/GitRef.cs
+++ b/src/app/GitCommands/Git/GitRef.cs
@@ -88,18 +88,18 @@ namespace GitCommands
             {
                 if (IsRemote)
                 {
-                    return CompleteName.SubstringAfterLast("remotes/");
+                    return CompleteName.SubstringAfter("remotes/");
                 }
 
                 if (IsTag)
                 {
                     // we need the one containing ^{}, because it contains the reference
-                    return CompleteName.RemoveSuffix(GitRefName.TagDereferenceSuffix).SubstringAfterLast("tags/");
+                    return CompleteName.RemoveSuffix(GitRefName.TagDereferenceSuffix).SubstringAfter("tags/");
                 }
 
                 if (IsHead)
                 {
-                    return CompleteName.SubstringAfterLast("heads/");
+                    return CompleteName.SubstringAfter("heads/");
                 }
 
                 // if we don't know ref type then we don't know if '/' is a valid ref character


### PR DESCRIPTION
Fixes #12387

## Proposed changes

- `GitRef.ParseName`: Use `SubstringAfter` instead of `SubstringAfterLast` for removing prefixes "remotes/", "tags/", "heads/"
(from one of the huge refactorings by Drew Noakes)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/f34aeac6-5260-4d5a-a273-71e6a51a1dd6)

### After

![image](https://github.com/user-attachments/assets/39cecddf-4320-4443-8bc2-3c28bc762ec9)

## Test methodology <!-- How did you ensure quality? -->

- manually
- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).