### PR TITLE
fix: dark+ update

### DIFF
--- a/src/app/GitUI/Themes/dark+.css
+++ b/src/app/GitUI/Themes/dark+.css
@@ -8,7 +8,7 @@
 .LineNumberBackground { color: #252526; }
 .AuthoredHighlight { color: #232c00; }
 .Selection { color: #2d6981; }
-.HighlightAllOccurences { color: #143746; }
+.HighlightAllOccurences { color: #1a475a; }
 .InactiveSelectionHighlight { color: #1e3d4b; }
 
 .Branch { color: #00d76b; }


### PR DESCRIPTION
Based on #12941 
If Selection is removed, then the changes could be applied, but the auto adopted selection color is hardly visible

## Proposed changes

Make dark+ theme slightly darker,  similar to the just updated VS Code 2026 dark theme.

The change makes other dark mode inconsistencies like categories in ListView, edit panel background and some app colors like settings overview be even worse, but overall I prefer it.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="1379" height="910" alt="image" src="https://github.com/user-attachments/assets/2570f39f-b203-48d8-b362-31543eb79f93" />

### After

<img width="1097" height="748" alt="image" src="https://github.com/user-attachments/assets/e36578f1-37a4-4fe9-9ee3-50e6ecc7a088" />

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
