### PR TITLE
fix: difftool second revision

### DIFF
--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -212,7 +212,7 @@ public static partial class GitUIExtensions
                 item.Item.Name,
                 item.Item.OldName,
                 firstId?.ToString(),
-                item.SecondRevision.ToString(),
+                item.SecondRevision.ObjectId.ToString(),
                 isTracked: item.Item.IsTracked);
         }
 


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/issues/12816#issuecomment-3899768861

## Proposed changes

Use the sha instead of the description for the secondrevision for difftool invoked with F3 in the file tree fileviewer.

This was not seen before 6.0 as F3 always invoked search next
The issue itself has been around some years.
(or the modifications to IGitItem etc  in GE6 caused this.)
A very brief investigation for other occurrences.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
