### PR TITLE
fix(multi-value git config): "credential.helper"

### DIFF
--- a/src/app/GitCommands/Settings/GitConfigSettings.cs
+++ b/src/app/GitCommands/Settings/GitConfigSettings.cs
@@ -80,7 +80,11 @@ public sealed class GitConfigSettings : GitConfigSettingsBase, IGitConfigSetting
     {
         name = NormalizeSettingName(name);
         Update();
-        return _multiValueSettings.TryGetValue(name, out List<string>? values) ? values : [];
+        return _multiValueSettings.TryGetValue(name, out List<string>? values)
+            ? values
+            : GetValue(name) is string value
+                ? [value]
+                : [];
     }
 
     public void Save()
@@ -106,7 +110,7 @@ public sealed class GitConfigSettings : GitConfigSettingsBase, IGitConfigSetting
     {
         if (_multiValueSettings.ContainsKey(name))
         {
-            throw new InvalidOperationException(@"Changing multi-value git settings is not supported. Tried to set ""{name}"" = ""{value}"".");
+            throw new InvalidOperationException(@$"Changing multi-value git settings is not supported. Tried to set ""{name}"" = ""{value}"".");
         }
 
         name = NormalizeSettingName(name);


### PR DESCRIPTION
Fixes #12422
Fixes regression from switch to `GitConfigSettings`

## Proposed changes

- `GitConfigSettings.GetValues`: Also return single value instead of empty list
- `GitConfigSettings.SetValue`: Fixup exception message in case of multi-value
- `credential.helper`:
  - Display multi-value config and disable edit
  - Hide in effective settings (because it is not worth running an additional git command for this single usecase)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/7c449ae5-381e-484c-a9b5-caab37619828)

### After

![image](https://github.com/user-attachments/assets/79b91a93-fb10-4fe1-a4a5-9863bb7206bc)

### Unchanged

![image](https://github.com/user-attachments/assets/eeb516d4-1953-42ca-8584-fbc53ad17636)

![image](https://github.com/user-attachments/assets/2c0fb101-9af9-4ff1-aa04-34f97bdde8e0)

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Please do not squash merge this PR

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).