### PR TITLE
feat(repo button): Mention Ctrl in tooltip

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -315,7 +315,6 @@ partial class FormBrowse
         // 
         _NO_TRANSLATE_WorkingDir.Size = new Size(83, 22);
         _NO_TRANSLATE_WorkingDir.Text = "WorkingDir";
-        _NO_TRANSLATE_WorkingDir.ToolTipText = "Change working directory";
         // 
         // branchSelect
         // 

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using GitCommands;
 using GitCommands.UserRepositoryHistory;
@@ -18,6 +18,7 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
     private static readonly TranslationString _noWorkingFolderText = new("No working directory");
     private static readonly TranslationString _configureWorkingDirMenu = new("Co&nfigure this menu...");
     private static readonly TranslationString _repositorySearchPlaceholder = new("Search repositories...");
+    private static readonly TranslationString _toolTip = new("Change working directory\nHold Ctrl in order to open the selected repository in a new instance.");
 
     private class Implementation
     {
@@ -67,6 +68,7 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
             button.ButtonClick += (s, e) => button.ShowDropDown();
             button.DropDownOpening += (s, e) => FillDropDown(button);
             button.MouseUp += MouseUpHandler;
+            button.ToolTipText = _toolTip.Text;
 
             _getUICommands = getUICommands;
             _repositoryHistoryUIService = repositoryHistoryUIService;

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2831,6 +2831,11 @@ compare with first:</source>
         <source>Superproject: {0}</source>
         <target />
       </trans-unit>
+      <trans-unit id="_toolTip.Text">
+        <source>Change working directory
+Hold Ctrl in order to open the selected repository in a new instance.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_topProjectModuleFormat.Text">
         <source>Top project: {0}</source>
         <target />


### PR DESCRIPTION
## Proposed changes

`WorkingDirectoryToolStripSplitButton`:
- extend `ToolTipText`
- turn it into `TranslationString`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="284" height="72" alt="image" src="https://github.com/user-attachments/assets/bf6171bc-712e-40c8-8a90-1790b7ec3d25" />

### After

<img width="413" height="83" alt="image" src="https://github.com/user-attachments/assets/2d03d4ed-13a3-4be5-ac5f-078bd7b4081a" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).