### PR TITLE
fix: icon for default PulMerge button

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -292,7 +292,7 @@ namespace GitUI.CommandsDialogs
                     break;
 
                 case GitPullAction.Rebase:
-                    toolStripButtonPull.Image = rebaseToolStripMenuItem.Image;
+                    toolStripButtonPull.Image = rebaseToolStripMenuItem1.Image;
                     toolStripButtonPull.ToolTipText = _pullRebase.Text;
                     break;
 


### PR DESCRIPTION
Fixes #12575

## Proposed changes

Incorrect icon reused, too similar names...

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

See issue

### After

<img width="91" height="30" alt="image" src="https://github.com/user-attachments/assets/8a35aa3c-3e10-4376-8908-70f31c5be72b" />

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
