### PR TITLE
fix(RegisterPlugins): Perfom using _loadOperations

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1746,10 +1746,13 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
             ShowDashboard();
         }
 
-        RegisterPlugins();
+        _loadOperations.InvokeAndForget(this, () =>
+        {
+            RegisterPlugins();
 
-        revisionDiff.RegisterGitHostingPluginInBlameControl();
-        fileTree.RegisterGitHostingPluginInBlameControl();
+            revisionDiff.RegisterGitHostingPluginInBlameControl();
+            fileTree.RegisterGitHostingPluginInBlameControl();
+        });
     }
 
     private void FileExplorerToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #12794, #12901 and several duplicates
Follow-up to #12707

## Proposed changes

`FormBrowse.SetGitModule`: 
Perform `RegisterPlugins` using `TaskManager _loadOperations` as already in `OnLoad`
so it can be awaited before opening settings.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- %

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).