### PR TITLE
Trivial: Switch to the null-conditional operator in a couple of places

### DIFF
--- a/src/app/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.cs
@@ -28,9 +28,9 @@ internal partial class StartToolStripMenuItem : ToolStripMenuItemEx
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
     protected override void Dispose(bool disposing)
     {
-        if (disposing && (components != null))
+        if (disposing)
         {
-            components.Dispose();
+            components?.Dispose();
 
             if (_repositoryHistoryUIService is not null)
             {

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabSettingsUserControl.Designer.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabSettingsUserControl.Designer.cs
@@ -13,9 +13,9 @@ partial class GitlabSettingsUserControl
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
     protected override void Dispose(bool disposing)
     {
-        if (disposing && (components != null))
+        if (disposing)
         {
-            components.Dispose();
+            components?.Dispose();
         }
         base.Dispose(disposing);
     }


### PR DESCRIPTION
> Prefer `nullable?.optionalCall()` over `if`.

This PR is a fairly trivial switch from "if (a != null) { a.Dispose(); ]" to "a?.Dispose()" in a couple of places.

In one of the cases, there's actually technically a very minor bug fix, because another member's disposal was incorrectly placed inside the `if (components != null)` scope.

## Test methodology <!-- How did you ensure quality? -->

It builds and tests run to completion.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
