### PR TITLE
fix(FileStatusList): set files as new for initial commit

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2563,7 +2563,12 @@ namespace GitCommands
             ExecutionResult executionResult = _gitExecutable.Execute(args, throwOnErrorExit: false);
             if (executionResult.ExitedSuccessfully && ObjectId.TryParse(executionResult.StandardOutput, out ObjectId? treeId))
             {
-                IReadOnlyList<GitItemStatus> files = GetTreeFiles(treeId, full: true);
+                IReadOnlyList<GitItemStatus> files = GetTreeFiles(treeId, full: true)
+                    .Select(i =>
+                    {
+                        i.IsNew = true;
+                        return i;
+                    }).ToList();
 
                 resultCollection.AddRange(files);
             }

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2563,12 +2563,12 @@ namespace GitCommands
             ExecutionResult executionResult = _gitExecutable.Execute(args, throwOnErrorExit: false);
             if (executionResult.ExitedSuccessfully && ObjectId.TryParse(executionResult.StandardOutput, out ObjectId? treeId))
             {
-                IReadOnlyList<GitItemStatus> files = GetTreeFiles(treeId, full: true)
+                IEnumerable<GitItemStatus> files = GetTreeFiles(treeId, full: true)
                     .Select(i =>
                     {
                         i.IsNew = true;
                         return i;
-                    }).ToList();
+                    });
 
                 resultCollection.AddRange(files);
             }

--- a/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -110,8 +110,13 @@ namespace GitUI
                             // likely index commit without HEAD
                             ? module.GetDiffFilesWithSubmodulesStatus(firstId: null, selectedRev.ObjectId, parentToSecond: null, cancellationToken)
 
-                            // No parent for the initial commit, show files
-                            : module.GetTreeFiles(selectedRev.TreeGuid, full: true, cancellationToken)));
+                            // No parent for the initial commit, show files and explicitly set IsNew
+                            : module.GetTreeFiles(selectedRev.TreeGuid, full: true, cancellationToken)
+                                .Select(i =>
+                                {
+                                    i.IsNew = true;
+                                    return i;
+                                }).ToList()));
                 }
 
                 // Show combined (merge conflicts) when a single merge commit is selected


### PR DESCRIPTION
Regression with the updated ls-tree implementation in  6.0

## Proposed changes

For the initial commit the files are just listed,
must explicitly be set.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="483" height="289" alt="image" src="https://github.com/user-attachments/assets/e766beeb-575a-492b-8452-a0e950e73335" />

### After

<img width="310" height="152" alt="image" src="https://github.com/user-attachments/assets/1a7b6d6d-758a-40cb-ab6c-31ce9b8fc873" />

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
