### PR TITLE
feat(filter): format native path to repo relative path

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1995,6 +1995,14 @@ namespace GitUI
 
             string filterText = _NO_TRANSLATE_FilterComboBox.Text;
 
+            if (filterText.StartsWith(Module.WorkingDir))
+            {
+                filterText = PathUtil.ToPosixPath(filterText.SubstringAfter(Module.WorkingDir));
+
+                _NO_TRANSLATE_FilterComboBox.Text = filterText;
+                _NO_TRANSLATE_FilterComboBox.SelectionStart = filterText.Length;
+            }
+
             // workaround for text getting selected if it matches the start of the combobox items
             if (_NO_TRANSLATE_FilterComboBox.SelectionLength == filterText.Length && _NO_TRANSLATE_FilterComboBox.SelectionStart == 0)
             {


### PR DESCRIPTION
to make it easier to filter using a path obtained from outside the application.
Working in diff **and* filetree filters.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![filter_not_working](https://github.com/user-attachments/assets/2272601b-327d-44b1-a602-8cd5234e53cf)


### After

![filter_working](https://github.com/user-attachments/assets/156493d7-287a-47f1-afb0-c3e43c957fa7)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build c551702f7aec7b9adde1332af71549d16397642d (Dirty)
- Git 2.47.1.windows.2
- Microsoft Windows NT 10.0.26100.0
- .NET 9.0.8
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
