### PR TITLE
fix: include rc in .net debug listings

### DIFF
--- a/src/app/GitUI/UserEnvironmentInformation.cs
+++ b/src/app/GitUI/UserEnvironmentInformation.cs
@@ -17,7 +17,7 @@ namespace GitUI
         private static bool _dirty;
         private static string? _sha;
 
-        [GeneratedRegex(@"^Microsoft\.WindowsDesktop\.App\s+([0-9.]+)\s+.*$", RegexOptions.Multiline)]
+        [GeneratedRegex(@"^Microsoft\.WindowsDesktop\.App\s+([\w.-]+)\s+.*$", RegexOptions.Multiline)]
         private static partial Regex DesktopAppRegex();
         [GeneratedRegex(@"^", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
         private static partial Regex LineStartRegex();


### PR DESCRIPTION
## Proposed changes

.net rc etc were not listed in NBug and About->Copy
 
## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

```
    Microsoft.WindowsDesktop.App 9.0.9 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

### After

```
    Microsoft.WindowsDesktop.App 9.0.9 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 10.0.0-rc.1.25451.107 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
