### PR TITLE
fix(CheckSettingsLogic): Prefer native executables

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -1,4 +1,6 @@
-﻿using GitCommands;
+﻿#nullable enable
+
+using GitCommands;
 using GitCommands.Git;
 using GitCommands.Utils;
 using GitExtensions.Extensibility.Git;
@@ -101,7 +103,7 @@ public class CheckSettingsLogic
 
     private static IEnumerable<string> GetGitLocations()
     {
-        string envVariable = Environment.GetEnvironmentVariable("GITEXT_GIT");
+        string? envVariable = Environment.GetEnvironmentVariable("GITEXT_GIT");
         if (!string.IsNullOrEmpty(envVariable))
         {
             yield return envVariable;
@@ -110,7 +112,7 @@ public class CheckSettingsLogic
         yield return
             CommonLogic.GetRegistryValue(Registry.LocalMachine,
                              "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Git_is1", "InstallLocation");
-        string programFiles = Environment.GetEnvironmentVariable("ProgramFiles");
+        string? programFiles = Environment.GetEnvironmentVariable("ProgramFiles");
         string? programFilesX86 = null;
         if (IntPtr.Size == 8
             || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432")))
@@ -118,18 +120,26 @@ public class CheckSettingsLogic
             programFilesX86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
         }
 
+        if (programFiles is not null)
+        {
+            yield return programFiles + @"\Git\";
+        }
+
         if (programFilesX86 is not null)
         {
             yield return programFilesX86 + @"\Git\";
         }
 
-        yield return programFiles + @"\Git\";
+        if (programFiles is not null)
+        {
+            yield return programFiles + @"\msysgit\";
+        }
+
         if (programFilesX86 is not null)
         {
             yield return programFilesX86 + @"\msysgit\";
         }
 
-        yield return programFiles + @"\msysgit\";
         yield return @"C:\msysgit\";
 
         // cygwin has old git version on windows and bash has a lot of bugs
@@ -138,7 +148,7 @@ public class CheckSettingsLogic
             "Programs", "Git\\");
     }
 
-    public bool SolveGitExtensionsDir()
+    public static bool SolveGitExtensionsDir()
     {
         string? fileName = AppSettings.GetGitExtensionsDirectory();
 


### PR DESCRIPTION
## Proposed changes

`CheckSettingsLogic`: Prefer native Git executables over x86

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).