### PR TITLE
fix: GetCommitData is includeNotes, not cache

### DIFF
--- a/src/app/GitCommands/CommitDataManager.cs
+++ b/src/app/GitCommands/CommitDataManager.cs
@@ -25,8 +25,9 @@ namespace GitCommands
         /// Gets <see cref="CommitData"/> for the specified <paramref name="commitId"/>.
         /// </summary>
         /// <param name="commitId">The sha or Git reference.</param>
-        /// <param name="cache">Allow caching of the Git command, should only be used if commitId is a sha and Notes are not used.</param>
-        CommitData? GetCommitData(string commitId, bool cache = false);
+        /// <param name="includeNotes">Include Notes with the commit info. This also means that the Git command is not cached.
+        /// Note that Notes are only needed if the full Body with Notes is to be used, regardless of Settings.</param>
+        CommitData? GetCommitData(string commitId, bool includeNotes = false);
 
         /// <summary>
         /// Updates the <see cref="CommitData.Body"/> (commit message) property of <paramref name="commitData"/>.

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -3673,7 +3673,7 @@ namespace GitCommands
 
             if (loadData)
             {
-                oldData = _commitDataManager.GetCommitData(oldCommit.ToString(), cache: true);
+                oldData = _commitDataManager.GetCommitData(oldCommit.ToString());
             }
 
             if (oldData is null)
@@ -3683,7 +3683,7 @@ namespace GitCommands
 
             if (loadData)
             {
-                data = _commitDataManager.GetCommitData(commit.ToString(), cache: true);
+                data = _commitDataManager.GetCommitData(commit.ToString());
             }
 
             if (data is null)

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -699,8 +699,8 @@ namespace GitUI.Editor
                 file.Name,
                 file.IsSubmodule,
                 getImage: () => ThreadHelper.JoinableTaskFactory.Run(GetImageAsync),
-                getFileText: GetFileTextIfBlobExists,
-                getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha, cache: true),
+                getFileText: GetFileText,
+                getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha),
                 item: item,
                 line: line,
                 openWithDifftool: openWithDifftool);

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -699,8 +699,8 @@ namespace GitUI.Editor
                 file.Name,
                 file.IsSubmodule,
                 getImage: () => ThreadHelper.JoinableTaskFactory.Run(GetImageAsync),
-                getFileText: GetFileText,
-                getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha, cache: objectId?.IsArtificial is false),
+                getFileText: GetFileTextIfBlobExists,
+                getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha, cache: true),
                 item: item,
                 line: line,
                 openWithDifftool: openWithDifftool);
@@ -777,7 +777,7 @@ namespace GitUI.Editor
                     isSubmodule,
                     getImage: GetImage,
                     getFileText: GetFileText,
-                    getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), "", cache: false),
+                    getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), ""),
                     item: item,
                     line: line,
                     openWithDifftool));

--- a/src/app/ResourceManager/LocalizationHelpers.cs
+++ b/src/app/ResourceManager/LocalizationHelpers.cs
@@ -75,7 +75,7 @@ namespace ResourceManager
             return datetime.LocalDateTime.ToString("G");
         }
 
