### PR TITLE
fix(copy file paths): Reactivate shortcut Ctrl+C

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -150,6 +150,7 @@ namespace GitUI
             // 
             FileStatusListView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             FileStatusListView.BorderStyle = BorderStyle.None;
+            FileStatusListView.ContextMenuStrip = ItemContextMenu;
             FileStatusListView.DrawMode = TreeViewDrawMode.OwnerDrawText;
             FileStatusListView.FullRowSelect = true;
             FileStatusListView.HideSelection = false;
@@ -1063,7 +1064,6 @@ namespace GitUI
             // FileStatusList
             // 
             AutoScaleMode = AutoScaleMode.Inherit;
-            ContextMenuStrip = ItemContextMenu;
             Controls.Add(LoadingFiles);
             Controls.Add(NoFiles);
             Controls.Add(lblFindInCommitFilesGitGrepWatermark);


### PR DESCRIPTION
Fixes #12417

## Proposed changes

`FileStatusList`:
Add context menu to `FileStatusListView` again - instead of to root control as before 2cdfc67ce010ca67c45ae30252e00c5e7779c57e
in order to make hard-coded shortcuts work, e.g. `Ctrl+C` for "Copy full path(s) - native"

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).