### PR TITLE
fix(FileStatusList): Calculate available width for truncating filenames

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1706,7 +1706,8 @@ public sealed partial class FileStatusList : GitModuleControl
 
         PathFormatter formatter = new(e.Graphics, FileStatusListView.Font);
 
-        (string? prefix, string text, string? suffix) = FormatListViewItem(item, formatter, item.Bounds.Width);
+        int maxWidth = FileStatusListView.ClientSize.Width - item.Bounds.X + 1;
+        (string? prefix, string text, string? suffix) = FormatListViewItem(item, formatter, maxWidth);
 
         Brush backgroundBrush = selected
             ? Focused


### PR DESCRIPTION
Fixes #12566

## Proposed changes

- `FileStatusListView_DrawNode`: Calculate available width for item
  and ignore `item.Bounds.Width` because the `TreeView` calculates `item.Bounds` using some underlying text.

## Known issue:
Do not use the horizontal scrollbar if truncation is active. It causes artifacts.
At a first glance, there is no option to keep the vertical and to hide the horizontal scrollbar.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="402" height="278" alt="image" src="https://github.com/user-attachments/assets/08b110cf-7dc7-4b01-a660-7ea5ff79e73c" />

### After

<img width="402" height="278" alt="image" src="https://github.com/user-attachments/assets/113b5535-0038-4ea0-a401-32813c4e43e0" />    <img width="402" height="278" alt="image" src="https://github.com/user-attachments/assets/ad3aed25-9189-4c5a-9aae-047391712d0e" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).