### PR TITLE
feat(recent repo list): Improve readability

### DIFF
--- a/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -109,7 +109,7 @@ public sealed class RepositoryDescriptionProvider : IRepositoryDescriptionProvid
         ReadOnlySpan<char> shortName = descriptive.AsSpan(0, descriptiveEnd).Trim();
 
         string unique = repositoryDir.TrimEnd(Path.DirectorySeparatorChar);
-        return shortName.Length == 0 ? unique : $"{shortName}    [{unique}]";
+        return shortName.Length == 0 ? unique : $"{shortName}  [{unique}]";
     }
 
     /// <summary>


### PR DESCRIPTION
Improves on
>  Just being able to see entries with different length is much easier to read and find the actual item I want to open.

from https://github.com/gitextensions/gitextensions/issues/12638#issuecomment-3501977835

## Proposed changes

Recent repo list (taskbar icon, Start menu):
- Separate repo name from repo path by 2 spaces
- Use `[]` for repo path in order to distinguish from the unavoidable, always identical path to GE's `recent` folder in `()` in the tooltip 

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="222" height="34" alt="image" src="https://github.com/user-attachments/assets/2355947e-4756-46fb-a95c-869df2b9eed0" />

### After

<img width="223" height="31" alt="image" src="https://github.com/user-attachments/assets/94b238e7-7c98-437b-aa23-345f9739c259" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Can squash merge this PR

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).