### PR TITLE
fix: format submodule status

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -914,9 +914,8 @@ namespace GitCommands
                 return "=";
             }
 
-            return
-                (removed > 0 ? ("-" + removed) : "") +
-                (added > 0 ? ("+" + added) : "");
+            // similar to AheadBehindData
+            return $"(+{added}-{removed})";
         }
 
         public void RunGitK()
@@ -3662,6 +3661,14 @@ namespace GitCommands
             }
 
             if (commit == oldCommit)
+            {
+                return SubmoduleStatus.SameTime;
+            }
+
+            // From this on, the status is by default Modified
+
+            // Submodule directory must exist to run commands
+            if (!IsValidGitWorkingDir())
             {
                 return SubmoduleStatus.Unknown;
             }

--- a/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
@@ -61,9 +61,7 @@ public sealed class GitSubmoduleStatus
             return "";
         }
 
-        return " (" +
-            (RemovedCommits == 0 ? "" : "-" + RemovedCommits) +
-            (AddedCommits == 0 ? "" : "+" + AddedCommits) +
-            ")";
+        // similar to GetCommitCountString
+        return $" (+{AddedCommits}-{RemovedCommits})";
     }
 }

--- a/src/app/ResourceManager/LocalizationHelpers.cs
+++ b/src/app/ResourceManager/LocalizationHelpers.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
@@ -7,9 +8,11 @@ using ResourceManager.CommitDataRenders;
 
 namespace ResourceManager
 {
-    public static class LocalizationHelpers
+    public static partial class LocalizationHelpers
     {
         private static readonly ICommitDataHeaderRenderer PlainCommitDataHeaderRenderer = new CommitDataHeaderRenderer(new MonospacedHeaderLabelFormatter(), new DateFormatter(), new MonospacedHeaderRenderStyleProvider(), null);
+        [GeneratedRegex(@"^(\s*\S+)\s+", RegexOptions.Multiline)]
+        private static partial Regex ReplaceTrailingSpacesWithTabRegex();
 
         private static DateTime RoundDateTime(DateTime dateTime)
         {
@@ -80,25 +83,17 @@ namespace ResourceManager
             StringBuilder sb = new();
             sb.AppendLine("Submodule " + name);
             sb.AppendLine();
-            IGitModule module = superproject.GetSubmodule(name);
 
             // Submodule directory must exist to run commands, unknown otherwise
-            if (module.IsValidGitWorkingDir())
+            IGitModule module = superproject.GetSubmodule(name);
+            if (module.IsValidGitWorkingDir()
+                && new CommitDataManager(() => module).GetCommitData(hash) is CommitData data)
             {
-                // TEMP, will be moved in the follow up refactor
-                ICommitDataManager commitDataManager = new CommitDataManager(() => module);
-
-                // Get body without git-notes, to cache the command
-                CommitData? data = commitDataManager.GetCommitData(hash);
-                if (data is null)
-                {
-                    sb.AppendLine("Commit hash:\t" + hash);
-                    return sb.ToString();
-                }
-
+                // Get body without Notes, to cache the command
                 string header = PlainCommitDataHeaderRenderer.RenderPlain(data);
-                string body = "\n" + data.Body.Trim();
+                string body = data.Body.Trim();
                 sb.AppendLine(header);
+                sb.AppendLine();
                 sb.Append(body);
             }
             else
@@ -127,64 +122,51 @@ namespace ResourceManager
 
             IGitModule gitModule = moduleIsParent ? module.GetSubmodule(status.Name) : module;
             StringBuilder sb = new();
-            sb.AppendLine("Submodule " + status.Name + " Change");
+            sb.AppendLine($"Submodule {status.Name}");
 
             // TEMP, will be moved in the follow up refactor
             ICommitDataManager commitDataManager = new CommitDataManager(() => gitModule);
 
             CommitData? oldCommitData = null;
-            if (status.OldCommit != status.Commit)
+            if (status.OldCommit != status.Commit && status.OldCommit is not null)
             {
                 sb.AppendLine();
-                sb.AppendLine("From:\t" + (status.OldCommit?.ToString() ?? "null"));
+                sb.Append("From:\t");
+                sb.AppendLine(status.OldCommit?.ToString() ?? "null");
 
                 // Submodule directory must exist to run commands, unknown otherwise
-                if (gitModule.IsValidGitWorkingDir())
+                if (gitModule.IsValidGitWorkingDir()
+                    && commitDataManager.GetCommitData(status.OldCommit.ToString()) is CommitData c)
                 {
-                    if (status.OldCommit is not null)
-                    {
-                        // Get body without git-notes, to cache the command
-                        oldCommitData = commitDataManager.GetCommitData(status.OldCommit.ToString());
-                    }
+                    oldCommitData = c;
 
-                    if (oldCommitData is not null)
+                    sb.AppendLine("\t\t\t" + GetRelativeDateString(DateTime.UtcNow, oldCommitData.CommitDate.UtcDateTime) + " (" +
+                                  GetFullDateString(oldCommitData.CommitDate) + ")");
+                    foreach (string line in oldCommitData.Body.Replace("\r\n", "\n").Split(Delimiters.LineFeed, StringSplitOptions.None))
                     {
-                        sb.AppendLine("\t\t\t\t\t" + GetRelativeDateString(DateTime.UtcNow, oldCommitData.CommitDate.UtcDateTime) + " (" +
-                                      GetFullDateString(oldCommitData.CommitDate) + ")");
-                        string[] lines = oldCommitData.Body.Trim(Delimiters.LineFeedAndCarriageReturn).Split("\r\n", StringSplitOptions.None);
-                        foreach (string line in lines)
-                        {
-                            sb.AppendLine("\t\t" + line);
-                        }
+                        sb.AppendLine("\t\t" + line);
                     }
-                }
-                else
-                {
-                    sb.AppendLine();
                 }
             }
 
-            sb.AppendLine();
-            string dirty = !status.IsDirty ? "" : " (dirty)";
-            sb.Append(status.OldCommit != status.Commit ? "To:\t" : "Commit:\t");
-            sb.AppendLine((status.Commit?.ToString() ?? "null") + dirty);
             CommitData? commitData = null;
-
-            // Submodule directory must exist to run commands, unknown otherwise
-            if (gitModule.IsValidGitWorkingDir())
+            if (status.Commit is not null)
             {
-                if (status.Commit is not null)
-                {
-                    commitData = commitDataManager.GetCommitData(status.Commit.ToString());
-                }
+                sb.AppendLine();
+                string dirty = !status.IsDirty ? "" : " (dirty)";
 
-                if (commitData is not null)
+                // Note: add spaces to get "To" aligned the same as From
+                sb.Append(status.OldCommit != status.Commit ? "To:  \t" : "Commit:\t");
+                sb.AppendLine((status.Commit?.ToString() ?? "null") + dirty);
+
+                // Submodule directory must exist to run commands, unknown otherwise
+                if (gitModule.IsValidGitWorkingDir()
+                    && commitDataManager.GetCommitData(status.Commit.ToString()) is CommitData c)
                 {
-                    sb.AppendLine("\t\t\t\t\t" + GetRelativeDateString(DateTime.UtcNow, commitData.CommitDate.UtcDateTime) + " (" +
+                    commitData = c;
+                    sb.AppendLine("\t\t\t" + GetRelativeDateString(DateTime.UtcNow, commitData.CommitDate.UtcDateTime) + " (" +
                                   GetFullDateString(commitData.CommitDate) + ")");
-                    char[] delimiter = new[] { '\n', '\r' };
-                    string[] lines = commitData.Body.Trim(delimiter).Split(new[] { "\r\n" }, StringSplitOptions.None);
-                    foreach (string line in lines)
+                    foreach (string line in commitData.Body.Replace("\r\n", "\n").LazySplit(Delimiters.LineFeed))
                     {
                         sb.AppendLine("\t\t" + line);
                     }
@@ -195,10 +177,6 @@ namespace ResourceManager
                     oldCommitData = commitData;
                 }
             }
-            else
-            {
-                sb.AppendLine();
-            }
 
             sb.AppendLine();
             SubmoduleStatus submoduleStatus = gitModule.CheckSubmoduleStatus(status.Commit, status.OldCommit, commitData, oldCommitData, loadData: false);
@@ -206,56 +184,43 @@ namespace ResourceManager
             switch (submoduleStatus)
             {
                 case SubmoduleStatus.NewSubmodule:
-                    sb.AppendLine("New submodule");
+                    sb.Append("New submodule");
                     break;
                 case SubmoduleStatus.RemovedSubmodule:
                     sb.AppendLine("Removed submodule");
                     break;
                 case SubmoduleStatus.FastForward:
-                    sb.AppendLine("Fast Forward");
+                    sb.Append("Fast Forward");
                     break;
                 case SubmoduleStatus.Rewind:
-                    sb.AppendLine("Rewind");
+                    sb.Append("Rewind");
                     break;
                 case SubmoduleStatus.NewerTime:
-                    sb.AppendLine("Newer commit time");
+                    sb.Append("Newer commit time");
                     break;
                 case SubmoduleStatus.OlderTime:
-                    sb.AppendLine("Older commit time");
+                    sb.Append("Older commit time");
                     break;
                 case SubmoduleStatus.SameTime:
-                    sb.AppendLine("Same commit time");
+                    sb.Append("Same commit time");
                     break;
+                case SubmoduleStatus.Unknown:
                 default:
-                    sb.AppendLine(status.IsDirty ? "Dirty" : "Unknown");
+                    sb.Append("Unknown");
 
                     break;
             }
 
-            if (status.AddedCommits is not null && status.RemovedCommits is not null &&
-                (status.AddedCommits != 0 || status.RemovedCommits != 0))
+            sb.AppendLine(status.IsDirty ? " Dirty" : "");
+
+            if (AddedAndRemovedStringLong(status) is string addedRemoved
+                && !string.IsNullOrWhiteSpace(addedRemoved))
             {
-                sb.Append("\nCommits: ");
-
-                if (status.RemovedCommits > 0)
-                {
-                    sb.Append(status.RemovedCommits + " removed");
-
-                    if (status.AddedCommits > 0)
-                    {
-                        sb.Append(", ");
-                    }
-                }
-
-                if (status.AddedCommits > 0)
-                {
-                    sb.Append(status.AddedCommits + " added");
-                }
-
                 sb.AppendLine();
+                sb.AppendLine($"Commits: {addedRemoved}");
             }
 
-            if (status.Commit is not null && status.OldCommit is not null)
+            if (status.Commit is not null && status.OldCommit is not null && gitModule.IsValidGitWorkingDir())
             {
                 const int maxLimitedLines = 5;
                 if (status.IsDirty)
@@ -263,10 +228,11 @@ namespace ResourceManager
                     string statusText = gitModule.GetStatusText(untracked: false);
                     if (!string.IsNullOrEmpty(statusText))
                     {
-                        sb.AppendLine("\nStatus:");
+                        sb.AppendLine();
+                        sb.AppendLine("Status:");
                         if (limitOutput)
                         {
-                            string[] txt = statusText.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
+                            string[] txt = statusText.Replace("\r\n", "\n").Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
                             if (txt.Length > maxLimitedLines)
                             {
                                 statusText = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +
@@ -274,36 +240,49 @@ namespace ResourceManager
                             }
                         }
 
-                        sb.Append(statusText);
+                        // format similar to Differences:
+                        sb.Append(ReplaceTrailingSpacesWithTab(statusText));
                     }
                 }
 
-                if (gitModule.IsValidGitWorkingDir())
+                ExecutionResult exec = gitModule.GetDiffFiles(status.OldCommit.ToString(), status.Commit.ToString(), noCache: false, rawParsable: false, cancellationToken: default);
+                if (exec.ExitedSuccessfully)
                 {
-                    ExecutionResult exec = gitModule.GetDiffFiles(status.OldCommit.ToString(), status.Commit.ToString(), noCache: false, rawParsable: false, cancellationToken: default);
-                    if (exec.ExitedSuccessfully)
+                    string diffs = exec.StandardOutput;
+                    if (!string.IsNullOrEmpty(diffs))
                     {
-                        string diffs = exec.StandardOutput;
-                        if (!string.IsNullOrEmpty(diffs))
+                        sb.AppendLine();
+                        sb.AppendLine("Differences:");
+                        if (limitOutput)
                         {
-                            sb.AppendLine("\nDifferences:");
-                            if (limitOutput)
+                            string[] txt = diffs.Replace("\r\n", "\n").Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
+                            if (txt.Length > maxLimitedLines)
                             {
-                                string[] txt = diffs.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
-                                if (txt.Length > maxLimitedLines)
-                                {
-                                    diffs = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +
-                                        $"{Environment.NewLine} {txt.Length - maxLimitedLines} more differences";
-                                }
+                                diffs = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +
+                                    $"{Environment.NewLine} {txt.Length - maxLimitedLines} more differences";
                             }
-
-                            sb.Append(diffs);
                         }
+
+                        sb.Append(diffs);
                     }
                 }
             }
 
             return sb.ToString();
+
+            static string AddedAndRemovedStringLong(GitSubmoduleStatus status)
+            {
+                if (status.RemovedCommits is null || status.AddedCommits is null ||
+                    (status.RemovedCommits == 0 && status.AddedCommits == 0))
+                {
+                    return "";
+                }
+
+                return $"{status.AddedCommits} added, {status.RemovedCommits} removed";
+            }
+
+            static string ReplaceTrailingSpacesWithTab(string input)
+                => ReplaceTrailingSpacesWithTabRegex().Replace(input, "$1\t");
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

align added/removed output with ahead/behind,
also for e.g. CreateBranch

fix some output formatting for submodules

Show "dirty" file icon if a submodule is changed but no specific icon exists.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

added
<img width="561" height="125" alt="image" src="https://github.com/user-attachments/assets/f782dccb-ab91-4063-809c-1ef4766c1e58" />
<img width="571" height="97" alt="image" src="https://github.com/user-attachments/assets/f31c4b77-adf5-4cfd-846e-de61fe6c1231" />


removed
<img width="566" height="104" alt="image" src="https://github.com/user-attachments/assets/075c61bf-e98f-402f-aed5-471c0a2d85f7" />
<img width="560" height="105" alt="image" src="https://github.com/user-attachments/assets/ada2808b-efd1-426c-812b-e75c56957a88" />


submodule diff
<img width="596" height="409" alt="image" src="https://github.com/user-attachments/assets/bf0d9b14-5909-4aa7-9e50-90f219b5576a" />
<img width="754" height="451" alt="image" src="https://github.com/user-attachments/assets/f94fcf96-0701-4e7b-b4cd-ca1f2feaae6e" />


submodule current
<img width="709" height="252" alt="image" src="https://github.com/user-attachments/assets/d1467320-bbda-4c8f-b5ee-4e94cf557810" />
<img width="734" height="242" alt="image" src="https://github.com/user-attachments/assets/a7c0ce8f-60fb-4381-879c-06e6b903418a" />

## Test methodology <!-- How did you ensure quality? -->

Visual, UI presentation

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
