### PR TITLE
fix: GitGrep toolbar options

### DIFF
--- a/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
+++ b/src/app/GitUI/Editor/FormFindInCommitFilesGitGrep.cs
@@ -10,7 +10,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
     /// <summary>
     ///  Action to search for files in the commit using git grep.
     /// </summary>
-    public Action<string, int> FilesGitGrepLocator;
+    public Action<string> FilesGitGrepLocator;
 
     /// <summary>
     /// Action to toggle the visibility of the "find in commit files" filter control.
@@ -99,7 +99,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
         // Close the search if search is not visible (or user has cleared input)
         if (string.IsNullOrEmpty(GitGrepExpressionText) || !chkShowSearchBox.Checked)
         {
-            FilesGitGrepLocator?.Invoke("", 0);
+            FilesGitGrepLocator?.Invoke("");
         }
     }
 
@@ -115,7 +115,7 @@ internal partial class FormFindInCommitFilesGitGrep : GitExtensionsDialog
     }
 
     private void Search()
-        => FilesGitGrepLocator?.Invoke(GitGrepExpressionText, 0);
+        => FilesGitGrepLocator?.Invoke(GitGrepExpressionText);
 
     private void btnSearch_Click(object sender, EventArgs e)
     {

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1742,6 +1742,14 @@ Suitable for some config files modified locally.</source>
         <source>Using &amp;input box</source>
         <target />
       </trans-unit>
+      <trans-unit id="tsmiFindUsingMatchCase.Text">
+        <source>Match &amp;case</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiFindUsingWholeWord.Text">
+        <source>Match &amp;whole word</source>
+        <target />
+      </trans-unit>
       <trans-unit id="tsmiGroupByFileExtensionFlat.Text">
         <source>Group by file e&amp;xtension - flat</source>
         <target />

--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -69,6 +69,9 @@ partial class FileStatusList
         btnSameChange = new ToolStripButton();
         sepOptions = new ToolStripSeparator();
         btnFindInFilesGitGrep = new ToolStripSplitButton();
+        tsmiFindUsingMatchCase = new ToolStripMenuItem();
+        tsmiFindUsingWholeWord = new ToolStripMenuItem();
+        sepFindUsingSettings = new ToolStripSeparator();
         tsmiFindUsingDialog = new ToolStripMenuItem();
         tsmiFindUsingInputBox = new ToolStripMenuItem();
         tsmiFindUsingBoth = new ToolStripMenuItem();
@@ -491,12 +494,34 @@ partial class FileStatusList
         // btnFindInFilesGitGrep
         // 
         btnFindInFilesGitGrep.DisplayStyle = ToolStripItemDisplayStyle.Image;
-        btnFindInFilesGitGrep.DropDownItems.AddRange(new ToolStripItem[] { tsmiFindUsingDialog, tsmiFindUsingInputBox, tsmiFindUsingBoth });
+        btnFindInFilesGitGrep.DropDownItems.AddRange(new ToolStripItem[] { tsmiFindUsingMatchCase, tsmiFindUsingWholeWord, sepFindUsingSettings, tsmiFindUsingDialog, tsmiFindUsingInputBox, tsmiFindUsingBoth });
         btnFindInFilesGitGrep.Image = Properties.Images.ViewFile;
         btnFindInFilesGitGrep.Name = "btnFindInFilesGitGrep";
         btnFindInFilesGitGrep.Size = new Size(32, 22);
         btnFindInFilesGitGrep.ToolTipText = "Toggle 'Find in commit files using git-grep'";
         btnFindInFilesGitGrep.ButtonClick += FindInFilesGitGrep_ButtonClick;
+        btnFindInFilesGitGrep.DropDownOpening += FindInFilesGitGrep_DropDownOpening;
+        // 
+        // tsmiFindUsingMatchCase
+        // 
+        tsmiFindUsingMatchCase.CheckOnClick = true;
+        tsmiFindUsingMatchCase.Name = "tsmiFindUsingMatchCase";
+        tsmiFindUsingMatchCase.Size = new Size(158, 22);
+        tsmiFindUsingMatchCase.Text = "Match &case";
+        tsmiFindUsingMatchCase.Click += FindUsingMatchCase_Click;
+        // 
+        // tsmiFindUsingWholeWord
+        // 
+        tsmiFindUsingWholeWord.CheckOnClick = true;
+        tsmiFindUsingWholeWord.Name = "tsmiFindUsingWholeWord";
+        tsmiFindUsingWholeWord.Size = new Size(158, 22);
+        tsmiFindUsingWholeWord.Text = "Match &whole word";
+        tsmiFindUsingWholeWord.Click += FindUsingWholeWord_Click;
+        // 
+        // sepFindUsingSettings
+        // 
+        sepFindUsingSettings.Name = "sepFindUsingSettings";
+        sepFindUsingSettings.Size = new Size(6, 25);
         // 
         // tsmiFindUsingDialog
         // 
@@ -1085,6 +1110,9 @@ partial class FileStatusList
     private ToolStripButton btnSameChange;
     private ToolStripSeparator sepOptions;
     private ToolStripSplitButton btnFindInFilesGitGrep;
+    private ToolStripMenuItem tsmiFindUsingMatchCase;
+    private ToolStripMenuItem tsmiFindUsingWholeWord;
+    private ToolStripSeparator sepFindUsingSettings;
     private ToolStripMenuItem tsmiFindUsingDialog;
     private ToolStripMenuItem tsmiFindUsingInputBox;
     private ToolStripMenuItem tsmiFindUsingBoth;

--- a/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
@@ -13,6 +13,9 @@ partial class FileStatusList
     private readonly Image _treeImage = Images.FileTree;
     private readonly Image _flatListImage = Images.DocumentTree.AdaptLightness();
 
+    // order in AppSettings.FileStatusFindInFilesGitGrepTypeIndex
+    private ToolStripMenuItem[] FindUsingMenuItems => field ??= [tsmiFindUsingDialog, tsmiFindUsingInputBox, tsmiFindUsingBoth];
+
     private void ApplyGroupBy()
     {
         bool flatList = btnAsTree.Image == _flatListImage;
@@ -132,16 +135,30 @@ partial class FileStatusList
         }
     }
 
