### PR TITLE
feat(git-grep): Add regex options to toolbar

### DIFF
--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1742,6 +1742,10 @@ Suitable for some config files modified locally.</source>
         <source>Match &amp;case</source>
         <target />
       </trans-unit>
+      <trans-unit id="tsmiFindUsingOptions.Text">
+        <source>&amp;Options</source>
+        <target />
+      </trans-unit>
       <trans-unit id="tsmiFindUsingWholeWord.Text">
         <source>Match &amp;whole word</source>
         <target />

--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -71,6 +71,11 @@ partial class FileStatusList
         btnFindInFilesGitGrep = new ToolStripSplitButton();
         tsmiFindUsingMatchCase = new ToolStripMenuItem();
         tsmiFindUsingWholeWord = new ToolStripMenuItem();
+        tsmiFindUsingOptions = new ToolStripMenuItem();
+        _NO_TRANSLATE_tsmiFindUsingBasic = new ToolStripMenuItem();
+        _NO_TRANSLATE_tsmiFindUsingExtended = new ToolStripMenuItem();
+        _NO_TRANSLATE_tsmiFindUsingFixed = new ToolStripMenuItem();
+        _NO_TRANSLATE_tsmiFindUsingPerl = new ToolStripMenuItem();
         sepFindUsingSettings = new ToolStripSeparator();
         tsmiFindUsingDialog = new ToolStripMenuItem();
         tsmiFindUsingInputBox = new ToolStripMenuItem();
@@ -494,7 +499,7 @@ partial class FileStatusList
         // btnFindInFilesGitGrep
         // 
         btnFindInFilesGitGrep.DisplayStyle = ToolStripItemDisplayStyle.Image;
-        btnFindInFilesGitGrep.DropDownItems.AddRange(new ToolStripItem[] { tsmiFindUsingMatchCase, tsmiFindUsingWholeWord, sepFindUsingSettings, tsmiFindUsingDialog, tsmiFindUsingInputBox, tsmiFindUsingBoth });
+        btnFindInFilesGitGrep.DropDownItems.AddRange(new ToolStripItem[] { tsmiFindUsingMatchCase, tsmiFindUsingWholeWord, tsmiFindUsingOptions, sepFindUsingSettings, tsmiFindUsingDialog, tsmiFindUsingInputBox, tsmiFindUsingBoth });
         btnFindInFilesGitGrep.Image = Properties.Images.ViewFile;
         btnFindInFilesGitGrep.Name = "btnFindInFilesGitGrep";
         btnFindInFilesGitGrep.Size = new Size(32, 22);
@@ -517,6 +522,41 @@ partial class FileStatusList
         tsmiFindUsingWholeWord.Size = new Size(158, 22);
         tsmiFindUsingWholeWord.Text = "Match &whole word";
         tsmiFindUsingWholeWord.Click += FindUsingWholeWord_Click;
+        // 
+        // tsmiFindUsingOptions
+        // 
+        tsmiFindUsingOptions.DropDownItems.AddRange(new ToolStripItem[] { _NO_TRANSLATE_tsmiFindUsingBasic, _NO_TRANSLATE_tsmiFindUsingExtended, _NO_TRANSLATE_tsmiFindUsingFixed, _NO_TRANSLATE_tsmiFindUsingPerl });
+        tsmiFindUsingOptions.Name = "tsmiFindUsingOptions";
+        tsmiFindUsingOptions.Size = new Size(180, 22);
+        tsmiFindUsingOptions.Text = "&Options";
+        // 
+        // tsmiFindUsingBasic
+        // 
+        _NO_TRANSLATE_tsmiFindUsingBasic.Name = "_NO_TRANSLATE_tsmiFindUsingBasic";
+        _NO_TRANSLATE_tsmiFindUsingBasic.Size = new Size(180, 22);
+        _NO_TRANSLATE_tsmiFindUsingBasic.Text = "--basic-regexp";
+        _NO_TRANSLATE_tsmiFindUsingBasic.Click += FindUsingOption_Click;
+        // 
+        // tsmiFindUsingExtended
+        // 
+        _NO_TRANSLATE_tsmiFindUsingExtended.Name = "_NO_TRANSLATE_tsmiFindUsingExtended";
+        _NO_TRANSLATE_tsmiFindUsingExtended.Size = new Size(180, 22);
+        _NO_TRANSLATE_tsmiFindUsingExtended.Text = "--extended-regexp";
+        _NO_TRANSLATE_tsmiFindUsingExtended.Click += FindUsingOption_Click;
+        // 
+        // tsmiFindUsingFixed
+        // 
+        _NO_TRANSLATE_tsmiFindUsingFixed.Name = "_NO_TRANSLATE_tsmiFindUsingFixed";
+        _NO_TRANSLATE_tsmiFindUsingFixed.Size = new Size(180, 22);
+        _NO_TRANSLATE_tsmiFindUsingFixed.Text = "--fixed-strings";
+        _NO_TRANSLATE_tsmiFindUsingFixed.Click += FindUsingOption_Click;
+        // 
+        // tsmiFindUsingPerl
+        // 
+        _NO_TRANSLATE_tsmiFindUsingPerl.Name = "_NO_TRANSLATE_tsmiFindUsingPerl";
+        _NO_TRANSLATE_tsmiFindUsingPerl.Size = new Size(180, 22);
+        _NO_TRANSLATE_tsmiFindUsingPerl.Text = "--perl-regexp";
+        _NO_TRANSLATE_tsmiFindUsingPerl.Click += FindUsingOption_Click;
         // 
         // sepFindUsingSettings
         // 
