### PR TITLE
feat(PluginSettingsPage): Add state to exception

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -19,6 +19,7 @@ public partial class PluginSettingsPage : AutoLayoutSettingsPage
 
     private void CreateSettingsControls()
     {
+        // Gather debug info for exceptions
         StringBuilder state = new();
         try
         {


### PR DESCRIPTION
Related to #12901 and several earlier, still occurring in v6.0.5

## Proposed changes

`PluginSettingsPage.CreateSettingsControls`:
- Add progress state to exception
- Materialize the enumerable before creating controls

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- open settings with standard plugins

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).