### PR TITLE
fix: show recent destination directories on clone

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -219,3 +219,4 @@ YYYY/MM/DD, github id, Full name, email
 2025/06/03, margaretselzer, Marcell Egyed, spam.myself@yahoo.com
 2025/07/09, KianFitz, Kian Fitzpatrick, kian.fitzpatrick2000(at)gmail.com
 2025/07/30, M-L-Ml, Mihas Malinouski, m.l.malinouski+gitextensions(at)gmail.comgmail.com
+2025/08/22, nikolaosginos, Nikolaos Ginos, nikolaos.gkinos(at)googlemail.com

--- a/src/app/GitCommands/UserRepositoryHistory/Repository.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/Repository.cs
@@ -38,6 +38,22 @@ namespace GitCommands.UserRepositoryHistory
             set => _path = value;
         }
 
+        public string GetParentPath()
+        {
+            if (Path.StartsWith(@"\\") || !Directory.Exists(Path))
+            {
+                return string.Empty;
+            }
+
+            DirectoryInfo dir = new(Path);
+            if (dir.Parent is null)
+            {
+                return Path;
+            }
+
+            return dir.Parent.FullName;
+        }
+
         public override string ToString()
         {
             return Path + " (" + Anchor + ")";

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -55,6 +55,12 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_From.DataSource = repositoryHistory;
             _NO_TRANSLATE_From.DisplayMember = nameof(Repository.Path);
 
+            IList<Repository> localsHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
+            string[] historicPaths = localsHistory.Select(x => x.GetParentPath())
+                                                      .Where(x => !string.IsNullOrEmpty(x))
+                                                      .Distinct(StringComparer.CurrentCultureIgnoreCase)
+                                                      .ToArray();
+            _NO_TRANSLATE_To.DataSource = historicPaths;
             _NO_TRANSLATE_To.Text = AppSettings.DefaultCloneDestinationPath;
 
             if (PathUtil.CanBeGitURL(_url))

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -57,9 +57,9 @@ namespace GitUI.CommandsDialogs
 
             IList<Repository> localsHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
             string[] historicPaths = localsHistory.Select(x => x.GetParentPath())
-                                                      .Where(x => !string.IsNullOrEmpty(x))
-                                                      .Distinct(StringComparer.CurrentCultureIgnoreCase)
-                                                      .ToArray();
+                                                  .Where(x => !string.IsNullOrEmpty(x))
+                                                  .Distinct(StringComparer.CurrentCultureIgnoreCase)
+                                                  .ToArray();
             _NO_TRANSLATE_To.DataSource = historicPaths;
             _NO_TRANSLATE_To.Text = AppSettings.DefaultCloneDestinationPath;
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -30,7 +30,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
 
             IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
-            string[] historicPaths = repositoryHistory.Select(GetParentPath())
+            string[] historicPaths = repositoryHistory.Select(x => x.GetParentPath())
                                                       .Where(x => !string.IsNullOrEmpty(x))
                                                       .Distinct(StringComparer.CurrentCultureIgnoreCase)
                                                       .ToArray();
@@ -127,25 +127,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.TelemetryEnabled = chkTelemetry.Checked;
 
             base.PageToSettings();
-        }
-
-        private static Func<Repository, string> GetParentPath()
-        {
-            return x =>
-            {
-                if (x.Path.StartsWith(@"\\") || !Directory.Exists(x.Path))
-                {
-                    return string.Empty;
-                }
-
-                DirectoryInfo dir = new(x.Path);
-                if (dir.Parent is null)
-                {
-                    return x.Path;
-                }
-
-                return dir.Parent.FullName;
-            };
         }
 
         private static CheckState ToCheckboxState(bool? booleanValue)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11760

## Proposed changes

- When showing the clone window, fill the destination path combo box with the parent directories of the recent repository destination's
- Use the same logic as on the general settings page's default location combo box

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="642" height="396" alt="image" src="https://github.com/user-attachments/assets/ca7290b5-88df-411a-aa55-947a7b6c22b8" />

### After

<img width="642" height="400" alt="image" src="https://github.com/user-attachments/assets/c74607ad-bfa0-4bc5-87fb-5cb620c7f773" />

## Test methodology <!-- How did you ensure quality? -->

- Manual testing only

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.51
- Windows 11 24H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
