### PR TITLE
fix(FormCommit): Prevent double diff loading

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1504,14 +1504,20 @@ namespace GitUI.CommandsDialogs
                 if (Unstaged.FocusedItem is null)
                 {
                     Unstaged.SelectFirstVisibleItem();
+                    if (!Unstaged.HasSelection)
+                    {
+                        UnstagedSelectionChanged(Unstaged, EventArgs.Empty);
+                    }
                 }
                 else
                 {
                     Unstaged.SelectedItems = [Unstaged.FocusedItem];
                 }
             }
-
-            UnstagedSelectionChanged(Unstaged, EventArgs.Empty);
+            else
+            {
+                UnstagedSelectionChanged(Unstaged, EventArgs.Empty);
+            }
         }
 
         private void Unstaged_FilterChanged(object sender, EventArgs e)
@@ -1759,6 +1765,11 @@ namespace GitUI.CommandsDialogs
 
         private void Staged_Enter(object sender, EnterEventArgs e)
         {
+            SelectStaged();
+        }
+
+        private void SelectStaged()
+        {
             _currentFilesList = Staged;
             _skipUpdate = false;
             if (!Staged.HasSelection)
@@ -1766,14 +1777,20 @@ namespace GitUI.CommandsDialogs
                 if (Staged.FocusedItem is null)
                 {
                     Staged.SelectFirstVisibleItem();
+                    if (!Staged.HasSelection)
+                    {
+                        StagedSelectionChanged(Staged, EventArgs.Empty);
+                    }
                 }
                 else
                 {
                     Staged.SelectedItems = [Staged.FocusedItem];
                 }
             }
-
-            StagedSelectionChanged(Staged, EventArgs.Empty);
+            else
+            {
+                StagedSelectionChanged(Staged, EventArgs.Empty);
+            }
         }
 
         private void Stage(IReadOnlyList<GitItemStatus> items)
@@ -2703,7 +2720,7 @@ namespace GitUI.CommandsDialogs
 
             UpdateButtonStates();
 
-            ViewFirstStagedFile();
+            SelectStaged();
         }
 
         private void StageInSuperproject_CheckedChanged(object sender, EventArgs e)
@@ -2737,17 +2754,7 @@ namespace GitUI.CommandsDialogs
 
         private void Message_Enter(object sender, EventArgs e)
         {
-            ViewFirstStagedFile();
-        }
-
-        private void ViewFirstStagedFile()
-        {
-            if (Staged.AllItemsCount != 0 && !Staged.SelectedItems.Any())
-            {
-                _currentFilesList = Staged;
-                Staged.SelectFirstVisibleItem();
-                StagedSelectionChanged(this, EventArgs.Empty);
-            }
+            SelectStaged();
         }
 
         private void modifyCommitMessageButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
Finishes @mdonatas' 493a2f4d2377e9bf269c999c29f062d0ad444fcc

## Proposed changes

`FormCommit`:
- `Unstaged_Enter` / `Staged_Enter`: Explicitly call `UnstagedSelectionChanged` / `StagedSelectionChanged` only if selection is empty or if selection has not changed
- Replace `ViewFirstStagedFile` with what is done in `Staged_Enter`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

before visible flicker mainly of bold current line number

## Test methodology <!-- How did you ensure quality? -->

- manual (with debug output)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).