### PR TITLE
fix: present removed submodules

### DIFF
--- a/src/app/GitCommands/Git/GitItem.cs
+++ b/src/app/GitCommands/Git/GitItem.cs
@@ -4,7 +4,7 @@ using GitExtensions.Extensibility.Git;
 namespace GitCommands.Git
 {
     [DebuggerDisplay("GitItem( {" + nameof(FileName) + "} )")]
-    public class GitItem : INamedGitItem
+    public class GitItem : IObjectGitItem
     {
         public GitItem(int mode, GitObjectType objectType, ObjectId objectId, string name)
         {
@@ -21,13 +21,5 @@ namespace GitCommands.Git
         public int Mode { get; }
 
         public string Guid => ObjectId.ToString();
-    }
-
-    public enum GitObjectType
-    {
-        None = 0,
-        Commit,
-        Tree,
-        Blob
     }
 }

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2560,10 +2560,7 @@ namespace GitCommands
         }
 
         public IReadOnlyList<GitItemStatus> GetTreeFiles(ObjectId commitId, bool full, CancellationToken cancellationToken = default)
-        {
-            IObjectGitItem[] tree = [.. GetTree(commitId, full, cancellationToken: cancellationToken)];
-
-            return tree
+            => GetTree(commitId, full, cancellationToken: cancellationToken)
                 .Select(file => new GitItemStatus(file.Name)
                 {
                     // IsTracked is always true, only tracked are reported
@@ -2577,7 +2574,6 @@ namespace GitCommands
                     IsSubmodule = file.ObjectType == GitObjectType.Commit
                 })
                 .ToList();
-        }
 
         public IReadOnlyList<GitItemStatus> GetAllChangedFiles(bool excludeIgnoredFiles = true,
             bool excludeAssumeUnchangedFiles = true, bool excludeSkipWorktreeFiles = true,

--- a/src/app/GitExtensions.Extensibility/Git/GitObjectType.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitObjectType.cs
@@ -1,0 +1,9 @@
+﻿namespace GitExtensions.Extensibility.Git;
+
+public enum GitObjectType
+{
+    None = 0,
+    Commit,
+    Tree,
+    Blob
+}

--- a/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
@@ -33,7 +33,20 @@ public sealed class GitSubmoduleStatus
     {
         if (submodule is null)
         {
-            Status = SubmoduleStatus.NewSubmodule;
+            if (OldCommit is null)
+            {
+                // If there is no old commit, it is a new submodule.
+                Status = SubmoduleStatus.NewSubmodule;
+                return;
+            }
+
+            if (Commit is null)
+            {
+                Status = SubmoduleStatus.RemovedSubmodule;
+                return;
+            }
+
+            Status = SubmoduleStatus.Unknown;
             return;
         }
 

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -21,7 +21,7 @@ public interface IGitModule
 
     IReadOnlyList<IGitRef> GetRefs(RefsFilter getRef);
     IEnumerable<string> GetSettings(string setting);
-    IEnumerable<INamedGitItem> GetTree(ObjectId? commitId, bool full, CancellationToken cancellationToken = default);
+    IEnumerable<IObjectGitItem> GetTree(ObjectId? commitId, bool full, string fileName = "", CancellationToken cancellationToken = default);
 
     /// <summary>
     ///  Loads the user-defined colors for the remote branches specific for the current repository.
@@ -436,7 +436,7 @@ public interface IGitModule
 
     bool ExistsMergeCommit(string? startRev, string? endRev);
 
-    string GetFileText(ObjectId id, Encoding encoding, bool stripAnsiEscapeCodes);
+    string? GetFileText(ObjectId id, Encoding encoding, bool stripAnsiEscapeCodes);
 
     Task<MemoryStream?> GetFileStreamAsync(string blob, CancellationToken cancellationToken);
 

--- a/src/app/GitExtensions.Extensibility/Git/IObjectGitItem.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IObjectGitItem.cs
@@ -1,0 +1,6 @@
+﻿namespace GitExtensions.Extensibility.Git;
+
+public interface IObjectGitItem : INamedGitItem
+{
+    GitObjectType ObjectType { get; }
+}

--- a/src/app/GitExtensions.Extensibility/Git/SubmoduleStatus.cs
+++ b/src/app/GitExtensions.Extensibility/Git/SubmoduleStatus.cs
@@ -4,6 +4,7 @@ public enum SubmoduleStatus
 {
     Unknown = 0,
     NewSubmodule,
+    RemovedSubmodule,
     FastForward,
     Rewind,
     NewerTime,

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1437,6 +1437,7 @@ namespace GitUI
                 {
                     if (gitItemStatus.IsSubmodule)
                     {
+                        // Image without evaluating added/removed etc
                         imageKey = GetSubmoduleItemImageKey(gitItemStatus);
                     }
                     else if (Path.GetExtension(gitItemStatus.Name) is string extension && _imageListData.StateImageIndexMap.TryGetValue(extension, out int imageIndex))
@@ -1453,7 +1454,9 @@ namespace GitUI
                 else
                 {
                     imageKey = gitItemStatus.IsStatusOnly || !string.IsNullOrWhiteSpace(gitItemStatus.ErrorMessage)
-                                ? gitItemStatus == noItemStatuses[0] ? nameof(Images.FileStatusCopiedSame) : nameof(Images.FileStatusUnknown)
+                                ? gitItemStatus == noItemStatuses[0]
+                                    ? nameof(Images.FileStatusCopiedSame)
+                                    : nameof(Images.FileStatusUnknown)
                                 : GetItemImageKey(gitItemStatus);
                 }
 

--- a/src/app/ResourceManager/LocalizationHelpers.cs
+++ b/src/app/ResourceManager/LocalizationHelpers.cs
@@ -206,6 +206,9 @@ namespace ResourceManager
                 case SubmoduleStatus.NewSubmodule:
                     sb.AppendLine("New submodule");
                     break;
+                case SubmoduleStatus.RemovedSubmodule:
+                    sb.AppendLine("Removed submodule");
+                    break;
                 case SubmoduleStatus.FastForward:
                     sb.AppendLine("Fast Forward");
                     break;

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitTreeParserTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitTreeParserTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GitCommands.Git;
+using GitExtensions.Extensibility.Git;
 
 namespace GitCommandsTests.Git
 {

--- a/tests/app/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
@@ -57,13 +57,13 @@ namespace GitCommandsTests
             item.ObjectId.Returns(objectId);
             item.Guid.Returns(objectId.ToString());
 
-            INamedGitItem[] items = new[] { Substitute.For<INamedGitItem>(), Substitute.For<INamedGitItem>(), Substitute.For<INamedGitItem>() };
+            IObjectGitItem[] items = new[] { Substitute.For<IObjectGitItem>(), Substitute.For<IObjectGitItem>(), Substitute.For<IObjectGitItem>() };
             _module.GetTree(objectId, full: false).Returns(items);
 
             IEnumerable<INamedGitItem> children = _provider.LoadChildren(item);
 
             children.Should().BeEquivalentTo(items);
-            _module.Received(1).GetTree(objectId, false);
+            _module.Received(1).GetTree(objectId, full: false);
         }
 
         [Test]
@@ -72,15 +72,15 @@ namespace GitCommandsTests
             ObjectId commitId = ObjectId.Random();
             GitItem item = new(0, GitObjectType.Tree, commitId, "folder");
 
-            INamedGitItem[] items = new[] { Substitute.For<INamedGitItem>(), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file3") };
-            _module.GetTree(commitId, false).Returns(items);
+            IObjectGitItem[] items = new[] { Substitute.For<IObjectGitItem>(), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file3") };
+            _module.GetTree(commitId, full: false).Returns(items);
 
             IEnumerable<INamedGitItem> children = _provider.LoadChildren(item);
 
             children.Should().BeEquivalentTo(items);
             ((GitItem)items[1]).FileName.Should().Be(Path.Combine(item.FileName, "file2"));
             ((GitItem)items[2]).FileName.Should().Be(Path.Combine(item.FileName, "file3"));
-            _module.Received(1).GetTree(commitId, false);
+            _module.Received(1).GetTree(commitId, full: false);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Follow up to https://github.com/gitextensions/gitextensions/pull/12421#issuecomment-3014378138
Based on #12421

present removed submodules

- Submodule presentation in the file tree and diff did not
present removed submodules.

- In diffs, detect if the path is a submodule also if the path
does not exist.

To present submodules as diff or in file tree the submodule must be present.
By default is only the path and the commit sha known.

Previously these paths were in some scenarios presented as files, which raised error messages.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

see also See #12421 for prev

removed submodule in commit, folder not available in worktree, .gitmodule contains the file
![image](https://github.com/user-attachments/assets/c3d339c8-1b91-4dcc-a1f0-df1a8625fc06)
![image](https://github.com/user-attachments/assets/3b2bae2b-e6c5-472c-a047-bc52f3f16456)

removed submodule, folder exists
![image](https://github.com/user-attachments/assets/6cf873f6-2827-4ccf-b87c-fa37acc292b1)
![image](https://github.com/user-attachments/assets/8177879c-a680-4143-9d7e-12e2491d5844)

added submodule, not in worktree
![image](https://github.com/user-attachments/assets/c3837c3a-cf2c-4623-b754-0355a23e0df9)
![image](https://github.com/user-attachments/assets/45034db1-10f3-4cc7-a1c9-cee1699878a2)

remove submodule is still like
![image](https://github.com/user-attachments/assets/6498e391-5e82-4319-bf2a-61f20845628a)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
