### PR TITLE
fix!: SupportLsFilesFormat in Extensibility

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -3242,9 +3242,7 @@ public sealed partial class GitModule : IGitModule
                 // ls-files with same format as ls-tree
                 "-z",
                 { commitId == ObjectId.IndexId, "--cached", "--no-cached" },
-
-                // TODO change to GitVersion.SupportLsFilesFormat when Extensibility.Git can be updated
-                { GitVersion.SupportNewGitConfigSyntax, @$"--format=""{_gitTreeParser.GitTreeFormat}""", "--stage" },
+                { GitVersion.SupportLsFilesFormat, @$"--format=""{_gitTreeParser.GitTreeFormat}""", "--stage" },
                 "--",
                 fileName.QuoteNE()
             }
@@ -3260,8 +3258,7 @@ public sealed partial class GitModule : IGitModule
 
         ExecutionResult result = _gitExecutable.Execute(args, cache: isArtificial ? null : GitCommandCache, cancellationToken: cancellationToken);
 
-        // TODO change to GitVersion.SupportLsFilesFormat when Extensibility.Git can be updated
-        if (isArtificial && !GitVersion.SupportNewGitConfigSyntax)
+        if (isArtificial && !GitVersion.SupportLsFilesFormat)
         {
             return _gitTreeParser.ParseLsFiles(result.StandardOutput);
         }

--- a/src/app/GitExtensions.Extensibility/Git/IGitVersion.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitVersion.cs
@@ -12,7 +12,7 @@ public interface IGitVersion : IComparable<IGitVersion>
     bool SupportStashStaged { get; }
     bool SupportUpdateRefs { get; }
 
-    // TODO bool SupportLsFilesFormat { get; }
+    bool SupportLsFilesFormat { get; }
 
     string ToString();
 


### PR DESCRIPTION
Follow-up to https://github.com/gitextensions/gitextensions/pull/12501, breaking GitExtensions.Extensibility version

## Proposed changes

Use correct  property.
Very minor improvement for users of Git [2.42, 2.46)
This should probably be moved out of GitExtensions.Extensibility...

## Test methodology <!-- How did you ensure quality? -->

codereview

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
