### PR TITLE
fix: compare branch check revgrid

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2997,7 +2997,12 @@ namespace GitUI
             {
                 Validates.NotNull(form.BranchName);
                 ObjectId baseCommit = Module.RevParse(form.BranchName);
-                Validates.NotNull(baseCommit);
+                if (baseCommit is null)
+                {
+                    MessageBox.Show(this, _noRevisionFoundError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+
                 ShowFormDiff(baseCommit, headCommit.ObjectId, form.BranchName, headCommit.Subject);
             }
         }

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2996,10 +2996,10 @@ namespace GitUI
             if (form.ShowDialog(ParentForm) == DialogResult.OK)
             {
                 Validates.NotNull(form.BranchName);
-                ObjectId baseCommit = Module.RevParse(form.BranchName);
+                ObjectId? baseCommit = Module.RevParse(form.BranchName);
                 if (baseCommit is null)
                 {
-                    MessageBox.Show(this, _noRevisionFoundError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.ShowError(this, _noRevisionFoundError.Text);
                     return;
                 }
 


### PR DESCRIPTION
Fixes #12484 

## Proposed changes

In revgrid->compare-Compare branches...
Show popupif no baseid found, if non existing branch written or the branches have no common ancestor.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
