### PR TITLE
feat(MultiSelectTreeView): Select block using keys

### DIFF
--- a/src/app/GitUI/UserControls/MultiSelectTreeView.cs
+++ b/src/app/GitUI/UserControls/MultiSelectTreeView.cs
@@ -12,6 +12,7 @@ namespace GitUI.UserControls;
 public class MultiSelectTreeView : NativeTreeView
 {
     private bool _mouseClickHandled = false;
+    private TreeNode? _multiselectionStartNode = null;
     private HashSet<TreeNode> _selectedNodes = [];
     private bool _settingFocusedNode = false;
     private TreeNode? _toBeFocusedNode = null;
@@ -92,7 +93,7 @@ public class MultiSelectTreeView : NativeTreeView
                 }
                 else
                 {
-                    SelectedNodesChanged?.Invoke(this, EventArgs.Empty);
+                    OnSelectionChanged();
                 }
             }
 
@@ -113,26 +114,19 @@ public class MultiSelectTreeView : NativeTreeView
         }
 
         _selectedNodes = selectedNodes;
-        if (focusedNode is not null)
+        if (!focusedNodeUnchanged && focusedNode is not null)
         {
             FocusedNode = focusedNode;
         }
+        else
+        {
+            OnSelectionChanged();
+        }
 
         Invalidate();
-        if (focusedNodeUnchanged)
-        {
-            SelectedNodesChanged?.Invoke(this, EventArgs.Empty);
-        }
     }
 
     public bool UpdateSuspended => _updateSuspendCount > 0;
-
-    public void AddToSelection(TreeNode node)
-    {
-        _selectedNodes.Add(node);
-        FocusedNode = node;
-        Invalidate();
-    }
 
     public new void BeginUpdate()
     {
@@ -158,10 +152,19 @@ public class MultiSelectTreeView : NativeTreeView
 
         if (!_settingFocusedNode && !_mouseClickHandled)
         {
-            SelectedNode = FocusedNode;
+            if (ModifierKeys == Keys.Shift && FocusedNode is TreeNode newFocusedNode)
+            {
+                UpdateSelection(newFocusedNode, replace: true, addRange: true);
+            }
+            else
+            {
+                SelectedNode = FocusedNode;
+            }
+
+            return;
         }
 
-        SelectedNodesChanged?.Invoke(this, e);
+        OnSelectionChanged();
     }
 
     protected override void OnBeforeSelect(TreeViewCancelEventArgs e)
@@ -215,7 +218,7 @@ public class MultiSelectTreeView : NativeTreeView
                 newFocusedNode.Collapse(ignoreChildren: true);
 
                 // Collapsing changes TreeView.SelectedNode without invoking AfterSelectHandler, need to explicitly emit SelectedNodesChanged
-                SelectedNodesChanged?.Invoke(this, e);
+                OnSelectionChanged();
             }
             else
             {
@@ -223,79 +226,8 @@ public class MultiSelectTreeView : NativeTreeView
             }
         }
 
-        UpdateSelection(replace: !modifierKeys.HasFlag(Keys.Control), addRange: modifierKeys.HasFlag(Keys.Shift));
-        Invalidate();
-
-        return;
-
-        void UpdateSelection(bool replace, bool addRange)
-        {
-            bool changed = false;
-
-            if (replace)
-            {
-                if (_selectedNodes.Count != 1 || _selectedNodes.First() != newFocusedNode)
-                {
-                    changed = true;
-                    _selectedNodes = [newFocusedNode];
-                }
-            }
-            else
-            {
-                changed = true;
-                if (!_selectedNodes.Remove(newFocusedNode))
-                {
-                    _selectedNodes.Add(newFocusedNode);
-                }
-            }
-
-            if (addRange)
-            {
-                TreeNode? lastNode = FocusedNode;
-                bool foundFirstNode = false;
-                foreach (TreeNode node in this.Items())
-                {
-                    if (!foundFirstNode)
-                    {
-                        if (node == newFocusedNode)
-                        {
-                            foundFirstNode = true;
-                        }
-                        else if (node == lastNode)
-                        {
-                            foundFirstNode = true;
-                            lastNode = newFocusedNode;
-                        }
-                        else
-                        {
-                            continue;
-                        }
-                    }
-
-                    _selectedNodes.Add(node);
-
-                    if (node == lastNode)
-                    {
-                        break;
-                    }
-                }
-
-                // Keep FocusedNode, but notify about the changed selection
-                _toBeFocusedNode = FocusedNode;
-                SelectedNodesChanged?.Invoke(this, e);
-                return;
-            }
-
-            _toBeFocusedNode = newFocusedNode;
-            if (FocusedNode != newFocusedNode)
-            {
-                FocusedNode = newFocusedNode;
-            }
-            else if (changed)
-            {
-                SelectedNodesChanged?.Invoke(this, e);
-            }
-        }
+        UpdateSelection(newFocusedNode, replace: !modifierKeys.HasFlag(Keys.Control), addRange: modifierKeys.HasFlag(Keys.Shift));
+        _toBeFocusedNode = newFocusedNode;
     }
 
     protected override void OnMouseUp(MouseEventArgs e)
