### PR TITLE
fix(RevisionGrid): Hide tooltip on app deactivate

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -586,6 +586,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         ReloadHotkeys();
         LoadCustomDifftools();
+
+        FindForm()?.Deactivate += (_, _) => _toolTipProvider.Hide();
     }
 
     public new void Load()


### PR DESCRIPTION
Follow up to #12859

## Proposed changes

`RevisionGrid`: Hide tooltip on `Deactivate` of parent form

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- Tooltip disappears e.g. on hitting `Start`

## Test environment(s) <!-- Remove any that don't apply -->

Win11 25H2

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).