### PR TITLE
fix(EditboxBasedConsoleOutputControl): Avoid NRE

### DIFF
--- a/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/src/app/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -88,7 +88,7 @@ public sealed class EditboxBasedConsoleOutputControl : ConsoleOutputControl
             return;
         }
 
-        _logProcessKilled();
+        _logProcessKilled?.Invoke();
 
         try
         {


### PR DESCRIPTION
Fixes #12912

## Proposed changes

`EditboxBasedConsoleOutputControl`: Avoid `NullReferenceException` on `Action? _logProcessKilled`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

%

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).