### PR TITLE
Add numbers and mnemonics in the “Recent repositories” menu

### DIFF
--- a/src/app/GitUI/RepositoryHistoryUIService.cs
+++ b/src/app/GitUI/RepositoryHistoryUIService.cs
@@ -42,9 +42,10 @@ internal class RepositoryHistoryUIService : IRepositoryHistoryUIService
         _invalidRepositoryRemover = invalidRepositoryRemover;
     }
 
-    private void AddRecentRepositories(ToolStripDropDownItem menuItemContainer, Repository repo, string? caption, bool anchored = false)
+    private void AddRecentRepositories(ToolStripDropDownItem menuItemContainer, Repository repo, string? caption, int number, bool anchored = false)
     {
-        ToolStripMenuItem item = new(caption)
+        string numberString = number switch { < 10 => $"&{number}", 10 => "1&0", _ => $"{number}" };
+        ToolStripMenuItem item = new($"{numberString}: {caption}")
         {
             DisplayStyle = ToolStripItemDisplayStyle.ImageAndText
         };
@@ -139,9 +140,10 @@ internal class RepositoryHistoryUIService : IRepositoryHistoryUIService
             }
 
             menuItemCategory.DropDown.SuspendLayout();
+            int number = 0;
             foreach (RecentRepoInfo r in repos)
             {
-                AddRecentRepositories(menuItemCategory, r.Repo, r.Caption);
+                AddRecentRepositories(menuItemCategory, r.Repo, r.Caption, ++number);
             }
 
             menuItemCategory.DropDown.ResumeLayout();
@@ -166,9 +168,10 @@ internal class RepositoryHistoryUIService : IRepositoryHistoryUIService
 
         splitter.SplitRecentRepos(repositoryHistory, pinnedRepos, allRecentRepos);
 
+        var number = 0;
         foreach (RecentRepoInfo repo in pinnedRepos)
         {
-            AddRecentRepositories(container, repo.Repo, repo.Caption, repo.Anchored);
+            AddRecentRepositories(container, repo.Repo, repo.Caption, ++number, repo.Anchored);
         }
 
         if (allRecentRepos.Count > 0)
@@ -180,7 +183,7 @@ internal class RepositoryHistoryUIService : IRepositoryHistoryUIService
 
             foreach (RecentRepoInfo repo in allRecentRepos)
             {
-                AddRecentRepositories(container, repo.Repo, repo.Caption, repo.Anchored);
+                AddRecentRepositories(container, repo.Repo, repo.Caption, ++number, repo.Anchored);
             }
         }
     }
@@ -197,8 +200,8 @@ internal class RepositoryHistoryUIService : IRepositoryHistoryUIService
             _service = service;
         }
 
-        internal void AddRecentRepositories(ToolStripDropDownItem menuItemContainer, Repository repo, string? caption)
-            => _service.AddRecentRepositories(menuItemContainer, repo, caption);
+        internal void AddRecentRepositories(ToolStripDropDownItem menuItemContainer, Repository repo, string? caption, int number)
+            => _service.AddRecentRepositories(menuItemContainer, repo, caption, number);
 
         internal void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container, in IList<Repository> repositoryHistory)
             => _service.PopulateFavouriteRepositoriesMenu(container, repositoryHistory);

--- a/tests/app/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
@@ -33,7 +33,7 @@ namespace GitUITests
             const string caption = "CAPTION";
             Repository repository = new(path);
 
-            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption, number: 1);
 
             containerMenu.DropDownItems.Count.Should().Be(1);
         }
@@ -47,10 +47,10 @@ namespace GitUITests
             const string caption = "CAPTION";
             Repository repository = new(path);
 
-            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption, number: 1);
 
             ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
-            item.Text.Should().Be(caption);
+            item.Text.Should().Be($"&1: {caption}");
             item.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
             item.ToolTipText.Should().BeEmpty();
         }
@@ -69,7 +69,7 @@ namespace GitUITests
             const string caption = "CAPTION";
             Repository repository = new(path);
 
-            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption, number: 1);
 
             // await adding branch name in ShortcutKeyDisplayString, done async
             AsyncTestHelper.JoinPendingOperations();
@@ -87,7 +87,7 @@ namespace GitUITests
             const string caption = "CAPTION";
             Repository repository = new(path);
 
-            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption, number: 1);
 
             ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
             item.PerformClick();


### PR DESCRIPTION
## Proposed changes

- The “Recent repositories” submenu now has “1.”, “2.”, etc. in front of the repo names.
- The first 10 of those numbers get the keyboard mnemonics 1–9 and 0.

## Screenshots

Before on left, after on right.

![temp](https://github.com/user-attachments/assets/6c28f7e6-227f-4b0e-864c-a3076c536e85)

## Test methodology

Test fixes are included. I did run `dotnet test` and it succeeded.

----

I agree that the maintainer squash merge this PR (if the commit message is clear).

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).