### PR TITLE
fix(FormCommit): update status for dirty unstaged submodules

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2704,7 +2704,7 @@ public sealed partial class GitModule : IGitModule
         return status;
     }
 
-    private void GetSubmoduleCurrentStatus(IReadOnlyList<GitItemStatus> status)
+    public void GetSubmoduleCurrentStatus(IReadOnlyList<GitItemStatus> status)
     {
         foreach (GitItemStatus item in status)
         {

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -367,6 +367,14 @@ public interface IGitModule
     string GetCommitCountString(ObjectId fromId, string to);
     IReadOnlyList<GitItemStatus> GetAllChangedFilesWithSubmodulesStatus(CancellationToken cancellationToken);
     IReadOnlyList<GitItemStatus> GetAllChangedFilesWithSubmodulesStatus(bool excludeIgnoredFiles, bool excludeAssumeUnchangedFiles, bool excludeSkipWorktreeFiles, UntrackedFilesMode untrackedFiles, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Initiate the submodule status async task, to calculate the statuses for the submodules in the list.
+    /// The task replaces the current task if it exists.
+    /// </summary>
+    /// <param name="status">List with GitItemStatus</param>
+    public void GetSubmoduleCurrentStatus(IReadOnlyList<GitItemStatus> status);
+
     bool ResetChanges(ObjectId? resetId, IReadOnlyList<GitItemStatus> selectedItems, bool resetAndDelete, IFullPathResolver fullPathResolver, out StringBuilder output, Action<BatchProgressEventArgs>? progressAction);
     bool HasSubmodules();
     void OpenWithDifftool(string? filename, string? oldFileName = "", string? firstRevision = GitRevision.IndexGuid, string? secondRevision = GitRevision.WorkTreeGuid, string? extraDiffArguments = null, bool isTracked = true, string? customTool = null);


### PR DESCRIPTION
## Proposed changes

The status for dirty submodules were not updated
when staging/unstaging submodules.

Note: Submodule statuses is not simple to modify (which wouldbe an alternative) and would still require some interpretation of the data, this is cleaner.
GetSubmoduleCurrentChangesAsync() could be moved to GitModule, would break the interface like #12647 

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![unstaged-dirty-1](https://github.com/user-attachments/assets/f0887509-b5cb-44e0-a305-428b85c77afd)

### After

![unstaged-dirty-2](https://github.com/user-attachments/assets/54437e22-d32f-4ec0-bd22-417658206725)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
