### PR TITLE
fix: submodule tooltip on default thread

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NString" Version="2.1.1" />
     <PackageVersion Include="RestSharp" Version="106.12.0" />
-    <PackageVersion Include="SmartFormat" Version="3.0.0" />
+    <PackageVersion Include="SmartFormat" Version="3.6.0" />
     <PackageVersion Include="StrongOf" Version="1.2.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="6.0.0" />    <!-- Required by GitExtensions.PluginManager -->

--- a/setup/installer/Product.wxs
+++ b/setup/installer/Product.wxs
@@ -188,9 +188,6 @@
       <Component Id="SmartFormat.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\SmartFormat.dll" />
       </Component>
-      <Component Id="SmartFormat.ZString.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\SmartFormat.ZString.dll" />
-      </Component>
       <Component Id="SpellChecker.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\SpellChecker.dll" />
       </Component>
@@ -235,6 +232,9 @@
       </Component>
       <Component Id="System.Reactive.Linq.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\System.Reactive.Linq.dll" />
+      </Component>
+      <Component Id="ZString.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\ZString.dll" />
       </Component>
       <!-- Shell extensions -->
       <?define ShellExCLSID = "{3C16B20A-BA16-4156-916F-0A375ECFFE24}"?>
@@ -678,7 +678,6 @@
       <ComponentRef Id="ResourceManager.dll" />
       <ComponentRef Id="RestSharp.dll" />
       <ComponentRef Id="SmartFormat.dll" />
-      <ComponentRef Id="SmartFormat.ZString.dll" />
       <ComponentRef Id="SpellChecker.dll" />
       <ComponentRef Id="StrongOf.dll" />
       <ComponentRef Id="System.ComponentModel.Composition.dll" />
@@ -694,6 +693,7 @@
       <ComponentRef Id="System.Reactive.dll" />
       <ComponentRef Id="System.Reactive.Interfaces.dll" />
       <ComponentRef Id="System.Reactive.Linq.dll" />
+      <ComponentRef Id="ZString.dll" />
       <!-- end application build artifacts -->
       <ComponentRef Id="gitextensions.ico" />
       <ComponentRef Id="gitex.cmd" />

--- a/src/app/GitUI/LeftPanel/SubmoduleNode.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleNode.cs
@@ -5,6 +5,7 @@ using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 
 namespace GitUI.LeftPanel
@@ -164,6 +165,7 @@ namespace GitUI.LeftPanel
             if (Info.Detailed?.RawStatus is not null)
             {
                 // Prefer submodule status, shows ahead/behind
+                await TaskScheduler.Default;
                 toolTip = LocalizationHelpers.ProcessSubmoduleStatus(
                     new GitModule(Info.Path),
                     Info.Detailed.RawStatus,
@@ -172,6 +174,7 @@ namespace GitUI.LeftPanel
             }
             else if (GitStatus is not null)
             {
+                await TaskScheduler.Default;
                 ArtificialCommitChangeCount changeCount = new();
                 changeCount.Update(GitStatus);
                 toolTip = changeCount.GetSummary();


### PR DESCRIPTION
## Proposed changes

Submodule tooltips in the left panel should not
be evaluated on the UI thread, that could give blocking in the GUI. Also, the update was slower.
This was only visible with many changed submodules, the UI is locked up occasionally.

Update SmartFormat dependency, the current version is not threadsafe.
I have only seen this when changing the submodule tooltip, could be occurring in other situations.
https://github.com/axuno/SmartFormat/releases

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