@@ -1112,6 +1152,11 @@ partial class FileStatusList
     private ToolStripSplitButton btnFindInFilesGitGrep;
     private ToolStripMenuItem tsmiFindUsingMatchCase;
     private ToolStripMenuItem tsmiFindUsingWholeWord;
+    private ToolStripMenuItem tsmiFindUsingOptions;
+    private ToolStripMenuItem _NO_TRANSLATE_tsmiFindUsingBasic;
+    private ToolStripMenuItem _NO_TRANSLATE_tsmiFindUsingExtended;
+    private ToolStripMenuItem _NO_TRANSLATE_tsmiFindUsingFixed;
+    private ToolStripMenuItem _NO_TRANSLATE_tsmiFindUsingPerl;
     private ToolStripSeparator sepFindUsingSettings;
     private ToolStripMenuItem tsmiFindUsingDialog;
     private ToolStripMenuItem tsmiFindUsingInputBox;

--- a/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
@@ -13,6 +13,8 @@ partial class FileStatusList
     private readonly Image _treeImage = Images.FileTree;
     private readonly Image _flatListImage = Images.DocumentTree.AdaptLightness();
 
+    private string? _findUsingOptionsPrefix;
+
     // order in AppSettings.FileStatusFindInFilesGitGrepTypeIndex
     private ToolStripMenuItem[] FindUsingMenuItems => field ??= [tsmiFindUsingDialog, tsmiFindUsingInputBox, tsmiFindUsingBoth];
 
@@ -147,6 +149,12 @@ partial class FileStatusList
         FindInCommitFilesGitGrep();
     }
 
+    private void FindUsingOption_Click(object sender, EventArgs e)
+    {
+        AppSettings.GitGrepUserArguments.Value = ((ToolStripMenuItem)sender).Text;
+        FindInCommitFilesGitGrep();
+    }
+
     private void FindUsing_Click(object sender, EventArgs e)
     {
         if (sender is ToolStripMenuItem item)
@@ -205,6 +213,8 @@ partial class FileStatusList
     {
         tsmiFindUsingMatchCase.Checked = !AppSettings.GitGrepIgnoreCase.Value;
         tsmiFindUsingWholeWord.Checked = AppSettings.GitGrepMatchWholeWord.Value;
+        _findUsingOptionsPrefix ??= tsmiFindUsingOptions.Text + ": ";
+        tsmiFindUsingOptions.Text = _findUsingOptionsPrefix + AppSettings.GitGrepUserArguments.Value;
     }
 
     private void ShowAssumeUnchangedFiles_Click(object sender, EventArgs e)

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -2057,6 +2057,7 @@ public sealed partial class FileStatusList : GitModuleControl
             string searchArg = search;
             if (!string.IsNullOrWhiteSpace(searchArg) && !GrepStringRegex().IsMatch(searchArg))
             {
+                searchArg = searchArg.Replace(@"\\", @"\\\\");
                 searchArg = $@"-e ""{searchArg}""";
             }
 


### PR DESCRIPTION
Follow-up to #12723

## Proposed changes

- `FileStatusList`: Add git-grep regex options to toolbar
- `FileStatusList.FindInCommitFilesGitGrep`: Escape double backslashes

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="346" height="171" alt="image" src="https://github.com/user-attachments/assets/b3e98446-c866-4769-a32e-4965a54c10aa" />

### After

<img width="520" height="193" alt="image" src="https://github.com/user-attachments/assets/259a1793-1571-44f2-a738-c1692fb4c2fa" />

<img width="510" height="375" alt="image" src="https://github.com/user-attachments/assets/43ceefcc-8bbd-4396-902d-7fdda931d6f3" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).