### PR TITLE
Update SourceLink to fix worktrees in this repo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />


### PR DESCRIPTION
The old version of SourceLink doesn't support relative worktrees. If you had one, then tried to build this repo, you'd get error:

```
GitExtensions.Analyzers.CSharp netstandard2.0 failed with 1 error(s) and 1 warning(s) (0.2s)
  C:\Users\drnoakes\.nuget\packages\microsoft.build.tasks.git\8.0.0\build\Microsoft.Build.Tasks.Git.targets(25,5): error Error reading git repository information: Unsupported repository extension 'relativeworktrees'. Only noop, preciousObjects, partialclone, worktreeConfig are supported.
  C:\Users\drnoakes\.nuget\packages\microsoft.build.tasks.git\8.0.0\build\Microsoft.Build.Tasks.Git.targets(25,5): warning Unable to locate repository with working directory that contains directory 'C:\dev\gitextensions.worktrees\copilot-delighted-wildfowl\src\app\GitExtensions.Analyzers.CSharp'.
```

Upgrading the SourceLink package fixes this.

## Test methodology <!-- How did you ensure quality? -->

- CI build

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