+    private void FindUsingMatchCase_Click(object sender, EventArgs e)
+    {
+        AppSettings.GitGrepIgnoreCase.Value = !tsmiFindUsingMatchCase.Checked;
+        FindInCommitFilesGitGrep();
+    }
+
+    private void FindUsingWholeWord_Click(object sender, EventArgs e)
+    {
+        AppSettings.GitGrepMatchWholeWord.Value = tsmiFindUsingWholeWord.Checked;
+        FindInCommitFilesGitGrep();
+    }
+
     private void FindUsing_Click(object sender, EventArgs e)
     {
         if (sender is ToolStripMenuItem item)
         {
-            AppSettings.FileStatusFindInFilesGitGrepTypeIndex.Value = btnFindInFilesGitGrep.DropDown.Items.IndexOf(item);
+            AppSettings.FileStatusFindInFilesGitGrepTypeIndex.Value = Array.IndexOf(FindUsingMenuItems, item);
         }
 
-        tsmiFindUsingDialog.Checked = sender == tsmiFindUsingDialog;
-        tsmiFindUsingInputBox.Checked = sender == tsmiFindUsingInputBox;
-        tsmiFindUsingBoth.Checked = sender == tsmiFindUsingBoth;
+        foreach (ToolStripMenuItem menuItem in FindUsingMenuItems)
+        {
+            menuItem.Checked = sender == menuItem;
+        }
+
         FindInFilesGitGrep_ButtonClick(sender, e);
     }
 
@@ -182,6 +199,12 @@ partial class FileStatusList
         tsmiShowDiffForAllParents.Visible = _enableDisablingShowDiffForAllParents;
         tsmiShowDiffForAllParents.Checked = AppSettings.ShowDiffForAllParents;
         tsmiShowDiffForAllParents.ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip;
+    }
+
+    private void FindInFilesGitGrep_DropDownOpening(object sender, EventArgs e)
+    {
+        tsmiFindUsingMatchCase.Checked = !AppSettings.GitGrepIgnoreCase.Value;
+        tsmiFindUsingWholeWord.Checked = AppSettings.GitGrepMatchWholeWord.Value;
     }
 
     private void ShowAssumeUnchangedFiles_Click(object sender, EventArgs e)