-        public static string GetSubmoduleText(IGitModule superproject, string name, string hash, bool cache)
+        public static string GetSubmoduleText(IGitModule superproject, string name, string hash)
         {
             StringBuilder sb = new();
             sb.AppendLine("Submodule " + name);
@@ -88,7 +88,8 @@ namespace ResourceManager
                 // TEMP, will be moved in the follow up refactor
                 ICommitDataManager commitDataManager = new CommitDataManager(() => module);
 
-                CommitData? data = commitDataManager.GetCommitData(hash, cache);
+                // Get body without Notes, to cache the command
+                CommitData? data = commitDataManager.GetCommitData(hash);
                 if (data is null)
                 {
                     sb.AppendLine("Commit hash:\t" + hash);
@@ -142,7 +143,8 @@ namespace ResourceManager
                 {
                     if (status.OldCommit is not null)
                     {
-                        oldCommitData = commitDataManager.GetCommitData(status.OldCommit.ToString(), cache: true);
+                        // Get body without Notes, to cache the command
+                        oldCommitData = commitDataManager.GetCommitData(status.OldCommit.ToString());
                     }
 
                     if (oldCommitData is not null)
@@ -173,7 +175,7 @@ namespace ResourceManager
             {
                 if (status.Commit is not null)
                 {
-                    commitData = commitDataManager.GetCommitData(status.Commit.ToString(), cache: true);
+                    commitData = commitDataManager.GetCommitData(status.Commit.ToString());
                 }
 
                 if (commitData is not null)

--- a/src/app/ResourceManager/LocalizationHelpers.cs
+++ b/src/app/ResourceManager/LocalizationHelpers.cs
@@ -88,7 +88,7 @@ namespace ResourceManager
                 // TEMP, will be moved in the follow up refactor
                 ICommitDataManager commitDataManager = new CommitDataManager(() => module);
 
-                // Get body without Notes, to cache the command
+                // Get body without git-notes, to cache the command
                 CommitData? data = commitDataManager.GetCommitData(hash);
                 if (data is null)
                 {
@@ -143,7 +143,7 @@ namespace ResourceManager
                 {
                     if (status.OldCommit is not null)
                     {
-                        // Get body without Notes, to cache the command
+                        // Get body without git-notes, to cache the command
                         oldCommitData = commitDataManager.GetCommitData(status.OldCommit.ToString());
                     }
 

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -90,19 +90,28 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void GetRevision_should_return_null_if_revision_does_not_exist()
+        public void GetRevision_should_return_null_if_objectid_does_not_exist()
         {
             RevisionReader reader = RevisionReader.TestAccessor.RevisionReader(new GitModule(""), _logOutputEncoding, _sixMonths);
-            GitRevision? revision = reader.GetRevision(GitRevision.WorkTreeGuid, hasNotes: false, throwOnError: false, cancellationToken: default);
+            GitRevision? revision = reader.GetRevision(ObjectId.Random().ToString(), hasNotes: false, throwOnError: false, cancellationToken: default);
 
             revision.Should().BeNull();
         }
 
         [Test]
-        public void GetRevision_should_throw_if_revision_does_not_exist()
+        public void GetRevision_should_return_null_if_revision_does_not_exist()
         {
             RevisionReader reader = RevisionReader.TestAccessor.RevisionReader(new GitModule(""), _logOutputEncoding, _sixMonths);
-            ClassicAssert.Throws<ExternalOperationException>(() =>
+            GitRevision? revision = reader.GetRevision("non/existing/ref", hasNotes: false, throwOnError: false, cancellationToken: default);
+
+            revision.Should().BeNull();
+        }
+
+        [Test]
+        public void GetRevision_should_throw_if_revision_is_artificial()
+        {
+            RevisionReader reader = RevisionReader.TestAccessor.RevisionReader(new GitModule(""), _logOutputEncoding, _sixMonths);
+            ClassicAssert.Throws<InvalidOperationException>(() =>
                 reader.GetRevision(GitRevision.WorkTreeGuid, hasNotes: false, throwOnError: true, cancellationToken: default));
         }
 


### PR DESCRIPTION
## Proposed changes

The  ICommitDataManager interface was incorrectly documenting the 'includeNotes' parameter as 'cache'.
Commands for submodules summary was therefore not cached.

Check that the git-log is cached only if it is a full parsable sha
(branches etc should not be cached).
Fail artificial commits explicitly (should not be an issue)

Note: There are currently no usage of Notes with this code path in CommitDataManager.
I choose to document the usage (and where Notes are ignored) instead of removing.

This is related to a caching change in #11245, that was not fully effective.

## Test methodology <!-- How did you ensure quality? -->

There are some tests related to commitmanager.
Check in GitLog that the commands for 
Manual review of usage.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
