### PR TITLE
refactor: ban direct MessageBox usage via BannedApiAnalyzers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,14 @@
 
 <https://github.blog/changelog/2025-01-21-custom-repository-instructions-are-now-available-for-copilot-on-github-com-public-preview/>
 
+## Repository setup
+
+This repository uses git submodules (under `externals/`). After cloning or creating a new worktree, always run:
+
+```shell
+git submodule update --init --recursive
+```
+
 ## General
 
 * Make only high confidence suggestions when reviewing code changes.
@@ -81,6 +89,7 @@ For example:
 * Do not repeat in a comment what the test name already expresses.
 * Use `NSubstitute` for mocking.
 * Use `FluentAssertions` for assertions, i.e. do not use `ClassicAssert`.
+* When you encounter a flaky test failure, take the time to understand the root cause and fix it. Do not dismiss it as a pre-existing issue. Flaky tests erode confidence and should be fixed or removed.
 
 ## Commit Messages
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,6 +70,9 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)eng\stylecop.json">
       <Link>stylecop.json</Link>
     </AdditionalFiles>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)eng\BannedSymbols.txt">
+      <Visible>False</Visible>
+    </AdditionalFiles>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)eng\vs-threading.MainThreadAssertingMethods.txt">
       <Visible>False</Visible>
     </AdditionalFiles>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,6 +5,10 @@
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(EnableVisualStudioThreading)' != 'false'">
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
 
     <!-- Analyzers -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
 
     <!-- Setup infra -->

--- a/eng/BannedSymbols.txt
+++ b/eng/BannedSymbols.txt
@@ -1,0 +1,1 @@
+T:System.Windows.Forms.MessageBox; Use MessageBoxes instead

--- a/src/app/BugReporter/BugReportForm.cs
+++ b/src/app/BugReporter/BugReportForm.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using BugReporter.Properties;
 using BugReporter.Serialization;
 using GitCommands;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Translations;
 using GitExtensions.Extensibility.Translations.Xliff;
 using GitExtUtils.GitUI;
@@ -156,13 +157,13 @@ Send report?");
         bool hasUserText = CheckContainsInfo(descriptionTextBox.Text);
         if (!hasUserText)
         {
-            MessageBox.Show(this, _noReproStepsSuppliedErrorMessage.Text, _title.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, _noReproStepsSuppliedErrorMessage.Text, _title.Text);
             descriptionTextBox.Focus();
             return;
         }
 
-        if (MessageBox.Show(this, _submitGitHubMessage.Text, _title.Text,
-                MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) == DialogResult.No)
+        if (!MessageBoxes.Confirm(this, _submitGitHubMessage.Text, _title.Text,
+                MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2))
         {
             return;
         }

--- a/src/app/GitCommands/CommitMessageManager.cs
+++ b/src/app/GitCommands/CommitMessageManager.cs
@@ -231,7 +231,7 @@ public sealed class CommitMessageManager : ICommitMessageManager
         catch (Exception ex) when (ex is not (OperationCanceledException or ObjectDisposedException))
         {
             await _owner.SwitchToMainThreadAsync(cancellationToken: cancellationToken);
-            MessageBox.Show(_owner, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            MessageBoxes.Show(_owner, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             return string.Empty;
         }
     }
@@ -255,7 +255,7 @@ public sealed class CommitMessageManager : ICommitMessageManager
             await _owner.SwitchToMainThreadAsync(cancellationToken: cancellationToken);
 
             // No need to cancel the other operations in FormCommit - just let the user know that something went wrong
-            MessageBox.Show(_owner, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            MessageBoxes.Show(_owner, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
         }
     }
 }

--- a/src/app/GitCommands/ExceptionUtils.cs
+++ b/src/app/GitCommands/ExceptionUtils.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Text;
+using GitExtensions.Extensibility;
 
 namespace GitCommands;
 
