### PR TITLE
fix(AsyncStreamReaderTests): Relax timing

### DIFF
--- a/tests/app/UnitTests/GitExtUtils.Tests/AsyncStreamReaderTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/AsyncStreamReaderTests.cs
@@ -26,7 +26,7 @@ public sealed class AsyncStreamReaderTests
     public async Task AsyncStreamReader()
     {
         const int millisecondsDelayForAsyncNotification = 50;
-        const int millisecondsDelayForPartialLine = 300;
+        const int millisecondsDelayForPartialLine = 500;
 
         const string line1 = "line with LF\n";
         const string line2 = "line with CRLF\r\n";


### PR DESCRIPTION
## Proposed changes

`AsyncStreamReaderTests`:
Relax timing `millisecondsDelayForPartialLine`
in order to adapt to CI build machines, which apparently have become slower

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- run test on AppVeyor

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).