### PR TITLE
fix(GitConfigSettingsBase): Fixup race condition

### DIFF
--- a/src/app/GitCommands/Settings/GitConfigSettingsBase.cs
+++ b/src/app/GitCommands/Settings/GitConfigSettingsBase.cs
@@ -26,7 +26,11 @@ public abstract class GitConfigSettingsBase(IExecutable gitExecutable, GitSettin
 
     public void Invalidate()
     {
-        Valid = false;
+        lock (_uniqueValueSettings)
+        {
+            Valid = false;
+        }
+
         ThreadHelper.FileAndForget(async () =>
         {
             await Task.Delay(millisecondsDelay: 250);


### PR DESCRIPTION
Fixes occasionally failing testcase `TestFetchArguments`

## Proposed changes

`GitConfigSettingsBase`: Fixup race condition between Invalidate and Update. Both need locking.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).