### PR TITLE
Fix statistics plugin not showing line counts

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -224,4 +224,3 @@ YYYY/MM/DD, github id, Full name, email
 2025/11/08, hultqvist, Peter Hultqvist, hultqvist@silentorbit.com
 2026/01/07, xan2622, Xan Seiehun, xan2622(at)online(dot).fr
 2026/01/09, jmg2k, Jonas Guss, 44924601+jmg2k@users.noreply.github.com
-2026/01/12, GHXX, GHXX, GHXX@users.noreply.github.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12746

## Proposed changes

The statistics plugin stopped being able to count lines in commit 3948354070b92c73e8e2c50447ef00e6ef2e52eb.
This commit appears to have tweaked argument building a bit, by setting commitId to null (and meaning HEAD by that). See https://github.com/gitextensions/gitextensions/commit/3948354070b92c73e8e2c50447ef00e6ef2e52eb#diff-8f9b8a7437f617ff1c6cb1bed00aff1835abe42fde0a9478ef8e770f6ef64b6dL185 and https://github.com/gitextensions/gitextensions/commit/3948354070b92c73e8e2c50447ef00e6ef2e52eb#diff-e77c88efcdcdf77d038ff331b9c68a3b1343a37168170218322ee2f1846a1e30L3230.

This ternary (of the previous link) is then *essentially* expressed as `null is null ? "HEAD" : null.ToString()`. This still throws an exception though as the last argument is still always evaluated, even though the result will be discarded. Therefore the proposal is to simply replace the member access `.` with `?.`.

### Before

<img width="758" height="507" alt="image" src="https://github.com/user-attachments/assets/97f0ead7-c934-4179-931b-e5d610523b6a" />
(Observe that the line counts and the pie chart never load)

### After

<img width="758" height="500" alt="image" src="https://github.com/user-attachments/assets/808a7197-6af6-4c6f-88da-a03a46019c69" />
(Observe that the statistics plugin shows the line count again)

## Test methodology <!-- How did you ensure quality? -->

The affected line is effectively a ternary expression, of which the second return value may now also be null if the `commitId` is null. (`commitId is null ? "HEAD" : commitId?.ToString()`)
But if that is the case, we will always choose the first one anyway and discard the second. 
This means we are never actually using the null value in the second case, thus are never changing existing behaviour, assuming existing code does not rely on an exception being thrown in exactly this case.
Therefore, there should be no way of things breaking.

Regardless, my commits were made with this commit applied and the core features indeed appear to be working (Committing, pushing, fetching, etc.).

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.52.0.windows.1
- Windows 10 64bit
- System language: German

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).