### PR TITLE
feat(repos dropdown): Allow to filter the recent repos

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
 public partial class UserRepositoriesList : GitExtensionsControl
 {
     private readonly TranslationString _groupRecentRepositories = new("Recent repositories");
-    private readonly TranslationString _repositorySearchPlaceholder = new("Search repositories");
+    private readonly TranslationString _repositorySearchPlaceholder = new("Search repositories...");
     private readonly TranslationString _groupActions = new("Actions");
     private readonly TranslationString _deleteCategoryCaption = new(
         "Delete Category");

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -262,7 +262,6 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         fileToolStripMenuItem.Initialize(() => UICommands);
         helpToolStripMenuItem.Initialize(() => UICommands);
         toolsToolStripMenuItem.Initialize(() => UICommands);
-        _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem, closeToolStripMenuItem);
 
         BackColor = OtherColors.BackgroundColor;
 
@@ -295,6 +294,10 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         LeftSplitContainer.Invalidated += FixupSplitterColor;
 
         InitializeComplete();
+
+        // The toolstrip and menu items must be initialised after InitializeComplete
+        // which invokes the translation logic and applies the current language to the components.
+        _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem, closeToolStripMenuItem);
 
         HotkeysEnabled = true;
         LoadHotkeys(HotkeySettingsName);

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -4,8 +4,8 @@ using GitCommands;
 using GitCommands.UserRepositoryHistory;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Translations;
