### PR TITLE
feat(file multi-selection): Display focused file, not nothing

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -475,7 +475,7 @@ public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUp
             DiffText.Focus();
         }
 
-        FileStatusItem? item = DiffFiles.SelectedItem;
+        FileStatusItem? item = DiffFiles.SelectedItems.Contains(DiffFiles.FocusedItem) ? DiffFiles.FocusedItem : DiffFiles.SelectedItems.FirstOrDefault();
         await DiffText.ViewChangesAsync(item,
             line: line,
             forceFileView: IsFileTreeMode && !DiffFiles.FindInCommitFilesGitGrepActive,


### PR DESCRIPTION
Fixes #12770
the main usecase as reported by the OP
leaving other proposals from comments as "PR-only"

## Proposed changes

- `RevisionDiffControl`: Display focused file of multi-selection if selected or else the first selected instead of nothing
 
## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="900" height="150" alt="image" src="https://github.com/user-attachments/assets/e77fc959-2301-4ce6-8f86-12c9e2fbfd5f" />

### After

<img width="900" height="150" alt="image" src="https://github.com/user-attachments/assets/ee249949-f86b-4766-aee1-198530297a88" />

<img width="900" height="150" alt="image" src="https://github.com/user-attachments/assets/cef1be5c-73e6-4a75-a752-fb1f5062cd5e" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).