### PR TITLE
fix(show skip-worktree): Make mnemonic unique

### DIFF
--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1871,7 +1871,7 @@ Suitable for some config files modified locally.</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiShowSkipWorktreeFiles.Text">
-        <source>Show &amp;skip-worktree files</source>
+        <source>Show s&amp;kip-worktree files</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiShowUntrackedFiles.Text">

--- a/src/app/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Designer.cs
@@ -615,7 +615,7 @@ partial class FileStatusList
         tsmiShowSkipWorktreeFiles.CheckOnClick = true;
         tsmiShowSkipWorktreeFiles.Name = "tsmiShowSkipWorktreeFiles";
         tsmiShowSkipWorktreeFiles.Size = new Size(286, 22);
-        tsmiShowSkipWorktreeFiles.Text = "Show &skip-worktree files";
+        tsmiShowSkipWorktreeFiles.Text = "Show s&kip-worktree files";
         tsmiShowSkipWorktreeFiles.Visible = true;
         tsmiShowSkipWorktreeFiles.Click += ShowSkipWorktreeFiles_Click;
         // 


### PR DESCRIPTION
Fixes duplicate mnemonic in Diff tab

## Proposed changes

`FileStatusList` toolbar: Make mnemonic of toolbar dropdown "Show skip-worktree files" unique
Use the same as in the context menu

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="497" height="227" alt="image" src="https://github.com/user-attachments/assets/8a3db314-ab0b-4060-b2ee-f8fb5b3bbe48" />
<img width="436" height="250" alt="image" src="https://github.com/user-attachments/assets/b745db10-e3ec-4264-8ece-6e94e1dcf5c4" />

### After

<img width="497" height="227" alt="image" src="https://github.com/user-attachments/assets/436f4a8d-f98d-4fe7-aff7-8556ee6e71d9" />
<img width="436" height="250" alt="image" src="https://github.com/user-attachments/assets/fb2fcd7c-fd69-4a62-b49b-2515598875ad" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).