### PR TITLE
Improve EnvironmentPathsProvider.IsValidPath API

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -217,3 +217,4 @@ YYYY/MM/DD, github id, Full name, email
 2025/04/19, borzag, Boris Zagar, boris.zagar(at)gmail.com
 2025/05/03, hnalpha323, Muhammad Hamza Noor, hnalpha323(at)gmail.com
 2025/06/03, margaretselzer, Marcell Egyed, spam.myself@yahoo.com
+2025/07/04, ashraful-asif, Mohammad Ashraful Alam, ashraful.asif@yahoo.com

--- a/src/app/GitCommands/EnvironmentPathsProvider.cs
+++ b/src/app/GitCommands/EnvironmentPathsProvider.cs
@@ -75,7 +75,7 @@ namespace GitCommands
                 // Path APIs don't throw an exception for invalid characters
                 // https://docs.microsoft.com/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
 
-                if (string.IsNullOrEmpty(path) || path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+                if (string.IsNullOrEmpty(path) || path.ContainsAny(Path.GetInvalidPathChars()))
                 {
                     return false;
                 }

--- a/src/app/GitCommands/EnvironmentPathsProvider.cs
+++ b/src/app/GitCommands/EnvironmentPathsProvider.cs
@@ -75,6 +75,11 @@ namespace GitCommands
                 // Path APIs don't throw an exception for invalid characters
                 // https://docs.microsoft.com/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
 
+                if (string.IsNullOrEmpty(path) || path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+                {
+                    return false;
+                }
+
                 _ = new FileInfo(path).Attributes;
 
                 return true;

--- a/tests/app/UnitTests/GitCommands.Tests/EnvironmentPathsProviderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/EnvironmentPathsProviderTests.cs
@@ -49,6 +49,7 @@ namespace GitCommandsTests
         [TestCase("\\\\my-pc\\Work\\GitExtensions\\", true)]
         [TestCase("C:\\Work\\GitExtensions\\", true)]
         [TestCase("C:\\Work\\", true)]
+        [TestCase("C:\\Work|space\\", false, TestName="Invalid char in path")]
         [TestCase("C:\\", true)]
         [TestCase("C:", true)]
         [TestCase("", false)]


### PR DESCRIPTION
Path APIs don't throw an exception for invalid characters. Recommended way to check it using Path.GetInvalidPathChars

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #
Improve EnvironmentPathsProvider.IsValidPath API

## Proposed changes

- Path APIs don't throw an exception for invalid characters. 
- Recommended way to check it using Path.GetInvalidPathChars-

## Test methodology <!-- How did you ensure quality? -->

- Added a new test case to check invalid char in path

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
