### PR TITLE
fix: load Dashboard once

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -792,7 +792,6 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
 
         Text = _appTitleGenerator.Generate(branchName: TranslatedStrings.NoBranch);
 
-        _dashboard.RefreshContent();
         _dashboard.Visible = true;
         _dashboard.BringToFront();
 


### PR DESCRIPTION
## Proposed changes

When starting to the Dashboard, only load the dashboard in OnLoad, not once before in ShowDashboard.

This has been around since 2018 and gives no noticable slowdown, even if all branchnames are loaded twice, but still an issue.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
