### PR TITLE
fix: read worktree files from the filesystem

### DIFF
--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -701,7 +701,11 @@ namespace GitUI.Editor
             Action? openWithDifftool,
             CancellationToken cancellationToken = default)
         {
-            if (file.TreeGuid is null)
+            // for worktree the TreeGuid is only valid if the file is not dirty, always get from file system
+            bool useTreeId = objectId != ObjectId.WorkTreeId;
+
+            // for index the treeid is not immutable and must be evaluated
+            if (useTreeId && (file.TreeGuid is null || objectId == ObjectId.IndexId))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 IObjectGitItem[] items = Module.GetTree(objectId, full: true, file.Name, cancellationToken).ToArray();
@@ -715,7 +719,7 @@ namespace GitUI.Editor
                 }
             }
 
-            if (file.TreeGuid is null)
+            if (!useTreeId || file.TreeGuid is null)
             {
                 string? fullPath = _fullPathResolver.Resolve(file.Name);
                 if (string.IsNullOrEmpty(fullPath))


### PR DESCRIPTION
fixes #12493 

## Proposed changes

for worktree the TreeGuid is only valid if the file is not dirty. The treeId is now included for worktree files but must not be used when viewing files, must always get from the file system.

Similar, for index files the treeid is not immutable and must be reevaluated.

Regression from 1bb9dad31922f7557acddabaed5de1faac24d7df

There may be an issue with using the treeid when patching lines, have not investigated.
Also, status in commit is not updated when staging/unstaging.

## Test methodology <!-- How did you ensure quality? -->

really just code review so far - just want to get this out

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
