### PR TITLE
fix(file tree): ls-tree if no grep

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2564,22 +2564,20 @@ namespace GitCommands
         {
             IEnumerable<GitItem> tree = GetGitItemTree(commitId, full, cancellationToken);
 
-            List<GitItemStatus> list = new(tree is ICollection<GitItem> collection ? collection.Count : 0);
-            foreach (GitItem file in tree)
-            {
-                list.Add(new GitItemStatus(file.Name)
+            return tree
+                .Select(file => new GitItemStatus(file.Name)
                 {
+                    // IsTracked is always true, only tracked are reported
+                    // New/Changed/Deleted are are just set
                     IsTracked = true,
-                    IsNew = true,
+                    IsNew = false,
                     IsChanged = false,
                     IsDeleted = false,
                     TreeGuid = file.ObjectId,
-                    Staged = StagedStatus.None,
+                    Staged = StagedStatus.Unset,
                     IsSubmodule = file.ObjectType == GitObjectType.Commit
-                });
-            }
-
-            return list;
+                })
+                .ToList();
         }
 
         public IReadOnlyList<GitItemStatus> GetAllChangedFiles(bool excludeIgnoredFiles = true,

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -21,7 +21,7 @@ public interface IGitModule
 
     IReadOnlyList<IGitRef> GetRefs(RefsFilter getRef);
     IEnumerable<string> GetSettings(string setting);
-    IEnumerable<INamedGitItem> GetTree(ObjectId? commitId, bool full);
+    IEnumerable<INamedGitItem> GetTree(ObjectId? commitId, bool full, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///  Loads the user-defined colors for the remote branches specific for the current repository.
@@ -332,7 +332,7 @@ public interface IGitModule
     ObjectId? GetMergeBase(ObjectId a, ObjectId b);
     (int? First, int? Second) GetCommitRangeDiffCount(ObjectId firstId, ObjectId secondId);
     IReadOnlyList<GitItemStatus> GetCombinedDiffFileList(ObjectId mergeCommitObjectId);
-    IReadOnlyList<GitItemStatus> GetTreeFiles(ObjectId treeGuid, bool full);
+    IReadOnlyList<GitItemStatus> GetTreeFiles(ObjectId treeGuid, bool full, CancellationToken cancellationToken = default);
     IReadOnlyList<string> GetFullTree(string id);
 
     /// <summary>

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitTreeParserTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitTreeParserTests.cs
@@ -25,28 +25,39 @@ namespace GitCommandsTests.Git
         {
             List<GitItem> items = _parser.Parse(GetLsTreeOutput()).ToList();
 
-            items.Should().HaveCount(10);
+            items.Should().HaveCount(13);
 
             items[3].Guid.Should().Be("46cccae116d2e5a1a2f818b0b31adde4ab3800a9");
             items[3].Mode.Should().Be(100644);
             items[3].Name.Should().Be(".gitignore");
             items[3].ObjectType.Should().Be(GitObjectType.Blob);
 
-            items[8].Guid.Should().Be("58d57013ed2ef925fc1b3f6fe72ead258c522e75");
-            items[8].Mode.Should().Be(040000);
-            items[8].Name.Should().Be("Bin");
-            items[8].ObjectType.Should().Be(GitObjectType.Tree);
+            items[9].Guid.Should().Be("38f33cf556b4aae690c640e48375cf1ff659b7a6");
+            items[9].Mode.Should().Be(100644);
+            items[9].Name.Should().Be(" space /in / path .txt");
+            items[9].ObjectType.Should().Be(GitObjectType.Blob);
+
+            items[10].Guid.Should().Be("58d57013ed2ef925fc1b3f6fe72ead258c522e75");
+            items[10].Mode.Should().Be(040000);
+            items[10].Name.Should().Be("Bin");
+            items[10].ObjectType.Should().Be(GitObjectType.Tree);
+
+            items[11].Guid.Should().Be("ec097fc11ec61f502d5fced60e27d54b5fe326c0");
+            items[11].Mode.Should().Be(160000);
+            items[11].Name.Should().Be("subm");
+            items[11].ObjectType.Should().Be(GitObjectType.Commit);
         }
 
         [TestCase(null)]
         [TestCase("")]
         [TestCase("Hello World")]
-        [TestCase("ZZZZZZ blob 0000000000000000000000000000000000000000    README.md")]
-        [TestCase("100644 blob 000000000000000000000000000000000000000    README.md")]
-        [TestCase("100644 blob 00000000000000000000000000000000000000000    README.md")]
-        [TestCase("100644 ZZZZ 00000000000000000000000000000000000000000    README.md")]
-        [TestCase("1006444 blob 0000000000000000000000000000000000000000    README.md")]
-        [TestCase("10064 blob 0000000000000000000000000000000000000000    README.md")]
+        [TestCase("ZZZZZZ blob 0000000000000000000000000000000000000000\tREADME.md")]
+        [TestCase("100644 blob 000000000000000000000000000000000000000\tREADME.md")]
+        [TestCase("100644 blob 00000000000000000000000000000000000000000\tREADME.md")]
+        [TestCase("100644 ZZZZ 00000000000000000000000000000000000000000\tREADME.md")]
+        [TestCase("1006444 blob 0000000000000000000000000000000000000000\tREADME.md")]
+        [TestCase("10064 blob 0000000000000000000000000000000000000000\tREADME.md")]
+        [TestCase("100644 blob 960498876e233a6119e20fc73171bca2e26f57c0 space")]
         public void ParseSingle_should_return_null_if_input_invalid(string s)
         {
             _parser.ParseSingle(s).Should().BeNull();
@@ -55,7 +66,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void ParseSingle_should_return_GitItem()
         {
-            const string s = "100644 blob 25d7b5d771e84982a3dfd8bd537531d8fb45d491    .editorconfig";
+            const string s = "100644 blob 25d7b5d771e84982a3dfd8bd537531d8fb45d491\t.editorconfig";
             GitItem item = _parser.ParseSingle(s);
 
             item.Guid.Should().Be("25d7b5d771e84982a3dfd8bd537531d8fb45d491");
@@ -67,16 +78,19 @@ namespace GitCommandsTests.Git
         private static string GetLsTreeOutput()
         {
             return string.Concat(
-                "100644 blob 25d7b5d771e84982a3dfd8bd537531d8fb45d491	.editorconfig", "\n",
-                "100644 blob bf29d31ff93be092ce746849e8db0984d4a83231	.gitattributes", "\0",
-                "040000 tree 93185d6bd18327f5a23bc34e7eb75e66ec0ef2d1	.github", "\n",
-                "100644 blob 46cccae116d2e5a1a2f818b0b31adde4ab3800a9	.gitignore", "\0",
-                "100644 blob e55070b6c781e278bc68fc1b2525f56318d18244	.gitmodules", "\n",
-                "100644 blob 1a569e3aa555e8cdf14dcc29f9bf4edf9aa465eb	.mailmap", "\n",
-                "040000 tree 5c1f6ae123f16e2bee1c5a064cf293c11250d98f	.nuget", "\n",
-                "100644 blob 1e53ed8f6759a92d4596af6a99ef04f1554bfd57	.travis.yml", "\0",
-                "040000 tree 58d57013ed2ef925fc1b3f6fe72ead258c522e75	Bin", "\0",
-                "040000 tree 0c7cce8981b980d03431f65b9b54c680a467fa2e	Build");
+                "100644 blob 25d7b5d771e84982a3dfd8bd537531d8fb45d491\t.editorconfig", "\0",
+                "100644 blob bf29d31ff93be092ce746849e8db0984d4a83231\t.gitattributes", "\0",
+                "040000 tree 93185d6bd18327f5a23bc34e7eb75e66ec0ef2d1\t.github", "\0",
+                "100644 blob 46cccae116d2e5a1a2f818b0b31adde4ab3800a9\t.gitignore", "\0",
+                "100644 blob e55070b6c781e278bc68fc1b2525f56318d18244\t.gitmodules", "\0",
+                "100644 blob 1a569e3aa555e8cdf14dcc29f9bf4edf9aa465eb\t.mailmap", "\0",
+                "040000 tree 5c1f6ae123f16e2bee1c5a064cf293c11250d98f\t.nuget", "\0",
+                "100644 blob 1e53ed8f6759a92d4596af6a99ef04f1554bfd57\t.travis.yml", "\0",
+                "100644 blob 960498876e233a6119e20fc73171bca2e26f57c0\t space first", "\0",
+                "100644 blob 38f33cf556b4aae690c640e48375cf1ff659b7a6\t space /in / path .txt", "\0",
+                "040000 tree 58d57013ed2ef925fc1b3f6fe72ead258c522e75\tBin", "\0",
+                "160000 commit ec097fc11ec61f502d5fced60e27d54b5fe326c0\tsubm", "\0",
+                "040000 tree 0c7cce8981b980d03431f65b9b54c680a467fa2e\tBuild");
         }
     }
 }


### PR DESCRIPTION
fixes #12413 
fixes #12464 

## Proposed changes

Improve performance (especially for lfs files) to display the file tree if no grep filter is active.
See the issue for the reduced time to run the command.

This could be moved to GitModule instead.
GitModule is a better place for checking that 

Note: ls-tree cannot be used for artificial commits, but ls-files could be used
That is a separate optimization

## Test methodology <!-- How did you ensure quality? -->

view manual git log

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
