### PR TITLE
fix(PathFirstComparer): Use InvariantCulture consistently

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.StatusSorter.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.StatusSorter.cs
@@ -154,7 +154,7 @@ partial class FileStatusList
 
                 static bool StartsWith(RelativePath longPath, RelativePath shortPath)
                 {
-                    return longPath.Value.StartsWith(shortPath.Value)
+                    return longPath.Value.StartsWith(shortPath.Value, StringComparison.InvariantCulture)
                         && longPath.Value[shortPath.Length] == '/';
                 }
             }


### PR DESCRIPTION
Fixes #12856
broken in #12598

## Proposed changes

- `PathFirstComparer`: Use `StringComparison.InvariantCulture` consistently for all comparisons

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests
- test by bug reporter (I cannot reproduce the error.)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).