### PR TITLE
fix(git status): Update after special rebase

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -10,6 +10,8 @@ partial class FormBrowse
 
     private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId, bool isFileHistoryMode)
     {
+        RevisionGrid.ArtificialChanged += (_, _) => RefreshGitStatusMonitor();
+
         RevisionGrid.IndexWatcher.Changed += (_, args) =>
         {
             bool indexChanged = args.IsIndexChanged;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -60,6 +60,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
     public event EventHandler<DoubleClickRevisionEventArgs>? DoubleClickRevision;
     public event EventHandler<FilterChangedEventArgs>? FilterChanged;
     public event EventHandler? SelectionChanged;
+    public event EventHandler? ArtificialChanged;
 
     /// <summary>
     ///  Occurs whenever the revision graph has started loading the data.
@@ -3179,6 +3180,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         formProcess.ShowDialog(ParentForm);
         PerformRefreshRevisions();
+        ArtificialChanged?.Invoke(this, EventArgs.Empty);
     }
 
     #region Drag/drop patch files on revision grid


### PR DESCRIPTION
Fixes wrong status display for artificial commits when rebasing with autostash
(waiting half a minute until this confusing state is updated is no option)

## Proposed changes

- Trigger `RefreshGitStatusMonitor` after running special rebase commands for (edit / reword commit)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

STR
- enable autostash
- have changes in wdir
- `Advanced` | `Edit commit`

### Before

<img width="850" height="478" alt="image" src="https://github.com/user-attachments/assets/98bccfbd-f91e-455a-9a48-1567893622bd" />

### After

<img width="630" height="487" alt="image" src="https://github.com/user-attachments/assets/65d6a983-4a4c-405e-9d58-660cf1e464fc" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).