### PR TITLE
feat(settings): Mention and show env var GIT_CONFIG_GLOBAL

### DIFF
--- a/src/app/GitCommands/Git/EnvironmentConfiguration.cs
+++ b/src/app/GitCommands/Git/EnvironmentConfiguration.cs
@@ -13,6 +13,8 @@ public static class EnvironmentConfiguration
         = Env.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User)
        ?? Env.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.Machine);
 
+    public static string? GetEnvironmentVariable(string name) => Env.GetEnvironmentVariable(name);
+
     /// <summary>
     /// Sets <c>PATH</c>, <c>HOME</c>, <c>TERM</c> and <c>SSH_ASKPASS</c> environment variables
     /// for the current process.

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -6,7 +6,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
 
 public partial class GitSettingsPage : SettingsPageWithHeader
 {
-    private readonly TranslationString _homeIsSetToString = new("HOME is set to:");
+    private readonly TranslationString _envIsSetToString = new("{0} is set to: {1}");
+    private readonly TranslationString _envIsNotSetString = new("{0} is not set.");
 
     public GitSettingsPage(IServiceProvider serviceProvider)
         : base(serviceProvider)
@@ -29,7 +30,17 @@ public partial class GitSettingsPage : SettingsPageWithHeader
     protected override void SettingsToPage()
     {
         EnvironmentConfiguration.SetEnvironmentVariables();
-        homeIsSetToLabel.Text = string.Concat(_homeIsSetToString.Text, " ", EnvironmentConfiguration.GetHomeDir());
+        string envName = "GIT_CONFIG_GLOBAL";
+        string? envValue = EnvironmentConfiguration.GetEnvironmentVariable(envName);
+        string additionalText = "";
+        if (envValue is null)
+        {
+            additionalText = $"    ({string.Format(_envIsNotSetString.Text, $"%{envName}%")})";
+            envValue = EnvironmentConfiguration.GetHomeDir();
+            envName = "HOME";
+        }
+
+        homeIsSetToLabel.Text = string.Format(_envIsSetToString.Text, $"%{envName}%", envValue) + additionalText;
 
         GitPath.Text = AppSettings.GitCommandValue;
         LinuxToolsDir.Text = AppSettings.LinuxToolsDir;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.resx
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.resx
@@ -121,8 +121,10 @@
     <value>False</value>
   </metadata>
   <data name="lblGlobalConfigPath.Text" xml:space="preserve">
-    <value>The global config file located in the location stored environment variable %HOME%. By default %HOME% will be set 
-to %HOMEDRIVE%%HOMEPATH% if empty. Change the default behaviour only if you experience problems.</value>
+    <value>By default, the global config file is located in the location stored in the environment variable %HOME%.
+(This can be overridden by setting %GIT_CONFIG_GLOBAL%.)
+If empty, %HOME% will be set to %HOMEDRIVE%%HOMEPATH% by default.
+Change the default behaviour only if you experience problems.</value>
   </data>
   <metadata name="tlpnlGitPaths.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -8281,8 +8281,12 @@ Check if file is accessible.</source>
         <source>Change HOME</source>
         <target />
       </trans-unit>
-      <trans-unit id="_homeIsSetToString.Text">
-        <source>HOME is set to:</source>
+      <trans-unit id="_envIsNotSetString.Text">
+        <source>{0} is not set.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_envIsSetToString.Text">
+        <source>{0} is set to: {1}</source>
         <target />
       </trans-unit>
       <trans-unit id="downloadGitForWindows.Text">
@@ -8310,8 +8314,10 @@ Check if file is accessible.</source>
         <target />
       </trans-unit>
       <trans-unit id="lblGlobalConfigPath.Text">
-        <source>The global config file located in the location stored environment variable %HOME%. By default %HOME% will be set 
-to %HOMEDRIVE%%HOMEPATH% if empty. Change the default behaviour only if you experience problems.</source>
+        <source>By default, the global config file is located in the location stored in the environment variable %HOME%.
+(This can be overridden by setting %GIT_CONFIG_GLOBAL%.)
+If empty, %HOME% will be set to %HOMEDRIVE%%HOMEPATH% by default.
+Change the default behaviour only if you experience problems.</source>
         <target />
       </trans-unit>
       <trans-unit id="lblShPath.Text">


### PR DESCRIPTION
Fixes #12525

## Proposed changes

`GitSettingsPage`:
- Add "%GIT_CONFIG_GLOBAL%" to info text
- Show "GIT_CONFIG_GLOBAL" value or "not set"

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="870" height="379" alt="image" src="https://github.com/user-attachments/assets/854acf1a-9b50-4b4f-94a5-7204dd840cc5" />

### After

<img width="791" height="409" alt="image" src="https://github.com/user-attachments/assets/2736e142-e8d1-4277-8e63-51f92a3b8811" />

or 

<img width="791" height="409" alt="image" src="https://github.com/user-attachments/assets/55172e8b-3cc3-4c07-a1ea-34cf3e82b61c" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).