### PR TITLE
fix: present git-status errors

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2502,7 +2502,7 @@ namespace GitCommands
             if (stagedStatus is StagedStatus.WorkTree or StagedStatus.Index)
             {
                 IReadOnlyList<GitItemStatus> status = GetAllChangedFilesWithSubmodulesStatus(cancellationToken: cancellationToken);
-                return status.Where(x => x.Staged == stagedStatus).ToList();
+                return status.Where(x => x.Staged == stagedStatus || x.IsStatusOnly).ToList();
             }
 
             ExecutionResult exec = GetDiffFiles(firstRevision, secondRevision, noCache: noCache, nullSeparated: true, cancellationToken);


### PR DESCRIPTION
## Proposed changes

If a submodule directory does not exist but .exists in gitmodules, git-status fails.
(delete or rename the subm directory)
GE can not reasonably handle this scenario.
Present the error in the diff tab, revgrid is still gray.

GitStatusMonitor fails with a popup still:

![image](https://github.com/user-attachments/assets/2b1b1391-6120-4326-a5b7-123de454e169)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![image](https://github.com/user-attachments/assets/90794ee9-5aef-4f3d-8f30-3c5fa29e593a)

### After

![image](https://github.com/user-attachments/assets/f37c255f-74c9-4d24-b152-232e6306ce38)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
