### PR TITLE
fix: Remove attribute ThemeAware

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/ThemeAwareAttribute.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ThemeAwareAttribute.cs
@@ -1,7 +1,0 @@
-﻿namespace GitExtUtils.GitUI.Theming
-{
-    [AttributeUsage(AttributeTargets.Class)]
-    public class ThemeAwareAttribute : Attribute
-    {
-    }
-}

--- a/src/app/GitExtUtils/GitUI/Theming/ThemeFix.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ThemeFix.cs
@@ -40,7 +40,7 @@ namespace GitExtUtils.GitUI.Theming
         private static IEnumerable<TControl> DescendantsToFix<TControl>(this Control c)
             where TControl : Control
         {
-            return c.FindDescendantsOfType<TControl>(SkipThemeAware)
+            return c.FindDescendantsOfType<TControl>()
                 .Where(control => TryAddToWeakTable(control, AlreadyFixedControls));
         }
 
@@ -51,9 +51,6 @@ namespace GitExtUtils.GitUI.Theming
                 .Select(_ => _.ContextMenuStrip)
                 .Where(_ => _ is not null);
         }
-
-        private static bool SkipThemeAware(Control c) =>
-            c.GetType().GetCustomAttribute<ThemeAwareAttribute>() is not null;
 
         private static void SetupTextBoxBase(TextBoxBase textBox)
         {

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -8,7 +8,6 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 {
-    [ThemeAware]
     public partial class Dashboard : GitModuleControl
     {
         private readonly TranslationString _cloneFork = new("Clone {0} repository");


### PR DESCRIPTION
## Proposed changes

https://github.com/gitextensions/gitextensions/pull/12454#discussion_r2217962198
No longer needed to theme the Dashboard

Follow up (kindof) to removing old theming in #21111

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
