### PR TITLE
Enforce WSL working directory, fix Git Command Log display

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -216,3 +216,4 @@ YYYY/MM/DD, github id, Full name, email
 2024/11/05, anhtrvn, Anh Tran, anhtran18202(at)gmail.com
 2025/04/19, borzag, Boris Zagar, boris.zagar(at)gmail.com
 2025/05/03, hnalpha323, Muhammad Hamza Noor, hnalpha323(at)gmail.com
+2025/06/03, margaretselzer, Marcell Egyed, spam.myself@yahoo.com

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -97,7 +98,9 @@ namespace GitCommands
             _wslDistro = AppSettings.WslGitEnabled ? PathUtil.GetWslDistro(WorkingDir) : "";
             if (!string.IsNullOrEmpty(_wslDistro))
             {
-                _gitExecutable = new Executable(() => AppSettings.WslGitCommand, WorkingDir, $"-d {_wslDistro} --cd {WorkingDir.Quote()} {AppSettings.WslGitPath} ");
+                // In some WSL environments the current working directory is not passed along to the git command without using the `--cd` argument. Adding it to
+                // the command line is required for these environments. For those that do not need it using the argument is just redundant.
+                _gitExecutable = new Executable(() => AppSettings.WslCommand, WorkingDir, $"-d {_wslDistro} --cd {WorkingDir.RemoveTrailingPathSeparator().Quote()} {AppSettings.WslGitCommand} ");
                 _gitCommandRunner = new GitCommandRunner(_gitExecutable, () => SystemEncoding);
             }
             else

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -97,7 +97,7 @@ namespace GitCommands
             _wslDistro = AppSettings.WslGitEnabled ? PathUtil.GetWslDistro(WorkingDir) : "";
             if (!string.IsNullOrEmpty(_wslDistro))
             {
-                _gitExecutable = new Executable(() => AppSettings.WslGitCommand, WorkingDir, $"-d {_wslDistro} {AppSettings.WslGitPath} ");
+                _gitExecutable = new Executable(() => AppSettings.WslGitCommand, WorkingDir, $"-d {_wslDistro} --cd {WorkingDir.Quote()} {AppSettings.WslGitPath} ");
                 _gitCommandRunner = new GitCommandRunner(_gitExecutable, () => SystemEncoding);
             }
             else

--- a/src/app/GitCommands/Logging/CommandLog.cs
+++ b/src/app/GitCommands/Logging/CommandLog.cs
@@ -92,37 +92,59 @@ namespace GitCommands.Logging
             IsOnMainThread = isOnMainThread;
         }
 
