### PR TITLE
fix(TextBoxSilencer): Allow Ctrl+Home/End to navigate to document boundaries

### DIFF
--- a/src/app/GitUI/UserControls/TextBoxSilencer.cs
+++ b/src/app/GitUI/UserControls/TextBoxSilencer.cs
@@ -31,13 +31,14 @@ internal sealed class TextBoxSilencer
         bool isAtEndColumn = position == GetLineEnd(text, startIndex: position);
         bool isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
         bool isAtLastLine = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex: position) < 0;
+        bool ctrl = e.Control;
 
         switch (e.KeyCode)
         {
             case Keys.Up when isAtFirstLine:
             case Keys.Down when isAtLastLine:
-            case Keys.Home when isAtFirstColumn:
-            case Keys.End when isAtEndColumn:
+            case Keys.Home when isAtFirstColumn && (!ctrl || isAtFirstLine):
+            case Keys.End when isAtEndColumn && (!ctrl || isAtLastLine):
             case Keys.Left or Keys.PageUp when isAtFirstLine && isAtFirstColumn:
             case Keys.Right or Keys.PageDown when isAtLastLine && isAtEndColumn:
                 e.Handled = true;


### PR DESCRIPTION
Fixes a regression introduced in fcbc2eaa4.

The TextBoxSilencer suppresses cursor movement keys at line boundaries to avoid the system ding sound. However, it did not account for the Ctrl modifier, which changes Home/End from line-level to document-level navigation. This caused Ctrl+End to be suppressed when the caret was at the end of a line (even if not at the end of the document), and similarly for Ctrl+Home at the first column.

Add Ctrl modifier checks so that Ctrl+Home is only suppressed when already at the start of the document, and Ctrl+End only when already at the end of the document.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
