### PR TITLE
fix(git error): Actually treat as user external operation

### DIFF
--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿#nullable enable
+
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Security;
 using System.Text;
@@ -32,7 +34,7 @@ public static class BugReportInvoker
     internal static string GetRootError(Exception exception)
     {
         string rootError = exception.Message;
-        for (Exception innerException = exception.InnerException; innerException is not null; innerException = innerException.InnerException)
+        for (Exception? innerException = exception.InnerException; innerException is not null; innerException = innerException.InnerException)
         {
             if (!string.IsNullOrEmpty(innerException.Message))
             {
@@ -140,7 +142,7 @@ public static class BugReportInvoker
             return;
         }
 
-        ExternalOperationException externalOperationException = exception as ExternalOperationException;
+        ExternalOperationException? externalOperationException = exception as ExternalOperationException;
 
         if (externalOperationException?.InnerException?.Message?.Contains(DubiousOwnershipSecurityConfigString) is true)
         {
@@ -191,7 +193,7 @@ public static class BugReportInvoker
         // prefer to ignore failed external operations
         if (isExternalOperation)
         {
-            AddIgnoreOrCloseButton(TranslatedStrings.ExternalErrorDescription);
+            AddIgnoreButton(TranslatedStrings.ExternalErrorDescription);
         }
         else
         {
@@ -206,23 +208,23 @@ public static class BugReportInvoker
                 : new(TranslatedStrings.ButtonReportBug);
         taskDialogCommandLink.Click += (s, e) =>
         {
-            ShowNBug(OwnerForm, exception, isExternalOperation, isUserExternalOperation, isTerminating);
+            ShowNBug(OwnerForm, exception, isExternalOperation, isUserExternalOperation, isTerminating: false);
         };
         page.Buttons.Add(taskDialogCommandLink);
 
         // let the user decide whether to report the bug
         if (!isExternalOperation)
         {
-            AddIgnoreOrCloseButton();
+            AddIgnoreButton();
         }
 
         page.Text = text.ToString().Trim();
         TaskDialog.ShowDialog(OwnerFormHandle, page);
         return;
 
-        void AddIgnoreOrCloseButton(string descriptionText = null)
+        void AddIgnoreButton(string? descriptionText = null)
         {
-            string buttonText = isTerminating ? TranslatedStrings.ButtonCloseApp : TranslatedStrings.ButtonIgnore;
+            string buttonText = TranslatedStrings.ButtonIgnore;
             TaskDialogCommandLinkButton taskDialogCommandLink = new(buttonText, descriptionText);
             page.Buttons.Add(taskDialogCommandLink);
         }
@@ -300,7 +302,7 @@ public static class BugReportInvoker
         {
             // Skipping the 1st parameter that, starting from .net core, contains the path to application dll (instead of exe)
             string arguments = string.Join(" ", Environment.GetCommandLineArgs().Skip(1));
-            ProcessStartInfo pi = new(Environment.ProcessPath, arguments);
+            ProcessStartInfo pi = new(Environment.ProcessPath!, arguments);
             pi.WorkingDirectory = Environment.CurrentDirectory;
             Process.Start(pi);
             Environment.Exit(0);

--- a/src/app/GitUI/TranslatedStrings.cs
+++ b/src/app/GitUI/TranslatedStrings.cs
@@ -17,7 +17,6 @@ internal sealed class TranslatedStrings : Translate
 
     private readonly TranslationString _buttonCheckoutBranch = new("Checkout branch");
     private readonly TranslationString _buttonContinue = new("Continue");
-    private readonly TranslationString _buttonCloseApp = new("Close application");
     private readonly TranslationString _buttonCreateBranch = new("Create branch");
     private readonly TranslationString _buttonIgnore = new("Ignore");
     private readonly TranslationString _buttonPush = new("&Push");
@@ -203,7 +202,6 @@ Copy error details to clipboard?");
 
     public static string ButtonContinue => _instance.Value._buttonContinue.Text;
     public static string ButtonCheckoutBranch => _instance.Value._buttonCheckoutBranch.Text;
-    public static string ButtonCloseApp => _instance.Value._buttonCloseApp.Text;
     public static string ButtonCreateBranch => _instance.Value._buttonCreateBranch.Text;
     public static string ButtonIgnore => _instance.Value._buttonIgnore.Text;
     public static string ButtonPush => _instance.Value._buttonPush.Text;

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -10032,10 +10032,6 @@ Select this commit to populate the full message.</source>
         <source>Checkout branch</source>
         <target />
       </trans-unit>
-      <trans-unit id="_buttonCloseApp.Text">
-        <source>Close application</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_buttonContinue.Text">
         <source>Continue</source>
         <target />


### PR DESCRIPTION
Avoids issue reports like #12644

## Proposed changes

- Actually treat errors from git like `UserExternalOperationException` defaulting to `Ignore error from git or ...` and with `Send and Quit` disabled

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="540" height="367" alt="image" src="https://github.com/user-attachments/assets/5908a736-40b1-4d73-9378-8c0b00584560" />   <img width="558" height="499" alt="image" src="https://github.com/user-attachments/assets/5fb0699f-6a81-4812-950e-62050cb49b43" />

### After

<img width="540" height="367" alt="image" src="https://github.com/user-attachments/assets/1a89c194-126f-43d7-a1e9-bf9b32b60e3a" />   <img width="558" height="499" alt="image" src="https://github.com/user-attachments/assets/aaba18fc-fab6-4cbb-a302-85ff39157eff" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).