+        // Log display name for the git command when run through WSL.
+        internal const string WslGitLogName = "~git";
+
+        // Log display name for the git command when run natively.
+        internal const string NativeGitLogName = "git";
+
         public string ColumnLine
         {
             get
             {
+                // The git command is handled specially as what we are really interested in is the - non configuration - arguments it was run with.
+                // So when a git command is run the displayed command is stripped from its path and config arguments and regardless of the actual
+                // git executable name the log will display only `NativeGitLogName` alternatively `WslGitLogName` when the git command is run via WSL.
+                // All other commands are displayed as is without any special treatment.
+
+                string wslCmd = AppSettings.WslCommand;
+                string wslGitCmd = AppSettings.WslGitCommand;
+                string gitCmd = AppSettings.GitCommand;
+
                 string duration = Duration is null
                     ? "running"
                     : $"{((TimeSpan)Duration).TotalMilliseconds:0,0} ms";
 
                 string fileName;
                 string arguments;
-                if (FileName.StartsWith("wsl ") && FileName.EndsWith("git"))
+                if (FileName.StartsWith(wslCmd) && FileName.EndsWith(wslGitCmd))
                 {
-                    fileName = "[wsl] git";
+                    // WSL git commands set in `GitModule`
+                    // E.g. `FileName` = "wsl <wsl args> git", `Arguments` = "<git args>".
+                    fileName = WslGitLogName;
                     arguments = GetGitArgumentsWithoutConfiguration(Arguments);
                 }
-                else if (FileName.Equals("wsl") && Arguments.Contains(" git "))
+                else if (FileName.Equals(wslCmd) && Arguments.IndexOf($" {wslGitCmd} ") is int gitIndex && gitIndex >= 0)
                 {
-                    // This is a hack for the correct display of the git command when coming from `FormProcess`. `FormProcess` logs
-                    // everything on the command line besides the "wsl" command in `Arguments` while `GitModule` logs the "wsl" command,
-                    // all its arguments with "git " on the end as part of `FileName` and only the git command arguments in `Arguments`.
-                    // When both classes log the same type of information the same way either this if branch or the one above can be removed.
-                    fileName = "[wsl] git";
-                    arguments = GetGitArgumentsWithoutConfiguration(Arguments.Substring(Arguments.IndexOf(" git ") + 5));
+                    // WSL git commands set in `FormProcess`
+                    // E.g. `FileName` = "wsl". `Arguments` = "<wsl args> git <git args>".
+                    //
+                    // When both `GitModule` and `FormProcess` instantiates `CommandLogEntry` with the same type of information
+                    // in `fileName` and `arguments` this if branch and the one above can be merged.
+                    fileName = WslGitLogName;
+                    const int numSpaces = 2;
+                    arguments = GetGitArgumentsWithoutConfiguration(Arguments.Substring(gitIndex + wslGitCmd.Length + numSpaces));
                 }
-                else if (FileName.EndsWith("git") || FileName.EndsWith("git.exe"))
+                else if (FileName.EndsWith(gitCmd))
                 {
-                    fileName = "git";
+                    // All natively run git commands
+                    // E.g. `FileName` = "git", `Arguments` = "<git args>".
+                    fileName = NativeGitLogName;
                     arguments = GetGitArgumentsWithoutConfiguration(Arguments);
                 }
                 else
                 {
+                    // Anything other than git commands
                     fileName = FileName;
                     arguments = Arguments;
                 }

--- a/src/app/GitCommands/Logging/CommandLog.cs
+++ b/src/app/GitCommands/Logging/CommandLog.cs
@@ -102,12 +102,21 @@ namespace GitCommands.Logging
 
                 string fileName;
                 string arguments;
-                if (FileName.StartsWith("wsl "))
+                if (FileName.StartsWith("wsl ") && FileName.EndsWith("git"))
                 {
-                    fileName = "wsl";
+                    fileName = "[wsl] git";
                     arguments = GetGitArgumentsWithoutConfiguration(Arguments);
                 }
-                else if (FileName.EndsWith("git.exe"))
+                else if (FileName.Equals("wsl") && Arguments.Contains(" git "))
+                {
+                    // This is a hack for the correct display of the git command when coming from `FormProcess`. `FormProcess` logs
+                    // everything on the command line besides the "wsl" command in `Arguments` while `GitModule` logs the "wsl" command,
+                    // all its arguments with "git " on the end as part of `FileName` and only the git command arguments in `Arguments`.
+                    // When both classes log the same type of information the same way either this if branch or the one above can be removed.
+                    fileName = "[wsl] git";
+                    arguments = GetGitArgumentsWithoutConfiguration(Arguments.Substring(Arguments.IndexOf(" git ") + 5));
+                }
+                else if (FileName.EndsWith("git") || FileName.EndsWith("git.exe"))
                 {
                     fileName = "git";
                     arguments = GetGitArgumentsWithoutConfiguration(Arguments);

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -384,15 +384,15 @@ namespace GitCommands
         }
 
         // Currently not configurable in UI (Set manually in settings file)
-        public static string WslGitCommand
+        public static string WslCommand
         {
-            get => GetString("WslGitCommand", "wsl");
+            get => GetString(nameof(WslCommand), "wsl");
         }
 
         // Currently not configurable in UI (Set manually in settings file)
-        public static string WslGitPath
+        public static string WslGitCommand
         {
-            get => GetString("WslGitPath", "git");
+            get => GetString(nameof(WslGitCommand), "git");
         }
 
         public static bool StashKeepIndex

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -32,8 +32,11 @@ namespace GitUI.HelperDialogs
                 string wslDistro = AppSettings.WslGitEnabled ? PathUtil.GetWslDistro(workingDirectory) : "";
                 if (!string.IsNullOrEmpty(wslDistro))
                 {
-                    process = AppSettings.WslGitCommand;
-                    arguments = $"-d {wslDistro} --cd {WorkingDirectory.Quote()} {AppSettings.WslGitPath} {arguments}";
+                    process = AppSettings.WslCommand;
+
+                    // In some WSL environments the current working directory is not passed along to the git command without using the `--cd` argument. Adding it to
+                    // the command line is required for these environments. For those that do not need it using the argument is just redundant.
+                    arguments = $"-d {wslDistro} --cd {WorkingDirectory.RemoveTrailingPathSeparator().Quote()} {AppSettings.WslGitCommand} {arguments}";
                 }
             }
 

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -33,7 +33,7 @@ namespace GitUI.HelperDialogs
                 if (!string.IsNullOrEmpty(wslDistro))
                 {
                     process = AppSettings.WslGitCommand;
-                    arguments = $"-d {wslDistro} {AppSettings.WslGitPath} {arguments}";
+                    arguments = $"-d {wslDistro} --cd {WorkingDirectory.Quote()} {AppSettings.WslGitPath} {arguments}";
                 }
             }
 

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -163,7 +163,7 @@ namespace GitUI.NBugReports
 
             // Treat all git errors as user issues
             if (string.Equals(AppSettings.GitCommand, externalOperationException?.Command, StringComparison.InvariantCultureIgnoreCase)
-             || string.Equals(AppSettings.WslGitCommand, externalOperationException?.Command, StringComparison.InvariantCultureIgnoreCase))
+             || string.Equals(AppSettings.WslCommand, externalOperationException?.Command, StringComparison.InvariantCultureIgnoreCase))
             {
                 isUserExternalOperation = true;
             }

