### PR TITLE
Enhances the 'remote repositories' window

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 
 namespace GitUI.CommandsDialogs;
 
@@ -121,7 +120,7 @@ partial class FormRemotes
         flowLayoutPanelSsh.Location = new Point(106, 31);
         flowLayoutPanelSsh.Margin = new Padding(0);
         flowLayoutPanelSsh.Name = "flowLayoutPanelSsh";
-        flowLayoutPanelSsh.Size = new Size(364, 31);
+        flowLayoutPanelSsh.Size = new Size(414, 31);
         flowLayoutPanelSsh.TabIndex = 3;
         // 
         // TestConnection
@@ -167,7 +166,7 @@ partial class FormRemotes
         flpnlRemoteColors.Location = new Point(106, 60);
         flpnlRemoteColors.Margin = new Padding(0);
         flpnlRemoteColors.Name = "flpnlRemoteColors";
-        flpnlRemoteColors.Size = new Size(364, 31);
+        flpnlRemoteColors.Size = new Size(414, 31);
         flpnlRemoteColors.TabIndex = 6;
         // 
         // btnRemoteColor
@@ -211,7 +210,7 @@ partial class FormRemotes
         flpnlRemoteManagement.RowStyles.Add(new RowStyle());
         flpnlRemoteManagement.RowStyles.Add(new RowStyle());
         flpnlRemoteManagement.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        flpnlRemoteManagement.Size = new Size(514, 309);
+        flpnlRemoteManagement.Size = new Size(564, 309);
         flpnlRemoteManagement.TabIndex = 0;
         // 
         // pnlMgtDetails
@@ -223,7 +222,7 @@ partial class FormRemotes
         pnlMgtDetails.Location = new Point(3, 3);
         pnlMgtDetails.Name = "pnlMgtDetails";
         pnlMgtDetails.Padding = new Padding(0, 0, 0, 8);
-        pnlMgtDetails.Size = new Size(508, 169);
+        pnlMgtDetails.Size = new Size(558, 169);
         pnlMgtDetails.TabIndex = 0;
         pnlMgtDetails.Text = "Details";
         // 
@@ -253,7 +252,7 @@ partial class FormRemotes
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
-        tblpnlMgtDetails.Size = new Size(470, 147);
+        tblpnlMgtDetails.Size = new Size(520, 147);
         tblpnlMgtDetails.TabIndex = 11;
         // 
         // label2
@@ -276,7 +275,7 @@ partial class FormRemotes
         Url.FormattingEnabled = true;
         Url.Location = new Point(109, 4);
         Url.Name = "Url";
-        Url.Size = new Size(248, 23);
+        Url.Size = new Size(298, 23);
         Url.TabIndex = 1;
         Url.Enter += Url_Enter;
         // 
@@ -285,7 +284,7 @@ partial class FormRemotes
         folderBrowserButtonUrl.AutoSize = true;
         folderBrowserButtonUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         folderBrowserButtonUrl.Dock = DockStyle.Fill;
-        folderBrowserButtonUrl.Location = new Point(363, 3);
+        folderBrowserButtonUrl.Location = new Point(413, 3);
         folderBrowserButtonUrl.MinimumSize = new Size(104, 25);
         folderBrowserButtonUrl.Name = "folderBrowserButtonUrl";
         folderBrowserButtonUrl.PathShowingControl = Url;
@@ -308,7 +307,7 @@ partial class FormRemotes
         RemoteName.Dock = DockStyle.Fill;
         RemoteName.Location = new Point(109, 34);
         RemoteName.Name = "RemoteName";
-        RemoteName.Size = new Size(248, 23);
+        RemoteName.Size = new Size(298, 23);
         RemoteName.TabIndex = 4;
         RemoteName.TextChanged += RemoteName_TextChanged;
         RemoteName.Enter += RemoteName_Enter;
@@ -358,7 +357,7 @@ partial class FormRemotes
         comboBoxPushUrl.FormattingEnabled = true;
         comboBoxPushUrl.Location = new Point(109, 120);
         comboBoxPushUrl.Name = "comboBoxPushUrl";
-        comboBoxPushUrl.Size = new Size(248, 23);
+        comboBoxPushUrl.Size = new Size(298, 23);
         comboBoxPushUrl.TabIndex = 11;
         comboBoxPushUrl.Visible = false;
         comboBoxPushUrl.Enter += ComboBoxPushUrl_Enter;
@@ -368,7 +367,7 @@ partial class FormRemotes
         folderBrowserButtonPushUrl.AutoSize = true;
         folderBrowserButtonPushUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         folderBrowserButtonPushUrl.Dock = DockStyle.Fill;
-        folderBrowserButtonPushUrl.Location = new Point(363, 119);
+        folderBrowserButtonPushUrl.Location = new Point(413, 119);
         folderBrowserButtonPushUrl.MinimumSize = new Size(104, 25);
         folderBrowserButtonPushUrl.Name = "folderBrowserButtonPushUrl";
         folderBrowserButtonPushUrl.PathShowingControl = comboBoxPushUrl;
@@ -388,7 +387,7 @@ partial class FormRemotes
         pnlMgtPuttySsh.Location = new Point(3, 178);
         pnlMgtPuttySsh.Name = "pnlMgtPuttySsh";
         pnlMgtPuttySsh.Padding = new Padding(0, 0, 0, 8);
-        pnlMgtPuttySsh.Size = new Size(508, 91);
+        pnlMgtPuttySsh.Size = new Size(558, 91);
         pnlMgtPuttySsh.TabIndex = 1;
         pnlMgtPuttySsh.Text = "PuTTY SSH";
         // 
