### PR TITLE
Load PR Template from local file

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -217,3 +217,4 @@ YYYY/MM/DD, github id, Full name, email
 2025/04/19, borzag, Boris Zagar, boris.zagar(at)gmail.com
 2025/05/03, hnalpha323, Muhammad Hamza Noor, hnalpha323(at)gmail.com
 2025/06/03, margaretselzer, Marcell Egyed, spam.myself@yahoo.com
+2025/07/09, KianFitz, Kian Fitzpatrick, kian.fitzpatrick2000(at)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5223

## Proposed changes

- Load the PR template from the local file when creating a pull request if it exists.

## Test methodology <!-- How did you ensure quality? -->

- Tested with GitExtensions repository.
- Tested with repository with no PR template to ensure no crash.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT - git version 2.50.0.windows.2
- Windows - Windows 11 24H2 26100.4351

<!-- Mention language, UI scaling, or anything else that might be relevant -->

This PR *currently* does not support
- More than one template
- Template in non "/.github" directory

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