+using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
-using Microsoft;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.Menus;
@@ -15,15 +15,241 @@ namespace GitUI.CommandsDialogs.Menus;
 /// </summary>
 internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITranslate
 {
-    private readonly TranslationString _noWorkingFolderText = new("No working directory");
-    private readonly TranslationString _configureWorkingDirMenu = new("Co&nfigure this menu...");
+    private static readonly TranslationString _noWorkingFolderText = new("No working directory");
+    private static readonly TranslationString _configureWorkingDirMenu = new("Co&nfigure this menu...");
+    private static readonly TranslationString _repositorySearchPlaceholder = new("Search repositories...");
 
-    private Func<IGitUICommands>? _getUICommands;
-    private IRepositoryHistoryUIService? _repositoryHistoryUIService;
+    private class Implementation
+    {
+        // This is used as Tag in order to mark controls which are to be excluded from the filtering considerations.
+        private static readonly object _excludeFromFilterMarker = new();
 
-    // NOTE: This is pretty bad, but we want to share the same look and feel of the menu items defined in the Start menu.
-    private StartToolStripMenuItem? _startToolStripMenuItem;
-    private ToolStripMenuItem? _closeToolStripMenuItem;
+        /// <summary>
+        ///  Gets the current instance of the git module.
+        /// </summary>
+        private IGitModule Module => UICommands.Module;
+
+        /// <summary>
+        ///  Gets the active or the first open form.
+        /// </summary>
+        private static Form? ActiveOrOpenForm
+            => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
+
+        /// <summary>
+        ///  Gets the current instance of the UI commands.
+        /// </summary>
+        private IGitUICommands UICommands => _getUICommands();
+
+        private readonly Func<IGitUICommands> _getUICommands;
+
+        /// <summary>
+        ///  The current instance of the <see cref="RepositoryHistoryUIService"/>.
+        /// </summary>
+        private readonly IRepositoryHistoryUIService _repositoryHistoryUIService;
+
+        private readonly ToolStripMenuItem _tsmiCategorisedRepos;
+        private readonly ToolStripMenuItem _tsmiOpenLocalRepository;
+        private readonly ToolStripMenuItem _tsmiCloseRepo;
+        private readonly ToolStripMenuItem _tsmiRecentReposSettings;
+        private readonly ToolStripTextBox _txtFilter = new();
+
+        // NOTE: This is pretty bad, but we want to share the same look and feel of the menu items defined in the Start menu.
+        private readonly StartToolStripMenuItem _startToolStripMenuItem;
+        private readonly ToolStripMenuItem _closeToolStripMenuItem;
+
+        internal Implementation(
+            ToolStripSplitButton button,
+            Func<IGitUICommands> getUICommands,
+            IRepositoryHistoryUIService repositoryHistoryUIService,
+            StartToolStripMenuItem startToolStripMenuItem,
+            ToolStripMenuItem closeToolStripMenuItem)
+        {
+            button.ButtonClick += (s, e) => button.ShowDropDown();
+            button.DropDownOpening += (s, e) => FillDropDown(button);
+            button.MouseUp += MouseUpHandler;
+
+            _getUICommands = getUICommands;
+            _repositoryHistoryUIService = repositoryHistoryUIService;
+            _startToolStripMenuItem = startToolStripMenuItem;
+            _closeToolStripMenuItem = closeToolStripMenuItem;
+
+            _txtFilter.Tag = _excludeFromFilterMarker;
+
+            TextBox filterTextbox = _txtFilter.TextBox;
+            filterTextbox.PlaceholderText = _repositorySearchPlaceholder.Text;
+            filterTextbox.TextChanged += (s, e) =>
+            {
+                if (_txtFilter.GetCurrentParent() is null)
+                {
+                    // We are clearing the textbox while opening the dropdown
+                    return;
+                }
+
+                // Default items include:
+                //  1. filter
+                //  2. separator
+                //  3. favourite items
+                //      ... recent items
+                //  4. "Open repo..."
+                //  5. "Close repo..."
+                //  6. separator
+                //  7. "Configure menu"
+                const int defaultItemCount = 7;
+                if (button.DropDown.Items.Count <= defaultItemCount)
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(filterTextbox.Text))
+                {
+                    foreach (ToolStripItem item in button.DropDown.Items)
+                    {
+                        item.Visible = true;
+                    }
+
+                    return;
+                }
+
+                foreach (ToolStripItem item in button.DropDown.Items)
+                {
+                    if (item is ToolStripSeparator || item.Tag == _excludeFromFilterMarker)
+                    {
+                        continue;
+                    }
+
+                    item.Visible = item.Text?.Contains(filterTextbox.Text, StringComparison.CurrentCultureIgnoreCase) is true;
+                }
+            };
+
+            // Initialize toolstip menu items
+            // ----------------------------------------
+            _tsmiCategorisedRepos = new(_startToolStripMenuItem.FavouriteRepositoriesMenuItem.Text, _startToolStripMenuItem.FavouriteRepositoriesMenuItem.Image)
+            {
+                Tag = _excludeFromFilterMarker
+            };
+
+            _tsmiOpenLocalRepository = new(_startToolStripMenuItem.OpenRepositoryMenuItem.Text, _startToolStripMenuItem.OpenRepositoryMenuItem.Image)
+            {
+                ShortcutKeyDisplayString = _startToolStripMenuItem.OpenRepositoryMenuItem.ShortcutKeyDisplayString,
+                Tag = _excludeFromFilterMarker
+            };
+            _tsmiOpenLocalRepository.Click += (s, e) => _startToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
+
+            _tsmiCloseRepo = new(_closeToolStripMenuItem.Text, _closeToolStripMenuItem.Image)
+            {
+                ShortcutKeyDisplayString = _closeToolStripMenuItem.ShortcutKeyDisplayString,
+                Tag = _excludeFromFilterMarker
+            };
+            _tsmiCloseRepo.Click += (hs, he) => _closeToolStripMenuItem.PerformClick();
+
+            _tsmiRecentReposSettings = new(_configureWorkingDirMenu.Text)
+            {
+                Tag = _excludeFromFilterMarker
+            };
+            _tsmiRecentReposSettings.Click += (hs, he) =>
+            {
+                using (FormRecentReposSettings frm = new())
+                {
+                    frm.ShowDialog(ActiveOrOpenForm);
+                }
+
+                RefreshContent(button);
+            };
+        }
+
+        private void FillDropDown(ToolStripDropDownItem button)
+        {
+            button.DropDown.SuspendLayout();
+            try
+            {
+                button.DropDown.Items.Clear();
+
+                _txtFilter.Text = string.Empty;
+
+                button.DropDown.Items.Add(_txtFilter);
+                button.DropDown.Items.Add(new ToolStripSeparator());
+
+                _repositoryHistoryUIService.PopulateFavouriteRepositoriesMenu(_tsmiCategorisedRepos);
+                if (_tsmiCategorisedRepos.DropDownItems.Count > 0)
+                {
+                    button.DropDown.Items.Add(_tsmiCategorisedRepos);
+                }
+
+                _repositoryHistoryUIService.PopulateRecentRepositoriesMenu(button);
+
+                button.DropDown.Items.Add(new ToolStripSeparator());
+                button.DropDown.Items.Add(_tsmiOpenLocalRepository);
+                button.DropDown.Items.Add(_tsmiCloseRepo);
+                button.DropDown.Items.Add(new ToolStripSeparator());
+                button.DropDown.Items.Add(_tsmiRecentReposSettings);
+            }
+            finally
+            {
+                button.DropDown.ResumeLayout();
+
+                int maxWidth = button.DropDownItems.Cast<ToolStripItem>().Max(item => item == _txtFilter ? 0 : item.Width);
+                const int paddingToAvoidGrowth = 60;
+                _txtFilter.Size = new Size(maxWidth - DpiUtil.Scale(paddingToAvoidGrowth), _txtFilter.Height);
+            }
+        }
+
+        private void MouseUpHandler(object? sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                _startToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
+            }
+        }
+
+        internal void RefreshContent(ToolStripSplitButton button)
+        {
+            if (ActiveOrOpenForm is not Form graphicsForm)
+            {
+                // The component is unparented, no point doing anything.
+                return;
+            }
+
+            string path = Module.WorkingDir;
+
+            // It appears at times Module.WorkingDir path is an empty string,
+            // this caused issues like https://github.com/gitextensions/gitextensions/issues/4874.
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                button.Text = _noWorkingFolderText.Text;
+                return;
+            }
+
+            IList<Repository> recentRepositoryHistory = ThreadHelper.JoinableTaskFactory.Run(
+                () => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
+
+            List<RecentRepoInfo> pinnedRepos = [];
+            using Graphics graphics = graphicsForm.CreateGraphics();
+            RecentRepoSplitter splitter = new()
+            {
+                MeasureFont = button.Font,
+            };
+
+            splitter.SplitRecentRepos(recentRepositoryHistory, pinnedRepos, pinnedRepos);
+
+            RecentRepoInfo? ri = pinnedRepos.Find(e => e.Repo.Path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
+
+            button.Text = PathUtil.GetDisplayPath(ri?.Caption ?? path);
+
+            if (AppSettings.RecentReposComboMinWidth > 0)
+            {
+                button.AutoSize = false;
+                float captionWidth = graphics.MeasureString(button.Text, button.Font).Width;
+                captionWidth = captionWidth + button.DropDownButtonWidth + 5;
+                button.Width = Math.Max(AppSettings.RecentReposComboMinWidth, (int)captionWidth);
+            }
+            else
+            {
+                button.AutoSize = true;
+            }
+        }
+    }
+
+    private Implementation? _implementation;
 
     public WorkingDirectoryToolStripSplitButton()
     {
@@ -35,18 +261,6 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
     }
 
     /// <summary>
