### PR TITLE
feat(user scripts): Support selected folder for "{SelectedRelativePaths}"

### DIFF
--- a/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
+++ b/src/app/GitUI/CommandsDialogs/ScriptOptionsProvider.cs
@@ -1,4 +1,5 @@
-using GitExtensions.Extensibility;
+﻿using GitExtensions.Extensibility;
+using GitExtensions.Extensibility.Git;
 using GitUI.ScriptsEngine;
 
 namespace GitUI.CommandsDialogs;
@@ -21,7 +22,10 @@ internal class ScriptOptionsProvider : IScriptOptionsProvider
     }
 
     public ScriptOptionsProvider(FileStatusList fileStatusList, Func<int?> getCurrentLineNumber, Func<int?> getCurrentColumn)
-        : this(() => fileStatusList.SelectedItems.Select(item => item.Item.Name), getCurrentLineNumber, getCurrentColumn)
+        : this(getSelectedRelativePaths: () => fileStatusList.SelectedFolder is RelativePath folder
+                ? [folder.Value]
+                : fileStatusList.SelectedItems.Select(item => item.Item.Name),
+            getCurrentLineNumber, getCurrentColumn)
     {
     }
 


### PR DESCRIPTION
Addresses https://github.com/gitextensions/gitextensions/issues/12838#issuecomment-3904111211

## Proposed changes

- `ScriptOptionsProvider`: Replace `{SelectedRelativePaths}` with selected folder instead of with all names of contained files

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="1611" height="558" alt="image" src="https://github.com/user-attachments/assets/d0d95a85-729c-46b6-b76f-c0877cc50e33" />

### After

<img width="1357" height="558" alt="image" src="https://github.com/user-attachments/assets/078f2d5e-1af9-4ee0-9f95-2506f682a24f" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).