### PR TITLE
fix(refresh artificial commit): Avoid no selection

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -72,7 +72,7 @@ namespace GitUI.CommandsDialogs
                 await SetDiffsAsync(revisions);
                 if (!DiffFiles.SelectedItems.Any())
                 {
-                    DiffFiles.SelectStoredNextItem();
+                    DiffFiles.SelectStoredNextItem(orSelectFirst: true);
                 }
             });
         }


### PR DESCRIPTION
Fixes empty file selection e.g. in case the previously selected file has been renamed

## Proposed changes

- `RevisionDiffControl.RefreshArtificial`: Tell `FileStatusList.SelectStoredNextItem` to select the first file if stored item cannot be found

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/ec574934-685f-46d2-a8e4-901bdecafd32)

### After

![image](https://github.com/user-attachments/assets/76b94343-0431-4fb7-8ca8-4e77a348f7f3)

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).