### PR TITLE
Fixup restore of file selection

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2981,6 +2981,8 @@ namespace GitUI.CommandsDialogs
             public SplitterManager SplitterManager => _form._splitterManager;
             public TabPage TreeTabPage => _form.TreeTabPage;
             public FilterToolBar ToolStripFilters => _form.ToolStripFilters;
+
+            public void RefreshRevisions() => _form.RefreshRevisions();
         }
 
         private void FormBrowse_DragDrop(object sender, DragEventArgs e)

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -668,6 +668,8 @@ namespace GitUI.CommandsDialogs
                 _control = control;
             }
 
+            public FileStatusList DiffFiles => _control.DiffFiles;
+            public Editor.FileViewer DiffText => _control.DiffText;
             public SplitContainer DiffSplitContainer => _control.DiffSplitContainer;
         }
     }

--- a/src/app/GitUI/UserControls/MultiSelectTreeView.cs
+++ b/src/app/GitUI/UserControls/MultiSelectTreeView.cs
@@ -256,13 +256,18 @@ public class MultiSelectTreeView : NativeTreeView
             }
 
             Keys modifierKeys = ModifierKeys;
-            if (SelectedNodes.Count > 1
-                && e.Button == MouseButtons.Left
+            if (e.Button == MouseButtons.Left
                 && modifierKeys == Keys.None
                 && HitTest(e.Location).Node is TreeNode newFocusedNode
                 && !ShallHandleRootIconClick(e.X, newFocusedNode, modifierKeys))
             {
-                if (FocusedNode != newFocusedNode)
+                // Explicit click on the same single item needs to be notified upstream.
+                // In case of multi-selection, the clicked item becomes the single selection.
+                if (SelectedNodes.Count == 1)
+                {
+                    OnSelectionChanged();
+                }
+                else if (FocusedNode != newFocusedNode)
                 {
                     SelectedNode = newFocusedNode;
                 }

--- a/src/app/GitUI/UserControls/MultiSelectTreeView.cs
+++ b/src/app/GitUI/UserControls/MultiSelectTreeView.cs
@@ -224,10 +224,12 @@ public class MultiSelectTreeView : NativeTreeView
             {
                 newFocusedNode.Expand();
             }
+
+            _toBeFocusedNode = newFocusedNode;
+            return;
         }
 
         UpdateSelection(newFocusedNode, replace: !modifierKeys.HasFlag(Keys.Control), addRange: modifierKeys.HasFlag(Keys.Shift));
-        _toBeFocusedNode = newFocusedNode;
     }
 
     protected override void OnMouseUp(MouseEventArgs e)

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -186,6 +186,64 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [Test]
+        public void FileSelection_should_be_restored_after_refresh()
+        {
+            // create a commit with multiple files changed
+            const string fileA = "fileA.txt";
+            const string fileB = "fileB.txt";
+            const string contentA = nameof(contentA);
+            const string contentB = nameof(contentB);
+
+            using ReferenceRepository referenceRepository = new();
+            GitUICommands commands = new(GlobalServiceContainer.CreateDefaultMockServiceContainer(), referenceRepository.Module);
+            referenceRepository.CreateCommit("multiple files",
+                $"{contentA}\n{new string('A', 20000)}", fileA,
+                $"{contentB}\n{new string('B', 20000)}", fileB);
+
+            const int maxMilliseconds = 1_000;
+            RunFormTest(
+                async form =>
+                {
+                    FormBrowse.TestAccessor ta = form.GetTestAccessor();
+                    ((TabControl)ta.DiffTabPage.Parent).SelectedTab = ta.DiffTabPage;
+
+                    RevisionDiffControl.TestAccessor tadiff = ta.RevisionDiffControl.GetTestAccessor();
+                    FileStatusList fileStatusList = tadiff.DiffFiles;
+
+                    WaitForRevisionsToBeLoaded(form);
+
+                    IReadOnlyList<GitItemStatus> files = [];
+                    UITest.ProcessUntil("waiting for files", () => { return (files = fileStatusList.GitItemStatuses).Count == 2; }, maxMilliseconds);
+                    GitItemStatus fileToSelect = files[1];
+                    fileStatusList.SelectedGitItems = [fileToSelect];
+                    await VerifySelectionAsync();
+                    const int expectedLine = 2;
+                    tadiff.DiffText.GoToLine(expectedLine);
+
+                    // repeat: refresh and check selection
+                    for (int i = 0; i < 15; ++i)
+                    {
+                        ta.RefreshRevisions();
+                        WaitForRevisionsToBeLoaded(form);
+                        await VerifySelectionAsync(expectedLine);
+                    }
+
+                    return;
+
+                    async Task VerifySelectionAsync(int expectedLine = 1)
+                    {
+                        await Task.Delay(FileStatusList.SelectedIndexChangeThrottleDuration);
+                        UITest.ProcessUntil("waiting for selection",
+                            () => fileStatusList.SelectedGitItem?.Name == fileB
+                                    && tadiff.DiffText.GetText().StartsWith(contentB)
+                                    && tadiff.DiffText.CurrentFileLine == expectedLine,
+                            maxMilliseconds);
+                    }
+                },
+                commands);
+        }
+
+        [Test]
         public void ShowStashes_starting_disabled_should_filter_as_expected()
         {
             using ReferenceRepository referenceRepository = new();
@@ -301,10 +359,10 @@ namespace GitExtensions.UITests.CommandsDialogs
                 });
         }
 
-        private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
+        private void RunFormTest(Func<FormBrowse, Task> testDriverAsync, GitUICommands? commands = null)
         {
             UITest.RunForm(
-                showForm: () => _commands.StartBrowseDialog(owner: null).Should().BeTrue(),
+                showForm: () => (commands ?? _commands).StartBrowseDialog(owner: null).Should().BeTrue(),
                 testDriverAsync);
         }
 


### PR DESCRIPTION
## Proposed changes

`MultiSelectTreeView`:
- Restore explicit click: Emit `SelectionChanged` also if the clicked item has already been selected (regression)
- Restrict focus workaround (`_toBeFocusedNode `) to be used for expand / collapse on root icon click only again and do not change the selection

`RevisionDiffControl`:
- Do not discard nor store selection info during loading diffs (bug)
  because it might be canceled before the stored selection is applied again
- Just clear the diff view if there are no diff items instead of calling `ShowSelectedFile` (bug)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- add `FileSelection_should_be_restored_after_refresh`
- existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).