### PR TITLE
feat(BugReportInvoker): Ignore missing runtime DLL on application exit and if repeated

### DIFF
--- a/src/app/GitExtensions/Program.cs
+++ b/src/app/GitExtensions/Program.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.Design;
+﻿using System.ComponentModel.Design;
 using System.Configuration;
 using System.Diagnostics;
 using GitCommands;
@@ -34,6 +34,7 @@ internal static class Program
         {
             AppDomain.CurrentDomain.UnhandledException += (s, e) => BugReportInvoker.Report((Exception)e.ExceptionObject, e.IsTerminating);
             Application.ThreadException += (s, e) => BugReportInvoker.Report(e.Exception, isTerminating: false);
+            Application.ApplicationExit += (s, e) => BugReportInvoker.IgnoreFailedToLoadAnAssembly = true;
         }
 
         if (Environment.OSVersion.Version.Major >= 6)

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -20,6 +20,12 @@ public static class BugReportInvoker
 
     private static bool _isReportingDubiousOwnershipSecurity;
 
+    /// <summary>
+    /// Set to <see langword ="true"/> on application exit
+    /// in order to suppress the popup to restart the app on missing runtime assembly.
+    /// </summary>
+    public static bool IgnoreFailedToLoadAnAssembly { get; set; } = false;
+
     private static Form? OwnerForm
         => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
 
@@ -114,7 +120,12 @@ public static class BugReportInvoker
 
         if (HasFailedToLoadAnAssembly(exception))
         {
-            ReportFailedToLoadAnAssembly(exception, isTerminating);
+            if (!IgnoreFailedToLoadAnAssembly)
+            {
+                IgnoreFailedToLoadAnAssembly = true;
+                ReportFailedToLoadAnAssembly(exception, isTerminating);
+            }
+
             return;
         }
 


### PR DESCRIPTION
Supersedes #12843

## Proposed changes

`BugReportInvoker`:
Add property `IgnoreFailedToLoadAnAssembly`, which is set to `true` on `ApplicationExit`
and before invoking `ReportFailedToLoadAnAssembly` in order to avoid repeating the popup
because I have got a popup about a missing .NET DLL and, after confirming to restart, another popup about missing VC runtime.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

 N/A

## Test methodology <!-- How did you ensure quality? -->

- N/A

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).