### PR TITLE
fix: appveyor warning for lineending

### DIFF
--- a/eng/Update-DotnetVersion.ps1
+++ b/eng/Update-DotnetVersion.ps1
@@ -17,7 +17,8 @@ $globalJson = Resolve-Path $globalJson
 $json = Get-Content $globalJson | ConvertFrom-Json
 Write-Output "Updating SDK version from $($json.sdk.version) to $($versionResult.'latest-sdk')"
 $json.sdk.version = $versionResult.'latest-sdk'
-$json | ConvertTo-Json  | Out-File -Encoding utf8 $globalJson
+$lfContent = ($json | ConvertTo-Json) -replace "`r`n", "`n"
+Set-Content -Path $globalJson -Value $lfContent -NoNewline -Encoding utf8
 
 # Update RepoLayout.props file
 $propsPath = [System.IO.Path]::Combine($path, "RepoLayout.props")
@@ -28,6 +29,8 @@ $nd.'#text' = $versionResult.'latest-runtime'
 $settings = [System.Xml.XmlWriterSettings]@{
   Encoding = $encoding
   Indent   = $true    
+  NewLineHandling = "Replace"
+  NewLineChars = "`n"
 }
 $writer = [System.Xml.XmlWriter]::Create($propsPath, $settings)
 $nd.OwnerDocument.Save($writer)

--- a/global.json
+++ b/global.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "sdk": {
         "version": "9.0",
         "rollForward": "feature"


### PR DESCRIPTION
## Proposed changes

Inconsistent lineendings raised warnings in Appveyor log
The script that updated the .net versions to latest wrote the files with carriage-return

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

https://ci.appveyor.com/project/gitextensions/gitextensions/builds/52818965#L89

```
EXEC : warning : in the working copy of 'eng/RepoLayout.props', CRLF will be replaced by LF the next time Git touches it [C:\projects\gitextensions\src\app\BugReporter\BugReporter.csproj]
EXEC : warning : in the working copy of 'global.json', CRLF will be replaced by LF the next time Git touches it [C:\projects\gitextensions\src\app\BugReporter\BugReporter.csproj]
EXEC : warning : in the working copy of 'eng/RepoLayout.props', CRLF will be replaced by LF the next time Git touches it [C:\projects\gitextensions\src\app\GitExtensions\GitExtensions.csproj]
EXEC : warning : in the working copy of 'global.json', CRLF will be replaced by LF the next time Git touches it [C:\projects\gitextensions\src\app\GitExtensions\GitExtensions.csproj]
```

### After

Not these warnings

## Test methodology <!-- How did you ensure quality? -->

appveyor log

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