--- a/tests/app/UnitTests/GitCommands.Tests/CommandLogTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/CommandLogTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using GitCommands;
 using GitCommands.Logging;
 
 namespace GitCommandsTests;
@@ -6,19 +7,59 @@ namespace GitCommandsTests;
 [TestFixture]
 public class CommandLogTests
 {
-    [TestCase("", "")]
-    [TestCase(@"verb -c config", "verb")]
-    [TestCase(@"-c config verb", "verb")]
-    [TestCase(@"-c config --no-optional-locks verb", "verb")]
-    [TestCase(@"-c config1 -c config2=x verb", "verb")]
-    [TestCase(@"-c config1 -c config2 x verb", "x verb")]
-    [TestCase(@"-c config=""value with space"" verb", "verb")]
+    [TestCase("somegit.exe", "", "")]
+    [TestCase("somegit.exe", @"verb -c config", "verb")]
+    [TestCase("somegit.exe", @"-c config verb", "verb")]
+    [TestCase("somegit.exe", @"-c config --no-optional-locks verb", "verb")]
+    [TestCase("somegit.exe", @"-c config1 -c config2=x verb", "verb")]
+    [TestCase("somegit.exe", @"-c config1 -c config2 x verb", "x verb")]
+    [TestCase("something.exe", @"-c config=""value with space"" verb", "verb")]
+    [TestCase("gitOnTheRocks", "config list --local --includes --null", "config list --local --includes --null")]
+    [TestCase("bitbucket", "--pam --param --parapam", "--pam --param --parapam")]
+    [TestCase(@"C:\bitbucket\bucketbit.kexe", "--pam --param --parapam", "--pam --param --parapam")]
     // Not needed and not implemented yet. It just removes '-c core.xxx=""something with \""' at the moment.
-    [TestCase(@"-c core.xxx=""something with \""value1 in escaped quotes\"" \""value2\"""" verb", @"value1 in escaped quotes\"" \""value2\"""" verb")]
-    public void CommanLogEntry_ColumnLine(string arguments, string expectedMainArguments)
+    [TestCase("somegit.exe", @"-c core.xxx=""something with \""value1 in escaped quotes\"" \""value2\"""" verb", @"value1 in escaped quotes\"" \""value2\"""" verb")]
+    [TestCase(@"C:\yesterday\someday.plexe", @"-c core.xxx=""something with \""value1 in escaped quotes\"" \""value2\"""" verb", @"value1 in escaped quotes\"" \""value2\"""" verb")]
+    public void CommanLogEntry_ColumnLine_should_display_native_git_command(string fileName, string arguments, string expectedMainArguments)
     {
-        const string gitExecutable = "somegit.exe";
-        CommandLogEntry commandLogEntry = new(gitExecutable, arguments, workingDir: "", startedAt: DateTime.MinValue, isOnMainThread: true);
-        commandLogEntry.ColumnLine.Should().Be($"00:00:00.000   running         UI     git {expectedMainArguments}");
+        string origGitCommandValue = AppSettings.GitCommand;
+        AppSettings.GitCommandValue = fileName;
+
+        CommandLogEntry commandLogEntry = new(fileName, arguments, workingDir: "", startedAt: DateTime.MinValue, isOnMainThread: true);
+        commandLogEntry.ColumnLine.Should().Be($"00:00:00.000   running         UI     {CommandLogEntry.NativeGitLogName} {expectedMainArguments}");
+
+        AppSettings.GitCommandValue = origGitCommandValue;
+    }
+
+    [TestCase("wsl", @"-d Ubuntu --cd ""\\wsl$\Ubuntu\home\user\repo\project"" git -c config=""value with space"" arg1 arg2", "arg1 arg2")]
+    [TestCase(@"wsl -d Ubuntu --cd ""\\wsl$\Ubuntu\home\user\repo\project"" git", @"-c config=""value with space"" arg1 arg2", "arg1 arg2")]
+    [TestCase("wsl", @"-d Ubuntu --cd ""\\wsl$\Ubuntu\home\user\repo\project"" git config list --local --includes --null", "config list --local --includes --null")]
+    [TestCase(@"wsl -d Ubuntu --cd ""\\wsl$\\Ubuntu\\home\\user\\repo\\project git", "config list --local --includes --null", "config list --local --includes --null")]
+    public void CommanLogEntry_ColumnLine_should_display_wsl_git_command(string fileName, string arguments, string expectedMainArguments)
+    {
+        string origGitCommandValue = AppSettings.GitCommand;
+        AppSettings.GitCommandValue = "git";
+
+        CommandLogEntry commandLogEntry = new(fileName, arguments, workingDir: "", startedAt: DateTime.MinValue, isOnMainThread: true);
+        commandLogEntry.ColumnLine.Should().Be($"00:00:00.000   running         UI     {CommandLogEntry.WslGitLogName} {expectedMainArguments}");
+
+        AppSettings.GitCommandValue = origGitCommandValue;
+    }
+
+    [TestCase("anycmd", @"-d Ubuntu --cd ""\\wsl$\Ubuntu\home\user\repo\project"" git -c config=""value with space"" agr1 arg2", @"-d Ubuntu --cd ""\\wsl$\Ubuntu\home\user\repo\project"" git -c config=""value with space"" agr1 arg2")]
+    [TestCase(@"anycmd -d Ubuntu --cd ""\\wsl$\Ubuntu\home\user\repo\project"" git", @"-c config=""value with space"" arg1 arg2", @"-c config=""value with space"" arg1 arg2")]
+    [TestCase("notAgit.exe", "", "")]
+    [TestCase("notAgit.exe", "69 < 420", "69 < 420")]
+    [TestCase("notAgit", "69 < 420", "69 < 420")]
+    [TestCase("git", "69 < 420", "69 < 420")]
+    public void CommanLogEntry_ColumnLine_should_display_non_git_command(string fileName, string arguments, string expectedMainArguments)
+    {
+        string origGitCommandValue = AppSettings.GitCommand;
+        AppSettings.GitCommandValue = "notanycmd";
+
+        CommandLogEntry commandLogEntry = new(fileName, arguments, workingDir: "", startedAt: DateTime.MinValue, isOnMainThread: true);
+        commandLogEntry.ColumnLine.Should().Be($"00:00:00.000   running         UI     {fileName} {expectedMainArguments}");
+
+        AppSettings.GitCommandValue = origGitCommandValue;
     }
 }


### PR DESCRIPTION
Fixes [issue #12381](https://github.com/gitextensions/gitextensions/issues/12381)
Resolves [issue #12400](https://github.com/gitextensions/gitextensions/issues/12400)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Adds the `--cd` argument with the current working directory to the `wsl` command
- Fixes correct display of commands that access remotes (fetch, pull, etc...) 
- Changes how `git` commands executed on WSL are logged. "wsl" --> "~git"
- Rename the setting "WslGitCommand" to "WslCommand" and "WslGitPath" to "WslGitCommand"

![image](https://github.com/user-attachments/assets/0a08a1a5-059c-41e7-9153-e8de3bb5517c)

## Test methodology <!-- How did you ensure quality? -->

- Empirical (i.e.: it fixes the error on my machine). I have no way of testing in any other environment but it should be a transparent change for anyone else.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.49.0
- WSL version: 2.5.7.0
- Kernel version: 6.6.87.1-1
- WSLg version: 1.0.66
- MSRDC version: 1.2.6074
- Direct3D version: 1.611.1-81528511
- DXCore version: 10.0.26100.1-240331-1435.ge-release
- Windows version: 10.0.22631.5335
<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
