### PR TITLE
fix: adopt LinkLabel for large files

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/ThemeFix.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ThemeFix.cs
@@ -67,6 +67,10 @@ namespace GitExtUtils.GitUI.Theming
         private static void SetupToolStrip(ToolStrip strip)
         {
             strip.RenderMode = ToolStripRenderMode.Professional;
+            foreach (ToolStripLabel item in strip.Items.OfType<ToolStripLabel>())
+            {
+                SetupToolStripStatusLabel(item);
+            }
         }
 
         private static void SetupContextMenu(ContextMenuStrip strip)
@@ -76,7 +80,14 @@ namespace GitExtUtils.GitUI.Theming
 
         private static void SetupLinkLabel(this LinkLabel label)
         {
-            label.LinkColor = label.LinkColor.AdaptTextColor();
+            label.LinkColor = Application.IsDarkModeEnabled ? Color.CornflowerBlue : label.LinkColor.AdaptTextColor();
+            label.VisitedLinkColor = label.VisitedLinkColor.AdaptTextColor();
+            label.ActiveLinkColor = label.ActiveLinkColor.AdaptTextColor();
+        }
+
+        private static void SetupToolStripStatusLabel(this ToolStripLabel label)
+        {
+            label.LinkColor = Application.IsDarkModeEnabled ? Color.CornflowerBlue : label.LinkColor.AdaptTextColor();
             label.VisitedLinkColor = label.VisitedLinkColor.AdaptTextColor();
             label.ActiveLinkColor = label.ActiveLinkColor.AdaptTextColor();
         }

--- a/src/app/GitUI/CommandsDialogs/FormAbout.cs
+++ b/src/app/GitUI/CommandsDialogs/FormAbout.cs
@@ -20,11 +20,6 @@ namespace GitUI.CommandsDialogs
 
             environmentInfo.SetCopyButtonTooltip(_copyTooltip.Text);
 
-            Color clrLink = SystemColors.Highlight;
-            _NO_TRANSLATE_labelProductName.LinkColor = clrLink;
-            _NO_TRANSLATE_ThanksTo.LinkColor = clrLink;
-            linkLabelIcons.LinkColor = clrLink;
-
             // Click handlers
             _NO_TRANSLATE_labelProductName.LinkClicked += delegate { OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions"); };
             _NO_TRANSLATE_ThanksTo.LinkClicked += delegate { ShowContributorsForm(); };

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -300,10 +300,6 @@ namespace GitUI.CommandsDialogs
 
             toolStripStatusBranchIcon.AdaptImageLightness();
 
-            // Change the link color
-            commitAuthorStatus.LinkColor = Application.IsDarkModeEnabled ? Color.CornflowerBlue : Color.FromArgb(0, 0, 0xff);
-            remoteNameLabel.LinkColor = Application.IsDarkModeEnabled ? Color.CornflowerBlue : Color.Blue;
-
             splitLeft.Panel1.BackColor = OtherColors.PanelBorderColor;
             splitLeft.Panel2.BackColor = OtherColors.PanelBorderColor;
             splitRight.Panel1.BackColor = OtherColors.PanelBorderColor;

--- a/src/app/GitUI/Editor/FileViewer.Designer.cs
+++ b/src/app/GitUI/Editor/FileViewer.Designer.cs
@@ -449,7 +449,6 @@ namespace GitUI.Editor
             // llShowPreview
             //
             _NO_TRANSLATE_lblShowPreview.AutoSize = true;
-            _NO_TRANSLATE_lblShowPreview.BackColor = Color.White;
             _NO_TRANSLATE_lblShowPreview.Location = new Point(43, 23);
             _NO_TRANSLATE_lblShowPreview.Name = "_NO_TRANSLATE_lblShowPreview";
             _NO_TRANSLATE_lblShowPreview.Size = new Size(214, 13);

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -74,7 +74,6 @@ namespace GitUI.Editor
             ShowEntireFile = false;
             NumberOfContextLines = AppSettings.NumberOfContextLines;
             InitializeComponent();
-            _NO_TRANSLATE_lblShowPreview.BackColor.AdaptBackColor();
 
             InitializeComplete();
 


### PR DESCRIPTION
## Proposed changes

Adjust LinkColor for dark mode, override the custom colors in some forms.

Override LinkColor for ToolStripLabel in the same way as LinkLabel. Only in use in FormCommit.
The link colors are adpted in the Dashboard too, very intentional there.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

![link-light1-about](https://github.com/user-attachments/assets/984463b0-52e1-4887-9798-128de6a85b41)
![link-light2-about](https://github.com/user-attachments/assets/ef800760-4f30-4535-a47d-790985179050)

link unchanged by the PR
![link-light1-file](https://github.com/user-attachments/assets/c063db4c-5505-476f-8178-85be2911b39f)

![link-dark1-about](https://github.com/user-attachments/assets/c4bd4b7d-0c75-42d0-b21d-b642c00e8cf3)
![link-dark2-about](https://github.com/user-attachments/assets/e03d3697-bb19-4a82-80ed-185f72270242)

![link-dark1-file](https://github.com/user-attachments/assets/17723020-0d7c-4038-aef1-b13f158c0f09)
![link-dark2-file](https://github.com/user-attachments/assets/60492827-1b2d-4fd8-a473-ecec89497d62)

Alternative, adapted colors (what other links looked like too)

![link-dark3-about](https://github.com/user-attachments/assets/15a00921-cba8-44c8-96d1-5c4d411b35b8)
![link-dark3-file](https://github.com/user-attachments/assets/248e74ee-1727-4567-9fc7-973652c54301)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
