### PR TITLE
fix: do not add / to submodule names

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1808,7 +1808,6 @@ namespace GitUI.CommandsDialogs
                     foreach (GitItemStatus item in items)
                     {
                         toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
-                        item.Name = item.Name.TrimEnd('/');
                         files.Add(item);
                     }
 

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1385,11 +1385,6 @@ namespace GitUI
                 string oldName = item.OldName is null ? "" : $" ({item.OldName})";
                 TreeNode listItem = new(text: $"{item.Name}{oldName}");
 
-                if (item.IsSubmodule)
-                {
-                    item.Name = $"{item.Name}/";
-                }
-
                 bool isGitGrep = FileStatusDiffCalculator.IsGrepItemStatuses(fileStatusWithDescription);
                 listItem.ImageIndex = GetItemImageIndex(item, isGitGrep);
                 listItem.SelectedImageIndex = listItem.ImageIndex;


### PR DESCRIPTION
Fixes #12432 

## Proposed changes

in FileStatusList.
compare to name in gitmodule config will fail.

The compare for name due to the added / fails in at least
https://github.com/gitextensions/gitextensions/blob/master/src/app/GitUI/CommandsDialogs/FormCommit.cs#L2047
I see no no reason to add the / to the name, it seem to have been added in the FileStatusList refactor.

## Test methodology <!-- How did you ensure quality? -->

Manual use.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
