### PR TITLE
chore(SettingsPageBase): Remove unused bindings

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -142,30 +142,6 @@ public abstract partial class SettingsPageBase : TranslatedControl, ISettingsPag
         _controlBindings.Add(binding);
     }
 
-    protected void AddSettingBinding(ISetting<bool> setting, CheckBox checkBox)
-    {
-        BoolCheckBoxAdapter adapter = new(setting, checkBox);
-        AddControlBinding(adapter.CreateControlBinding());
-    }
-
-    protected void AddSettingBinding(ISetting<bool?> setting, CheckBox checkBox)
-    {
-        BoolCheckBoxAdapter adapter = new(setting, checkBox);
-        AddControlBinding(adapter.CreateControlBinding());
-    }
-
-    protected void AddSettingBinding(ISetting<int> setting, TextBox control)
-    {
-        IntTextBoxAdapter adapter = new(setting, control);
-        AddControlBinding(adapter.CreateControlBinding());
-    }
-
-    protected void AddSettingBinding(ISetting<int?> setting, TextBox control)
-    {
-        IntTextBoxAdapter adapter = new(setting, control);
-        AddControlBinding(adapter.CreateControlBinding());
-    }
-
     protected void AddSettingBinding(ISetting<string> setting, ComboBox comboBox)
     {
         StringComboBoxAdapter adapter = new(setting, comboBox);
@@ -220,41 +196,11 @@ public abstract partial class SettingsPageBase : TranslatedControl, ISettingsPag
     }
 }
 
-public class BoolCheckBoxAdapter : BoolSetting
-{
-    public BoolCheckBoxAdapter(ISetting<bool> setting, CheckBox checkBox)
-        : base(setting.FullPath, setting.Default)
-    {
-        CustomControl = checkBox;
-    }
-
-    public BoolCheckBoxAdapter(ISetting<bool?> setting, CheckBox checkBox)
-        : base(setting.FullPath, setting.Default ?? false)
-    {
-        CustomControl = checkBox;
-    }
-}
-
 public class StringComboBoxAdapter : ChoiceSetting
 {
     public StringComboBoxAdapter(ISetting<string> setting, ComboBox comboBox)
         : base(setting.FullPath, comboBox.Items.Cast<string>().ToList(), setting.Default)
     {
         CustomControl = comboBox;
-    }
-}
-
-public class IntTextBoxAdapter : NumberSetting<int>
-{
-    public IntTextBoxAdapter(ISetting<int> setting, TextBox control)
-        : base(setting.FullPath, setting.Default)
-    {
-        CustomControl = control;
-    }
-
-    public IntTextBoxAdapter(ISetting<int?> setting, TextBox control)
-        : base(setting.FullPath, setting.Default ?? 0)
-    {
-        CustomControl = control;
     }
 }


### PR DESCRIPTION
## Proposed changes

`SettingsPageBase`: Remove unused bindings
Some usage was removed in #8458.
The last usage `AddSettingBinding(AppSettings.ConEmuStyle, _NO_TRANSLATE_cboStyle);` could be removed in addition.

Or else, is anybody going to use `AddSettingBinding`?

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).