@@ -259,9 +282,10 @@ partial class FileStatusList
         bool findInFilesGitGrepVisible = CanUseFindInCommitFilesGitGrep;
         btnFindInFilesGitGrep.Visible = findInFilesGitGrepVisible;
         sepOptions.Visible = findInFilesGitGrepVisible;
-        for (int itemIndex = 0; itemIndex < btnFindInFilesGitGrep.DropDown.Items.Count; ++itemIndex)
+
+        for (int itemIndex = 0; itemIndex < FindUsingMenuItems.Length; ++itemIndex)
         {
-            ((ToolStripMenuItem)btnFindInFilesGitGrep.DropDown.Items[itemIndex]).Checked = AppSettings.FileStatusFindInFilesGitGrepTypeIndex.Value == itemIndex;
+            FindUsingMenuItems[itemIndex].Checked = AppSettings.FileStatusFindInFilesGitGrepTypeIndex.Value == itemIndex;
         }
 
         if (tsmiToolbar.DropDown.Items.Count == 0)

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -471,7 +471,7 @@ public sealed partial class FileStatusList : GitModuleControl
         else if (_formFindInCommitFilesGitGrep?.Visible is not true && cboFindInCommitFilesGitGrep.Text.Length > 0)
         {
             cboFindInCommitFilesGitGrep.Text = "";
-            FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 0);
+            FindInCommitFilesGitGrep();
         }
 
         SetFileStatusListVisibility(showNoFiles: NoFiles.Visible);
@@ -1624,9 +1624,9 @@ public sealed partial class FileStatusList : GitModuleControl
         Validates.NotNull(TopLevelControl);
         _formFindInCommitFilesGitGrep ??= new FormFindInCommitFilesGitGrep(UICommands)
         {
-            FilesGitGrepLocator = (text, delay) =>
+            FilesGitGrepLocator = (text) =>
             {
-                FindInCommitFilesGitGrep(text, delay);
+                FindInCommitFilesGitGrep(text);
                 cboFindInCommitFilesGitGrep.Text = text;
             },
 
@@ -2007,11 +2007,14 @@ public sealed partial class FileStatusList : GitModuleControl
     }
 
     private void cboFindInCommitFilesGitGrep_TextUpdate(object? sender, EventArgs e)
+        => FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 200);
+
+    private void FindInCommitFilesGitGrep()
     {
         FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text);
     }
 
-    private void FindInCommitFilesGitGrep(string search, int delay = 200)
+    private void FindInCommitFilesGitGrep(string search, int delay = 0)
     {
         SetDeleteSearchButtonVisibility();
 
@@ -2102,7 +2105,7 @@ public sealed partial class FileStatusList : GitModuleControl
 
     private void cboFindInCommitFilesGitGrep_SelectedIndexChanged(object? sender, EventArgs e)
     {
-        FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 0);
+        FindInCommitFilesGitGrep();
     }
 
     private void cboFindInCommitFilesGitGrep_SizeChanged(object? sender, EventArgs e)
@@ -2113,7 +2116,7 @@ public sealed partial class FileStatusList : GitModuleControl
     private void DeleteSearchButton_Click(object? sender, EventArgs e)
     {
         cboFindInCommitFilesGitGrep.Text = "";
-        FindInCommitFilesGitGrep(cboFindInCommitFilesGitGrep.Text, delay: 0);
+        FindInCommitFilesGitGrep();
     }
 
     private void StoreFilter(string value)


### PR DESCRIPTION
## Proposed changes

Add "Match case" and "Match whole words" to the revdiff toolbar, in addition to the options in the popup.
I change this often enough...

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

unchanged
<img width="424" height="172" alt="image" src="https://github.com/user-attachments/assets/e05a5bb3-c39f-4ae3-8127-174a853e5982" />

### Before

<img width="332" height="105" alt="image" src="https://github.com/user-attachments/assets/d9d7c0d4-cd36-4668-b60e-758a7d9e9dad" />
<!-- TODO -->

### After

<img width="191" height="147" alt="image" src="https://github.com/user-attachments/assets/7b5b31fd-ab57-4847-9502-7c5a7cecfe58" />

<!--
<img width="351" height="150" alt="image" src="https://github.com/user-attachments/assets/34bdf438-5412-40f7-bfbe-9ce9110de300" />
-->
## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
