### PR TITLE
fix: create worktrees with relative paths

### DIFF
--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -3,176 +3,202 @@ using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 
-namespace GitUI.CommandsDialogs.WorktreeDialog
+namespace GitUI.CommandsDialogs.WorktreeDialog;
+
+public sealed partial class FormCreateWorktree : GitModuleForm
 {
-    public sealed partial class FormCreateWorktree : GitModuleForm
+    private readonly AsyncLoader _branchesLoader = new();
+    private readonly char[] _invalidCharsInPath = Path.GetInvalidFileNameChars();
+
+    private readonly string? _initialDirectoryPath;
+
+    public string WorktreeDirectory => newWorktreeDirectory.Text;
+    public bool OpenWorktree => openWorktreeCheckBox.Checked;
+
+    public IReadOnlyList<IGitRef>? ExistingBranches { get; set; }
+
+    public FormCreateWorktree(IGitUICommands commands, string? path)
+        : base(commands)
     {
-        private readonly AsyncLoader _branchesLoader = new();
-        private readonly char[] _invalidCharsInPath = Path.GetInvalidFileNameChars();
+        InitializeComponent();
+        InitializeComplete();
+        _initialDirectoryPath = path;
+    }
 
-        private readonly string? _initialDirectoryPath;
+    private void FormCreateWorktree_Load(object sender, EventArgs e)
+    {
+        LoadBranchesAsync();
 
-        public string WorktreeDirectory => newWorktreeDirectory.Text;
-        public bool OpenWorktree => openWorktreeCheckBox.Checked;
+        UpdateWorktreePathAndValidateWorktreeOptions();
 
-        public IReadOnlyList<IGitRef>? ExistingBranches { get; set; }
-
-        public FormCreateWorktree(IGitUICommands commands, string? path)
-            : base(commands)
+        Task LoadBranchesAsync()
         {
-            InitializeComponent();
-            InitializeComplete();
-            _initialDirectoryPath = path;
-        }
-
-        private void FormCreateWorktree_Load(object sender, EventArgs e)
-        {
-            LoadBranchesAsync();
-
-            UpdateWorktreePathAndValidateWorktreeOptions();
-
-            Task LoadBranchesAsync()
+            string selectedBranch = UICommands.Module.GetSelectedBranch();
+            ExistingBranches = Module.GetRefs(RefsFilter.Heads);
+            comboBoxBranches.Text = TranslatedStrings.LoadingData;
+            ThreadHelper.FileAndForget(async () =>
             {
-                string selectedBranch = UICommands.Module.GetSelectedBranch();
-                ExistingBranches = Module.GetRefs(RefsFilter.Heads);
-                comboBoxBranches.Text = TranslatedStrings.LoadingData;
-                ThreadHelper.FileAndForget(async () =>
+                await _branchesLoader.LoadAsync(
+                    () => ExistingBranches.Where(r => r.Name != selectedBranch).ToList(),
+                    list =>
+                    {
+                        comboBoxBranches.Text = string.Empty;
+                        comboBoxBranches.DataSource = list;
+                        comboBoxBranches.DisplayMember = nameof(IGitRef.LocalName);
+                    });
+
+                await this.SwitchToMainThreadAsync();
+                if (comboBoxBranches.Items.Count == 0)
                 {
-                    await _branchesLoader.LoadAsync(
-                        () => ExistingBranches.Where(r => r.Name != selectedBranch).ToList(),
-                        list =>
-                        {
-                            comboBoxBranches.Text = string.Empty;
-                            comboBoxBranches.DataSource = list;
-                            comboBoxBranches.DisplayMember = nameof(IGitRef.LocalName);
-                        });
+                    radioButtonCreateNewBranch.Checked = true;
+                    radioButtonCheckoutExistingBranch.Enabled = false;
+                }
+                else
+                {
+                    radioButtonCheckoutExistingBranch.Checked = true;
+                }
 
-                    await this.SwitchToMainThreadAsync();
-                    if (comboBoxBranches.Items.Count == 0)
-                    {
-                        radioButtonCreateNewBranch.Checked = true;
-                        radioButtonCheckoutExistingBranch.Enabled = false;
-                    }
-                    else
-                    {
-                        radioButtonCheckoutExistingBranch.Checked = true;
-                    }
+                ValidateWorktreeOptions();
+            });
 
-                    ValidateWorktreeOptions();
-                });
-
-                return Task.CompletedTask;
-            }
+            return Task.CompletedTask;
         }