-    ///  Gets the form that is displaying the menu item.
-    /// </summary>
-    private static Form? OwnerForm
-        => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
-
-    /// <summary>
-    ///  Gets the current instance of the UI commands.
-    /// </summary>
-    private IGitUICommands UICommands
-        => (_getUICommands ?? throw new InvalidOperationException("The button is not initialized")).Invoke();
-
-    /// <summary>
     ///  Initializes the menu item.
     /// </summary>
     /// <param name="getUICommands">The method that returns the current instance of UI commands.</param>
@@ -55,122 +269,14 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
     {
         Translator.Translate(this, AppSettings.CurrentTranslation);
 
-        _getUICommands = getUICommands;
-        _repositoryHistoryUIService = repositoryHistoryUIService;
-        _startToolStripMenuItem = startToolStripMenuItem;
-        _closeToolStripMenuItem = closeToolStripMenuItem;
-    }
-
-    protected override void OnButtonClick(EventArgs e)
-    {
-        base.OnButtonClick(e);
-
-        ShowDropDown();
-    }
-
-    protected override void OnDropDownShow(EventArgs e)
-    {
-        Assumes.NotNull(_repositoryHistoryUIService);
-        Assumes.NotNull(_startToolStripMenuItem);
-        Assumes.NotNull(_closeToolStripMenuItem);
-
-        base.OnDropDownShow(e);
-
-        DropDown.SuspendLayout();
-        DropDownItems.Clear();
-
-        ToolStripMenuItem tsmiCategorisedRepos = new(_startToolStripMenuItem.FavouriteRepositoriesMenuItem.Text, _startToolStripMenuItem.FavouriteRepositoriesMenuItem.Image);
-        _repositoryHistoryUIService.PopulateFavouriteRepositoriesMenu(tsmiCategorisedRepos);
-        if (tsmiCategorisedRepos.DropDownItems.Count > 0)
-        {
-            DropDownItems.Add(tsmiCategorisedRepos);
-        }
-
-        _repositoryHistoryUIService.PopulateRecentRepositoriesMenu(this);
-
-        DropDownItems.Add(new ToolStripSeparator());
-
-        ToolStripMenuItem mnuOpenLocalRepository = new(_startToolStripMenuItem.OpenRepositoryMenuItem.Text, _startToolStripMenuItem.OpenRepositoryMenuItem.Image)
-        {
-            ShortcutKeyDisplayString = _startToolStripMenuItem.OpenRepositoryMenuItem.ShortcutKeyDisplayString
-        };
-        mnuOpenLocalRepository.Click += (s, e) => _startToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
-        DropDownItems.Add(mnuOpenLocalRepository);
-
-        ToolStripMenuItem mnuCloseRepo = new(_closeToolStripMenuItem.Text)
-        {
-            ShortcutKeyDisplayString = _closeToolStripMenuItem.ShortcutKeyDisplayString
-        };
-        mnuCloseRepo.Click += (hs, he) => _closeToolStripMenuItem.PerformClick();
-        DropDownItems.Add(mnuCloseRepo);
-
-        DropDownItems.Add(new ToolStripSeparator());
-
-        ToolStripMenuItem mnuRecentReposSettings = new(_configureWorkingDirMenu.Text);
-        mnuRecentReposSettings.Click += (hs, he) =>
-        {
-            using (FormRecentReposSettings frm = new())
-            {
-                frm.ShowDialog(OwnerForm);
-            }
-
-            RefreshContent();
-        };
-
-        DropDownItems.Add(mnuRecentReposSettings);
-
-        DropDown.ResumeLayout();
-    }
-
-    protected override void OnMouseUp(MouseEventArgs e)
-    {
-        base.OnMouseUp(e);
-
-        if (e.Button == MouseButtons.Right)
-        {
-            Assumes.NotNull(_startToolStripMenuItem);
-            _startToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
-        }
+        _implementation = new Implementation(this, getUICommands, repositoryHistoryUIService, startToolStripMenuItem, closeToolStripMenuItem);
     }
 
     /// <summary>Updates the text shown on the combo button itself.</summary>
     public void RefreshContent()
     {
-        string path = UICommands.Module.WorkingDir;
-
-        // it appears at times Module.WorkingDir path is an empty string, this caused issues like #4874
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            Text = _noWorkingFolderText.Text;
-            return;
-        }
-
-        IList<Repository> recentRepositoryHistory = ThreadHelper.JoinableTaskFactory.Run(
-            () => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
-
-        List<RecentRepoInfo> topRepos = [];
-        RecentRepoSplitter splitter = new()
-        {
-            MeasureFont = Font,
-        };
-
-        splitter.SplitRecentRepos(recentRepositoryHistory, topRepos, topRepos);
-
-        RecentRepoInfo? ri = topRepos.Find(e => e.Repo.Path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
-
-        Text = PathUtil.GetDisplayPath(ri?.Caption ?? path);
-
-        if (AppSettings.RecentReposComboMinWidth > 0)
-        {
-            AutoSize = false;
-            int captionWidth = TextRenderer.MeasureText(Text, Font).Width;
-            captionWidth = captionWidth + DropDownButtonWidth + 5;
-            Width = Math.Max(AppSettings.RecentReposComboMinWidth, captionWidth);
-        }
-        else
-        {
-            AutoSize = true;
-        }
+        // If the component is not initialized, no point doing anything.
+        _implementation?.RefreshContent(this);
     }
 
     void ITranslate.AddTranslationItems(ITranslation translation)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2819,6 +2819,10 @@ compare with first:</source>
         <source>(Repository hosts)</source>
         <target />
       </trans-unit>
+      <trans-unit id="_repositorySearchPlaceholder.Text">
+        <source>Search repositories...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_superprojectModuleFormat.Text">
         <source>Superproject: {0}</source>
         <target />
@@ -10701,7 +10705,7 @@ The action cannot be undone.</source>
         <target />
       </trans-unit>
       <trans-unit id="_repositorySearchPlaceholder.Text">
-        <source>Search repositories</source>
+        <source>Search repositories...</source>
         <target />
       </trans-unit>
       <trans-unit id="clmhdrBranch.Text">


### PR DESCRIPTION
Fixes #10810
(Blindly) rebased variant of #10906

## Proposed changes

- FormBrowse: Allow to filter the recent repositories dropdown

## Known issue

The dropdown closes when attempting to input some special chars using the `Alt Gr` (`Ctrl` + `Alt`) key, e.g. `@`, `µ`, `€`, etc.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="495" height="901" alt="image" src="https://github.com/user-attachments/assets/6ddc9a77-c8ff-4167-9606-d5e15e17df77" />

### After

<img width="496" height="536" alt="image" src="https://github.com/user-attachments/assets/b5097e4e-03ec-4bc0-9328-8b4b703536f7" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).