### PR TITLE
fix(FormPush): Align labels with fields

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -212,10 +212,10 @@
             // labelTo
             // 
             labelTo.AutoSize = true;
-            labelTo.Location = new Point(200, 0);
+            labelTo.Location = new Point(200, 3);
+            labelTo.Margin = new Padding(4, 3, 2, 0);
             labelTo.Name = "labelTo";
-            labelTo.RightToLeft = RightToLeft.Yes;
-            labelTo.Size = new Size(17, 22);
+            labelTo.Size = new Size(18, 15);
             labelTo.TabIndex = 1;
             labelTo.Text = "&to";
             labelTo.TextAlign = ContentAlignment.MiddleCenter;
@@ -250,10 +250,10 @@
             flowLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             flowLayoutPanel1.Controls.Add(label2);
             flowLayoutPanel1.Controls.Add(RecursiveSubmodules);
-            flowLayoutPanel1.Location = new Point(319, 2);
+            flowLayoutPanel1.Location = new Point(307, 1);
             flowLayoutPanel1.Margin = new Padding(0);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
-            flowLayoutPanel1.Size = new Size(215, 25);
+            flowLayoutPanel1.Size = new Size(227, 27);
             flowLayoutPanel1.TabIndex = 2;
             flowLayoutPanel1.WrapContents = false;
             // 


### PR DESCRIPTION
## Proposed changes

- `FormPush`: Align labels "to" and "Recursive submodules"

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/afcb694e-713d-4520-a3c3-c17f77cd2030)

### After

![image](https://github.com/user-attachments/assets/c54f8f19-1d8c-4e3d-bb96-36b17a173c76)

![image](https://github.com/user-attachments/assets/44db4da7-6166-4b97-a72c-9b0e290b0f3b)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).