### PR TITLE
fix(stash picker): Add 1px offset if high DPI scaling factor is fractional

### DIFF
--- a/src/app/GitExtUtils/GitUI/DpiUtil.cs
+++ b/src/app/GitExtUtils/GitUI/DpiUtil.cs
@@ -41,6 +41,11 @@ public static class DpiUtil
     }
 
     /// <summary>
+    /// Gets whether the current scaling factor is not integer.
+    /// </summary>
+    public static bool IsFractional => Math.Floor(ScaleX) != ScaleX || Math.Floor(ScaleY) != ScaleY;
+
+    /// <summary>
     /// Gets whether the current pixel density is not 96 DPI.
     /// </summary>
     public static bool IsNonStandard => DpiX != 96 || DpiY != 96;

--- a/src/app/GitUI/CommandsDialogs/FormStash.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.cs
@@ -292,7 +292,8 @@ public sealed partial class FormStash : GitModuleForm
     private void ResizeStashesWidth()
     {
         const int spacingBetweenLabelAndComboBox = 5;
-        Stashes.Width = toolStrip1.Width - DpiUtil.Scale(spacingBetweenLabelAndComboBox, ceiling: true) - showToolStripLabel.Width;
+        int compensationForOddToolbarScaling = DpiUtil.IsFractional ? 1 : 0;
+        Stashes.Width = toolStrip1.Width - DpiUtil.Scale(spacingBetweenLabelAndComboBox, ceiling: true) - compensationForOddToolbarScaling - showToolStripLabel.Width;
     }
 
     private void StashedSelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #12588

## Proposed changes

`ResizeStashesWidth`: Reduce the combobox width by another pixel if the high DPI scaling factor is fractional
because the calculation in the toolbar seems to suffer from rounding artifacts in an incomprehensible manner

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

no combobox

### After

<img width="501" height="192" alt="image" src="https://github.com/user-attachments/assets/eb99235a-31f7-4495-8764-0c7909a66b56" />

## Test methodology <!-- How did you ensure quality? -->

- manually (Always logoff and logon after changing scaling factors!)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).