### PR TITLE
Test robustness: Isolation

### DIFF
--- a/tests/CommonTestUtils/ReferenceRepository.cs
+++ b/tests/CommonTestUtils/ReferenceRepository.cs
@@ -24,32 +24,6 @@ namespace CommonTestUtils
             }
         }
 
-        /// <summary>
-        /// Reset the repo if possible, if it is null or reset throws create a new.
-        /// </summary>
-        /// <param name="refRepo">The repo to reset, possibly null.</param>
-        public static void ResetRepo([NotNull] ref ReferenceRepository? refRepo)
-        {
-            if (refRepo is null)
-            {
-                refRepo = new ReferenceRepository();
-            }
-            else
-            {
-                try
-                {
-                    refRepo.Reset();
-                }
-                catch (LockedFileException)
-                {
-                    // the index is locked; this might be due to a concurrent or crashed process
-                    refRepo.Dispose();
-                    refRepo = new ReferenceRepository();
-                    Trace.WriteLine("Repo is locked, creating new");
-                }
-            }
-        }
-
         public GitModule Module => _moduleTestHelper.Module;
 
         public string? CommitHash { get; private set; }

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
@@ -53,7 +53,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _remoteReferenceRepository);
+            _remoteReferenceRepository = new ReferenceRepository();
 
             // we will be modifying .git/config and need to completely reset each time
             _referenceRepository = new ReferenceRepository();
@@ -75,6 +75,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [TearDown]
         public void TearDown()
         {
+            _remoteReferenceRepository.Dispose();
             _referenceRepository.Dispose();
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -47,7 +47,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
 
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCloneTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCloneTests.cs
@@ -17,7 +17,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -32,7 +32,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
 
             ServiceContainer serviceContainer = GlobalServiceContainer.CreateDefaultMockServiceContainer();
             serviceContainer.RemoveService<IScriptsRunner>();

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
@@ -18,7 +18,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
@@ -17,7 +17,7 @@ public class FormFileHistoryTests
     [SetUp]
     public void SetUp()
     {
-        ReferenceRepository.ResetRepo(ref _referenceRepository);
+        _referenceRepository = new ReferenceRepository();
         _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
 
         AppSettings.UseBrowseForFileHistory.Value = false;

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormInitTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormInitTests.cs
@@ -16,7 +16,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
@@ -26,7 +26,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             _originalFormPullAction = AppSettings.FormPullAction;
             _originalAutoStash = AppSettings.AutoStash;
 
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPushTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPushTests.cs
@@ -18,7 +18,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRebaseTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRebaseTests.cs
@@ -14,7 +14,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormUpdatesTests.cs
@@ -17,7 +17,7 @@ public class FormUpdatesTests
     [SetUp]
     public void SetUp()
     {
-        ReferenceRepository.ResetRepo(ref _referenceRepository);
+        _referenceRepository = new ReferenceRepository();
         _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
     }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.NoPlugins.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.NoPlugins.cs
@@ -28,7 +28,7 @@ namespace UITests.CommandsDialogs.SettingsDialog.Pages
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             ExportProvider mefExportProvider = TestComposition.Empty.ExportProviderFactory.CreateExportProvider();
             ManagedExtensibility.SetTestExportProvider(mefExportProvider);
         }

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.WithPlugins.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.WithPlugins.cs
@@ -28,7 +28,7 @@ namespace UITests.CommandsDialogs.SettingsDialog.Pages
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             TestComposition composition = TestComposition.Empty
                 .AddParts(typeof(MockGenericBuildServerAdapter))
                 .AddParts(typeof(MockGenericBuildServerSettingsUserControl));

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
@@ -42,7 +42,7 @@ public class SplitterPersistenceTests
 
         _windowPositionManager = Substitute.For<IWindowPositionManager>();
 
-        ReferenceRepository.ResetRepo(ref _referenceRepository);
+        _referenceRepository = new ReferenceRepository();
 
         _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
     }

--- a/tests/app/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -22,20 +22,17 @@ namespace GitUITests.GitUICommandsTests
         public void SetUp()
         {
             bool first = _referenceRepository is null;
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
 
-            if (first)
-            {
-                string cmdPath = (Environment.GetEnvironmentVariable("COMSPEC") ?? "C:/WINDOWS/system32/cmd.exe").ToPosixPath().QuoteNE();
-                _referenceRepository.Module.GitExecutable.RunCommand($"config --local difftool.cmd.path {cmdPath}").Should().BeTrue();
-                _referenceRepository.Module.GitExecutable.RunCommand($"config --local mergetool.cmd.path {cmdPath}").Should().BeTrue();
-                _referenceRepository.Module.GitExecutable.RunCommand("config --local diff.guitool cmd").Should().BeTrue();
-                _referenceRepository.Module.GitExecutable.RunCommand("config --local merge.guitool cmd").Should().BeTrue();
+            string cmdPath = (Environment.GetEnvironmentVariable("COMSPEC") ?? "C:/WINDOWS/system32/cmd.exe").ToPosixPath().QuoteNE();
+            _referenceRepository.Module.GitExecutable.RunCommand($"config --local difftool.cmd.path {cmdPath}").Should().BeTrue();
+            _referenceRepository.Module.GitExecutable.RunCommand($"config --local mergetool.cmd.path {cmdPath}").Should().BeTrue();
+            _referenceRepository.Module.GitExecutable.RunCommand("config --local diff.guitool cmd").Should().BeTrue();
+            _referenceRepository.Module.GitExecutable.RunCommand("config --local merge.guitool cmd").Should().BeTrue();
 
-                AppSettings.UseConsoleEmulatorForCommands = false;
-                AppSettings.CloseProcessDialog = true;
-                AppSettings.UseBrowseForFileHistory.Value = false;
-            }
+            AppSettings.UseConsoleEmulatorForCommands = false;
+            AppSettings.CloseProcessDialog = true;
+            AppSettings.UseBrowseForFileHistory.Value = false;
 
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }

