### PR TITLE
refactor: replace StringPool with HashSet alternate lookup for string deduplication

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,6 @@
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
-    <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/setup/installer/Product.wxs
+++ b/setup/installer/Product.wxs
@@ -151,9 +151,6 @@
       <Component Id="Microsoft.ApplicationInsights.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Microsoft.ApplicationInsights.dll" />
       </Component>
-      <Component Id="Microsoft.Toolkit.HighPerformance.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.Toolkit.HighPerformance.dll" />
-      </Component>
       <Component Id="Microsoft.VisualStudio.Composition.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Composition.dll" />
       </Component>
@@ -652,7 +649,6 @@
       <ComponentRef Id="ICSharpCode.TextEditor.dll" />
       <ComponentRef Id="Microsoft.AI.DependencyCollector.dll" />
       <ComponentRef Id="Microsoft.ApplicationInsights.dll" />
-      <ComponentRef Id="Microsoft.Toolkit.HighPerformance.dll" />
       <ComponentRef Id="Microsoft.VisualStudio.Composition.dll" />
       <ComponentRef Id="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" />
       <ComponentRef Id="Microsoft.VisualStudio.Interop.dll" />

--- a/src/app/GitCommands/GitCommands.csproj
+++ b/src/app/GitCommands/GitCommands.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
-    <PackageReference Include="Microsoft.Toolkit.HighPerformance" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="System.Reactive.Linq" />

--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -10,8 +10,6 @@ using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 using GitUI;
 using GitUIPluginInterfaces;
-using Microsoft.Toolkit.HighPerformance;
-using Microsoft.Toolkit.HighPerformance.Buffers;
 using Microsoft.VisualStudio.Threading;
 
 namespace GitCommands;
@@ -56,8 +54,12 @@ public sealed class RevisionReader
     // Include Git Notes for the commit
     private bool _hasNotes;
 
-    // Buffer to decode subject
+    // Reusable buffer for decoding byte spans to chars (names, emails, subject, body)
     private char[] _decodeBuffer = new char[4096];
+
+    // Per-instance string pool for deduplicating author/committer names and emails
+    private readonly HashSet<string>.AlternateLookup<ReadOnlySpan<char>> _stringPool
+        = new HashSet<string>(StringComparer.Ordinal).GetAlternateLookup<ReadOnlySpan<char>>();
 
     public RevisionReader(IGitModule module, bool allBodies = false)
         : this(module, module.LogOutputEncoding, allBodies ? 0 : GetUnixTimeForOffset(_offsetDaysForOldestBody))
@@ -549,18 +551,7 @@ public sealed class RevisionReader
         // Body is occasionally big, like linux repo has 35K bytes, the buffer is over 100K
         // Use a backing buffer on the heap
         int maxChars = _logOutputEncoding.GetMaxByteCount(buffer.Slice(offset).Length);
-        if (maxChars > _decodeBuffer.Length)
-        {
-            // Default should be sufficient for most repos, Linux though has
-            // unencoded of 36K, which results in maxChars being greater than 100K
-            int newSize = _decodeBuffer.Length;
-            while (newSize < maxChars)
-            {
-                newSize *= 2;
-            }
-
-            _decodeBuffer = new char[newSize];
-        }
+        EnsureDecodeBufferSize(maxChars);
 
         int decodedLength = _logOutputEncoding.GetChars(bufferSpan.Slice(offset), _decodeBuffer);
         Span<char> decoded = _decodeBuffer.AsSpan(0, decodedLength).TrimEnd();
@@ -639,7 +630,7 @@ public sealed class RevisionReader
 
         return true;
 
-        // Authors etc are limited, use a shared string pool
+        // Authors etc are limited, use a per-instance string pool to deduplicate
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         string? GetNextLine(in ReadOnlySpan<byte> s)
         {
@@ -657,7 +648,21 @@ public sealed class RevisionReader
 
             ReadOnlySpan<byte> r = s.Slice(offset, lineLength);
             offset += lineLength + 1;
-            return StringPool.Shared.GetOrAdd(r, _logOutputEncoding);
+
+            int maxCharCount = _logOutputEncoding.GetMaxCharCount(r.Length);
+            EnsureDecodeBufferSize(maxCharCount);
+
+            int charCount = _logOutputEncoding.GetChars(r, _decodeBuffer);
+            ReadOnlySpan<char> decoded = _decodeBuffer.AsSpan(0, charCount);
+
+            if (_stringPool.TryGetValue(decoded, out string? existing))
+            {
+                return existing;
+            }
+
+            string newStr = new(decoded);
+            _stringPool.Add(newStr);
+            return newStr;
         }
 
         void ParseAssert(string message)
@@ -684,6 +689,22 @@ public sealed class RevisionReader
 
     internal TestAccessor GetTestAccessor()
         => new(this);
+
+    private void EnsureDecodeBufferSize(int requiredLength)
+    {
+        if (requiredLength <= _decodeBuffer.Length)
+        {
+            return;
+        }
+
+        int newSize = _decodeBuffer.Length;
+        while (newSize < requiredLength)
+        {
+            newSize *= 2;
+        }
+
+        _decodeBuffer = new char[newSize];
+    }
 
     internal readonly struct TestAccessor
     {


### PR DESCRIPTION
Replace `Microsoft.Toolkit.HighPerformance` `StringPool.Shared` with a per-instance `HashSet<string>` using .NET 9+ `GetAlternateLookup` API for deduplicating author/committer names and emails in `RevisionReader`.

Benefits:
- No eviction: StringPool.Shared is a fixed-size set-associative cache that can evict entries under pressure, causing re-allocation. HashSet is deterministic.
- Fewer allocations: StringPool rents char[] from ArrayPool per call. The new code uses stackalloc for the decode buffer.
- No external dependency: removes the Microsoft.Toolkit.HighPerformance NuGet package (v7.1.2), which was only used here.
- Scoped lifetime: the pool is per-instance rather than a global singleton, so strings are GC'd when the reader is done.

## Test methodology <!-- How did you ensure quality? -->

- Has good unit test coverage
- Manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
