### PR TITLE
fix(output history): Ensure collapsed panels if disabled after showing as panel

### DIFF
--- a/src/app/GitUI/UserControls/OutputHistoryPanelController.cs
+++ b/src/app/GitUI/UserControls/OutputHistoryPanelController.cs
@@ -30,6 +30,8 @@ internal partial class OutputHistoryPanelController : OutputHistoryControllerBas
 
         if (!outputHistoryProvider.Enabled)
         {
+            _verticalSplitContainer1.Panel2Collapsed = true;
+            _verticalSplitContainer2.Panel2Collapsed = true;
             return;
         }
 


### PR DESCRIPTION
Fixes #12902

## Proposed changes

`OutputHistoryPanelController`: Collapse both lower panels of involved SplitContainers if the Output History is disabled (by settings its length to 0)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

empty panel, not collapsible

<img width="1192" height="931" alt="Image" src="https://github.com/user-attachments/assets/0b6af17c-0a46-4f84-8ce8-4ca5b3beaf48" />

### After

panels collapsed 

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).