### PR TITLE
Feature/branch name in reftable repos

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2886,7 +2886,8 @@ public sealed partial class GitModule : IGitModule
         _gitExecutable.RunCommand(args);
     }
 
-    /// <summary>Dirty but fast. This sometimes fails.</summary>
+    /// <summary>Attempt to read the branch name from the HEAD file instead of calling a git command.</summary>
+    /// <remarks>Dirty but fast. This sometimes fails. In reftable repos, it always returns ".invalid".</remarks>
     public static string GetSelectedBranchFast(string? repositoryPath, bool emptyIfDetached = false)
     {
         if (string.IsNullOrEmpty(repositoryPath))
@@ -2935,7 +2936,7 @@ public sealed partial class GitModule : IGitModule
     {
         string head = GetSelectedBranchFast(WorkingDir, emptyIfDetached);
 
-        if (!string.IsNullOrEmpty(head))
+        if (!string.IsNullOrEmpty(head) && head != ".invalid")
         {
             return head;
         }
@@ -2948,7 +2949,7 @@ public sealed partial class GitModule : IGitModule
         ExecutionResult result = _gitExecutable.Execute(args, throwOnErrorExit: false);
 
         return result.ExitedSuccessfully
-            ? result.StandardOutput
+            ? result.StandardOutput[GitRefName.RefsHeadsPrefix.Length..].TrimEnd()
             : emptyIfDetached ? string.Empty : DetachedHeadParser.DetachedBranch;
     }
 

--- a/tests/CommonTestUtils/MockExecutable.cs
+++ b/tests/CommonTestUtils/MockExecutable.cs
@@ -160,7 +160,7 @@ public sealed class MockExecutable : IExecutable
 
         public Task<int> WaitForExitAsync(CancellationToken token)
         {
-            return Task.FromResult(0);
+            return Task.FromResult(_exitCode ?? 0);
         }
 
         public void WaitForInputIdle()

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -585,6 +585,28 @@ public sealed partial class GitModuleTests
         ClassicAssert.AreEqual(expectedResult, result);
     }
 
+    [TestCase("refs/heads/feature/my-test-branch", "feature/my-test-branch")]
+    public void GetSelectedBranch_should_return_simple_branch_name(string gitCommandResult, string expectedResult)
+    {
+        _executable.StageOutput("symbolic-ref --quiet HEAD", gitCommandResult);
+
+        string result = _gitModule.GetSelectedBranch();
+
+        ClassicAssert.AreEqual(expectedResult, result);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void GetSelectedBranch_should_return_requested_result_in_detached_state(bool emptyIfDetached)
+    {
+        _executable.StageOutput("symbolic-ref --quiet HEAD", "", exitCode: 1);
+
+        string expectedResult = emptyIfDetached ? "" : DetachedHeadParser.DetachedBranch;
+        string result = _gitModule.GetSelectedBranch(emptyIfDetached);
+
+        ClassicAssert.AreEqual(expectedResult, result);
+    }
+
     private static IEnumerable<TestCaseData> BatchUnstageFilesTestCases
     {
         get


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12491

## Proposed changes

In git reftable repos , the HEAD file names the current branch ".invalid", since that information is stored in the binary reftable format instead. This causes GitExtenstions `GetSelectedBranchFast` to return the branch name ".invalid".

- When the branch name is ".invalid", treat it as if the function failed to retrieve the current branch name
- When the "fast" function fails to retrieve the current branch name, use the traditional method instead

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="655" height="278" alt="image" src="https://github.com/user-attachments/assets/02b79a76-1e07-4407-a2b9-dffdda0f9771" />

### After

<img width="651" height="253" alt="image" src="https://github.com/user-attachments/assets/85846db5-b4ae-4b6d-9f62-957c918febb1" />


## Test methodology <!-- How did you ensure quality? -->

- Manual tests with the instructions provided in the issue
- Used a build of GitExtensions that contains these changes productively for a week

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.51
- Windows 11 24H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
