### PR TITLE
Keyboard mnemonic for “Remember choice”

### DIFF
--- a/src/app/GitUI/MessageBoxes.cs
+++ b/src/app/GitUI/MessageBoxes.cs
@@ -33,7 +33,7 @@ namespace GitUI
         private readonly TranslationString _updateSubmodules = new("Update submodules");
         private readonly TranslationString _theRepositorySubmodules = new("Update submodules on checkout?");
         private readonly TranslationString _updateSubmodulesToo = new("Since this repository has submodules, it's necessary to update them on every checkout.\r\n\r\nThis will just checkout on the submodule the commit determined by the superproject.");
-        private readonly TranslationString _rememberChoice = new("Remember choice");
+        private readonly TranslationString _rememberChoice = new("&Remember choice");
 
         private readonly TranslationString _reason = new("Reason");
 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -8649,7 +8649,7 @@ help</source>
         <target />
       </trans-unit>
       <trans-unit id="_rememberChoice.Text">
-        <source>Remember choice</source>
+        <source>&amp;Remember choice</source>
         <target />
       </trans-unit>
       <trans-unit id="_retry.Text">


### PR DESCRIPTION
## Proposed changes

Added a keyboard mnemonic for the “Remember choice” checkbox in confirmation dialogs.

## Screenshots

Unfortunately I couldn’t get it to happen again, even after checking all of the options in Settings→Confirmations and restarting the app. :(

----
I agree that the maintainer squash merge this PR (if the commit message is clear).

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