+    }
 
-        protected override void Dispose(bool disposing)
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
         {
-            if (disposing)
-            {
-                _branchesLoader.Dispose();
+            _branchesLoader.Dispose();
 
-                components?.Dispose();
-            }
-
-            base.Dispose(disposing);
+            components?.Dispose();
         }
 
-        private void comboBoxBranches_KeyUp(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Enter)
-            {
-                CreateWorktree();
-            }
-        }
+        base.Dispose(disposing);
+    }
 
-        private void createWorktreeButton_Click(object sender, EventArgs e)
+    private void comboBoxBranches_KeyUp(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Enter)
         {
             CreateWorktree();
         }
+    }
 
-        private void CreateWorktree()
+    private void createWorktreeButton_Click(object sender, EventArgs e)
+    {
+        CreateWorktree();
+    }
+
+    private void CreateWorktree()
+    {
+        string relativePath = Path.GetRelativePath(
+            Module.WorkingDir, WorktreeDirectory).ToPosixPath().Quote();
+        string newBranchOption =
+            radioButtonCreateNewBranch.Checked ?
+            $"-b {textBoxNewBranchName.Text}" :
+            comboBoxBranches.SelectedItem is not null ? ((GitRef)comboBoxBranches.SelectedItem).Name : null;
+
+        DialogResult = UICommands.StartGitCommandProcessDialog(this, CreateWorktreeCommand(Module, relativePath, newBranchOption)) ? DialogResult.OK : DialogResult.None;
+    }
+
+    private GitArgumentBuilder CreateWorktreeCommand(IGitModule module, string relativePath, string newBranchOption)
+    {
+        // https://git-scm.com/docs/git-worktree
+
+        // Get the default value, set if unset in config.
+        // Similar in DiffHighlightService.
+        string command = "worktree";
+        GitCommandConfiguration commandConfiguration = new();
+        IReadOnlyList<GitConfigItem> items = GitCommandConfiguration.Default.Get(command);
+        foreach (GitConfigItem cfg in items)
         {
-            // https://git-scm.com/docs/git-worktree
-
-            GitArgumentBuilder args = new("worktree")
-            {
-                "add",
-                Path.GetRelativePath(Module.WorkingDir, WorktreeDirectory).ToPosixPath().Quote(),
-                {
-                    radioButtonCreateNewBranch.Checked,
-                    $"-b {textBoxNewBranchName.Text}",
-                    comboBoxBranches.SelectedItem is not null ? ((GitRef)comboBoxBranches.SelectedItem).Name : null
-                }
-            };
-
-            DialogResult = UICommands.StartGitCommandProcessDialog(this, args) ? DialogResult.OK : DialogResult.None;
+            commandConfiguration.Add(cfg, command);
         }
 
-        private void ValidateWorktreeOptions()
+        SetIfUnsetInGit("worktree.useRelativePaths", "true");
+        GitArgumentBuilder args = new(command, commandConfiguration)
         {
-            comboBoxBranches.Enabled = radioButtonCheckoutExistingBranch.Checked;
-            textBoxNewBranchName.Enabled = radioButtonCreateNewBranch.Checked;
-            if (radioButtonCheckoutExistingBranch.Checked)
-            {
-                createWorktreeButton.Enabled = comboBoxBranches.SelectedItem is not null;
-            }
-            else
-            {
-                createWorktreeButton.Enabled = !(string.IsNullOrWhiteSpace(textBoxNewBranchName.Text)
-                                                 || ExistingBranches.Any(b => b.Name == textBoxNewBranchName.Text));
-            }
+            "add",
+            relativePath,
+            newBranchOption,
+        };
 
-            if (createWorktreeButton.Enabled)
+        return args;
+
+        void SetIfUnsetInGit(string key, string value)
+        {
+            if (string.IsNullOrEmpty(module.GetEffectiveSetting(key)))
             {
-                createWorktreeButton.Enabled = IsTargetFolderValid();
-            }
-
-            return;
-
-            bool IsTargetFolderValid()
-            {
-                if (string.IsNullOrWhiteSpace(newWorktreeDirectory.Text))
-                {
-                    return false;
-                }
-
-                try
-                {
-                    DirectoryInfo directoryInfo = new(newWorktreeDirectory.Text);
-                    return !directoryInfo.Exists || (!directoryInfo.EnumerateFiles().Any() && !directoryInfo.EnumerateDirectories().Any());
-                }
-                catch
-                {
-                    return false;
-                }
+                commandConfiguration.Add(new GitConfigItem(key, value), command);
             }
         }
+    }
 