--- a/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
@@ -51,7 +51,7 @@ namespace GitExtensions.UITests.ScriptEngine
             serviceContainer.AddService<IScriptsManager>(scriptsManager);
             serviceContainer.AddService<IScriptsRunner>(scriptsManager);
 
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _uiCommands = new GitUICommands(serviceContainer, _referenceRepository.Module);
 
             _module = Substitute.For<IGitModule>();

--- a/tests/app/IntegrationTests/UI.IntegrationTests/UserControls/PatchGridTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/UserControls/PatchGridTests.cs
@@ -22,7 +22,7 @@ namespace UITests.UserControls
         [SetUp]
         public void SetUp()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
 
             _commands = new GitUICommands(GlobalServiceContainer.CreateDefaultMockServiceContainer(), _referenceRepository.Module);
         }

--- a/tests/app/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
@@ -52,7 +52,7 @@ namespace GitCommandsTests
         [SetUp]
         public void Setup()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
 
             _file = Substitute.For<FileBase>();
             _file.ReadAllTextAsync(_commitMessagePath, _encoding, cancellationToken: default).Returns(_commitMessage);

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/FormOpenDirectoryTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/FormOpenDirectoryTests.cs
@@ -17,7 +17,7 @@ namespace GitUITests.CommandsDialogs
         [SetUp]
         public void Setup()
         {
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
             _localRepositoryManager = Substitute.For<ILocalRepositoryManager>();
         }
 

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -67,7 +67,7 @@ namespace GitUITests.UserControls
                 new(blameCommit2, 4, 4, "line4"),
             });
 
-            ReferenceRepository.ResetRepo(ref _referenceRepository);
+            _referenceRepository = new ReferenceRepository();
 
             // Creates/updates a file with name in DefaultRepoFileName
             _referenceRepository.CreateCommit("1",


### PR DESCRIPTION
Replace ReferenceRepository.ResetRepo with simply creating a new ReferenceRepository for each test.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

A general principle in automated testing is that tests should always be logically independent. What happens in one test should not affect the correctness or results of any other test. Tests here leveraging `ReferenceRepository` to set up a testing space for verifying Git operations are violating this principle. `ReferenceRepository` has a method `ResetRepo` used to prepare a repository at the start of each new test. It does clear some of the changes that could be made to a repository during testing, but not all of them. The result is that the exact order of the tests affects what state the repository will be in at the start of each test. While it does not currently occur, it is conceivable that a test could start having spurious failures because another test left the repository in a state that diverged from its assumptions about the initial state of the repository.

During debugging of an unrelated issue, I paused execution between tests, located the temporary folder containing the `ReferenceRepository` for the test fixture in question, and then ran `git checkout -b splonk`. Then I ran the next test and checked the state of the repository:

<img width="1511" height="905" alt="image" src="https://github.com/user-attachments/assets/2c5ed04a-b2a2-4425-a72d-6580ad880fad" />

The history shows changes made by the test(s) under the ref `main`, and then changes made by the second test under the ref `splonk`.

At present, it so happens that all tests are resilient to whatever noise they encounter from other tests; the test suite does in fact run without failures. However, the quality of that testing is compromised by the tests not being well-isolated.

This PR removes the method `ReferenceRepository.ResetRepo`, which is used as a "create or reset" function in the SetUp methods of a number of tests, and replaces calls to it with simply instantiating a brand new `ReferenceRepository`. This means that every such test now creates a new temporary folder and runs `git init` in it. This _is_ a little bit slower than before, but the difference isn't as large as one might expect. I think the reason is that `ResetRepo` was actually doing a fair bit of work:

- `git reset --hard`
- `RemoveUntrackedFiles()`
- `Network.Remotes.Remove(remoteName)` for each remote
- `Config.Set` twice

These changes take some time to process, and they aren't comprehensive. For instance, if the repository were ever to be left with its HEAD pointed at a different branch than the value of `init.defaultbranch`, which is what my `splonk` test simulated, it would not be reset back. And, commits are not removed.

Despite the small increase in testing time, I believe this change constitutes a concrete improvement to the quality of the test suite.

## Test methodology <!-- How did you ensure quality? -->

Ran the test suite, made sure everything still passed, compared runtimes.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT version 2.43.0.windows.1
- Windows 11 Version 22H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
