### PR TITLE
fix(Settings): Do not re-enable CredentialHelper edit if multi-value

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -129,7 +129,6 @@ public partial class GitConfigSettingsPage : GitConfigBaseSettingsPage
 
         GlobalUserName.Enabled = canFindGitCmd;
         GlobalUserEmail.Enabled = canFindGitCmd;
-        cbxCredentialHelper.Enabled = canFindGitCmd;
         GlobalEditor.Enabled = canFindGitCmd;
         txtCommitTemplatePath.Enabled = canFindGitCmd;
         _NO_TRANSLATE_cboMergeTool.Enabled = canFindGitCmd;


### PR DESCRIPTION
Fixes #12623

## Proposed changes

fix(Git Config Settings):
- Do not enable `cbxCredentialHelper` in dependency on availability of git command
- because it would override disabling on multi-value settings if settings are opened without open repo
- then `OnPageShown` is called late

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="616" height="134" alt="Image" src="https://github.com/user-attachments/assets/d747ef29-693c-441e-95e8-05c0e4e2fa26" />

### After

<img width="392" height="141" alt="image" src="https://github.com/user-attachments/assets/28d34c75-8232-4575-89c8-79a83e2081cc" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).