### PR TITLE
Rename to FireAndForget.

### DIFF
--- a/src/app/GitCommands/Git/GitCommandRunner.cs
+++ b/src/app/GitCommands/Git/GitCommandRunner.cs
@@ -40,7 +40,7 @@ namespace GitCommands
             bool redirectOutput = false,
             Encoding? outputEncoding = null)
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     using IProcess process = RunDetached(CancellationToken.None, arguments, createWindow, redirectInput, redirectOutput, outputEncoding);
                     await process.WaitForExitAsync();

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -652,7 +652,7 @@ namespace GitCommands
         }
 
         public void SaveBlobAs(string saveAs, string blob, CancellationToken cancellationToken = default)
-            => ThreadHelper.FileAndForget(() => SaveBlobAsAsync(saveAs, blob, cancellationToken));
+            => ThreadHelper.FireAndForget(() => SaveBlobAsAsync(saveAs, blob, cancellationToken));
 
         public async Task SaveBlobAsAsync(string saveAs, string blob, CancellationToken cancellationToken)
         {

--- a/src/app/GitCommands/Settings/GitConfigSettingsBase.cs
+++ b/src/app/GitCommands/Settings/GitConfigSettingsBase.cs
@@ -31,7 +31,7 @@ public abstract class GitConfigSettingsBase(IExecutable gitExecutable, GitSettin
             Valid = false;
         }
 
-        ThreadHelper.FileAndForget(async () =>
+        ThreadHelper.FireAndForget(async () =>
         {
             await Task.Delay(millisecondsDelay: 250);
             if (Path.Exists(_gitExecutable.WorkingDir))

--- a/src/app/GitExtUtils/AsyncStreamReader.cs
+++ b/src/app/GitExtUtils/AsyncStreamReader.cs
@@ -28,7 +28,7 @@ public sealed class AsyncStreamReader : IDisposable
     public AsyncStreamReader(IStreamReader streamReader, Action<string> notify)
     {
         CancellationToken cancellationToken = _cancellationTokenSource.Token;
-        _taskManager.FileAndForget(async () =>
+        _taskManager.FireAndForget(async () =>
         {
             // Read single chars because ReadAsync blocks until a line end is received
             // Wait for start of new output without timeout, but read consecutive chars with timeout in order to display prompts having no line end

--- a/src/app/GitExtUtils/GitUI/TaskManager.cs
+++ b/src/app/GitExtUtils/GitUI/TaskManager.cs
@@ -77,7 +77,7 @@ namespace GitUI
         /// <summary>
         /// Asynchronously run <paramref name="asyncAction"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
         /// </summary>
-        public void FileAndForget(Func<Task> asyncAction)
+        public void FireAndForget(Func<Task> asyncAction)
         {
             _ = JoinableTaskFactory.RunAsync(async () =>
                 {
@@ -89,18 +89,18 @@ namespace GitUI
         /// <summary>
         /// Asynchronously run <paramref name="action"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
         /// </summary>
-        public void FileAndForget(Action action)
+        public void FireAndForget(Action action)
         {
-            FileAndForget(AsyncAction(action));
+            FireAndForget(AsyncAction(action));
         }
 
         /// <summary>
         /// Asynchronously run <paramref name="task"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
         /// </summary>
-        public void FileAndForget(Task task)
+        public void FireAndForget(Task task)
         {
             TimeSpan infiniteTimeout = new(-TimeSpan.TicksPerMillisecond);
-            FileAndForget(() => task.WaitAsync(infiniteTimeout));
+            FireAndForget(() => task.WaitAsync(infiniteTimeout));
         }
 
         /// <summary>

--- a/src/app/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/src/app/GitExtUtils/GitUI/ThreadHelper.cs
@@ -69,26 +69,26 @@ namespace GitUI
         /// <summary>
         /// Asynchronously run <paramref name="asyncAction"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
         /// </summary>
-        public static void FileAndForget(Func<Task> asyncAction)
-            => _taskManager.FileAndForget(asyncAction);
+        public static void FireAndForget(Func<Task> asyncAction)
+            => _taskManager.FireAndForget(asyncAction);
 
         /// <summary>
         /// Asynchronously run <paramref name="action"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
         /// </summary>
-        public static void FileAndForget(Action action)
-            => _taskManager.FileAndForget(action);
+        public static void FireAndForget(Action action)
+            => _taskManager.FireAndForget(action);
 
         /// <summary>
         /// Asynchronously run <paramref name="joinableTask"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
         /// </summary>
-        public static void FileAndForget(this JoinableTask joinableTask)
-            => _taskManager.FileAndForget(joinableTask.Task);
+        public static void FireAndForget(this JoinableTask joinableTask)
+            => _taskManager.FireAndForget(joinableTask.Task);
 
         /// <summary>
         /// Asynchronously run <paramref name="task"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
         /// </summary>
-        public static void FileAndForget(this Task task)
-            => _taskManager.FileAndForget(task);
+        public static void FireAndForget(this Task task)
+            => _taskManager.FireAndForget(task);
 
         /// <summary>
         /// Asynchronously run <paramref name="asyncAction"/> on the UI thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -348,7 +348,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                     };
                     listView1.Items.Add(item);
 
-                    ThreadHelper.FileAndForget(async () =>
+                    ThreadHelper.FireAndForget(async () =>
                     {
                         bool isValidGitDir = _controller.IsValidGitWorkingDir(recent.Repo.Path);
                         string branchName = isValidGitDir ? _controller.GetCurrentBranchName(recent.Repo.Path) : "";

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -35,8 +35,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void FormGoToCommit_Load(object sender, EventArgs e)
         {
-            LoadTagsAsync().FileAndForget();
-            LoadBranchesAsync().FileAndForget();
+            LoadTagsAsync().FireAndForget();
+            LoadBranchesAsync().FireAndForget();
             SetCommitExpressionFromClipboard();
         }
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -249,7 +249,7 @@ public partial class FormUpdates : GitExtensionsDialog
         btnUpdateNow.Enabled = false;
         UpdateLabel.Text = _downloadingUpdate.Text;
 
-        ThreadHelper.FileAndForget(async () =>
+        ThreadHelper.FireAndForget(async () =>
         {
             string fileName = Path.GetFileName(_updateUrl);
             try

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -491,7 +491,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 _isFirstPostRepoChanged = false;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                     {
                         try
                         {

--- a/src/app/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/src/app/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -186,7 +186,7 @@ namespace GitUI.CommandsDialogs
 
             if (favIconUrl is not null)
             {
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                     {
                         using Stream imageStream = await DownloadRemoteImageFileAsync(favIconUrl);
                         if (imageStream is not null)

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -380,7 +380,7 @@ namespace GitUI.CommandsDialogs
                         {
                             Validates.NotNull(_submoduleStatusProvider);
 
-                            ThreadHelper.FileAndForget(async () =>
+                            ThreadHelper.FireAndForget(async () =>
                             {
                                 try
                                 {
@@ -1047,7 +1047,7 @@ namespace GitUI.CommandsDialogs
                     if (AppSettings.ShowAheadBehindData)
                     {
                         string currentBranch = RevisionGrid.CurrentBranch.Value;
-                        ThreadHelper.FileAndForget(async () =>
+                        ThreadHelper.FireAndForget(async () =>
                         {
                             // Always query only current branch here
                             // because, due to race condition with left panel async refresh:
@@ -1169,7 +1169,7 @@ namespace GitUI.CommandsDialogs
         {
             if (AppSettings.ShowStashCount && !Module.IsBareRepository())
             {
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     // Add a delay to not interfere with GUI updates when switching repository
                     await Task.Delay(500);
@@ -1464,8 +1464,8 @@ namespace GitUI.CommandsDialogs
             AvatarService.UpdateAvatarInitialFontsSettings();
 
             // Clear the separate caches for diff/merge tools
-            ThreadHelper.FileAndForget(() => new CustomDiffMergeToolProvider().ClearAsync(isDiff: false));
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(() => new CustomDiffMergeToolProvider().ClearAsync(isDiff: false));
+            ThreadHelper.FireAndForget(async () =>
             {
                 revisionDiff.CancelLoadCustomDifftools();
                 RevisionGrid.CancelLoadCustomDifftools();
@@ -2526,7 +2526,7 @@ namespace GitUI.CommandsDialogs
 
             toolStripButtonLevelUp.ToolTipText = "";
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 try
                 {

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -476,7 +476,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     // not applicable if there is no checkout yet
                     string aheadBehindInfo = "";

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -402,7 +402,7 @@ namespace GitUI.CommandsDialogs
             Cursor = Cursors.AppStarting;
 
             CancellationToken cancellationToken = _branchLoaderSequence.Next();
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 RemoteActionResult<IReadOnlyList<IGitRef>> branchList;
 

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -441,7 +441,7 @@ namespace GitUI.CommandsDialogs
                     // Run async as we're closing the form
                     string message = Message.Text;
                     bool isAmend = Amend.Checked;
-                    ThreadHelper.FileAndForget(async () =>
+                    ThreadHelper.FireAndForget(async () =>
                     {
                         await _commitMessageManager.SetMergeOrCommitMessageAsync(message);
                         await _commitMessageManager.SetAmendStateAsync(isAmend);
@@ -791,7 +791,7 @@ namespace GitUI.CommandsDialogs
 
             if (doAsync)
             {
-                ThreadHelper.FileAndForget(() => _unstagedLoader.LoadAsync(GetAllChangedFilesWithSubmodulesStatus, onComputed));
+                ThreadHelper.FireAndForget(() => _unstagedLoader.LoadAsync(GetAllChangedFilesWithSubmodulesStatus, onComputed));
             }
             else
             {
@@ -879,7 +879,7 @@ namespace GitUI.CommandsDialogs
         {
             _initialized = true;
 
-            ThreadHelper.FileAndForget(UpdateBranchNameDisplayAsync);
+            ThreadHelper.FireAndForget(UpdateBranchNameDisplayAsync);
 
             using (WaitCursorScope.Enter())
             {
@@ -2195,7 +2195,7 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateAuthorInfo()
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     string committer = $"{_commitCommitterInfo.Text} {GetSetting(SettingKeyString.UserName)} <{GetSetting(SettingKeyString.UserEmail)}>";
 
@@ -2745,7 +2745,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ThreadHelper.FileAndForget(UpdateBranchNameDisplayAsync);
+            ThreadHelper.FireAndForget(UpdateBranchNameDisplayAsync);
         }
 
         private void Message_Enter(object sender, EventArgs e)
@@ -2771,7 +2771,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!_skipUpdate && !_bypassActivatedEventHandler)
             {
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                     {
                         await this.SwitchToMainThreadAsync();
                         RescanChanges();

--- a/src/app/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -25,7 +25,7 @@ namespace GitUI.CommandsDialogs
         public FormDeleteRemoteBranch(IGitUICommands commands, string defaultRemoteBranch)
             : base(commands, enablePositionRestore: false)
         {
-            _taskManager.FileAndForget(() => _mergedBranches = Module.GetMergedRemoteBranches().ToHashSet());
+            _taskManager.FireAndForget(() => _mergedBranches = Module.GetMergedRemoteBranches().ToHashSet());
 
             _defaultRemoteBranch = defaultRemoteBranch;
 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -587,7 +587,7 @@ Inactive remote is completely invisible to git.");
         private void TestConnectionClick(object sender, EventArgs e)
         {
             string url = Url.Text;
-            ThreadHelper.FileAndForget(() => new Plink().ConnectAsync(url));
+            ThreadHelper.FireAndForget(() => new Plink().ConnectAsync(url));
         }
 
         private void RemoteBranchesDataError(object sender, DataGridViewDataErrorEventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -368,7 +368,7 @@ namespace GitUI.CommandsDialogs
         {
             if (ShowOtherObjects.Checked & !_typeDetected)
             {
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     _typeDetected = true;
                     foreach (LostObject item in _lostObjects.Where(o => o.ObjectType == LostObjectType.Blob))

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -123,7 +123,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void PopulateBranchesComboAndEnableCreateButton(IHostedRemote remote, ComboBox comboBox)
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                     {
                         try
                         {

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -91,7 +91,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             myReposLV.Items.Clear();
             myReposLV.Items.Add(new ListViewItem { Text = _strLoading.Text });
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     try
                     {
@@ -150,7 +150,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             PrepareSearch(sender, e);
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     try
                     {
@@ -180,7 +180,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             PrepareSearch(sender, e);
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     try
                     {

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -129,7 +129,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _selectHostedRepoCB.Enabled = false;
             ResetAllAndShowLoadingPullRequests();
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     try
                     {
@@ -326,7 +326,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void LoadDiscussion()
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     try
                     {
@@ -364,7 +364,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private void LoadDiffPatch()
         {
             Validates.NotNull(_currentPullRequestInfo);
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     try
                     {

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -310,7 +310,7 @@ namespace GitUI.CommandsDialogs
             }
             finally
             {
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     // DiffFiles_SelectedIndexChanged is called asynchronously with throttling. _isImplicitListSelection must not be reset before.
                     await Task.Delay(FileStatusList.SelectedIndexChangeThrottleDuration + TimeSpan.FromSeconds(1), cancellationToken);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void ClearImageCache_Click(object sender, EventArgs e)
         {
-            ThreadHelper.FileAndForget(AvatarService.CacheCleaner.ClearCacheAsync);
+            ThreadHelper.FireAndForget(AvatarService.CacheCleaner.ClearCacheAsync);
         }
 
         private void helpTranslate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -56,7 +56,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void SettingsToPage()
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     Validates.NotNull(_populateBuildServerTypeTask);
 

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                 string selectedBranch = UICommands.Module.GetSelectedBranch();
                 ExistingBranches = Module.GetRefs(RefsFilter.Heads);
                 comboBoxBranches.Text = TranslatedStrings.LoadingData;
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     await _branchesLoader.LoadAsync(
                         () => ExistingBranches.Where(r => r.Name != selectedBranch).ToList(),

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -187,7 +187,7 @@ namespace GitUI.CommitInfo
                 return;
             }
 
-            ThreadHelper.FileAndForget(LoadSortedTagsAsync);
+            ThreadHelper.FireAndForget(LoadSortedTagsAsync);
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -388,7 +388,7 @@ namespace GitUI.CommitInfo
             {
                 GitRevision initialRevision = _revision;
 
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/app/GitUI/CustomDiffMergeToolProvider.cs
+++ b/src/app/GitUI/CustomDiffMergeToolProvider.cs
@@ -45,7 +45,7 @@ namespace GitUI
                 return;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 // get the tools, possibly with a delay as requesting requires considerable time
                 // cache is shared

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -999,7 +999,7 @@ namespace GitUI.Editor
                     return;
                 }
 
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     bool enabled = IsDifftasticEnabled.Value;
 

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1329,7 +1329,7 @@ namespace GitUI
             WrapRepoHostingCall(TranslatedStrings.AddUpstreamRemote, gitHoster,
                                 gh =>
                                 {
-                                    ThreadHelper.FileAndForget(async () =>
+                                    ThreadHelper.FireAndForget(async () =>
                                     {
                                         string remoteName = await gh.AddUpstreamRemoteAsync();
                                         if (!string.IsNullOrEmpty(remoteName))

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -164,7 +164,7 @@ namespace GitUI.HelperDialogs
 
             _validatedBranch = branch;
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 ArgumentString command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.WorkingDir, Module.GetPathForGitExecution, ForceReset.Checked, dryRun: true);
                 ExecutionResult executionResult = await Module.GitExecutable.ExecuteAsync(command, throwOnErrorExit: false, cancellationToken: cancellationToken);

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -303,7 +303,7 @@ namespace GitUI.LeftPanel
                 selectedGuid = selectedRevision.IsArtificial ? "HEAD" : selectedRevision.Guid;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 HashSet<string> mergedBranches = selectedGuid is null

--- a/src/app/GitUI/RepositoryHistoryUIService.cs
+++ b/src/app/GitUI/RepositoryHistoryUIService.cs
@@ -67,7 +67,7 @@ internal class RepositoryHistoryUIService : IRepositoryHistoryUIService
             item.ToolTipText = repo.Path;
         }
 
-        ThreadHelper.FileAndForget(async () =>
+        ThreadHelper.FireAndForget(async () =>
         {
             string branchName = _repositoryCurrentBranchNameProvider.GetCurrentBranchName(repo.Path);
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/app/GitUI/SpellChecker/EditNetSpell.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.cs
@@ -405,7 +405,7 @@ namespace GitUI.SpellChecker
             Validates.NotNull(_autoCompleteListTask);
             Validates.NotNull(_spelling);
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     IEnumerable<AutoCompleteWord> words = await _autoCompleteListTask.GetValueAsync(cancellationToken);
                     await this.SwitchToMainThreadAsync(cancellationToken);

--- a/src/app/GitUI/UserControls/AvatarControl.cs
+++ b/src/app/GitUI/UserControls/AvatarControl.cs
@@ -59,7 +59,7 @@ namespace GitUI
 
         public void ClearCache()
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                     {
                         AvatarService.UpdateAvatarProvider();
                         await _avatarCacheCleaner.ClearCacheAsync();
@@ -98,7 +98,7 @@ namespace GitUI
 
             Email = email;
             AuthorName = name;
-            ThreadHelper.FileAndForget(UpdateAvatarAsync);
+            ThreadHelper.FireAndForget(UpdateAvatarAsync);
         }
 
         private void RefreshImage(Image? image)

--- a/src/app/GitUI/UserControls/BranchSelector.cs
+++ b/src/app/GitUI/UserControls/BranchSelector.cs
@@ -123,7 +123,7 @@ namespace GitUI.UserControls
                     return;
                 }
 
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     string text = Module.GetCommitCountString(currentCheckout, branchName);
                     await this.SwitchToMainThreadAsync();

--- a/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -51,7 +51,7 @@ namespace GitUI.UserControls
             else
             {
                 textBoxCommitHash.Text = SelectedObjectId.ToShortString();
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                     {
                         ObjectId currentCheckout = Module.GetCurrentCheckout();
 

--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -154,7 +154,7 @@ namespace GitUI.UserControls
 
                 _process.Exited += delegate
                 {
-                    ThreadHelper.FileAndForget(async () =>
+                    ThreadHelper.FireAndForget(async () =>
                         {
                             if (_process is null)
                             {

--- a/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
@@ -649,7 +649,7 @@ partial class FileStatusList
         }
 
         CancellationToken token = _interactiveAddResetChunkSequence.Next();
-        ThreadHelper.FileAndForget(async () =>
+        ThreadHelper.FireAndForget(async () =>
         {
             await Module.AddInteractiveAsync(item);
             await this.SwitchToMainThreadAsync(token);
@@ -923,7 +923,7 @@ partial class FileStatusList
         }
 
         CancellationToken token = _interactiveAddResetChunkSequence.Next();
-        ThreadHelper.FileAndForget(async () =>
+        ThreadHelper.FireAndForget(async () =>
         {
             await Module.ResetInteractiveAsync(item);
             await this.SwitchToMainThreadAsync(token);
@@ -1088,7 +1088,7 @@ partial class FileStatusList
             return;
         }
 
-        ThreadHelper.FileAndForget(async () =>
+        ThreadHelper.FireAndForget(async () =>
         {
             ObjectId? blob = Module.GetFileBlobHash(item.Item.Name, item.SecondRevision.ObjectId);
 

--- a/src/app/GitUI/UserControls/FileStatusList.FileIcons.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.FileIcons.cs
@@ -11,7 +11,7 @@ partial class FileStatusList
         Dictionary<string, MissingIcon> missingIconsByExtension = FindMissingIcons(nodes);
         if (missingIconsByExtension.Count > 0 && Module?.WorkingDir is string workingDir)
         {
-            ThreadHelper.FileAndForget(() => LoadFileIconsAsync(missingIconsByExtension, fileName => _iconProvider.Get(workingDir, fileName), _imageListData.ImageList.ImageSize, FileStatusListView, cancellationToken));
+            ThreadHelper.FireAndForget(() => LoadFileIconsAsync(missingIconsByExtension, fileName => _iconProvider.Get(workingDir, fileName), _imageListData.ImageList.ImageSize, FileStatusListView, cancellationToken));
         }
 
         return;

--- a/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
@@ -194,7 +194,7 @@ partial class FileStatusList
         AppSettings.ShowDiffForAllParents = tsmiShowDiffForAllParents.Checked;
         CancellationToken cancellationToken = _reloadSequence.Next();
         FileStatusListLoading();
-        ThreadHelper.FileAndForget(async () =>
+        ThreadHelper.FireAndForget(async () =>
         {
             IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.Calculate(prevList: GitItemStatusesWithDescription, refreshDiff: true, refreshGrep: false, cancellationToken);
 

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1398,7 +1398,7 @@ namespace GitUI
                 {
                     GitItemStatus capturedItem = item;
 
-                    ThreadHelper.FileAndForget(async () =>
+                    ThreadHelper.FireAndForget(async () =>
                     {
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                         await task;
@@ -2026,7 +2026,7 @@ namespace GitUI
             SetDeleteSearchButtonVisibility();
 
             CancellationToken cancellationToken = _reloadSequence.Next();
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 // delay to handle keypresses
                 await Task.Delay(delay, cancellationToken);

--- a/src/app/GitUI/UserControls/FilterToolBar.cs
+++ b/src/app/GitUI/UserControls/FilterToolBar.cs
@@ -289,7 +289,7 @@ namespace GitUI.UserControls
             }
 
             Enabled = true;
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 if (_getRefs is null)
                 {

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -120,7 +120,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                         imageTask.Dispose();
                     }, TaskScheduler.Current)
-                    .FileAndForget();
+                    .FireAndForget();
                 return;
             }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
@@ -30,7 +30,7 @@
                     {
                         // if not running, start it
                         _executing = true;
-                        _taskManager.FileAndForget(WrappedOperationAsync);
+                        _taskManager.FireAndForget(WrappedOperationAsync);
                     }
                     else
                     {
@@ -54,7 +54,7 @@
                     {
                         if (_rerunRequested)
                         {
-                            _taskManager.FileAndForget(WrappedOperationAsync);
+                            _taskManager.FireAndForget(WrappedOperationAsync);
                             _rerunRequested = false;
                         }
                         else

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -989,7 +989,7 @@ namespace GitUI
                 bool showStashes = AppSettings.ShowStashes;
 
                 // Evaluate GitRefs and current commit
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
@@ -1042,7 +1042,7 @@ namespace GitUI
                 }
                 else
                 {
-                    ThreadHelper.FileAndForget(() =>
+                    ThreadHelper.FireAndForget(() =>
                     {
                         try
                         {
@@ -1093,7 +1093,7 @@ namespace GitUI
                 }
 
                 // Get info about all Git commits, update the grid
-                ThreadHelper.FileAndForget(() =>
+                ThreadHelper.FireAndForget(() =>
                 {
                     TaskManager.HandleExceptions(() =>
                     {
@@ -1360,14 +1360,14 @@ namespace GitUI
                 _isRefreshingRevisions = false;
 
                 // Rethrow the exception on the UI thread
-                ThreadHelper.FileAndForget(() => ExceptionDispatchInfo.Throw(exception));
+                ThreadHelper.FireAndForget(() => ExceptionDispatchInfo.Throw(exception));
             }
 
             void OnRevisionReadCompleted()
             {
                 if (!firstRevisionReceived && !FilterIsApplied())
                 {
-                    ThreadHelper.FileAndForget(async () =>
+                    ThreadHelper.FireAndForget(async () =>
                     {
                         // No revisions at all received without any filter
                         await semaphoreUpdateGrid.WaitAsync(cancellationToken);
@@ -1392,7 +1392,7 @@ namespace GitUI
                     return;
                 }
 
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                 {
                     if (!firstRevisionReceived)
                     {

--- a/src/app/GitUI/VisualStudioIntegration.cs
+++ b/src/app/GitUI/VisualStudioIntegration.cs
@@ -15,7 +15,7 @@ namespace GitUI
 
         static VisualStudioIntegration()
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 string vswhere = $@"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}\Microsoft Visual Studio\Installer\vswhere.exe";
                 if (!File.Exists(vswhere))
@@ -40,7 +40,7 @@ namespace GitUI
 
         public static void OpenFile(string filePath, int lineNumber = 0)
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 while (true)
                 {

--- a/src/plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/src/plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -67,7 +67,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 return;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 List<Repository> repositories = await GetRepositoriesAsync();
 
@@ -103,7 +103,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 return;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 List<PullRequest> pullRequests = await GetPullRequestsAsync();
 

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabSettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabSettingsUserControl.cs
@@ -64,7 +64,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
             {
                 if (host is not null)
                 {
-                    ThreadHelper.FileAndForget(async () =>
+                    ThreadHelper.FireAndForget(async () =>
                     {
                         projectId = await UpdateProjectIdAsync(host, apiToken);
                         if (projectId is > 0)
@@ -124,7 +124,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
 
             GetProjectIdStatusText.Visible = false;
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 int? projectId = await UpdateProjectIdAsync(InstanceUrlTextBox.Text, ApiTokenTextBox.Text);
                 if (projectId is > 0)

--- a/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -177,7 +177,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             SetWorkingState(isWorking: true);
             lblStatus.Text = _deletingBranches.Text;
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 try
                 {

--- a/src/plugins/GitHub3/GitHub3Plugin.cs
+++ b/src/plugins/GitHub3/GitHub3Plugin.cs
@@ -177,7 +177,7 @@ namespace GitExtensions.Plugins.GitHub3
                 return;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 IHostedRemote[] hostedRemotes = GetHostedRemotes().ToArray();
                 if (hostedRemotes.Length == 0)

--- a/src/plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/src/plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -76,7 +76,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
                 return false;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     JiraTaskDTO[] message = await GetMessageToCommitAsync(_jira, _query, _stringTemplate);
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -167,7 +167,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
                 string localQuery = _jqlQuerySettings.CustomControl.Text;
                 string localStringTemplate = _stringTemplateSetting.CustomControl.Text;
 
-                ThreadHelper.FileAndForget(async () =>
+                ThreadHelper.FireAndForget(async () =>
                     {
                         JiraTaskDTO[] message = await GetMessageToCommitAsync(localJira, localQuery, localStringTemplate);
                         await _btnPreview.SwitchToMainThreadAsync();
@@ -299,7 +299,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
                 return;
             }
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 JiraTaskDTO[] currentMessages = await GetMessageToCommitAsync(_jira, _query, _stringTemplate);
 

--- a/src/plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/src/plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -92,7 +92,7 @@ namespace GitExtensions.Plugins.GitImpact
 
             IReadOnlyList<JoinableTask> tasks = GetTasks(token);
 
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
             {
                 try
                 {

--- a/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -93,7 +93,7 @@ namespace GitExtensions.Plugins.GitStatistics
 
         private void InitializeCommitCount()
         {
-            ThreadHelper.FileAndForget(async () =>
+            ThreadHelper.FireAndForget(async () =>
                 {
                     (int totalCommits, Dictionary<string, int> commitsPerUser) = _module.GetCommitsByContributor();
 

--- a/tests/app/UnitTests/GitUI.Tests/ThreadHelperTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ThreadHelperTests.cs
@@ -22,25 +22,25 @@ namespace GitUITests
         }
 
         [Test]
-        public async Task FileAndForgetReportsThreadException()
+        public async Task FireAndForgetReportsThreadException()
         {
             using ThreadExceptionHelper helper = new();
             Exception ex = new();
 
-            ThrowExceptionAsync(ex).FileAndForget();
+            ThrowExceptionAsync(ex).FireAndForget();
 
             await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
             ClassicAssert.AreSame(ex, helper.Exception);
         }
 
         [Test]
-        public async Task FileAndForgetIgnoresCancellationExceptions()
+        public async Task FireAndForgetIgnoresCancellationExceptions()
         {
             using ThreadExceptionHelper helper = new();
             Form form = new();
             form.Dispose();
 
-            YieldOntoControlMainThreadAsync(form).FileAndForget();
+            YieldOntoControlMainThreadAsync(form).FireAndForget();
 
             await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
             ClassicAssert.Null(helper.Exception, helper.Message);


### PR DESCRIPTION
Rename to FireAndForget.
 Nothing to do with VsTaskLibraryHelper.FileAndForget Method

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