@@ -338,7 +270,7 @@ public class MultiSelectTreeView : NativeTreeView
                 {
                     _selectedNodes = [newFocusedNode];
                     Invalidate();
-                    SelectedNodesChanged?.Invoke(this, e);
+                    OnSelectionChanged();
                 }
             }
 
@@ -350,10 +282,90 @@ public class MultiSelectTreeView : NativeTreeView
         }
     }
 
+    private void OnSelectionChanged()
+    {
+        if (SelectedNodes.Count <= 1 && FocusedNode is TreeNode focusedNode)
+        {
+            _multiselectionStartNode = focusedNode;
+        }
+
+        SelectedNodesChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     private bool ShallHandleRootIconClick(int x, TreeNode newFocusedNode, Keys modifierKeys)
     {
         Validates.NotNull(ImageList);
         int spacing = DpiUtil.Scale(8);
         return modifierKeys == Keys.None && !ShowRootLines && newFocusedNode.Parent is null && x <= (spacing + ImageList.ImageSize.Width);
+    }
+
+    private void UpdateSelection(TreeNode newFocusedNode, bool replace, bool addRange)
+    {
+        bool changed = false;
+
+        if (replace)
+        {
+            if (_selectedNodes.Count != 1 || _selectedNodes.First() != newFocusedNode)
+            {
+                changed = true;
+                _selectedNodes = [newFocusedNode];
+            }
+        }
+        else
+        {
+            changed = true;
+            if (!_selectedNodes.Remove(newFocusedNode))
+            {
+                _selectedNodes.Add(newFocusedNode);
+            }
+        }
+
+        if (addRange)
+        {
+            changed = true;
+            _multiselectionStartNode ??= newFocusedNode;
+            TreeNode? lastNode = _multiselectionStartNode;
+            bool foundFirstNode = false;
+            foreach (TreeNode node in this.Items())
+            {
+                if (!foundFirstNode)
+                {
+                    if (node == newFocusedNode)
+                    {
+                        foundFirstNode = true;
+                    }
+                    else if (node == lastNode)
+                    {
+                        foundFirstNode = true;
+                        lastNode = newFocusedNode;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                _selectedNodes.Add(node);
+
+                if (node == lastNode)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (FocusedNode != newFocusedNode)
+        {
+            FocusedNode = newFocusedNode;
+        }
+        else if (changed)
+        {
+            OnSelectionChanged();
+        }
+
+        if (changed)
+        {
+            Invalidate();
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

`MultiSelectTreeView`:
- Select block using `Shift` + arrow keys
- Rework multi-selection by mouse (replace misuse of `FocusedNode` as `_multiselectionStartNode`)
- Remove unused function `AddToSelection`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

Result after `Shift+click` (focused node has highlighted icon):

### Before

![image](https://github.com/user-attachments/assets/e9c9f03c-c2da-4f30-b751-c08c30b17938)

### After

![image](https://github.com/user-attachments/assets/0a59665c-a809-478a-bdae-4edc1732b12e)

## Test methodology <!-- How did you ensure quality? -->

- manually & existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).