### PR TITLE
refactor: remove dead BinaryFormatter-era serialization code

### DIFF
--- a/src/app/BugReporter/Info/GeneralInfo.cs
+++ b/src/app/BugReporter/Info/GeneralInfo.cs
@@ -10,7 +10,6 @@ using GitCommands;
 
 namespace BugReporter.Info;
 
-[Serializable]
 public class GeneralInfo
 {
     /// <summary>

--- a/src/app/BugReporter/Info/Report.cs
+++ b/src/app/BugReporter/Info/Report.cs
@@ -10,7 +10,6 @@ using BugReporter.Serialization;
 
 namespace BugReporter.Info;
 
-[Serializable]
 public class Report
 {
     /// <summary>

--- a/src/app/BugReporter/Serialization/SerializableDictionary.cs
+++ b/src/app/BugReporter/Serialization/SerializableDictionary.cs
@@ -11,7 +11,6 @@ using System.Xml.Serialization;
 
 namespace BugReporter.Serialization;
 
-[Serializable]
 [XmlRoot("dictionary")]
 public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IXmlSerializable where TKey : notnull where TValue : notnull
 {
@@ -66,26 +65,12 @@ public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IX
         {
             writer.WriteStartElement(key.ToString().Replace(" ", ""));
 
-            // Check to see if we can actually serialize element
-#pragma warning disable SYSLIB0050 // 'Type.IsSerializable' is obsolete: 'Formatter-based serialization is obsolete and should not be used.'
-            if (this[key].GetType().IsSerializable)
-#pragma warning restore SYSLIB0050
+            try
             {
-                // if it's Serializable doesn't mean serialization will succeed (IE. GUID and SQLError types)
-                try
-                {
-                    writer.WriteValue(this[key]);
-                }
-                catch (Exception)
-                {
-                    // we're not Throwing anything here, otherwise evil thing will happen
-                    writer.WriteValue(this[key].ToString());
-                }
+                writer.WriteValue(this[key]);
             }
-            else
+            catch (Exception)
             {
-                // If Type has custom implementation of ToString() we'll get something useful here
-                // Otherwise we'll get Type string. (Still better than crashing).
                 writer.WriteValue(this[key].ToString());
             }
 

--- a/src/app/BugReporter/Serialization/SerializableException.cs
+++ b/src/app/BugReporter/Serialization/SerializableException.cs
@@ -13,7 +13,6 @@ using System.Xml.Serialization;
 
 namespace BugReporter.Serialization;
 
-[Serializable]
 public class SerializableException
 {
     /// <summary>

--- a/src/app/GitCommands/CommitTemplateItem.cs
+++ b/src/app/GitCommands/CommitTemplateItem.cs
@@ -1,10 +1,8 @@
-﻿using System.Runtime.Serialization;
-using GitCommands.Utils;
+﻿using GitCommands.Utils;
 
 namespace GitCommands;
 
-[Serializable]
-public sealed class CommitTemplateItem : ISerializable
+public sealed class CommitTemplateItem
 {
     public string Name { get; set; }
     public string Text { get; set; }
@@ -25,37 +23,6 @@ public sealed class CommitTemplateItem : ISerializable
         Text = string.Empty;
         Icon = null;
         IsRegex = false;
-    }
-
-    private CommitTemplateItem(SerializationInfo info, StreamingContext context)
-    {
-        Name = (string)info.GetValue("Name", typeof(string));
-        Text = (string)info.GetValue("Text", typeof(string));
-
-        if (HasKey(info, "IsRegex"))
-        {
-            IsRegex = (bool)info.GetValue("IsRegex", typeof(bool));
-        }
-    }
-
-    public void GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-        info.AddValue("Name", Name);
-        info.AddValue("Text", Text);
-        info.AddValue("IsRegex", IsRegex);
-    }
-
-    private bool HasKey(SerializationInfo info, string key)
-    {
-        foreach (SerializationEntry entry in info)
-        {
-            if (entry.Name == key)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public static void SaveToSettings(CommitTemplateItem[]? items)

--- a/src/app/GitCommands/UserRepositoryHistory/Repository.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/Repository.cs
@@ -2,7 +2,6 @@
 
 namespace GitCommands.UserRepositoryHistory;
 
-[Serializable]
 public class Repository
 {
     private string? _path;

--- a/src/app/GitCommands/XmlSerializableDictionary.cs
+++ b/src/app/GitCommands/XmlSerializableDictionary.cs
@@ -1,24 +1,15 @@
-﻿using System.Runtime.Serialization;
-using System.Xml;
+﻿using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace GitCommands;
 
 [XmlRoot("dictionary")]
-[Serializable]
 public class XmlSerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IXmlSerializable
 {
     public XmlSerializableDictionary()
     {
     }
-
-#pragma warning disable SYSLIB0051 // This ctor is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.'
-    protected XmlSerializableDictionary(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-#pragma warning restore SYSLIB0051
 
     #region IXmlSerializable Members
 

--- a/src/app/GitUI/Hotkey/HotkeySettings.cs
+++ b/src/app/GitUI/Hotkey/HotkeySettings.cs
@@ -6,7 +6,6 @@ namespace GitUI.Hotkey;
 /// <summary>
 /// Stores all hotkey mappings of one target.
 /// </summary>
-[Serializable]
 public class HotkeySettings
 {
     [XmlArray]

--- a/src/app/GitUI/WindowPositionList.cs
+++ b/src/app/GitUI/WindowPositionList.cs
@@ -9,7 +9,6 @@ namespace GitUI;
 ///   Stores the state and position of a single window.
 /// </summary>
 [DebuggerDisplay("Name={Name} Rect={Rect} DeviceDpi={DeviceDpi} State={State}")]
-[Serializable]
 public class WindowPosition
 {
     protected WindowPosition()
@@ -32,7 +31,6 @@ public class WindowPosition
     public string? Name { get; set; }
 }
 
-[Serializable]
 public class WindowPositionList
 {
     private static readonly string ConfigFilePath = Path.Combine(AppSettings.LocalApplicationDataPath.Value, "WindowPositions.xml");

--- a/src/app/ResourceManager/Hotkey/HotkeyCommand.cs
+++ b/src/app/ResourceManager/Hotkey/HotkeyCommand.cs
@@ -3,7 +3,6 @@ using System.Xml.Serialization;
 
 namespace ResourceManager;
 
-[Serializable]
 [DebuggerDisplay("Hotkey: {CommandCode} {Name}")]
 public class HotkeyCommand
 {


### PR DESCRIPTION
Remove [Serializable] attributes, ISerializable implementation, SerializationInfo/StreamingContext constructors, and SYSLIB005x suppressions across 10 files. None of these were used — all actual serialization uses XmlSerializer or System.Text.Json.

## Test methodology <!-- How did you ensure quality? -->

- Unit tests and manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
