### PR TITLE
feat(portable): Pinnable to taskbar per folder

### DIFF
--- a/src/app/GitUI/WindowsJumpListManager.cs
+++ b/src/app/GitUI/WindowsJumpListManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using GitCommands;
 using GitCommands.UserRepositoryHistory;
@@ -40,7 +41,10 @@ public sealed class WindowsJumpListManager : IWindowsJumpListManager
     {
         if (TaskbarManager.IsPlatformSupported)
         {
-            TaskbarManager.Instance.ApplicationId = AppSettings.ApplicationId;
+            string id = AppSettings.ApplicationId;
+            TaskbarManager.Instance.ApplicationId = AppSettings.IsPortable()
+                ? $"{id}.{Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes(Application.ExecutablePath)))}"
+                : id;
         }
     }
 


### PR DESCRIPTION
Fixes #12524

## Proposed changes

`WindowsJumpListManager`: Set path-dependent `ApplicationId` for portable installations

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

only one pinned taskbar icon

### After

<img width="259" height="117" alt="image" src="https://github.com/user-attachments/assets/73645966-9da3-408b-af40-ac050fbe45dc" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).