### PR TITLE
Restore 5.2 behavior when focusing commit msg with no staged changes 

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -222,3 +222,4 @@ YYYY/MM/DD, github id, Full name, email
 2025/08/22, nikolaosginos, Nikolaos Ginos, nikolaos.gkinos(at)googlemail.com
 2025/10/06, logiclrd, Jonathan Gilbert, logic(at)deltaq.org
 2025/11/08, hultqvist, Peter Hultqvist, hultqvist@silentorbit.com
+2025/12/09, DanielStout5, Daniel Stout, dstout@immediac.com

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1766,6 +1766,11 @@ public sealed partial class FormCommit : GitModuleForm
 
     private void SelectStaged()
     {
+        if (Staged.AllItemsCount == 0)
+        {
+            return;
+        }
+
         _currentFilesList = Staged;
         _skipUpdate = false;
         if (!Staged.HasSelection)


### PR DESCRIPTION
## Proposed changes
Addresses #12630 (Commit dialog: file content disappears when editing message)

## Test methodology <!-- How did you ensure quality? -->
Tested manually by focusing commit msg box with and without staged changes

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.52.0
- Windows 11

## Merge strategy


I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
