### PR TITLE
fix(dashboard): focus search on start

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -750,7 +750,7 @@ public partial class UserRepositoriesList : GitExtensionsControl
         ToolStripMenuItem dashboardMenu = (ToolStripMenuItem)menuStrip.Items.Cast<ToolStripItem>().SingleOrDefault(p => p.Name == "dashboardToolStripMenuItem");
         dashboardMenu?.DropDownItems.AddRange(menus);
 
-        BeginInvoke(() => textBoxSearch.Focus());
+        BeginInvoke(textBoxSearch.Focus);
     }
 
     private void tsmiCategories_DropDownOpening(object sender, EventArgs e)


### PR DESCRIPTION
## Proposed changes

When starting the app to Dashboard, the search box is not focused (probably the grid, but no selection) (the box is briefly selected until the grid(?) takes over).
You have to manually select the box.
When exiting browse to dashboard, the box is focused.

A drawback is that the watermark text _Search _repositories..._ is only shown when selecting something else (that do not open a repo or hiding the dashboard). But the use should be obvious.

![search-focus-before](https://github.com/user-attachments/assets/eebffeae-bb18-4e72-baa2-f001c88dde16)

![search-focus-after](https://github.com/user-attachments/assets/05b729cd-c7a9-4d36-87bc-b29c585e8045)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