-        private void ValidateWorktreeOptions(object sender, EventArgs e)
+    private void ValidateWorktreeOptions()
+    {
+        comboBoxBranches.Enabled = radioButtonCheckoutExistingBranch.Checked;
+        textBoxNewBranchName.Enabled = radioButtonCreateNewBranch.Checked;
+        if (radioButtonCheckoutExistingBranch.Checked)
         {
-            ValidateWorktreeOptions();
+            createWorktreeButton.Enabled = comboBoxBranches.SelectedItem is not null;
+        }
+        else
+        {
+            createWorktreeButton.Enabled = !(string.IsNullOrWhiteSpace(textBoxNewBranchName.Text)
+                                             || ExistingBranches.Any(b => b.Name == textBoxNewBranchName.Text));
         }
 
-        private void UpdateWorktreePathAndValidateWorktreeOptions(object sender, EventArgs e)
-            => UpdateWorktreePathAndValidateWorktreeOptions();
-
-        private void UpdateWorktreePathAndValidateWorktreeOptions()
+        if (createWorktreeButton.Enabled)
         {
-            UpdateWorktreePath();
+            createWorktreeButton.Enabled = IsTargetFolderValid();
+        }
 
-            ValidateWorktreeOptions();
+        return;
 
-            return;
-
-            void UpdateWorktreePath()
+        bool IsTargetFolderValid()
+        {
+            if (string.IsNullOrWhiteSpace(newWorktreeDirectory.Text))
             {
-                string branchNameNormalized = NormalizeBranchName(radioButtonCheckoutExistingBranch.Checked
-                    ? ((IGitRef)comboBoxBranches.SelectedItem)?.Name ?? string.Empty
-                    : textBoxNewBranchName.Text);
-                newWorktreeDirectory.Text = $"{_initialDirectoryPath}_{branchNameNormalized}";
+                return false;
             }
 
-            string NormalizeBranchName(string branchName) => string.Join("_", branchName.Split(_invalidCharsInPath, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
+            try
+            {
+                DirectoryInfo directoryInfo = new(newWorktreeDirectory.Text);
+                return !directoryInfo.Exists || (!directoryInfo.EnumerateFiles().Any() && !directoryInfo.EnumerateDirectories().Any());
+            }
+            catch
+            {
+                return false;
+            }
         }
+    }
+
+    private void ValidateWorktreeOptions(object sender, EventArgs e)
+    {
+        ValidateWorktreeOptions();
+    }
+
+    private void UpdateWorktreePathAndValidateWorktreeOptions(object sender, EventArgs e)
+        => UpdateWorktreePathAndValidateWorktreeOptions();
+
+    private void UpdateWorktreePathAndValidateWorktreeOptions()
+    {
+        UpdateWorktreePath();
+
+        ValidateWorktreeOptions();
+
+        return;
+
+        void UpdateWorktreePath()
+        {
+            string branchNameNormalized = NormalizeBranchName(radioButtonCheckoutExistingBranch.Checked
+                ? ((IGitRef)comboBoxBranches.SelectedItem)?.Name ?? string.Empty
+                : textBoxNewBranchName.Text);
+            newWorktreeDirectory.Text = $"{_initialDirectoryPath}_{branchNameNormalized}";
+        }
+
+        string NormalizeBranchName(string branchName) => string.Join("_", branchName.Split(_invalidCharsInPath, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
     }
 }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12479

## Proposed changes

Unless git-config "worktree.useRelativePaths"  is already set, use default paths (Git default is historically absolute). This works better if the (combined) directories are moved around as well in a WSL.

Note: No GUI, but doc is to be updated.
Basically replacing the current note for WSL
https://git-extensions-documentation.readthedocs.io/en/main/worktrees.html#note-for-wsl

Note: Microsoft.Build.Tasks.Git.LocateRepository does not like extensions.relativeworktrees
so this cannot be used for the clone building GE itself (manually editing is fine though).

## Test methodology <!-- How did you ensure quality? -->

Manual.
Started to prepare an idiot test, but ran into the extensions.relativeworktrees limitation
and there are strong relations with the GUI anyway, so I do not think that is useful.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
