### PR TITLE
Enforce WSL working directory when accessing repositories on WSL

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -97,7 +97,7 @@ namespace GitCommands
             _wslDistro = AppSettings.WslGitEnabled ? PathUtil.GetWslDistro(WorkingDir) : "";
             if (!string.IsNullOrEmpty(_wslDistro))
             {
-                _gitExecutable = new Executable(() => AppSettings.WslGitCommand, WorkingDir, $"-d {_wslDistro} {AppSettings.WslGitPath} ");
+                _gitExecutable = new Executable(() => AppSettings.WslGitCommand, WorkingDir, $"-d {_wslDistro} --cd {WorkingDir.Quote()} {AppSettings.WslGitPath} ");
                 _gitCommandRunner = new GitCommandRunner(_gitExecutable, () => SystemEncoding);
             }
             else


### PR DESCRIPTION
[issue #1238](https://github.com/gitextensions/gitextensions/issues/12381)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Add the `--cd` argument with the current working directory to the `wsl` command
- Fix correct display of commands that access remotes (FormProcess.cs)
- Change how `git` commands executed on WSL are logged. "wsl" --> "[wsl] git"

![image](https://github.com/user-attachments/assets/6f5f7759-c8d2-4e45-90e4-355586b599ee)

## Test methodology <!-- How did you ensure quality? -->

- Empirical (i.e.: it fixes the error on my machine). I have no way of testing in any other environment but it should be a transparent change for anyone else.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.49.0
- WSL version: 2.5.7.0
- Kernel version: 6.6.87.1-1
- WSLg version: 1.0.66
- MSRDC version: 1.2.6074
- Direct3D version: 1.611.1-81528511
- DXCore version: 10.0.26100.1-240331-1435.ge-release
- Windows version: 10.0.22631.5335
<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
