### PR TITLE
fix(repo menu): Display hotkeys again

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1134,6 +1134,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         fileToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
         helpToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
         toolsToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
+        _NO_TRANSLATE_WorkingDir.RefreshShortcutKeys(Hotkeys);
         ToolStripFilters.RefreshBrowseDialogShortcutKeys(Hotkeys);
         ToolStripFilters.RefreshRevisionGridShortcutKeys(GetHotkeys(RevisionGridControl.HotkeySettingsName));
 

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -7,6 +7,7 @@ using GitExtensions.Extensibility.Translations;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using ResourceManager;
+using ResourceManager.Hotkey;
 
 namespace GitUI.CommandsDialogs.Menus;
 
@@ -18,7 +19,12 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
     private static readonly TranslationString _noWorkingFolderText = new("No working directory");
     private static readonly TranslationString _configureWorkingDirMenu = new("Co&nfigure this menu...");
     private static readonly TranslationString _repositorySearchPlaceholder = new("Search repositories...");
-    private static readonly TranslationString _toolTip = new("Change working directory\nHold Ctrl in order to open the selected repository in a new instance.");
+    private static readonly TranslationString _toolTip = new("""
+        Change working directory
+        Left click opens the drop-down menu.
+        Then hold Ctrl in order to open the selected repository in a new instance.
+        Right click starts the "Open repository" dialog.
+        """);
 
     private class Implementation
     {
@@ -249,6 +255,12 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
                 button.AutoSize = true;
             }
         }
+
+        internal void RefreshShortcutKeys(IEnumerable<HotkeyCommand>? hotkeys)
+        {
+            _tsmiOpenLocalRepository.ShortcutKeyDisplayString = hotkeys.GetShortcutDisplay(FormBrowse.Command.OpenRepo);
+            _tsmiCloseRepo.ShortcutKeyDisplayString = hotkeys.GetShortcutDisplay(FormBrowse.Command.CloseRepository);
+        }
     }
 
     private Implementation? _implementation;
@@ -279,6 +291,11 @@ internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITra
     {
         // If the component is not initialized, no point doing anything.
         _implementation?.RefreshContent(this);
+    }
+
+    public void RefreshShortcutKeys(IEnumerable<HotkeyCommand>? hotkeys)
+    {
+        _implementation?.RefreshShortcutKeys(hotkeys);
     }
 
     void ITranslate.AddTranslationItems(ITranslation translation)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2833,7 +2833,9 @@ compare with first:</source>
       </trans-unit>
       <trans-unit id="_toolTip.Text">
         <source>Change working directory
-Hold Ctrl in order to open the selected repository in a new instance.</source>
+Left click opens the drop-down menu.
+Then hold Ctrl in order to open the selected repository in a new instance.
+Right click starts the "Open repository" dialog.</source>
         <target />
       </trans-unit>
       <trans-unit id="_topProjectModuleFormat.Text">


### PR DESCRIPTION
## Proposed changes

`WorkingDirectoryToolStripSplitButton`
- Make setting `ShortcutKeyDisplayString` work again
- Mention right click in tooltip

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="496" height="101" alt="image" src="https://github.com/user-attachments/assets/b92a2409-2129-4b4c-bf6d-3055b5493ac9" />
<img width="457" height="76" alt="image" src="https://github.com/user-attachments/assets/8c332441-ccc5-4e55-b2c1-74aa22f6e3f9" />

### After

<img width="493" height="99" alt="image" src="https://github.com/user-attachments/assets/93dcf0d9-9d82-490d-b814-149415e35b13" />
<img width="502" height="109" alt="image" src="https://github.com/user-attachments/assets/2239ddeb-3925-40a0-9890-27271f06c1c8" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).