@@ -19,7 +20,7 @@ public static class ExceptionUtils
     {
         if (!(canIgnore && IsIgnorable(e)))
         {
-            MessageBox.Show(owner, string.Join(Environment.NewLine + Environment.NewLine, info, e.ToStringWithData()), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(owner, string.Join(Environment.NewLine + Environment.NewLine, info, e.ToStringWithData()));
         }
     }
 

--- a/src/app/GitCommands/Git/GitVersion.cs
+++ b/src/app/GitCommands/Git/GitVersion.cs
@@ -72,7 +72,7 @@ public class GitVersion : IComparable<GitVersion>, IGitVersion
                 if (gitVersion < LastVersionWithoutKnownLimitations)
                 {
                     // Report the last supported version rather than the last version without known issues
-                    MessageBox.Show(null, $"{gitVersion} is lower than {LastSupportedVersion}. Some commands can fail.", "Unsupported Git version", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.ShowError(owner: null, $"{gitVersion} is lower than {LastSupportedVersion}. Some commands can fail.", "Unsupported Git version");
                 }
             }
             catch (Exception exception)

--- a/src/app/GitExtensions.Extensibility/MessageBoxes.cs
+++ b/src/app/GitExtensions.Extensibility/MessageBoxes.cs
@@ -1,0 +1,60 @@
+﻿namespace GitExtensions.Extensibility;
+
+/// <summary>
+///  Provides general-purpose wrappers around <c>System.Windows.Forms.MessageBox</c>
+///  for use by plugins and other projects that cannot reference GitUI.
+///  Projects within GitUI should prefer the <c>GitUI.MessageBoxes</c> class
+///  which provides additional domain-specific methods with translatable strings.
+/// </summary>
+public static class MessageBoxes
+{
+    /// <summary>
+    ///  Shows a message box with the specified parameters.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+#pragma warning disable RS0030 // Do not use banned APIs -- MessageBoxes is the approved wrapper
+    public static DialogResult Show(IWin32Window? owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Button1)
+        => MessageBox.Show(owner ?? Form.ActiveForm, text, caption, buttons, icon, defaultButton);
+#pragma warning restore RS0030
+
+    /// <summary>
+    ///  Shows a message box without specifying an icon.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(IWin32Window? owner, string text, string caption, MessageBoxButtons buttons)
+        => Show(owner, text, caption, buttons, MessageBoxIcon.None);
+
+    /// <summary>
+    ///  Shows a message box without an explicit owner window.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton)
+        => Show(owner: null, text, caption, buttons, icon, defaultButton);
+
+    /// <summary>
+    ///  Shows a message box without an explicit owner window.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
+        => Show(owner: null, text, caption, buttons, icon);
+
+    /// <summary>
+    ///  Shows a message box without an explicit owner window or icon.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(string text, string caption, MessageBoxButtons buttons)
+        => Show(owner: null, text, caption, buttons, MessageBoxIcon.None);
+
+    /// <summary>
+    ///  Shows an error message box.
+    /// </summary>
+    public static void ShowError(IWin32Window? owner, string text, string? caption = null)
+        => Show(owner, text, caption ?? "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+    /// <summary>
+    ///  Shows a Yes/No confirmation dialog.
+    /// </summary>
+    /// <returns><see langword="true"/> if the user selected Yes.</returns>
+    public static bool Confirm(IWin32Window? owner, string text, string caption, MessageBoxIcon icon = MessageBoxIcon.Question, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Button1)
+        => Show(owner, text, caption, MessageBoxButtons.YesNo, icon, defaultButton) == DialogResult.Yes;
+}

--- a/src/app/GitExtensions/Program.cs
+++ b/src/app/GitExtensions/Program.cs
@@ -15,6 +15,7 @@ using GitUI.NBugReports;
 using GitUI.Theming;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
+using MessageBoxes = GitUI.MessageBoxes;
 
 namespace GitExtensions;
 
@@ -125,7 +126,7 @@ internal static class Program
             formChoose.ShowDialog();
         }
 
-        AppSettings.TelemetryEnabled ??= MessageBox.Show(
+        AppSettings.TelemetryEnabled ??= MessageBoxes.Show(
             null,
             ResourceManager.TranslatedStrings.TelemetryPermissionMessage,
             ResourceManager.TranslatedStrings.TelemetryPermissionCaption,
@@ -282,13 +283,13 @@ internal static class Program
                 {
                     string messageContent = string.Format("There is a problem with the user.xml configuration file.{0}{0}The error message was: {1}{0}{0}The configuration file is usually found in: {2}{0}{0}Problems with configuration can usually be solved by deleting the configuration file. Would you like to delete the file?", Environment.NewLine, in3.Message, localSettingsPath);
 
-                    if (MessageBox.Show(messageContent, "Configuration Error",
+                    if (MessageBoxes.Show(messageContent, "Configuration Error",
                                         MessageBoxButtons.YesNo, MessageBoxIcon.Error, MessageBoxDefaultButton.Button2) == DialogResult.Yes)
                     {
                         if (localSettingsPath.TryDeleteDirectory(out string? errorMessage))
                         {
                             // Restart Git Extensions with the same arguments after old config is deleted?
-                            if (DialogResult.OK.Equals(MessageBox.Show(string.Format("Files have been deleted.{0}{0}Would you like to attempt to restart Git Extensions?", Environment.NewLine), "Configuration Error", MessageBoxButtons.OKCancel, MessageBoxIcon.Question)))
+                            if (DialogResult.OK.Equals(MessageBoxes.Show(string.Format("Files have been deleted.{0}{0}Would you like to attempt to restart Git Extensions?", Environment.NewLine), "Configuration Error", MessageBoxButtons.OKCancel, MessageBoxIcon.Question)))
                             {
                                 string[] args = Environment.GetCommandLineArgs();
                                 Process p = new() { StartInfo = { FileName = args[0] } };
@@ -303,7 +304,7 @@ internal static class Program
                         }
                         else
                         {
-                            MessageBox.Show(string.Format("Could not delete all files and folders in {0}!", localSettingsPath), "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            MessageBoxes.Show(string.Format("Could not delete all files and folders in {0}!", localSettingsPath), "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }
                 }
@@ -312,7 +313,7 @@ internal static class Program
                 else
                 {
                     string messageContent = string.Format("There is a problem with the application settings XML configuration file.{0}{0}The error message was: {1}{0}{0}Problems with configuration can usually be solved by deleting the configuration file.", Environment.NewLine, in3.Message);
-                    MessageBox.Show(messageContent, "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(messageContent, "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 exceptionHandled = true;
@@ -323,7 +324,7 @@ internal static class Program
             // if we fail in this somehow at least this message might get somewhere
             if (!exceptionHandled)
             {
-                MessageBox.Show(ce.ToString(), "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(ce.ToString(), "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             Environment.Exit(1);

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
@@ -1,4 +1,4 @@
-﻿using ResourceManager;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
 
@@ -41,13 +41,13 @@ public partial class FormDashboardCategoryTitle : GitExtensionsForm
     {
         if (string.IsNullOrEmpty(txtCategoryName.Text))
         {
-            MessageBox.Show(this, _categoryNameRequiredText.Text, lblCategoryName.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _categoryNameRequiredText.Text, lblCategoryName.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
         if (_existingCategories.Contains(txtCategoryName.Text, StringComparer.Ordinal))
         {
-            MessageBox.Show(this, _categoryNameExistsText.Text, lblCategoryName.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _categoryNameExistsText.Text, lblCategoryName.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using GitCommands;
 using GitCommands.UserRepositoryHistory;
@@ -537,7 +537,7 @@ public partial class UserRepositoriesList : GitExtensionsControl
 
     private bool PromptUserConfirm(string question, string caption)
     {
-        DialogResult dialogResult = MessageBox.Show(this,
+        DialogResult dialogResult = MessageBoxes.Show(this,
             question,
             caption,
             MessageBoxButtons.YesNo,
@@ -912,7 +912,7 @@ public partial class UserRepositoriesList : GitExtensionsControl
 
                 if (!module.IsValidGitWorkingDir())
                 {
-                    MessageBox.Show(this, TranslatedStrings.DirectoryInvalidRepository,
+                    MessageBoxes.Show(this, TranslatedStrings.DirectoryInvalidRepository,
                         _cannotOpenTheFolder.Text, MessageBoxButtons.OK,
                         MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1);
                     return;

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -43,7 +43,7 @@ public sealed partial class FormBisect : GitModuleForm
         IReadOnlyList<GitRevision> revisions = _revisionGridInfo.GetSelectedRevisions();
         if (revisions.Count > 1)
         {
-            if (MessageBox.Show(this, _bisectStart.Text, Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            if (MessageBoxes.Show(this, _bisectStart.Text, Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
                 BisectRange(revisions[0].ObjectId, revisions[^1].ObjectId);
                 Close();

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -96,7 +96,7 @@ public partial class FormOpenDirectory : GitExtensionsForm
             return;
         }
 
-        MessageBox.Show(this, _warningOpenFailed.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        MessageBoxes.Show(this, _warningOpenFailed.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
     }
 
     private void DirectoryKeyPress(object sender, KeyPressEventArgs e)

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -268,7 +268,7 @@ public partial class FormUpdates : GitExtensionsDialog
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _errorMessage.Text + Environment.NewLine + ex.Message, _errorHeading.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBoxes.Show(this, _errorMessage.Text + Environment.NewLine + ex.Message, _errorHeading.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace GitUI.CommandsDialogs.BrowseDialog;
+namespace GitUI.CommandsDialogs.BrowseDialog;
 
 /// <summary>
 /// Represents a menu command with Text, ShortcutKey or ShortcutDisplayString, Action,
@@ -64,7 +64,7 @@ internal class MenuCommand
             }
             else
             {
-                MessageBox.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         };
 

--- a/src/app/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/src/app/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -88,7 +88,7 @@ public sealed partial class FormAddToGitIgnore : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, ex.ToString(), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, ex.ToString(), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         Close();

--- a/src/app/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -175,7 +175,7 @@ public partial class FormApplyPatch : GitModuleForm
 
         if (string.IsNullOrEmpty(patchFile) && string.IsNullOrEmpty(dirText))
         {
-            MessageBox.Show(this, _noFileSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK,  MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _noFileSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK,  MessageBoxIcon.Error);
             return;
         }
 

--- a/src/app/GitUI/CommandsDialogs/FormArchive.cs
+++ b/src/app/GitUI/CommandsDialogs/FormArchive.cs
@@ -103,7 +103,7 @@ public partial class FormArchive : GitModuleForm
     {
         if (checkboxRevisionFilter.Checked && DiffSelectedRevision is null)
         {
-            MessageBox.Show(this, _noRevisionSelected.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            MessageBoxes.Show(this, _noRevisionSelected.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             return;
         }
 

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Drawing2D;
 using System.Globalization;
@@ -1855,7 +1855,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         }
         else
         {
-            MessageBox.Show(this, _noReposHostPluginLoaded.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _noReposHostPluginLoaded.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -1894,7 +1894,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         repoHost = PluginRegistry.TryGetGitHosterForModule(Module);
         if (repoHost is null)
         {
-            MessageBox.Show(this, _noReposHostFound.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _noReposHostFound.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
@@ -2771,7 +2771,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
             catch (InvalidOperationException)
             {
 #if DEBUG
-                MessageBox.Show(@"ConEmu appears to be missing. Please perform a full rebuild and try again.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(@"ConEmu appears to be missing. Please perform a full rebuild and try again.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
 #else
                 throw;
 #endif
@@ -2956,7 +2956,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
 
     private void undoLastCommitToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        if (AppSettings.DontConfirmUndoLastCommit || MessageBox.Show(this, _undoLastCommitText.Text, _undoLastCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+        if (AppSettings.DontConfirmUndoLastCommit || MessageBoxes.Show(this, _undoLastCommitText.Text, _undoLastCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
         {
             ArgumentString args = Commands.Reset(ResetMode.Soft, "HEAD~1");
             Module.GitExecutable.GetOutput(args);

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -273,14 +273,14 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
                 newBranchMode = CheckoutNewBranchMode.Create;
                 if (string.IsNullOrWhiteSpace(newBranchName))
                 {
-                    MessageBox.Show(_customBranchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(_customBranchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     DialogResult = DialogResult.None;
                     return DialogResult.None;
                 }
 
                 if (!Module.CheckBranchFormat(newBranchName))
                 {
-                    MessageBox.Show(string.Format(_customBranchNameIsNotValid.Text, newBranchName), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(string.Format(_customBranchNameIsNotValid.Text, newBranchName), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     DialogResult = DialogResult.None;
                     return DialogResult.None;
                 }
@@ -302,7 +302,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
 
                         string warningMessage = string.Format(_resetNonFastForwardBranch.Text, _localBranchName, mergeBaseText);
 
-                        if (MessageBox.Show(this, warningMessage, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.No)
+                        if (MessageBoxes.Show(this, warningMessage, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.No)
                         {
                             DialogResult = DialogResult.None;
                             return DialogResult.None;

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
@@ -34,7 +34,7 @@ public partial class FormCheckoutRevision : GitExtensionsDialog
 
             if (selectedObjectId is null)
             {
-                MessageBox.Show(this, _noRevisionSelectedMsgBox.Text, _noRevisionSelectedMsgBoxCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _noRevisionSelectedMsgBox.Text, _noRevisionSelectedMsgBoxCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -156,7 +156,7 @@ public partial class FormCherryPick : GitExtensionsDialog
         {
             if (lvParentsList.SelectedItems.Count == 0)
             {
-                MessageBox.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 canExecute = false;
             }
             else

--- a/src/app/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Git;
 using GitCommands.Utils;
 using GitExtensions.Extensibility;
@@ -71,7 +71,7 @@ public partial class FormCleanupRepository : GitModuleForm
 
     private void Cleanup_Click(object sender, EventArgs e)
     {
-        if (MessageBox.Show(this, _reallyCleanupQuestion.Text, _reallyCleanupQuestionCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+        if (MessageBoxes.Show(this, _reallyCleanupQuestion.Text, _reallyCleanupQuestionCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
         {
             CleanUp(dryRun: false);
         }

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.UserRepositoryHistory;
@@ -167,14 +167,14 @@ public partial class FormClone : GitExtensionsDialog
             string destination = _NO_TRANSLATE_To.Text;
             if (string.IsNullOrWhiteSpace(destination))
             {
-                MessageBox.Show(this, _errorDestinationNotSupplied.Text, _errorCloneFailed.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _errorDestinationNotSupplied.Text, _errorCloneFailed.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 _NO_TRANSLATE_To.Focus();
                 return;
             }
 
             if (!Path.IsPathRooted(destination))
             {
-                MessageBox.Show(this, _errorDestinationNotRooted.Text, _errorCloneFailed.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _errorDestinationNotRooted.Text, _errorCloneFailed.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 _NO_TRANSLATE_To.Focus();
                 return;
             }
@@ -263,13 +263,13 @@ public partial class FormClone : GitExtensionsDialog
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, "Exception: " + ex.Message, _errorCloneFailed.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, "Exception: " + ex.Message, _errorCloneFailed.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
     private bool AskIfNewRepositoryShouldBeOpened(string dirTo)
     {
-        return MessageBox.Show(this, string.Format(_questionOpenRepo.Text, dirTo), _questionOpenRepoCaption.Text,
+        return MessageBoxes.Show(this, string.Format(_questionOpenRepo.Text, dirTo), _questionOpenRepoCaption.Text,
             MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
     }
 

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.InteropServices;
@@ -539,12 +539,12 @@ public sealed partial class FormCommit : GitModuleForm
             }
             catch (FileNotFoundException ex)
             {
-                MessageBox.Show(this, string.Format(_templateNotFound.Text, ex.FileName),
+                MessageBoxes.Show(this, string.Format(_templateNotFound.Text, ex.FileName),
                     _templateNotFoundCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message,
+                MessageBoxes.Show(this, ex.Message,
                     _templateLoadErrorCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
@@ -1101,7 +1101,7 @@ public sealed partial class FormCommit : GitModuleForm
                 // commit, because amend may be used just to change the commit message or timestamp.
                 if (!AppSettings.DontConfirmAmend)
                 {
-                    if (MessageBox.Show(this, _amendCommit.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
+                    if (MessageBoxes.Show(this, _amendCommit.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
                     {
                         return false;
                     }
@@ -1114,7 +1114,7 @@ public sealed partial class FormCommit : GitModuleForm
             {
                 // it is a merge commit, so user can commit just for merging two branches even the changeset is empty,
                 // but also user may forget to add files, so only ask for confirmation that user really wants to commit an empty changeset
-                if (MessageBox.Show(this, _noFilesStagedAndConfirmAnEmptyMergeCommit.Text, _noStagedChanges.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+                if (MessageBoxes.Show(this, _noFilesStagedAndConfirmAnEmptyMergeCommit.Text, _noStagedChanges.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
                 {
                     return false;
                 }
@@ -1173,13 +1173,13 @@ public sealed partial class FormCommit : GitModuleForm
         {
             if (Module.InTheMiddleOfConflictedMerge())
             {
-                MessageBox.Show(this, _mergeConflicts.Text, _mergeConflictsCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _mergeConflicts.Text, _mergeConflictsCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (_useFormCommitMessage && (string.IsNullOrEmpty(Message.Text) || Message.Text == _commitTemplate))
             {
-                MessageBox.Show(this, _enterCommitMessage.Text, _enterCommitMessageCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Asterisk);
+                MessageBoxes.Show(this, _enterCommitMessage.Text, _enterCommitMessageCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Asterisk);
                 return;
             }
 
@@ -1323,7 +1323,7 @@ public sealed partial class FormCommit : GitModuleForm
             }
             catch (Exception e)
             {
-                MessageBox.Show(this, $"Exception: {e.Message}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, $"Exception: {e.Message}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return;
@@ -1334,7 +1334,7 @@ public sealed partial class FormCommit : GitModuleForm
                 {
                     string firstLine = Message.Text.Split(Delimiters.NewLines, StringSplitOptions.RemoveEmptyEntries)[0];
                     if (firstLine.Length > AppSettings.CommitValidationMaxCntCharsFirstLine &&
-                        MessageBox.Show(this, _commitMsgFirstLineInvalid.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
+                        MessageBoxes.Show(this, _commitMsgFirstLineInvalid.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
                     {
                         return false;
                     }
@@ -1346,7 +1346,7 @@ public sealed partial class FormCommit : GitModuleForm
                     foreach (string line in lines)
                     {
                         if (line.Length > AppSettings.CommitValidationMaxCntCharsPerLine &&
-                            MessageBox.Show(this, string.Format(_commitMsgLineInvalid.Text, line), _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
+                            MessageBoxes.Show(this, string.Format(_commitMsgLineInvalid.Text, line), _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
                         {
                             return false;
                         }
@@ -1358,7 +1358,7 @@ public sealed partial class FormCommit : GitModuleForm
                     string[] lines = Message.Text.Split(Delimiters.NewLines, StringSplitOptions.None);
                     if (lines.Length > 2 &&
                         lines[1].Length != 0 &&
-                        MessageBox.Show(this, _commitMsgSecondLineNotEmpty.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
+                        MessageBoxes.Show(this, _commitMsgSecondLineNotEmpty.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
                     {
                         return false;
                     }
@@ -1371,7 +1371,7 @@ public sealed partial class FormCommit : GitModuleForm
                         if (!Message.Text.StartsWith(CommitKind.Fixup.GetPrefix()) &&
                             !Message.Text.StartsWith(CommitKind.Squash.GetPrefix()) &&
                             !Regex.IsMatch(GetTextToValidate(Message.Text), AppSettings.CommitValidationRegEx) &&
-                            MessageBox.Show(this, _commitMsgRegExNotMatched.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
+                            MessageBoxes.Show(this, _commitMsgRegExNotMatched.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
                         {
                             return false;
                         }
@@ -1946,7 +1946,7 @@ public sealed partial class FormCommit : GitModuleForm
     {
         if (!AppSettings.DontConfirmAmend)
         {
-            if (MessageBox.Show(this, _amendResetSoft.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
+            if (MessageBoxes.Show(this, _amendResetSoft.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
             {
                 return;
             }

--- a/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
@@ -124,7 +124,7 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
             objectId = commitPicker.SelectedObjectId;
             if (objectId is null)
             {
-                MessageBox.Show(this, _noRevisionSelected.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _noRevisionSelected.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 DialogResult = DialogResult.None;
                 return;
             }
@@ -133,14 +133,14 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
         string branchName = BranchNameTextBox.Text.Trim();
         if (string.IsNullOrWhiteSpace(branchName))
         {
-            MessageBox.Show(_branchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(_branchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             DialogResult = DialogResult.None;
             return;
         }
 
         if (!Module.CheckBranchFormat(branchName))
         {
-            MessageBox.Show(string.Format(_branchNameIsNotValid.Text, branchName), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(string.Format(_branchNameIsNotValid.Text, branchName), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             DialogResult = DialogResult.None;
             return;
         }

--- a/src/app/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands.Git;
+using GitCommands.Git;
 using GitCommands.Git.Extensions;
 using GitCommands.Git.Tag;
 using GitExtensions.Extensibility;
@@ -72,7 +72,7 @@ public sealed partial class FormCreateTag : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -82,7 +82,7 @@ public sealed partial class FormCreateTag : GitModuleForm
 
         if (objectId is null)
         {
-            MessageBox.Show(this, _noRevisionSelected.Text, _messageCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _noRevisionSelected.Text, _messageCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return "";
         }
 

--- a/src/app/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -75,7 +75,7 @@ public sealed partial class FormDeleteBranch : GitExtensionsDialog
 
         if (_currentBranch is not null && selectedBranches.Any(branch => branch.Name == _currentBranch))
         {
-            MessageBox.Show(this, string.Format(_cannotDeleteCurrentBranchMessage.Text, _currentBranch), _deleteBranchCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, string.Format(_cannotDeleteCurrentBranchMessage.Text, _currentBranch), _deleteBranchCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 

--- a/src/app/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -111,7 +111,7 @@ public sealed partial class FormDeleteRemoteBranch : GitExtensionsDialog
         bool hasUnmergedBranches = selectedBranches.Any(branch => !_mergedBranches.Contains(branch.CompleteName));
         if (hasUnmergedBranches)
         {
-            if (MessageBox.Show(this,
+            if (MessageBoxes.Show(this,
                                 _confirmDeleteUnmergedRemoteBranchMessage.Text,
                                 _deleteRemoteBranchesCaption.Text,
                                 MessageBoxButtons.YesNo,

--- a/src/app/GitUI/CommandsDialogs/FormEditor.cs
+++ b/src/app/GitUI/CommandsDialogs/FormEditor.cs
@@ -62,7 +62,7 @@ public sealed partial class FormEditor : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _cannotOpenFile.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _cannotOpenFile.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             Close();
         }
     }
@@ -72,7 +72,7 @@ public sealed partial class FormEditor : GitModuleForm
         // only offer to save if there's something to save.
         if (HasChanges)
         {
-            DialogResult saveChangesAnswer = MessageBox.Show(this, _saveChanges.Text, _saveChangesCaption.Text,
+            DialogResult saveChangesAnswer = MessageBoxes.Show(this, _saveChanges.Text, _saveChangesCaption.Text,
                                      MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
             switch (saveChangesAnswer)
             {
@@ -83,7 +83,7 @@ public sealed partial class FormEditor : GitModuleForm
                     }
                     catch (Exception ex)
                     {
-                        if (MessageBox.Show(this, $"{_cannotSaveFile.Text}{Environment.NewLine}{ex.Message}", TranslatedStrings.Error, MessageBoxButtons.OKCancel, MessageBoxIcon.Error) == DialogResult.Cancel)
+                        if (MessageBoxes.Show(this, $"{_cannotSaveFile.Text}{Environment.NewLine}{ex.Message}", TranslatedStrings.Error, MessageBoxButtons.OKCancel, MessageBoxIcon.Error) == DialogResult.Cancel)
                         {
                             e.Cancel = true;
                             return;

--- a/src/app/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -59,7 +59,7 @@ public partial class FormFormatPatch : GitModuleForm
     {
         if (string.IsNullOrEmpty(OutputPath.Text))
         {
-            MessageBox.Show(this, _noOutputPathEnteredText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _noOutputPathEnteredText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -70,7 +70,7 @@ public partial class FormFormatPatch : GitModuleForm
         IReadOnlyList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions(SortDirection.Descending);
         if (revisions.Count == 0)
         {
-            MessageBox.Show(this, _revisionsNeededText.Text, _revisionsNeededCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _revisionsNeededText.Text, _revisionsNeededCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -103,11 +103,11 @@ public partial class FormFormatPatch : GitModuleForm
 
         if (string.IsNullOrEmpty(result))
         {
-            MessageBox.Show(this, _failCreatePatch.Text, _revisionsNeededCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _failCreatePatch.Text, _revisionsNeededCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         else
         {
-            MessageBox.Show(this, result, _patchResultCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBoxes.Show(this, result, _patchResultCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             Close();
         }
     }

--- a/src/app/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -85,7 +85,7 @@ public partial class FormGitAttributes : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _cannotAccessGitattributes.Text + Environment.NewLine + ex.Message,
+            MessageBoxes.Show(this, _cannotAccessGitattributes.Text + Environment.NewLine + ex.Message,
                 _cannotAccessGitattributesCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
@@ -97,7 +97,7 @@ public partial class FormGitAttributes : GitModuleForm
 
         if (!IsFileUpToDate())
         {
-            switch (MessageBox.Show(this, _saveFileQuestion.Text, _saveFileQuestionCaption.Text, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
+            switch (MessageBoxes.Show(this, _saveFileQuestion.Text, _saveFileQuestionCaption.Text, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
             {
                 case DialogResult.Yes:
                     if (SaveFile())
@@ -129,7 +129,7 @@ public partial class FormGitAttributes : GitModuleForm
             return;
         }
 
-        MessageBox.Show(this, _noWorkingDir.Text, _noWorkingDirCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        MessageBoxes.Show(this, _noWorkingDir.Text, _noWorkingDirCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         Close();
     }
 

--- a/src/app/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/src/app/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitUI.CommandsDialogs.GitIgnoreDialog;
@@ -153,7 +153,7 @@ public sealed partial class FormGitIgnore : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _dialogModel.CannotAccessFile + Environment.NewLine + ex.Message,
+            MessageBoxes.Show(this, _dialogModel.CannotAccessFile + Environment.NewLine + ex.Message,
                 _dialogModel.CannotAccessFileCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
@@ -163,7 +163,7 @@ public sealed partial class FormGitIgnore : GitModuleForm
     {
         if (HasUnsavedChanges())
         {
-            switch (MessageBox.Show(this, _dialogModel.SaveFileQuestion, _saveFileQuestionCaption.Text,
+            switch (MessageBoxes.Show(this, _dialogModel.SaveFileQuestion, _saveFileQuestionCaption.Text,
                                 MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
             {
                 case DialogResult.Yes:
@@ -187,7 +187,7 @@ public sealed partial class FormGitIgnore : GitModuleForm
             return;
         }
 
-        MessageBox.Show(this, _dialogModel.FileOnlyInWorkingDirSupported, _gitignoreOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        MessageBoxes.Show(this, _dialogModel.FileOnlyInWorkingDirSupported, _gitignoreOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         Close();
     }
 

--- a/src/app/GitUI/CommandsDialogs/FormInit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormInit.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.UserRepositoryHistory;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -46,13 +46,13 @@ public partial class FormInit : GitExtensionsDialog
 
         if (!IsRootedDirectoryPath(directoryPath))
         {
-            MessageBox.Show(this, _chooseDirectory.Text, _chooseDirectoryCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _chooseDirectory.Text, _chooseDirectoryCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
         if (File.Exists(directoryPath))
         {
-            MessageBox.Show(this, _chooseDirectoryNotFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _chooseDirectoryNotFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -63,7 +63,7 @@ public partial class FormInit : GitExtensionsDialog
             System.IO.Directory.CreateDirectory(module.WorkingDir);
         }
 
-        MessageBox.Show(this, module.Init(Central.Checked, Central.Checked), _initMsgBoxCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        MessageBoxes.Show(this, module.Init(Central.Checked, Central.Checked), _initMsgBoxCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
         _gitModuleChanged?.Invoke(this, new GitModuleEventArgs(module));
 

--- a/src/app/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/src/app/GitUI/CommandsDialogs/FormMailMap.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -89,7 +89,7 @@ public partial class FormMailMap : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _cannotAccessMailmap.Text + Environment.NewLine + ex.Message,
+            MessageBoxes.Show(this, _cannotAccessMailmap.Text + Environment.NewLine + ex.Message,
                 _cannotAccessMailmapCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
@@ -101,7 +101,7 @@ public partial class FormMailMap : GitModuleForm
 
         if (!IsFileUpToDate())
         {
-            switch (MessageBox.Show(this, _saveFileQuestion.Text, _saveFileQuestionCaption.Text, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
+            switch (MessageBoxes.Show(this, _saveFileQuestion.Text, _saveFileQuestionCaption.Text, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
             {
                 case DialogResult.Yes:
                     if (SaveFile())
@@ -133,7 +133,7 @@ public partial class FormMailMap : GitModuleForm
             return;
         }
 
-        MessageBox.Show(this, _mailmapOnlyInWorkingDirSupported.Text, _mailmapOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        MessageBoxes.Show(this, _mailmapOnlyInWorkingDirSupported.Text, _mailmapOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         Close();
     }
 

--- a/src/app/GitUI/CommandsDialogs/FormPull.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPull.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Config;
@@ -262,7 +262,7 @@ public sealed partial class FormPull : GitExtensionsDialog
             }
 
             bool isActionConfirmed = AppSettings.DontConfirmFetchAndPruneAll
-                                     || MessageBox.Show(
+                                     || MessageBoxes.Show(
                                          owner,
                                          _pullFetchPruneAllConfirmation.Text,
                                          messageBoxTitle,
@@ -292,7 +292,7 @@ public sealed partial class FormPull : GitExtensionsDialog
     {
         Module.RunMergeTool();
 
-        if (MessageBox.Show(this, _allMergeConflictSolvedQuestion.Text, _allMergeConflictSolvedQuestionCaption.Text,
+        if (MessageBoxes.Show(this, _allMergeConflictSolvedQuestion.Text, _allMergeConflictSolvedQuestionCaption.Text,
                             MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
         {
             return;
@@ -480,19 +480,19 @@ public sealed partial class FormPull : GitExtensionsDialog
         {
             if (PullFromUrl.Checked && string.IsNullOrEmpty(comboBoxPullSource.Text))
             {
-                MessageBox.Show(this, _selectSourceDirectory.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _selectSourceDirectory.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
             if (PullFromRemote.Checked && string.IsNullOrEmpty(_NO_TRANSLATE_Remotes.Text) && !IsPullAll())
             {
-                MessageBox.Show(this, _selectRemoteRepository.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _selectRemoteRepository.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
             if (!Fetch.Checked && Branches.Text == "*")
             {
-                MessageBox.Show(this, _fetchAllBranchesCanOnlyWithFetch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _fetchAllBranchesCanOnlyWithFetch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -542,7 +542,7 @@ public sealed partial class FormPull : GitExtensionsDialog
 
             bool AskIfSubmodulesShouldBeInitialized()
             {
-                return MessageBox.Show(this, _questionInitSubmodules.Text, _questionInitSubmodulesCaption.Text,
+                return MessageBoxes.Show(this, _questionInitSubmodules.Text, _questionInitSubmodulesCaption.Text,
                            MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
             }
         }
@@ -643,7 +643,7 @@ public sealed partial class FormPull : GitExtensionsDialog
         // ask only if exists commit not pushed to remote yet
         if (Rebase.Checked && PullFromRemote.Checked && MergeCommitExists())
         {
-            dialogResult = MessageBox.Show(this, _areYouSureYouWantToRebaseMerge.Text,
+            dialogResult = MessageBoxes.Show(this, _areYouSureYouWantToRebaseMerge.Text,
                                               _areYouSureYouWantToRebaseMergeCaption.Text,
                                               MessageBoxButtons.YesNoCancel,
                                               MessageBoxIcon.Warning,

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Config;
@@ -166,7 +166,7 @@ public partial class FormPush : GitModuleForm
 
         if (UserGitRemotes.Count < 1)
         {
-            if (MessageBox.Show(this, _configureRemote.Text, _errorPushToRemoteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Error) == DialogResult.Yes)
+            if (MessageBoxes.Show(this, _configureRemote.Text, _errorPushToRemoteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Error) == DialogResult.Yes)
             {
                 OpenRemotesDialogAndRefreshList(null);
                 return UserGitRemotes.Count > 0;
@@ -260,7 +260,7 @@ public partial class FormPush : GitModuleForm
         ErrorOccurred = false;
         if (PushToUrl.Checked && !Uri.IsWellFormedUriString(PushDestination.Text, UriKind.Absolute))
         {
-            MessageBox.Show(owner, _selectDestinationDirectory.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(owner, _selectDestinationDirectory.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
@@ -274,7 +274,7 @@ public partial class FormPush : GitModuleForm
         string selectedRemoteName = _selectedRemote.Name;
         if (TabControlTagBranch.SelectedTab == TagTab && string.IsNullOrEmpty(TagComboBox.Text))
         {
-            MessageBox.Show(owner, _selectTag.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(owner, _selectTag.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
@@ -284,7 +284,7 @@ public partial class FormPush : GitModuleForm
                 || string.IsNullOrWhiteSpace(RemoteBranch.Text)
                 || RemoteBranch.Text == DetachedHeadParser.DetachedBranch))
         {
-            MessageBox.Show(owner, _noCurrentBranch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(owner, _noCurrentBranch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
@@ -302,7 +302,7 @@ public partial class FormPush : GitModuleForm
             {
                 // Ask if this is really what the user wants
                 if (!AppSettings.DontConfirmPushNewBranch &&
-                    MessageBox.Show(owner, _branchNewForRemote.Text, _pushCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+                    MessageBoxes.Show(owner, _branchNewForRemote.Text, _pushCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
                 {
                     return false;
                 }
@@ -350,7 +350,7 @@ public partial class FormPush : GitModuleForm
                 if (track && !AppSettings.DontConfirmAddTrackingRef)
                 {
                     Validates.NotNull(selectedLocalBranch);
-                    DialogResult result = MessageBox.Show(owner,
+                    DialogResult result = MessageBoxes.Show(owner,
                                                  string.Format(_updateTrackingReference.Text, selectedLocalBranch.Name, RemoteBranch.Text),
                                                  _pushCaption.Text,
                                                  MessageBoxButtons.YesNoCancel,
@@ -367,7 +367,7 @@ public partial class FormPush : GitModuleForm
 
             if (ForcePushBranches.Checked)
             {
-                DialogResult choice = MessageBox.Show(owner,
+                DialogResult choice = MessageBoxes.Show(owner,
                                              _useForceWithLeaseInstead.Text,
                                              "Question", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question,
                                              MessageBoxDefaultButton.Button1);

--- a/src/app/GitUI/CommandsDialogs/FormRebase.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRebase.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -320,7 +320,7 @@ public partial class FormRebase : GitExtensionsDialog
         {
             if (string.IsNullOrEmpty(cboBranches.Text))
             {
-                MessageBox.Show(this, _noBranchSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _noBranchSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -362,7 +362,7 @@ public partial class FormRebase : GitExtensionsDialog
             string cmdOutput = FormProcess.ReadDialog(this, UICommands, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true);
             if (cmdOutput.Trim() == "Current branch a is up to date.")
             {
-                MessageBox.Show(this, _branchUpToDateText.Text, _branchUpToDateCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBoxes.Show(this, _branchUpToDateText.Text, _branchUpToDateCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
 
             if (!Module.InTheMiddleOfAction() &&

--- a/src/app/GitUI/CommandsDialogs/FormReflog.cs
+++ b/src/app/GitUI/CommandsDialogs/FormReflog.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
@@ -145,7 +145,7 @@ public partial class FormReflog : GitModuleForm
     {
         if (_isDirtyDir)
         {
-            if (MessageBox.Show(this, _continueResetCurrentBranchEvenWithChangesText.Text,
+            if (MessageBoxes.Show(this, _continueResetCurrentBranchEvenWithChangesText.Text,
                     _continueResetCurrentBranchCaptionText.Text,
                     MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) == DialogResult.No)
             {

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -457,14 +457,14 @@ Inactive remote is completely invisible to git.");
 
         if (_remotesManager.EnabledRemoteExists(remote))
         {
-            MessageBox.Show(this, string.Format(_enabledRemoteAlreadyExists.Text, remote), _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            MessageBoxes.Show(this, string.Format(_enabledRemoteAlreadyExists.Text, remote), _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
 
             return false;
         }
 
         if (_remotesManager.DisabledRemoteExists(remote))
         {
-            MessageBox.Show(this, string.Format(_disabledRemoteAlreadyExists.Text, remote), _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            MessageBoxes.Show(this, string.Format(_disabledRemoteAlreadyExists.Text, remote), _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
 
             return false;
         }
@@ -518,7 +518,7 @@ Inactive remote is completely invisible to git.");
 
             if (!string.IsNullOrEmpty(result.UserMessage))
             {
-                MessageBox.Show(this, result.UserMessage, _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBoxes.Show(this, result.UserMessage, _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
             else
@@ -545,7 +545,7 @@ Inactive remote is completely invisible to git.");
             // there may be a need to configure it
             if (result.ShouldUpdateRemote &&
                 !string.IsNullOrEmpty(remoteUrl) &&
-                MessageBox.Show(this,
+                MessageBoxes.Show(this,
                     _questionAutoPullBehaviour.Text,
                     _questionAutoPullBehaviourCaption.Text,
                     MessageBoxButtons.YesNo,
@@ -579,7 +579,7 @@ Inactive remote is completely invisible to git.");
             return;
         }
 
-        if (MessageBox.Show(this,
+        if (MessageBoxes.Show(this,
                             _questionDeleteRemote.Text,
                             _questionDeleteRemoteCaption.Text,
                             MessageBoxButtons.YesNo,
@@ -591,7 +591,7 @@ Inactive remote is completely invisible to git.");
             string output = _remotesManager.RemoveRemote(_selectedRemote);
             if (!string.IsNullOrEmpty(output))
             {
-                MessageBox.Show(this, output, _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBoxes.Show(this, output, _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
 
             // Deleting a remote from the history list may be undesirable as
@@ -629,7 +629,7 @@ Inactive remote is completely invisible to git.");
 
     private void RemoteBranchesDataError(object sender, DataGridViewDataErrorEventArgs e)
     {
-        MessageBox.Show(this,
+        MessageBoxes.Show(this,
                         string.Format(_remoteBranchDataError.Text, RemoteBranches.Rows[e.RowIndex].Cells[0].Value, RemoteBranches.Columns[e.ColumnIndex].HeaderText),
                         TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         RemoteBranches.Rows[e.RowIndex].Cells[e.ColumnIndex].Value = "";

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
@@ -285,7 +285,7 @@ public partial class FormResolveConflicts : GitModuleForm
                 if (!Module.InTheMiddleOfPatch() && !_inTheMiddleOfRebase && _offerCommit)
                 {
                     if (AppSettings.DontConfirmCommitAfterConflictsResolved ||
-                        MessageBox.Show(this, _allConflictsResolved.Text, _allConflictsResolvedCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                        MessageBoxes.Show(this, _allConflictsResolved.Text, _allConflictsResolvedCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                     {
                         UICommands.StartCommitDialog(this);
                     }
@@ -407,7 +407,7 @@ public partial class FormResolveConflicts : GitModuleForm
                 if (_mergeScripts.TryGetValue(extension, out string mergeScript) &&
                     File.Exists(Path.Combine(dir!, mergeScript)))
                 {
-                    if (MessageBox.Show(this, string.Format(_uskUseCustomMergeScript.Text, mergeScript),
+                    if (MessageBoxes.Show(this, string.Format(_uskUseCustomMergeScript.Text, mergeScript),
                                         _uskUseCustomMergeScriptCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) ==
                         DialogResult.Yes)
                     {
@@ -420,7 +420,7 @@ public partial class FormResolveConflicts : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, "Merge using script failed.\n" + ex, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, "Merge using script failed.\n" + ex, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         return false;
@@ -443,7 +443,7 @@ public partial class FormResolveConflicts : GitModuleForm
 
         new Executable("wscript", Module.WorkingDir).Start(args);
 
-        if (MessageBox.Show(this, string.Format(_askMergeConflictSolvedAfterCustomMergeScript.Text,
+        if (MessageBoxes.Show(this, string.Format(_askMergeConflictSolvedAfterCustomMergeScript.Text,
             FixPath(filePath)), _askMergeConflictSolvedCaption.Text,
             MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
         {
@@ -452,7 +452,7 @@ public partial class FormResolveConflicts : GitModuleForm
             // The file is not modified, do not stage file and present warning
             if (lastWriteTimeBeforeMerge == lastWriteTimeAfterMerge)
             {
-                MessageBox.Show(this, _fileUnchangedAfterMerge.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBoxes.Show(this, _fileUnchangedAfterMerge.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             else
             {
@@ -575,7 +575,7 @@ public partial class FormResolveConflicts : GitModuleForm
 
                 if (FileHelper.IsBinaryFileName(Module, item.Local.Filename))
                 {
-                    if (MessageBox.Show(this, string.Format(_fileIsBinary.Text, _mergetool),
+                    if (MessageBoxes.Show(this, string.Format(_fileIsBinary.Text, _mergetool),
                             TranslatedStrings.Warning, MessageBoxButtons.YesNo, MessageBoxIcon.Warning,
                             MessageBoxDefaultButton.Button2) == DialogResult.No)
                     {
@@ -603,7 +603,7 @@ public partial class FormResolveConflicts : GitModuleForm
                 if (item.Base.Filename is null)
                 {
                     string text = string.Format(_noBaseRevision.Text, item.Filename);
-                    DialogResult result = MessageBox.Show(this, text, _noBaseFileMergeCaption.Text,
+                    DialogResult result = MessageBoxes.Show(this, text, _noBaseFileMergeCaption.Text,
                         MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
                     if (result == DialogResult.Yes)
                     {
@@ -633,7 +633,7 @@ public partial class FormResolveConflicts : GitModuleForm
                 catch (Exception)
                 {
                     string text = string.Format(_errorStartingMergetool.Text, _mergetoolPath);
-                    MessageBox.Show(this, text, _noBaseFileMergeCaption.Text,
+                    MessageBoxes.Show(this, text, _noBaseFileMergeCaption.Text,
                         MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
@@ -652,7 +652,7 @@ public partial class FormResolveConflicts : GitModuleForm
                 if ((res.ExitCode == 1 && lastWriteTimeBeforeMerge != lastWriteTimeAfterMerge) ||
                     (res.ExitCode == 0 && lastWriteTimeBeforeMerge == lastWriteTimeAfterMerge))
                 {
-                    if (MessageBox.Show(this, _askMergeConflictSolved.Text, _askMergeConflictSolvedCaption.Text,
+                    if (MessageBoxes.Show(this, _askMergeConflictSolved.Text, _askMergeConflictSolvedCaption.Text,
                         MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                     {
                         StageFile(item.Filename);
@@ -696,7 +696,7 @@ public partial class FormResolveConflicts : GitModuleForm
 
         if (string.IsNullOrEmpty(_mergetool))
         {
-            MessageBox.Show(this, _noMergeTool.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _noMergeTool.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
@@ -733,7 +733,7 @@ public partial class FormResolveConflicts : GitModuleForm
 
             if (!PathUtil.TryFindFullPath(_mergetoolPath, out string? fullPath))
             {
-                MessageBox.Show(this, _noMergeToolConfigured.Text, TranslatedStrings.Warning, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBoxes.Show(this, _noMergeToolConfigured.Text, TranslatedStrings.Warning, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return false;
             }
 
@@ -745,11 +745,11 @@ public partial class FormResolveConflicts : GitModuleForm
 
     private bool ShowAbortMessage()
     {
-        if (MessageBox.Show(_abortCurrentOperation.Text, _resetCaption.Text,
+        if (MessageBoxes.Show(_abortCurrentOperation.Text, _resetCaption.Text,
             MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
         {
             if (AppSettings.DontConfirmSecondAbortConfirmation ||
-                MessageBox.Show(_areYouSureYouWantDeleteFiles.Text, _areYouSureYouWantDeleteFilesCaption.Text,
+                MessageBoxes.Show(_areYouSureYouWantDeleteFiles.Text, _areYouSureYouWantDeleteFilesCaption.Text,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
             {
                 return true;
@@ -890,7 +890,7 @@ public partial class FormResolveConflicts : GitModuleForm
     {
         if (!Module.HandleConflictSelectSide(fileName, "BASE"))
         {
-            MessageBox.Show(this, _chooseBaseFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _chooseBaseFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -917,7 +917,7 @@ public partial class FormResolveConflicts : GitModuleForm
     {
         if (!Module.HandleConflictSelectSide(fileName, "LOCAL"))
         {
-            MessageBox.Show(this, _chooseLocalFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _chooseLocalFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -944,7 +944,7 @@ public partial class FormResolveConflicts : GitModuleForm
     {
         if (!Module.HandleConflictSelectSide(fileName, "REMOTE"))
         {
-            MessageBox.Show(this, _chooseRemoteFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _chooseRemoteFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -1319,7 +1319,7 @@ public partial class FormResolveConflicts : GitModuleForm
 
             if (!Module.HandleConflictsSaveSide(conflictData.Filename, fileName, side))
             {
-                MessageBox.Show(this, _failureWhileOpenFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _failureWhileOpenFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             OsShellUtil.OpenAs(fileName);
@@ -1374,7 +1374,7 @@ public partial class FormResolveConflicts : GitModuleForm
             {
                 if (!Module.HandleConflictsSaveSide(conflictData.Filename, fileDialog.FileName, side))
                 {
-                    MessageBox.Show(this, _failureWhileSaveFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(this, _failureWhileSaveFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }

--- a/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -123,7 +123,7 @@ public partial class FormRevertCommit : GitExtensionsDialog
         {
             if (lvParentsList.SelectedItems.Count != 1)
             {
-                MessageBox.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
             else

--- a/src/app/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/src/app/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
@@ -39,7 +39,7 @@ public sealed partial class FormSparseWorkingCopy : GitModuleForm
                 // Closing/canceling, prompt to save if dirty
                 if (sparse.IsWithUnsavedChanges())
                 {
-                    switch (MessageBox.Show(this, Globalized.Strings.YouHaveMadeChangesToSettingsOrRulesWouldYouLikeToSaveThem.Text, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.Cancel.Text, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
+                    switch (MessageBoxes.Show(this, Globalized.Strings.YouHaveMadeChangesToSettingsOrRulesWouldYouLikeToSaveThem.Text, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.Cancel.Text, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
                     {
                         case DialogResult.Yes:
                             sparse.SaveChanges();
@@ -56,7 +56,7 @@ public sealed partial class FormSparseWorkingCopy : GitModuleForm
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ActiveForm, Globalized.Strings.CouldNotSave.Text + "\n\n" + ex.Message, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.SaveFile.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(ActiveForm, Globalized.Strings.CouldNotSave.Text + "\n\n" + ex.Message, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.SaveFile.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         };
     }
@@ -69,7 +69,7 @@ public sealed partial class FormSparseWorkingCopy : GitModuleForm
         {
             if (!args.Cancel)
             {
-                args.Cancel |= MessageBox.Show(this, string.Format(Globalized.Strings.ConfirmDisableGitSparse.Text, args.IsCurrentRuleSetEmpty ? Globalized.Strings.WithTheSparsePassFilterEmptyOrMissing.Text : Globalized.Strings.WithSomeRulesStillInTheSparsePassFilter.Text), Globalized.Strings.DisableGitSparse.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes;
+                args.Cancel |= MessageBoxes.Show(this, string.Format(Globalized.Strings.ConfirmDisableGitSparse.Text, args.IsCurrentRuleSetEmpty ? Globalized.Strings.WithTheSparsePassFilterEmptyOrMissing.Text : Globalized.Strings.WithSomeRulesStillInTheSparsePassFilter.Text), Globalized.Strings.DisableGitSparse.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes;
             }
         };
     }
@@ -193,7 +193,7 @@ public sealed partial class FormSparseWorkingCopy : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(ActiveForm, Globalized.Strings.CannotLoadTheTextOfTheSparseFile.Text + "\n\n" + ex.Message, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.LoadFile.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(ActiveForm, Globalized.Strings.CannotLoadTheTextOfTheSparseFile.Text + "\n\n" + ex.Message, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.LoadFile.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         editor.TextChanged += (sender, args) => sparse.RulesText = editor.GetText() ?? "";

--- a/src/app/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/src/app/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
@@ -139,7 +139,7 @@ public partial class FormSubmodules : GitModuleForm
     private void RemoveSubmoduleClick(object sender, EventArgs e)
     {
         if (Submodules.SelectedRows.Count != 1 ||
-            MessageBox.Show(this, _removeSelectedSubmodule.Text, _removeSelectedSubmoduleCaption.Text,
+            MessageBoxes.Show(this, _removeSelectedSubmodule.Text, _removeSelectedSubmoduleCaption.Text,
                             MessageBoxButtons.YesNo, MessageBoxIcon.Warning) !=
             DialogResult.Yes)
         {

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands.Git;
+using GitCommands.Git;
 using GitCommands.Git.Tag;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -145,7 +145,7 @@ public sealed partial class FormVerify : GitModuleForm
 
     private void RemoveClick(object sender, EventArgs e)
     {
-        if (MessageBox.Show(this,
+        if (MessageBoxes.Show(this,
             _removeDanglingObjectsQuestion.Text,
             _removeDanglingObjectsCaption.Text,
             MessageBoxButtons.YesNo,
@@ -199,7 +199,7 @@ public sealed partial class FormVerify : GitModuleForm
             return;
         }
 
-        MessageBox.Show(this, string.Format(_xTagsCreated.Text, restoredObjectsCount), "Tags created", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        MessageBoxes.Show(this, string.Format(_xTagsCreated.Text, restoredObjectsCount), "Tags created", MessageBoxButtons.OK, MessageBoxIcon.Information);
 
         // if user restored all items, nothing else to do in this form.
         // User wants to see restored commits, so close this dialog and return to the main window.
@@ -453,7 +453,7 @@ public sealed partial class FormVerify : GitModuleForm
 
         if (selectedLostObjects.Count == 0)
         {
-            MessageBox.Show(this, _selectLostObjectsToRestoreMessage.Text, _selectLostObjectsToRestoreCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            MessageBoxes.Show(this, _selectLostObjectsToRestoreMessage.Text, _selectLostObjectsToRestoreCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             return 0;
         }
 

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Plugins;
@@ -52,7 +52,7 @@ public partial class CreatePullRequestForm : GitModuleForm
             {
                 if (foreignHostedRemotes.Length == 0)
                 {
-                    MessageBox.Show(this, _strFailedToCreatePullRequest.Text + Environment.NewLine +
+                    MessageBoxes.Show(this, _strFailedToCreatePullRequest.Text + Environment.NewLine +
                                           _strPleaseCloneGitHubRep.Text, "", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     Close();
                     return;
@@ -217,7 +217,7 @@ public partial class CreatePullRequestForm : GitModuleForm
         string body = _bodyTB.Text.Trim();
         if (title.Length == 0)
         {
-            MessageBox.Show(this, _strYouMustSpecifyATitle.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _strYouMustSpecifyATitle.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -226,12 +226,12 @@ public partial class CreatePullRequestForm : GitModuleForm
             IHostedRepository hostedRepo = _currentHostedRemote.GetHostedRepository();
 
             hostedRepo.CreatePullRequest(_yourBranchesCB.Text, _remoteBranchesCB.Text, title, body);
-            MessageBox.Show(this, _strDone.Text, _strPullRequest.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBoxes.Show(this, _strDone.Text, _strPullRequest.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             Close();
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _strFailedToCreatePullRequest.Text + Environment.NewLine +
+            MessageBoxes.Show(this, _strFailedToCreatePullRequest.Text + Environment.NewLine +
                 ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -165,7 +165,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
                 {
                     await this.SwitchToMainThreadAsync();
 
-                    MessageBox.Show(this, _strSearchFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(this, _strSearchFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     searchBtn.Enabled = true;
                 }
             });
@@ -197,11 +197,11 @@ public partial class ForkAndCloneForm : GitExtensionsForm
 
                     if (ex.Message.Contains("404"))
                     {
-                        MessageBox.Show(this, _strUserNotFound.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBoxes.Show(this, _strUserNotFound.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                     else
                     {
-                        MessageBox.Show(this, _strCouldNotFetchReposOfUser.Text + Environment.NewLine +
+                        MessageBoxes.Show(this, _strCouldNotFetchReposOfUser.Text + Environment.NewLine +
                                               ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
 
@@ -247,7 +247,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
     {
         if (searchResultsLV.SelectedItems.Count != 1)
         {
-            MessageBox.Show(this, _strSelectOneItem.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _strSelectOneItem.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -258,7 +258,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _strFailedToFork.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _strFailedToFork.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         tabControl.SelectedTab = myReposPage;
@@ -322,7 +322,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
         string hp = CurrentySelectedGitRepo.Homepage;
         if (string.IsNullOrEmpty(hp) || (!hp.StartsWith("http://") && !hp.StartsWith("https://")))
         {
-            MessageBox.Show(this, _strNoHomepageDefined.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _strNoHomepageDefined.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         else
         {
@@ -394,7 +394,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
             string error = module.AddRemote(addUpstreamRemoteAsCB.Text.Trim(), repo.ParentUrl);
             if (!string.IsNullOrEmpty(error))
             {
-                MessageBox.Show(this, error, _strCouldNotAddRemote.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, error, _strCouldNotAddRemote.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -504,7 +504,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
         string targetDir = destinationTB.Text.Trim();
         if (targetDir.Length == 0)
         {
-            MessageBox.Show(this, _strCloneFolderCanNotBeEmpty.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _strCloneFolderCanNotBeEmpty.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return null;
         }
 

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Plugins;
@@ -49,7 +49,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
         _diffViewer.ExtraDiffArgumentsChanged += _fileStatusList_SelectedIndexChanged;
         _loader.LoadingError += (sender, ex) =>
         {
-            MessageBox.Show(this, ex.Exception.ToString(), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, ex.Exception.ToString(), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             this.UnMask();
         };
         _diffViewer.TopScrollReached += FileViewer_TopScrollReached;
@@ -142,7 +142,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    MessageBox.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             });
 
@@ -340,7 +340,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    MessageBox.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     LoadDiscussion(null);
                 }
             });
@@ -376,7 +376,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    MessageBox.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             });
     }
@@ -393,7 +393,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
         GitRevision? secondRev = ObjectId.TryParse(secondSha, out ObjectId? secondId) ? new GitRevision(secondId) : null;
         if (secondRev is null)
         {
-            MessageBox.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -402,7 +402,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
             Match match = FilePartRegex.Match(part);
             if (!match.Success)
             {
-                MessageBox.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -464,7 +464,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
                 hostedRepository.CloneProtocol = _cloneGitProtocol;
                 if (hostedRepository.CloneUrl != remoteUrl)
                 {
-                    MessageBox.Show(this, string.Format(_strRemoteAlreadyExist.Text, remoteName, hostedRepository.CloneUrl, remoteUrl),
+                    MessageBoxes.Show(this, string.Format(_strRemoteAlreadyExist.Text, remoteName, hostedRepository.CloneUrl, remoteUrl),
                         TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
@@ -474,7 +474,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
                 string error = Module.AddRemote(remoteName, remoteUrl);
                 if (!string.IsNullOrEmpty(error))
                 {
-                    MessageBox.Show(this, error, string.Format(_strCouldNotAddRemote.Text, remoteName, remoteUrl), MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(this, error, string.Format(_strCouldNotAddRemote.Text, remoteName, remoteUrl), MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -540,7 +540,7 @@ public partial class ViewPullRequestsForm : GitModuleForm
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _strFailedToClosePullRequest.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _strFailedToClosePullRequest.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Text;
 using GitCommands;
@@ -89,7 +89,7 @@ public sealed class CommonLogic : Translate
         }
         catch (UnauthorizedAccessException)
         {
-            MessageBox.Show(_cantReadRegistry.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(_cantReadRegistry.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         return value ?? "";

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitCommands.Utils;
 using GitExtensions.Extensibility.Settings;
 using GitExtensions.Extensibility.Translations;
@@ -189,7 +189,7 @@ public partial class AppearanceSettingsPage : SettingsPageWithHeader
         }
         catch
         {
-            MessageBox.Show(this, string.Format(_noDictFilesFound.Text, AppSettings.GetDictionaryDir()), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, string.Format(_noDictFilesFound.Text, AppSettings.GetDictionaryDir()), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using GitCommands;
 using GitCommands.Config;
@@ -188,7 +188,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
             Validates.NotNull(SshSettingsPage);
             if (SshSettingsPage.AutoFindPuttyPaths())
             {
-                MessageBox.Show(this, _puttyFoundAuto.Text, _putty, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBoxes.Show(this, _puttyFoundAuto.Text, _putty, MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             else
             {
@@ -211,12 +211,12 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     {
         if (!CheckSettingsLogic.SolveLinuxToolsDir())
         {
-            MessageBox.Show(this, _linuxToolsShNotFound.Text, _linuxToolsShNotFoundCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _linuxToolsShNotFound.Text, _linuxToolsShNotFoundCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             PageHost.GotoPage(GitSettingsPage.GetPageReference());
             return;
         }
 
-        MessageBox.Show(this, string.Format(_shCanBeRun.Text, AppSettings.LinuxToolsDir), _shCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        MessageBoxes.Show(this, string.Format(_shCanBeRun.Text, AppSettings.LinuxToolsDir), _shCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
         PageHost.LoadAll(); // apply settings to dialog controls (otherwise the later called SaveAndRescan_Click would overwrite settings again)
         SaveAndRescan_Click(this, EventArgs.Empty);
     }
@@ -270,13 +270,13 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     {
         if (!CheckSettingsLogic.SolveGitCommand())
         {
-            MessageBox.Show(this, _solveGitCommandFailed.Text, _solveGitCommandFailedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _solveGitCommandFailed.Text, _solveGitCommandFailedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
             PageHost.GotoPage(GitSettingsPage.GetPageReference());
             return;
         }
 
-        MessageBox.Show(this, string.Format(_gitCanBeRun.Text, AppSettings.GitCommandValue), _gitCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        MessageBoxes.Show(this, string.Format(_gitCanBeRun.Text, AppSettings.GitCommandValue), _gitCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
         PageHost.GotoPage(GitSettingsPage.GetPageReference());
         SaveAndRescan_Click(this, EventArgs.Empty);
@@ -316,7 +316,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show(this, e.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBoxes.Show(this, e.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
@@ -91,7 +91,7 @@ public partial class FormFixHome : GitExtensionsForm
 
     public void ShowIfUserWant()
     {
-        if (MessageBox.Show(string.Format(_gitGlobalConfigNotFound.Text, Environment.GetEnvironmentVariable("HOME")),
+        if (MessageBoxes.Show(string.Format(_gitGlobalConfigNotFound.Text, Environment.GetEnvironmentVariable("HOME")),
                  _gitGlobalConfigNotFoundCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Error) == DialogResult.Yes)
         {
             ShowDialog();
@@ -141,7 +141,7 @@ public partial class FormFixHome : GitExtensionsForm
             string userHomeDir = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
             if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(Path.Combine(userHomeDir, ".gitconfig")))
             {
-                MessageBox.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBoxes.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
                 return;
             }
@@ -159,7 +159,7 @@ public partial class FormFixHome : GitExtensionsForm
                        Environment.GetEnvironmentVariable("HOMEPATH");
             if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
             {
-                MessageBox.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBoxes.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
                 return;
             }
@@ -176,7 +176,7 @@ public partial class FormFixHome : GitExtensionsForm
             string path = Environment.GetEnvironmentVariable("USERPROFILE");
             if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
             {
-                MessageBox.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBoxes.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 userprofileHome.Checked = true;
                 return;
             }
@@ -193,7 +193,7 @@ public partial class FormFixHome : GitExtensionsForm
             string path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
             if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
             {
-                MessageBox.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
+                MessageBoxes.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
                     "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 otherHome.Checked = true;
                 otherHomeDir.Text = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
@@ -213,7 +213,7 @@ public partial class FormFixHome : GitExtensionsForm
         {
             if (string.IsNullOrEmpty(otherHomeDir.Text))
             {
-                MessageBox.Show(this, _noHomeDirectorySpecified.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _noHomeDirectorySpecified.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -230,7 +230,7 @@ public partial class FormFixHome : GitExtensionsForm
         string path = Environment.GetEnvironmentVariable("HOME");
         if (!Directory.Exists(path) || string.IsNullOrEmpty(path))
         {
-            MessageBox.Show(this, string.Format(_homeNotAccessible.Text, path), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, string.Format(_homeNotAccessible.Text, path), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
             return;
         }

--- a/src/app/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/src/app/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.UserRepositoryHistory;
@@ -44,7 +44,7 @@ public partial class FormAddSubmodule : GitModuleForm
     {
         if (string.IsNullOrEmpty(Directory.Text) || string.IsNullOrEmpty(LocalPath.Text))
         {
-            MessageBox.Show(this, _remoteAndLocalPathRequired.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _remoteAndLocalPathRequired.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -170,7 +170,7 @@ public partial class FormManageWorktree : GitExtensionsDialog
             return;
         }
 
-        if (MessageBox.Show(this, _deleteWorktreeText.Text, _deleteWorktreeTitle.Text,
+        if (MessageBoxes.Show(this, _deleteWorktreeText.Text, _deleteWorktreeTitle.Text,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
         {
             Validates.NotNull(workTree.Path);
@@ -181,7 +181,7 @@ public partial class FormManageWorktree : GitExtensionsDialog
             }
             else
             {
-                MessageBox.Show(this, $@"{_deleteWorktreeFailedText.Text}: {workTree.Path}{Environment.NewLine}{errorMessage}", TranslatedStrings.Error,
+                MessageBoxes.Show(this, $@"{_deleteWorktreeFailedText.Text}: {workTree.Path}{Environment.NewLine}{errorMessage}", TranslatedStrings.Error,
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
@@ -212,7 +212,7 @@ public partial class FormManageWorktree : GitExtensionsDialog
             return;
         }
 
-        if (AppSettings.DontConfirmSwitchWorktree || MessageBox.Show(this,
+        if (AppSettings.DontConfirmSwitchWorktree || MessageBoxes.Show(this,
                 _switchWorktreeText.Text, _switchWorktreeTitle.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
         {
             if (Directory.Exists(workTree.Path))

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -213,7 +213,7 @@ public partial class CommitInfo : GitModuleControl
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -300,7 +300,7 @@ public partial class CommitInfo : GitModuleControl
         catch (RefsWarningException ex)
         {
             await this.SwitchToMainThreadAsync();
-            MessageBox.Show(this, string.Format("{0}{1}{1}{2}", _brokenRefs.Text, Environment.NewLine, ex.Message), _repoFailure.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, string.Format("{0}{1}{1}{2}", _brokenRefs.Text, Environment.NewLine, ex.Message), _repoFailure.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 

--- a/src/app/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -123,7 +123,7 @@ public partial class CommitInfoHeader : GitModuleControl
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -1072,7 +1072,7 @@ public partial class FileViewer : GitModuleControl
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, $"{ex.Message}{Environment.NewLine}{fullPath}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, $"{ex.Message}{Environment.NewLine}{fullPath}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             // If the file does not exist, it doesn't matter what size we
@@ -1899,7 +1899,7 @@ public partial class FileViewer : GitModuleControl
 
         if (!result.ExitedSuccessfully && (patchUpdateDiff || !MergeConflictHandler.HandleMergeConflicts(UICommands, this, false, false)))
         {
-            MessageBox.Show(this, $"{output}\n\n{Encoding.GetString(patch)}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, $"{output}\n\n{Encoding.GetString(patch)}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         else if (!result.ExitedSuccessfully || output.StartsWith("error: ") || output.StartsWith("warning: "))
         {

--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -135,7 +135,7 @@ public partial class FindAndReplaceForm : GitExtensionsForm
     {
         if (string.IsNullOrEmpty(txtLookFor.Text))
         {
-            MessageBox.Show(this, _noSearchString.Text, Text, MessageBoxButtons.OK,
+            MessageBoxes.Show(this, _noSearchString.Text, Text, MessageBoxButtons.OK,
                             MessageBoxIcon.Information);
             return null;
         }
@@ -208,7 +208,7 @@ public partial class FindAndReplaceForm : GitExtensionsForm
         while (range is null && startItem != currentItem && currentItem is not null);
         if (range is null && messageIfNotFound is not null)
         {
-            MessageBox.Show(this, messageIfNotFound, " ", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBoxes.Show(this, messageIfNotFound, " ", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
         return range;
@@ -274,7 +274,7 @@ public partial class FindAndReplaceForm : GitExtensionsForm
 
             if (count == 0)
             {
-                MessageBox.Show(this, _textNotFoundString2.Text, _notFoundString.Text, MessageBoxButtons.OK,
+                MessageBoxes.Show(this, _textNotFoundString2.Text, _notFoundString.Text, MessageBoxButtons.OK,
                                 MessageBoxIcon.Information);
             }
             else
@@ -356,11 +356,11 @@ public partial class FindAndReplaceForm : GitExtensionsForm
 
         if (count == 0)
         {
-            MessageBox.Show(this, _noOccurrencesFoundString.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBoxes.Show(this, _noOccurrencesFoundString.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
         else
         {
-            MessageBox.Show(this, string.Format(_replacedOccurrencesString.Text, count), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBoxes.Show(this, string.Format(_replacedOccurrencesString.Text, count), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
             Close();
         }
     }

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -180,7 +180,7 @@ public sealed class GitUICommands : IGitUICommands
         ObjectId objectId = Module.RevParse(branch);
         if (objectId is null)
         {
-            MessageBox.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
@@ -436,7 +436,7 @@ public sealed class GitUICommands : IGitUICommands
         ObjectId objectId = Module.RevParse(branch);
         if (objectId is null)
         {
-            MessageBox.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
@@ -788,7 +788,7 @@ public sealed class GitUICommands : IGitUICommands
             Module.ResetChanges(resetId: null, selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out StringBuilder output, progressAction: null);
             if (output.Length > 0)
             {
-                MessageBox.Show(null, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(owner: null, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -1182,7 +1182,7 @@ public sealed class GitUICommands : IGitUICommands
 
         if (!RevisionDiffInfoProvider.TryGet(revisions, diffKind, out string firstRevision, out string secondRevision, out string error))
         {
-            MessageBox.Show(owner, error, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(owner, error, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         else
         {
@@ -1268,7 +1268,7 @@ public sealed class GitUICommands : IGitUICommands
         }
         catch (Exception ex)
         {
-            MessageBox.Show(ex.Message, "Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(ex.Message, "Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         return true;
@@ -1299,7 +1299,7 @@ public sealed class GitUICommands : IGitUICommands
             }
             catch (Exception ex)
             {
-                MessageBox.Show(
+                MessageBoxes.Show(
                     string.Format("ERROR: {0} failed. Message: {1}\r\n\r\n{2}", name, ex.Message, ex.StackTrace),
                     "Error! :(", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
@@ -1348,7 +1348,7 @@ public sealed class GitUICommands : IGitUICommands
 
         if (relevantHosts.Count == 0)
         {
-            MessageBox.Show(owner, "Could not find any repo hosts for current working directory", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(owner, "Could not find any repo hosts for current working directory", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         else if (relevantHosts.Count == 1)
         {
@@ -1356,7 +1356,7 @@ public sealed class GitUICommands : IGitUICommands
         }
         else
         {
-            MessageBox.Show("StartCreatePullRequest:Selection not implemented!", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show("StartCreatePullRequest:Selection not implemented!", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -1389,31 +1389,31 @@ public sealed class GitUICommands : IGitUICommands
 
         if (command == "blame" && args.Count <= 2)
         {
-            MessageBox.Show("Cannot open blame, there is no file selected.", "Blame", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show("Cannot open blame, there is no file selected.", "Blame", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
         if (command == "difftool" && args.Count <= 2)
         {
-            MessageBox.Show("Cannot open difftool, there is no file selected.", "Difftool", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show("Cannot open difftool, there is no file selected.", "Difftool", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
         if (command is (BlameHistoryCommand or FileHistoryCommand) && args.Count <= 2)
         {
-            MessageBox.Show("Cannot open blame / file history, there is no file selected.", "Blame / file history", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show("Cannot open blame / file history, there is no file selected.", "Blame / file history", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
         if (command == "fileeditor" && args.Count <= 2)
         {
-            MessageBox.Show("Cannot open file editor, there is no file selected.", "File editor", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show("Cannot open file editor, there is no file selected.", "File editor", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 
         if (command == "revert" && args.Count <= 2)
         {
-            MessageBox.Show("Cannot open revert, there is no file selected.", "Revert", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show("Cannot open revert, there is no file selected.", "Revert", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 

--- a/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -146,7 +146,7 @@ Do you want to register the host's fingerprint and restart the process?");
     {
         if (Plink && e.Text.Contains("If you trust this host, enter \"y\" to add the key to"))
         {
-            if (MessageBox.Show(this, _fingerprintNotRegistredText.Text, _fingerprintNotRegistredTextCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+            if (MessageBoxes.Show(this, _fingerprintNotRegistredText.Text, _fingerprintNotRegistredTextCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
                 string remoteUrl;
                 if (string.IsNullOrEmpty(_urlTryingToConnect))

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -98,7 +98,7 @@ public partial class FormResetAnotherBranch : GitModuleForm
         IGitRef gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
         if (gitRefToReset is null)
         {
-            MessageBox.Show(string.Format(_localRefInvalid.Text, Branches.Text), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(string.Format(_localRefInvalid.Text, Branches.Text), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 

--- a/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -80,7 +80,7 @@ public partial class FormResetCurrentBranch : GitModuleForm
         }
         else if (Hard.Checked)
         {
-            if (MessageBox.Show(this, _resetHardWarning.Text, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
+            if (MessageBoxes.Show(this, _resetHardWarning.Text, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
             {
                 ObjectId currentCheckout = Module.GetCurrentCheckout();
                 bool success = FormProcess.ShowDialog(this, UICommands, arguments: Commands.Reset(ResetMode.Hard, Revision.Guid), Module.WorkingDir, input: null, useDialogSettings: true);

--- a/src/app/GitUI/MessageBoxes.cs
+++ b/src/app/GitUI/MessageBoxes.cs
@@ -59,9 +59,7 @@ public class MessageBoxes : Translate
         Translator.Translate(this, AppSettings.CurrentTranslation);
     }
 
-    private static MessageBoxes? instance;
-
-    private static MessageBoxes Instance => instance ??= new();
+    private static MessageBoxes Instance => field ??= new();
 
     public static void RevisionFilteredInGrid(IWin32Window? owner, ObjectId objectId)
         => ShowError(owner, string.Format(Instance._cannotFindRevisionFilter.Text, objectId.ToShortString()), Instance._cannotFindRevisionCaption.Text);
@@ -146,9 +144,41 @@ public class MessageBoxes : Translate
     public static void ShowError(IWin32Window? owner, string text, string? caption = null)
         => Show(owner, text, caption ?? TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-    private static bool Confirm(IWin32Window? owner, string text, string caption)
-        => Show(owner, text, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
+    public static bool Confirm(IWin32Window? owner, string text, string caption, MessageBoxIcon icon = MessageBoxIcon.Question, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Button1)
+        => Show(owner, text, caption, MessageBoxButtons.YesNo, icon, defaultButton) == DialogResult.Yes;
 
-    private static DialogResult Show(IWin32Window? owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
-        => MessageBox.Show(owner ?? Form.ActiveForm, text, caption, buttons, icon);
+    /// <summary>
+    ///  Shows a message box with the specified parameters.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(IWin32Window? owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Button1)
+        => GitExtensions.Extensibility.MessageBoxes.Show(owner, text, caption, buttons, icon, defaultButton);
+
+    /// <summary>
+    ///  Shows a message box without specifying an icon.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(IWin32Window? owner, string text, string caption, MessageBoxButtons buttons)
+        => GitExtensions.Extensibility.MessageBoxes.Show(owner, text, caption, buttons);
+
+    /// <summary>
+    ///  Shows a message box without an explicit owner window.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton)
+        => GitExtensions.Extensibility.MessageBoxes.Show(text, caption, buttons, icon, defaultButton);
+
+    /// <summary>
+    ///  Shows a message box without an explicit owner window.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
+        => GitExtensions.Extensibility.MessageBoxes.Show(text, caption, buttons, icon);
+
+    /// <summary>
+    ///  Shows a message box without an explicit owner window or icon.
+    /// </summary>
+    /// <returns>The <see cref="DialogResult"/> selected by the user.</returns>
+    public static DialogResult Show(string text, string caption, MessageBoxButtons buttons)
+        => GitExtensions.Extensibility.MessageBoxes.Show(text, caption, buttons);
 }

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.ComponentModel;
 using System.Diagnostics;
@@ -79,7 +79,7 @@ public static class BugReportInvoker
         }
         catch (Exception ex)
         {
-            MessageBox.Show($"Failed to log error to {tempFile}\r\n{ex.Message}", "Error writing log", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show($"Failed to log error to {tempFile}\r\n{ex.Message}", "Error writing log", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 

--- a/src/app/GitUI/Plugin/FailedPluginWrapper.cs
+++ b/src/app/GitUI/Plugin/FailedPluginWrapper.cs
@@ -45,7 +45,7 @@ internal partial class FailedPluginWrapper : IGitPlugin
 
     public bool Execute(GitUIEventArgs args)
     {
-        DialogResult result = MessageBox.Show(string.Format(TranslatedStrings.FailedToLoadPluginPopupText, _exception),
+        DialogResult result = MessageBoxes.Show(string.Format(TranslatedStrings.FailedToLoadPluginPopupText, _exception),
             TranslatedStrings.FailedToLoadPlugin, MessageBoxButtons.OKCancel, MessageBoxIcon.Error);
         if (result == DialogResult.OK)
         {

--- a/src/app/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Text.RegularExpressions;
 using GitCommands;
@@ -122,7 +122,7 @@ partial class ScriptsManager
             }
 
             if (script.AskConfirmation &&
-                MessageBox.Show(owner, $"{TranslatedStrings.ScriptConfirmExecute}: '{script.GetDisplayName()}'?", TranslatedStrings.ScriptText,
+                MessageBoxes.Show(owner, $"{TranslatedStrings.ScriptConfirmExecute}: '{script.GetDisplayName()}'?", TranslatedStrings.ScriptText,
                                 MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
             {
                 return false;
@@ -134,7 +134,7 @@ partial class ScriptsManager
 
             if (cancelled)
             {
-                MessageBox.Show(owner, TranslatedStrings.ScriptUserCanceledRun, script.GetDisplayName(), MessageBoxButtons.OK);
+                MessageBoxes.Show(owner, TranslatedStrings.ScriptUserCanceledRun, script.GetDisplayName(), MessageBoxButtons.OK);
                 return false;
             }
 

--- a/src/app/GitUI/UserControls/BranchComboBox.cs
+++ b/src/app/GitUI/UserControls/BranchComboBox.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -57,7 +57,7 @@ public partial class BranchComboBox : GitExtensionsControl
             IGitRef gitHead = _branchesToSelect.FirstOrDefault(g => g.Name == branch);
             if (gitHead is null)
             {
-                MessageBox.Show(string.Format(_branchCheckoutError.Text, branch), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(string.Format(_branchCheckoutError.Text, branch), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {

--- a/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using GitExtensions.Extensibility.Git;
 using GitUI.HelperDialogs;
 
@@ -33,7 +33,7 @@ public partial class CommitPickerSmallControl : GitModuleControl
         if (SelectedObjectId is null && !string.IsNullOrWhiteSpace(commitHash))
         {
             SelectedObjectId = oldCommitHash;
-            MessageBox.Show("The given commit hash is not valid for this repository and was therefore discarded.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show("The given commit hash is not valid for this repository and was therefore discarded.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         else
         {

--- a/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Text;
 using GitCommands;
@@ -237,7 +237,7 @@ partial class FileStatusList
         {
             FileStatusItem[] selected = [.. SelectedItems];
             if (selected.Length == 0 || !selected[0].SecondRevision.IsArtificial ||
-                MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo,
+                MessageBoxes.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning) !=
                 DialogResult.Yes)
             {
@@ -257,7 +257,7 @@ partial class FileStatusList
         }
         catch (Exception ex)
         {
-            MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         return;
@@ -999,7 +999,7 @@ partial class FileStatusList
 
                     if (output.Length > 0)
                     {
-                        MessageBox.Show(this, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBoxes.Show(this, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
             }
@@ -1184,7 +1184,7 @@ partial class FileStatusList
         }
         else
         {
-            MessageBox.Show(string.Format(_stopTrackingFail.Text, filename), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(string.Format(_stopTrackingFail.Text, filename), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Net.Mail;
 using System.Text.RegularExpressions;
@@ -406,7 +406,7 @@ public partial class PatchGrid : GitModuleControl
 
         if (string.IsNullOrEmpty(patchFile.FullName))
         {
-            MessageBox.Show(_unableToShowPatchDetails.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(_unableToShowPatchDetails.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Concurrency;
@@ -2387,7 +2387,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         IReadOnlyList<GitRevision> selectedRevisions = GetSelectedRevisions();
         if (selectedRevisions.Count is > 2)
         {
-            MessageBox.Show(this, "Select only one or two revisions. Abort.", "Archive revision", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, "Select only one or two revisions. Abort.", "Archive revision", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -2991,7 +2991,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         }
         else if (showNoRevisionMsg)
         {
-            MessageBox.Show(this, _noRevisionFoundError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _noRevisionFoundError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -3054,7 +3054,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
     {
         if (string.IsNullOrWhiteSpace(CurrentBranch.Value) || CurrentCheckout is null)
         {
-            MessageBox.Show(this, "No branch is currently selected", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, "No branch is currently selected", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -3077,7 +3077,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
     {
         if (_baseCommitToCompare is null)
         {
-            MessageBox.Show(this, _baseForCompareNotSelectedError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, _baseForCompareNotSelectedError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -3100,7 +3100,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         if (baseCommit.ObjectId == ObjectId.WorkTreeId)
         {
-            MessageBox.Show(this, "Cannot diff working directory to itself", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, "Cannot diff working directory to itself", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
@@ -3118,7 +3118,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         }
         else
         {
-            MessageBox.Show(this, "You must have two commits selected to compare", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, "You must have two commits selected to compare", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -3223,7 +3223,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             if (fileNameArray.Length > 10)
             {
                 // Some users need to be protected against themselves!
-                MessageBox.Show(this, _droppingFilesBlocked.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.Show(this, _droppingFilesBlocked.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using GitCommands;
 using GitCommands.Settings;
 using GitExtensions.Extensibility.Git;
@@ -179,7 +179,7 @@ internal class RevisionGridMenuCommands : MenuCommandsBase
                 Name = "QuickSearch",
                 Text = "&Quick search",
                 ToolTipText = _quickSearchQuickHelp.Text,
-                ExecuteAction = () => MessageBox.Show(_quickSearchQuickHelp.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
+                ExecuteAction = () => MessageBoxes.Show(_quickSearchQuickHelp.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
             },
             new MenuCommand
             {

--- a/src/plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
+++ b/src/plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.Composition;
 using System.Text;
 using GitCommands;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Plugins;
 using GitExtensions.Extensibility.Settings;
@@ -75,7 +76,7 @@ public class AutoCompileSubModulesPlugin : GitPluginBase, IGitPluginForRepositor
             FileInfo solutionFile = solutionFiles[n];
 
             DialogResult result =
-                MessageBox.Show(args.OwnerForm,
+                MessageBoxes.Show(args.OwnerForm,
                     string.Format(_doYouWantBuild.Text,
                                   solutionFile.Name,
                                   SolutionFilesToString(solutionFiles)),
@@ -95,7 +96,7 @@ public class AutoCompileSubModulesPlugin : GitPluginBase, IGitPluginForRepositor
 
             if (string.IsNullOrEmpty(msbuildPath) || !File.Exists(msbuildPath))
             {
-                MessageBox.Show(args.OwnerForm, _enterCorrectMsBuildPath.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.ShowError(args.OwnerForm, _enterCorrectMsBuildPath.Text);
             }
             else
             {

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -4,6 +4,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Text.Json.Nodes;
 using AzureDevOpsIntegration.Settings;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.BuildServerIntegration;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Settings;
@@ -257,7 +258,7 @@ Detail of the error:");
             if (_projectOnErrorKey is null || _projectOnErrorKey != CacheKey)
             {
                 _projectOnErrorKey = CacheKey;
-                MessageBox.Show(errorMessage, _buildIntegrationErrorCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.ShowError(owner: null, errorMessage, _buildIntegrationErrorCaption.Text);
             }
         }
 

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
@@ -1,5 +1,6 @@
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using GitCommands;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Settings;
 using GitExtUtils.GitUI.Theming;
 using GitUI;
@@ -148,14 +149,14 @@ public partial class SettingsUserControl : GitExtensionsControl, IBuildServerSet
                     }
                     catch (Exception)
                     {
-                        MessageBox.Show(_failToLoadBuildDefinitionInfoMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBoxes.ShowError(owner: null, _failToLoadBuildDefinitionInfoMessage.Text, _failToExtractDataFromClipboardCaption.Text);
                         return;
                     }
                 }
                 else
                 {
                     buildDefinitionName = "";
-                    MessageBox.Show(_infoNoApiTokenMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    MessageBoxes.Show(owner: null, _infoNoApiTokenMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
 
                 _currentSettings.ProjectUrl = projectUrl;
@@ -164,7 +165,7 @@ public partial class SettingsUserControl : GitExtensionsControl, IBuildServerSet
             }
             else
             {
-                MessageBox.Show(_failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.ShowError(owner: null, _failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text);
             }
         });
     }

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/GitlabAdapter.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/GitlabAdapter.cs
@@ -36,6 +36,8 @@ public class GitlabAdapter : IBuildServerAdapter
 
     public void Initialize(IBuildServerWatcher buildServerWatcher, SettingsSource config, Action openSettings, Func<ObjectId, bool>? isCommitInRevisionGrid = null)
     {
+        _loadedItems.Clear();
+
         _apiClient = _apiClientFactory.CreateGitlabApiClient(
             config.GetString("InstanceUrl", string.Empty),
             config.GetString("ApiToken", string.Empty),

--- a/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.Composition;
 using System.Text.RegularExpressions;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Settings;
 using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces.BuildServerIntegration;
@@ -96,7 +97,7 @@ public partial class TeamCitySettingsUserControl : GitExtensionsControl, IBuildS
         }
         catch
         {
-            MessageBox.Show(this, _failToLoadProjectMessage.Text, _failToLoadProjectCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, _failToLoadProjectMessage.Text, _failToLoadProjectCaption.Text);
         }
     }
 
@@ -135,7 +136,7 @@ public partial class TeamCitySettingsUserControl : GitExtensionsControl, IBuildS
             }
         }
 
-        MessageBox.Show(this, _failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text,
+        MessageBoxes.Show(this, _failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text,
             MessageBoxButtons.OK, MessageBoxIcon.Warning);
     }
 }

--- a/src/plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
+++ b/src/plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
@@ -25,7 +25,7 @@ public partial class CreateLocalBranchesForm : ResourceManager.GitExtensionsForm
 
         if (references.Length == 0)
         {
-            MessageBox.Show(this, "No remote branches found.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, "No remote branches found.");
             DialogResult = DialogResult.Cancel;
             return;
         }
@@ -52,7 +52,7 @@ public partial class CreateLocalBranchesForm : ResourceManager.GitExtensionsForm
             }
         }
 
-        MessageBox.Show(this, string.Format("{0} local tracking branches have been created/updated.", references.Length),
+        MessageBoxes.Show(this, string.Format("{0} local tracking branches have been created/updated.", references.Length),
             "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
         Close();
     }

--- a/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -12,6 +12,7 @@ using GitUI.NBugReports;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
+using MessageBoxes = GitUI.MessageBoxes;
 
 namespace GitExtensions.Plugins.DeleteUnusedBranches;
 
@@ -136,7 +137,7 @@ public sealed partial class DeleteUnusedBranchesForm : GitExtensionsFormBase
 
         if (!result.ExitedSuccessfully)
         {
-            MessageBox.Show(this, result.AllOutput, $"git {args}", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, result.AllOutput, $"git {args}", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return [];
         }
 
@@ -152,11 +153,11 @@ public sealed partial class DeleteUnusedBranchesForm : GitExtensionsFormBase
         List<Branch> selectedBranches = [.. _branches.Where(branch => branch.Delete)];
         if (selectedBranches.Count == 0)
         {
-            MessageBox.Show(string.Format(_selectBranchesToDelete.Text, _NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.HeaderText), _deleteCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(string.Format(_selectBranchesToDelete.Text, _NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.HeaderText), _deleteCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 
-        if (MessageBox.Show(this, string.Format(_areYouSureToDelete.Text, selectedBranches.Count), _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
+        if (MessageBoxes.Show(this, string.Format(_areYouSureToDelete.Text, selectedBranches.Count), _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
         {
             return;
         }
@@ -171,7 +172,7 @@ public sealed partial class DeleteUnusedBranchesForm : GitExtensionsFormBase
         if (remoteBranches.Count > 0)
         {
             string message = string.Format(_dangerousAction.Text, remoteName);
-            if (MessageBox.Show(this, message, _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
+            if (MessageBoxes.Show(this, message, _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
             {
                 return;
             }
@@ -247,7 +248,7 @@ public sealed partial class DeleteUnusedBranchesForm : GitExtensionsFormBase
 
         if (includeUnmergedBranches.Checked)
         {
-            MessageBox.Show(this, _deletingUnmergedBranches.Text, _deleteCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            MessageBoxes.Show(this, _deletingUnmergedBranches.Text, _deleteCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
     }
 

--- a/src/plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/src/plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -218,7 +218,7 @@ public sealed partial class FindLargeFilesForm : GitExtensionsFormBase
 
     private void Delete_Click(object sender, EventArgs e)
     {
-        if (MessageBox.Show(this, _areYouSureToDelete.Text, _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+        if (MessageBoxes.Show(this, _areYouSureToDelete.Text, _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
         {
             _commands.StartBatchFileProcessDialog(GenerateCommand(_gitObjects));
         }

--- a/src/plugins/GitHub3/GitHub3Plugin.cs
+++ b/src/plugins/GitHub3/GitHub3Plugin.cs
@@ -3,6 +3,7 @@ using Git.hub;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remotes;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Plugins;
 using GitExtensions.Extensibility.Settings;
@@ -148,7 +149,7 @@ public class GitHub3Plugin : GitPluginBase, IRepositoryHostPlugin, IGitPluginFor
         }
         catch (Exception ex)
         {
-            MessageBox.Show(_openLinkFailed.Text + ex.Message);
+            MessageBoxes.Show(owner: null, _openLinkFailed.Text + ex.Message, caption: string.Empty, MessageBoxButtons.OK, MessageBoxIcon.None);
         }
     }
 
@@ -242,7 +243,7 @@ public class GitHub3Plugin : GitPluginBase, IRepositoryHostPlugin, IGitPluginFor
         }
         else
         {
-            MessageBox.Show(args.OwnerForm, _tokenAlreadyExist.Text, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(args.OwnerForm, _tokenAlreadyExist.Text, _error.Text);
         }
 
         return false;

--- a/src/plugins/Gource/GourcePlugin.cs
+++ b/src/plugins/Gource/GourcePlugin.cs
@@ -70,7 +70,7 @@ public class GourcePlugin : GitPluginBase, IGitPluginForRepository
 
         if (!string.IsNullOrEmpty(pathToGource) && !File.Exists(pathToGource))
         {
-            DialogResult result = MessageBox.Show(
+            DialogResult result = MessageBoxes.Show(
                 args.OwnerForm,
                 string.Format(_resetConfigPath.Text, pathToGource), _gource.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
@@ -83,7 +83,7 @@ public class GourcePlugin : GitPluginBase, IGitPluginForRepository
 
         if (string.IsNullOrEmpty(pathToGource))
         {
-            if (MessageBox.Show(
+            if (MessageBoxes.Show(
                     args.OwnerForm, _doYouWantDownloadGource.Text, _download.Text,
                     MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
@@ -100,14 +100,14 @@ public class GourcePlugin : GitPluginBase, IGitPluginForRepository
                 int downloadSize = ThreadHelper.JoinableTaskFactory.Run(() => DownloadFileAsync(args.OwnerForm, gourceUrl, fileName));
                 if (downloadSize > 0)
                 {
-                    MessageBox.Show(args.OwnerForm, string.Format(_bytesDownloaded.Text, downloadSize), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    MessageBoxes.Show(args.OwnerForm, string.Format(_bytesDownloaded.Text, downloadSize), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     Directory.CreateDirectory(Path.Combine(downloadDir, "gource"));
                     UnZipFiles(args.OwnerForm, fileName, Path.Combine(downloadDir, "gource"), true);
 
                     string newGourcePath = Path.Combine(downloadDir, "gource\\gource.exe");
                     if (File.Exists(newGourcePath))
                     {
-                        MessageBox.Show(args.OwnerForm, _gourceDownloadedAndUnzipped.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        MessageBoxes.Show(args.OwnerForm, _gourceDownloadedAndUnzipped.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         pathToGource = newGourcePath;
                     }
                 }

--- a/src/plugins/Gource/GourceStart.cs
+++ b/src/plugins/Gource/GourceStart.cs
@@ -52,7 +52,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
         }
         catch (Exception e)
         {
-            MessageBox.Show(this, e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -62,7 +62,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
 
         if (!File.Exists(GourcePath.Text))
         {
-            MessageBox.Show(this, "Cannot find Gource.\nPlease download Gource and set the correct path.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.Show(this, "Cannot find Gource.\nPlease download Gource and set the correct path.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 

--- a/src/plugins/ProxySwitcher/ProxySwitcherForm.cs
+++ b/src/plugins/ProxySwitcher/ProxySwitcherForm.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Settings;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Settings;
 using GitExtUtils;
@@ -52,7 +53,7 @@ public partial class ProxySwitcherForm : GitExtensionsFormBase
     {
         if (string.IsNullOrEmpty(_plugin.HttpProxy.ValueOrDefault(_settings)))
         {
-            MessageBox.Show(this, _pleaseSetProxy.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, _pleaseSetProxy.Text, Text);
             Close();
         }
         else

--- a/src/plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/src/plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using GitCommands;
 using GitCommands.Utils;
+using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 using ResourceManager;
@@ -44,14 +45,14 @@ public partial class ReleaseNotesGeneratorForm : GitExtensionsFormBase
 
         if (string.IsNullOrWhiteSpace(textBoxRevFrom.Text))
         {
-            MessageBox.Show(this, _fromCommitNotSpecified.Text, _caption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, _fromCommitNotSpecified.Text, _caption.Text);
             textBoxRevFrom.Focus();
             return;
         }
 
         if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_textBoxRevTo.Text))
         {
-            MessageBox.Show(this, _toCommitNotSpecified.Text, _caption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, _toCommitNotSpecified.Text, _caption.Text);
             _NO_TRANSLATE_textBoxRevTo.Focus();
             return;
         }

--- a/tests/app/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
@@ -187,7 +187,7 @@ public sealed class AsyncLoaderTests
     {
         ThreadHelper.JoinableTaskFactory.Run(async () =>
         {
-            _loader.Delay = TimeSpan.FromMilliseconds(100);
+            _loader.Delay = TimeSpan.FromMilliseconds(200);
 
             Stopwatch sw = Stopwatch.StartNew();
 
@@ -195,7 +195,7 @@ public sealed class AsyncLoaderTests
                 () => sw.Stop(),
                 () => { });
 
-            ClassicAssert.GreaterOrEqual(sw.Elapsed, _loader.Delay - TimeSpan.FromMilliseconds(10));
+            ClassicAssert.GreaterOrEqual(sw.Elapsed, _loader.Delay - TimeSpan.FromMilliseconds(20));
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/12927#discussion_r3032429481

Add Microsoft.CodeAnalysis.BannedApiAnalyzers (3.3.4) and configure eng/BannedSymbols.txt to ban System.Windows.Forms.MessageBox. All existing callers are migrated to GitUI.MessageBoxes, which serves as the single approved wrapper.

- Make MessageBoxes.Show and MessageBoxes.Confirm public so callers outside the class can use them as drop-in replacements.
- Replace ~180 direct MessageBox.Show calls across 72 GitUI and plugin files with MessageBoxes.Show.
- Suppress RS0030 with pragmas in GitCommands and BugReporter (which cannot reference GitUI) and in plugins that only reference the extensibility interfaces.

Move the general-purpose Show/ShowError/Confirm wrappers into GitExtensions.Extensibility.MessageBoxes so plugins and other projects that cannot reference GitUI can use the approved wrapper instead of calling MessageBox.Show directly. GitUI.MessageBoxes.Show now delegates to the extensibility version. All usages updated.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
