### PR TITLE
fix(FormOpenDirectory): Restore button label

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
@@ -83,6 +83,7 @@
             folderBrowserButton.Name = "folderBrowserButton";
             folderBrowserButton.Size = new Size(135, 25);
             folderBrowserButton.TabIndex = 4;
+            folderBrowserButton.Text = "&Browse...";
             folderBrowserButton.UseVisualStyleBackColor = true;
             folderBrowserButton.Click += folderBrowserButton_Click;
             // 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -5655,6 +5655,10 @@ command "git help shortlog"</source>
         <source>The selected directory is not a valid git repository.</source>
         <target />
       </trans-unit>
+      <trans-unit id="folderBrowserButton.Text">
+        <source>&amp;Browse...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="folderGoUpButton.toolTip1">
         <source>Go to parent directory...</source>
         <target />


### PR DESCRIPTION
Fixes #12433
Broken by #12282

## Proposed changes

`FormOpenDirectory.folderBrowserButton`: Restore button label
Using `FolderBrowserButton` here would be too intrusive.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

no label, refer to bug report

### After

![image](https://github.com/user-attachments/assets/6e838bf8-6d29-442f-b605-275e3c44cf2e)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).