### PR TITLE
fix(file tree context menu): Unique mnemonic for "Collapse root folders"

### DIFF
--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1538,7 +1538,7 @@ Git will never check if the file has changed that will improve status check perf
         <target />
       </trans-unit>
       <trans-unit id="_collapseRootFolders.Text">
-        <source>Co&amp;llapse root folders</source>
+        <source>Collap&amp;se root folders</source>
         <target />
       </trans-unit>
       <trans-unit id="_deleteFailed.Text">

--- a/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
@@ -39,7 +39,7 @@ partial class FileStatusList
         P Copy paths
         Q
         R Reset files
-        S Stage, Sort and group by
+        S Stage, Sort and group by, Collapse root folders (file tree only)
         T Show in file tree, Stash submodule
         U Unstage, Update submodule
         V Open in VS

--- a/src/app/GitUI/UserControls/FileStatusList.TreeContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.TreeContextMenu.cs
@@ -8,7 +8,7 @@ namespace GitUI;
 partial class FileStatusList
 {
     private ToolStripMenuItem _collapseAll = new("C&ollapse all", Images.CollapseAll);
-    private ToolStripMenuItem _collapseRootFolders = new("Co&llapse root folders", Images.TreeCollapseAll);
+    private ToolStripMenuItem _collapseRootFolders = new("Collap&se root folders", Images.TreeCollapseAll);
     private ToolStripMenuItem _expandAll = new("E&xpand all", Images.ExpandAll);
     private ToolStripMenuItem _selectAll = new("S&elect all", Images.FileTree);
     private ToolStripSeparator _treeContextMenuSeparator = new() { Name = nameof(_treeContextMenuSeparator) };


### PR DESCRIPTION
## Proposed changes

`FileStatusList.TreeContextMenu`:
Since "Stage" and "Sort and group by" do not apply to the file-tree only "Collapse root folders", 'S' can be  used as mnemonic
in order to not interfere with "Show "Find in commit fi&les".

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before | After

![image](https://github.com/user-attachments/assets/fa56803e-d1f5-428a-8e59-68eacdd141f8)   ![image](https://github.com/user-attachments/assets/51f2a6fc-ed2d-47b2-9eef-e7b9a3dd7a2f)

## Test methodology <!-- How did you ensure quality? -->

- manual
- review

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).