### PR TITLE
fix(FindNextOrOpenWithDifftool): Show "Text not found"

### DIFF
--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -178,7 +178,7 @@ public partial class FindAndReplaceForm : GitExtensionsForm
                 range = null;
                 if (!Visible)
                 {
-                    return range;
+                    break;
                 }
 
                 if (currentItem is not null && startItem is null)


### PR DESCRIPTION
Fixes very non-obvious behavior

## Proposed changes

`FindAndReplaceForm`:
Show "Text not found" message instead of silently doing nothing on `F3`
if form was used and closed once before - in the long session (hibernation!)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

- focus diff text
- `Ctrl+F`
- enter some search string
- close the `FindAndReplaceForm`
- `F3`

### Before

nothing

### After

<img width="556" height="284" alt="image" src="https://github.com/user-attachments/assets/9ed1e89b-dbf7-4b75-bbc5-8d97388a0b3b" />

Then I know that I have to open and close the `FindAndReplaceForm` in order to remove the search string so that `F3` opens the difftool again.

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).