### PR TITLE
Test robustness: Account for core.autocrlf in DiffHighlightServiceTests.MarkInlineGap

### DIFF
--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
@@ -96,6 +96,10 @@ public class DiffHighlightServiceTests
         DiffViewerLineNumberControl diffViewerLineNumber = new(textEditor.ActiveTextAreaControl.TextArea);
         string testDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
         string text = File.ReadAllText(Path.Combine(testDataDir, "gaps.diff"));
+
+        // ensure that the test doesn't fail if the local Git configuration has core.autocrlf enabled
+        text = text.Replace("\r\n", "\n");
+
         _ = new PatchHighlightService(ref text, useGitColoring: true, diffViewerLineNumber);
         DiffLinesInfo result = diffViewerLineNumber.GetTestAccessor().Result;
         DiffLineInfo[] diffLines = [.. result.DiffLines.Values.OrderBy(l => l.LineNumInDiff)];


### PR DESCRIPTION
## Proposed changes

On a fresh clone, the test DiffHighlightServiceTests.MarkInlineGap was failing. This turned out to have been caused by the default configuration of Git on my Windows workstation: the configuration setting `core.autocrlf` is `true`. As a result, the file `gaps.diff`, which the test loads in as a known starting point for analysis by the test subject, has `\r\n` newlines, but the known-good data has byte ranges computed from the same file with `\n` newlines.

This PR makes the test work whether `core.autocrlf` is enabled or not by the simple expedience of replacing all `"\r\n"` sequences with `"\n"` before the file gets analyzed.

### Before

<img width="1148" height="104" alt="image" src="https://github.com/user-attachments/assets/22fd1fd0-cbca-450a-a290-987884cb4aa9" />

<img width="941" height="1162" alt="image" src="https://github.com/user-attachments/assets/16731b5e-32dd-4239-8c75-4ba6d22b2117" />

### After

<img width="604" height="19" alt="image" src="https://github.com/user-attachments/assets/dae6a70f-5757-4920-bc5b-34278b6416ed" />

## Test methodology <!-- How did you ensure quality? -->

The subject of this PR is itself an automated test. It passes with the change in this PR. 🙂 

## Test environment(s) <!-- Remove any that don't apply -->

- GIT version 2.43.0.windows.1
    - `core.autocrlf` is set to `true`
- Windows 11 Version 22H2

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