@@ -410,7 +409,7 @@ partial class FormRemotes
         tableLayoutPanel1.RowCount = 2;
         tableLayoutPanel1.RowStyles.Add(new RowStyle());
         tableLayoutPanel1.RowStyles.Add(new RowStyle());
-        tableLayoutPanel1.Size = new Size(470, 62);
+        tableLayoutPanel1.Size = new Size(520, 62);
         tableLayoutPanel1.TabIndex = 12;
         // 
         // label3
@@ -430,7 +429,7 @@ partial class FormRemotes
         PuttySshKey.Anchor = AnchorStyles.Left | AnchorStyles.Right;
         PuttySshKey.Location = new Point(109, 4);
         PuttySshKey.Name = "PuttySshKey";
-        PuttySshKey.Size = new Size(248, 23);
+        PuttySshKey.Size = new Size(298, 23);
         PuttySshKey.TabIndex = 1;
         // 
         // SshBrowse
@@ -440,7 +439,7 @@ partial class FormRemotes
         SshBrowse.Dock = DockStyle.Fill;
         SshBrowse.Image = Properties.Images.FileNew;
         SshBrowse.ImageAlign = ContentAlignment.MiddleLeft;
-        SshBrowse.Location = new Point(363, 3);
+        SshBrowse.Location = new Point(413, 3);
         SshBrowse.MinimumSize = new Size(104, 25);
         SshBrowse.Name = "SshBrowse";
         SshBrowse.Size = new Size(104, 25);
@@ -465,7 +464,7 @@ partial class FormRemotes
         lblHeaderLine2.BorderStyle = BorderStyle.Fixed3D;
         lblHeaderLine2.Location = new Point(16, 8);
         lblHeaderLine2.Name = "lblHeaderLine2";
-        lblHeaderLine2.Size = new Size(481, 3);
+        lblHeaderLine2.Size = new Size(531, 3);
         lblHeaderLine2.TabIndex = 1;
         // 
         // flowLayoutPanel2
@@ -478,7 +477,7 @@ partial class FormRemotes
         flowLayoutPanel2.Location = new Point(3, 275);
         flowLayoutPanel2.Name = "flowLayoutPanel2";
         flowLayoutPanel2.Padding = new Padding(0, 0, 20, 0);
-        flowLayoutPanel2.Size = new Size(508, 31);
+        flowLayoutPanel2.Size = new Size(558, 31);
         flowLayoutPanel2.TabIndex = 2;
         // 
         // Save
@@ -498,7 +497,7 @@ partial class FormRemotes
         // 
         pnlManagementContainer.Controls.Add(gbMgtPanel);
         pnlManagementContainer.Dock = DockStyle.Fill;
-        pnlManagementContainer.Location = new Point(197, 3);
+        pnlManagementContainer.Location = new Point(277, 3);
         pnlManagementContainer.Name = "pnlManagementContainer";
         pnlManagementContainer.Padding = new Padding(8, 4, 8, 8);
         pnlManagementContainer.Size = new Size(536, 327);
@@ -525,7 +524,7 @@ partial class FormRemotes
         panelButtons.Controls.Add(btnToggleState);
         panelButtons.Dock = DockStyle.Right;
         panelButtons.FlowDirection = FlowDirection.TopDown;
-        panelButtons.Location = new Point(150, 8);
+        panelButtons.Location = new Point(230, 8);
         panelButtons.Margin = new Padding(8);
         panelButtons.Name = "panelButtons";
         panelButtons.Padding = new Padding(4, 0, 0, 0);
@@ -596,7 +595,7 @@ partial class FormRemotes
         panel1.Location = new Point(3, 3);
         panel1.Name = "panel1";
         panel1.Padding = new Padding(8);
-        panel1.Size = new Size(194, 327);
+        panel1.Size = new Size(350, 327);
         panel1.TabIndex = 0;
         // 
         // Remotes
@@ -613,7 +612,7 @@ partial class FormRemotes
         Remotes.Location = new Point(8, 8);
         Remotes.MultiSelect = false;
         Remotes.Name = "Remotes";
-        Remotes.Size = new Size(142, 311);
+        Remotes.Size = new Size(222, 311);
         Remotes.TabIndex = 1;
         Remotes.TileSize = new Size(136, 18);
         Remotes.UseCompatibleStateImageBehavior = false;
@@ -623,7 +622,7 @@ partial class FormRemotes
         // columnHeader1
         // 
         columnHeader1.Text = "";
-        columnHeader1.Width = 120;
+        columnHeader1.Width = 200;
         // 
         // tabPage2
         // 
@@ -791,7 +790,7 @@ partial class FormRemotes
         Controls.Add(tabControl1);
         MaximizeBox = false;
         MinimizeBox = false;
-        MinimumSize = new Size(760, 400);
+        MinimumSize = new Size(950, 400);
         Name = "FormRemotes";
         SizeGripStyle = SizeGripStyle.Show;
         StartPosition = FormStartPosition.CenterParent;


### PR DESCRIPTION
Fixes: https://github.com/gitextensions/gitextensions/issues/12771


## Proposed changes
- Increased the width of the ListView in order to be able to read longer repositories names
- Made the horizontal scrollbar appear if the remote repository name is still too long
- Made the "Add new remote" (+) button clickable at all times
- Modified the Panel1 size to 350 pixels
- Modified the minimum size for the window to 950 pixels

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before
<img width="930" height="411" alt="image" src="https://github.com/user-attachments/assets/5d056a2b-c158-4e83-82d8-e855288b3b82" />

### After
<img width="936" height="334" alt="image" src="https://github.com/user-attachments/assets/e832c233-7eb2-46d6-b6a2-053e8267e185" />


## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 6.0.5.18375
- Windows 11


## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
