### PR TITLE
fix(GitModuleForm): Avoid InvalidOperationException

### DIFF
--- a/src/app/GitExtensions/Properties/launchSettings.json
+++ b/src/app/GitExtensions/Properties/launchSettings.json
@@ -26,6 +26,10 @@
     "Commit dialog": {
       "commandName": "Project",
       "commandLineArgs": "commit ."
+    },
+    "Init / Create": {
+      "commandName": "Project",
+      "commandLineArgs": "init"
     }
   }
 }

--- a/src/app/GitUI/GitModuleForm.cs
+++ b/src/app/GitUI/GitModuleForm.cs
@@ -45,9 +45,11 @@ public class GitModuleForm : GitExtensionsForm, IGitUICommandsSource, IGitModule
     {
         get
         {
-            // If this exception is seen, it's because the parameterless constructor was called.
+            // If this exception is seen, it might be because the parameterless constructor was called.
             // That constructor is only for use by the VS designer, and translation unit tests.
             // Using it at run time is an error.
+            // If no IGitUICommands instance has been passed to the protected ctor on purpose,
+            // the properties UICommands and Module must not be accessed.
             return _uiCommands
                    ?? throw new InvalidOperationException(
                        $"{nameof(UICommands)} is null. {GetType().FullName} was constructed incorrectly.");
@@ -131,9 +133,9 @@ public class GitModuleForm : GitExtensionsForm, IGitUICommandsSource, IGitModule
     {
         base.OnApplicationActivated();
 
-        if (_isReactivation)
+        if (_isReactivation && _uiCommands is IGitUICommands uiCommands)
         {
-            Module.InvalidateGitSettings();
+            uiCommands.Module.InvalidateGitSettings();
         }
         else
         {


### PR DESCRIPTION
Fixes #12688

## Proposed changes

`GitModuleForm`:
- Update outdated misleading comment
- Avoid `InvalidOperationException` on accessing `UICommands` / `Module` in `OnApplicationActivated` for `GitExtensionsDialog` that executes a git command which is completely self contained

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

InvalidOperationException (refer to issue)

### After

no exception

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).