### PR TITLE
fix(DpiUtil): Avoid breaking plugin compatibility

### DIFF
--- a/src/app/GitExtUtils/GitUI/DpiUtil.cs
+++ b/src/app/GitExtUtils/GitUI/DpiUtil.cs
@@ -85,10 +85,18 @@ public static class DpiUtil
     /// </summary>
     /// <param name="i">The value to scale.</param>
     /// <param name="ceiling">If <see langword="true" />, uses ceiling rounding to ensure the result is never smaller than the scaled value.</param>
-    public static int Scale(int i, bool ceiling = false)
+    public static int Scale(int i, bool ceiling)
     {
         return ceiling ? (int)Math.Ceiling(i * ScaleX) : (int)Math.Round(i * ScaleX);
     }
+
+    /// <summary>
+    /// Returns a scaled copy of measurement <paramref name="i"/> which has
+    /// equivalent length on screen at the current DPI as the original would
+    /// at 96 DPI.
+    /// </summary>
+    /// <param name="i">The value to scale.</param>
+    public static int Scale(int i) => Scale(i, ceiling: false);
 
     /// <summary>
     /// Returns a scaled copy of <paramref name="i"/> which has equivalent


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/12594#issuecomment-3478121218

## Proposed changes

- Restore original `DpiUtil.Scale` as overlaod

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).