### PR TITLE
refactor: replace EnvUtils methods with modern .NET framework equivalents

### DIFF
--- a/src/app/GitCommands/DiffMergeTools/VsDiffMerge.cs
+++ b/src/app/GitCommands/DiffMergeTools/VsDiffMerge.cs
@@ -1,4 +1,3 @@
-using GitCommands.Utils;
 using Microsoft.Win32;
 
 namespace GitCommands.DiffMergeTools;
@@ -24,7 +23,7 @@ internal class VsDiffMerge : DiffMergeTool
 
     private static string GetVsDiffMergePath()
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return ExeName;
         }

--- a/src/app/GitCommands/EnvironmentPathsProvider.cs
+++ b/src/app/GitCommands/EnvironmentPathsProvider.cs
@@ -1,5 +1,4 @@
-﻿using GitCommands.Utils;
-using GitExtensions.Extensibility;
+﻿using GitExtensions.Extensibility;
 
 namespace GitCommands;
 
@@ -40,7 +39,7 @@ public sealed class EnvironmentPathsProvider : IEnvironmentPathsProvider
             yield break;
         }
 
-        foreach (string rawDir in pathVariable.LazySplit(EnvUtils.EnvVariableSeparator))
+        foreach (string rawDir in pathVariable.LazySplit(Path.PathSeparator))
         {
             string dir = rawDir;
 

--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -1,5 +1,4 @@
 ﻿using GitCommands.Config;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -169,9 +168,9 @@ public static partial class Commands
 
         toPath = getPathForGitExecution(toPath.Trim());
 
-        DebugHelpers.Assert(!EnvUtils.RunningOnWindows() || fromPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
+        DebugHelpers.Assert(!OperatingSystem.IsWindows() || fromPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
            $"'CloneCmd' must be called with 'fromPath' in Posix format");
-        DebugHelpers.Assert(!EnvUtils.RunningOnWindows() || toPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
+        DebugHelpers.Assert(!OperatingSystem.IsWindows() || toPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
            $"'CloneCmd' must be called with 'toPath' in Posix format");
 
         return new GitArgumentBuilder("clone")

--- a/src/app/GitCommands/Git/EnvironmentConfiguration.cs
+++ b/src/app/GitCommands/Git/EnvironmentConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using GitCommands.Utils;
-
-namespace GitCommands;
+﻿namespace GitCommands;
 
 public static class EnvironmentConfiguration
 {
@@ -54,7 +52,7 @@ public static class EnvironmentConfiguration
 
         // SSH_ASKPASS variable
 
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             string sshAskPass = Path.Combine(AppSettings.GetInstallDir(), "GitExtSshAskPass.exe");
 
@@ -108,7 +106,7 @@ public static class EnvironmentConfiguration
             return UserHomeDir;
         }
 
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             // Use the Windows default home directory
             string homeDrive = Env.GetEnvironmentVariable("HOMEDRIVE");

--- a/src/app/GitCommands/Git/Extended/MoveCommand.cs
+++ b/src/app/GitCommands/Git/Extended/MoveCommand.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtUtils;
 
@@ -58,6 +57,6 @@ public sealed class MoveCommand(IExecutable _gitExecutable) : IExtendedCommand<M
         // Git does not support changing only the case of folders in Windows
         return !arguments.IsFolder || string.Compare(arguments.OldName, arguments.NewName, ignoreCase: true) != 0 || !IsRunningOnNativeWindows();
 
-        bool IsRunningOnNativeWindows() => EnvUtils.RunningOnWindows() && !PathUtil.IsWslPath(_gitExecutable.WorkingDir);
+        bool IsRunningOnNativeWindows() => OperatingSystem.IsWindows() && !PathUtil.IsWslPath(_gitExecutable.WorkingDir);
     }
 }

--- a/src/app/GitCommands/Git/Extensions/ProcessExtensions.cs
+++ b/src/app/GitCommands/Git/Extensions/ProcessExtensions.cs
@@ -1,14 +1,12 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
-using GitCommands.Utils;
-
 namespace GitCommands.Git.Extensions;
 
 public static class ProcessExtensions
 {
     public static void TerminateTree(this Process process)
     {
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             // Send Ctrl+C
             NativeMethods.AttachConsole(process.Id);

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -10,7 +10,6 @@ using GitCommands.Git.Extensions;
 using GitCommands.Patches;
 using GitCommands.Remotes;
 using GitCommands.Settings;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Configurations;
 using GitExtensions.Extensibility.Git;
@@ -895,7 +894,7 @@ public sealed partial class GitModule : IGitModule
 
     public void RunGitK()
     {
-        if (EnvUtils.RunningOnUnix())
+        if (!OperatingSystem.IsWindows())
         {
             new Executable("gitk", WorkingDir).Start(createWindow: true);
         }
@@ -915,7 +914,7 @@ public sealed partial class GitModule : IGitModule
     public void RunGui()
     {
         ArgumentBuilder args;
-        if (EnvUtils.RunningOnUnix())
+        if (!OperatingSystem.IsWindows())
         {
             args = new GitArgumentBuilder("gui");
             _ = GitExecutable.Start(args, createWindow: true);
@@ -3629,7 +3628,7 @@ public sealed partial class GitModule : IGitModule
             return true;
         }
 
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             return Process.GetProcessesByName("git").Length > 0;
         }

--- a/src/app/GitCommands/PathEqualityComparer.cs
+++ b/src/app/GitCommands/PathEqualityComparer.cs
@@ -1,6 +1,4 @@
-﻿using GitCommands.Utils;
-
-namespace GitCommands;
+﻿namespace GitCommands;
 
 public class PathEqualityComparer : IEqualityComparer<string>
 {
@@ -8,7 +6,7 @@ public class PathEqualityComparer : IEqualityComparer<string>
     {
         path1 = Path.GetFullPath(path1).TrimEnd('\\');
         path2 = Path.GetFullPath(path2).TrimEnd('\\');
-        StringComparison comparison = !EnvUtils.RunningOnWindows()
+        StringComparison comparison = !OperatingSystem.IsWindows()
             ? StringComparison.InvariantCulture
             : StringComparison.InvariantCultureIgnoreCase;
 
@@ -18,7 +16,7 @@ public class PathEqualityComparer : IEqualityComparer<string>
     public int GetHashCode(string path)
     {
         path = Path.GetFullPath(path).TrimEnd('\\');
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             path = path.ToLower();
         }

--- a/src/app/GitCommands/PathUtil.cs
+++ b/src/app/GitCommands/PathUtil.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
-using GitCommands.Utils;
 
 namespace GitCommands;
 
@@ -19,7 +18,7 @@ public static partial class PathUtil
     /// <summary>The user's profile folder path.</summary>
     // TODO verify whether the user profile contains forwards/backwards slashes on other platforms
     public static readonly string UserProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-    private static StringComparison _pathComparison = EnvUtils.RunningOnWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    private static StringComparison _pathComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
     [GeneratedRegex(@"^(\w+):\/\/([\S]+)", RegexOptions.ExplicitCapture)]
     private static partial Regex DriveLetterRegex { get; }

--- a/src/app/GitCommands/StringExtensions.cs
+++ b/src/app/GitCommands/StringExtensions.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Text;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 
 // ReSharper disable once CheckNamespace
@@ -213,7 +212,7 @@ public static class StringExtensions
     [Pure]
     public static string EscapeForCommandLine(this string s, bool? forWindows = null)
     {
-        return (forWindows ?? EnvUtils.RunningOnWindows()) ? EscapeForWindowsCommandLine(s) : EscapeForPosixCommandLine(s);
+        return (forWindows ?? OperatingSystem.IsWindows()) ? EscapeForWindowsCommandLine(s) : EscapeForPosixCommandLine(s);
 
         static string EscapeForWindowsCommandLine(string s) => s.Replace("\"", "\"\"");
         static string EscapeForPosixCommandLine(string s) => s.Replace(@"\", @"\\").Replace("\"", "\\\"").Replace("'", @"\'");

--- a/src/app/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/src/app/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using GitCommands.Git;
-using GitCommands.Utils;
 using GitExtensions.Extensibility.Git;
 using GitUI;
 using Microsoft;
@@ -242,7 +241,7 @@ internal sealed class SubmoduleStatusProvider(IGitExecutorProvider executorProvi
             }
 
             if (string.IsNullOrWhiteSpace(path)
-                || (EnvUtils.RunningOnWindows()
+                || (OperatingSystem.IsWindows()
                     && result.AllSubmodules.Any(info => path.Equals(info.Path, StringComparison.OrdinalIgnoreCase))))
             {
                 Trace.WriteLine($"Ignoring duplicate submodule path: {path} ({name})");

--- a/src/app/GitCommands/Utils/EnvUtils.cs
+++ b/src/app/GitCommands/Utils/EnvUtils.cs
@@ -1,27 +1,12 @@
 ﻿using System.Diagnostics;
-using Microsoft.Win32;
 
 namespace GitCommands.Utils;
 
 public static class EnvUtils
 {
-    public static bool RunningOnWindows()
-    {
-        switch (Environment.OSVersion.Platform)
-        {
-            case PlatformID.Win32NT:
-            case PlatformID.Win32S:
-            case PlatformID.Win32Windows:
-            case PlatformID.WinCE:
-                return true;
-            default:
-                return false;
-        }
-    }
-
     public static bool RunningOnWindowsWithMainWindow()
     {
-        if (!RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return false;
         }
@@ -35,75 +20,6 @@ public static class EnvUtils
         return currentProcess.MainWindowHandle != IntPtr.Zero;
     }
 
-    public static bool IsWindowsVistaOrGreater()
-    {
-        return Environment.OSVersion.Platform == PlatformID.Win32NT
-               && Environment.OSVersion.Version.CompareTo(new Version(6, 0)) >= 0;
-    }
-
-    public static bool IsWindows7OrGreater()
-    {
-        return Environment.OSVersion.Platform == PlatformID.Win32NT
-               && Environment.OSVersion.Version.CompareTo(new Version(6, 1)) >= 0;
-    }
-
-    public static bool IsWindows8OrGreater()
-    {
-        return Environment.OSVersion.Platform == PlatformID.Win32NT
-               && Environment.OSVersion.Version.CompareTo(new Version(6, 2)) >= 0;
-    }
-
-    public static bool IsWindows8Point1OrGreater()
-    {
-        return Environment.OSVersion.Platform == PlatformID.Win32NT
-               && Environment.OSVersion.Version.CompareTo(new Version(6, 3)) >= 0;
-    }
-
-    public static bool RunningOnUnix()
-    {
-        return Environment.OSVersion.Platform == PlatformID.Unix;
-    }
-
-    public static bool RunningOnMacOSX()
-    {
-        return Environment.OSVersion.Platform == PlatformID.MacOSX;
-    }
-
-    public static bool IsNet4FullOrHigher()
-    {
-        if (Environment.Version.Major > 4)
-        {
-            return true;
-        }
-
-        if (Environment.Version.Major == 4)
-        {
-            if (Environment.Version.Minor >= 5)
-            {
-                return true;
-            }
-
-            try
-            {
-                RegistryKey? registryKey = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", false);
-                if (registryKey is not null)
-                {
-                    using (registryKey)
-                    {
-                        object v = registryKey.GetValue("Install");
-                        return v?.ToString() is "1";
-                    }
-                }
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                System.Diagnostics.Trace.WriteLine(e);
-            }
-        }
-
-        return false;
-    }
-
     public static string? ReplaceLinuxNewLinesDependingOnPlatform(string? s)
     {
         if (string.IsNullOrEmpty(s))
@@ -111,13 +27,11 @@ public static class EnvUtils
             return s;
         }
 
-        if (RunningOnUnix())
+        if (!OperatingSystem.IsWindows())
         {
             return s;
         }
 
         return s.Replace("\n", Environment.NewLine);
     }
-
-    public static char EnvVariableSeparator => RunningOnWindows() ? ';' : ':';
 }

--- a/src/app/GitExtensions/Program.cs
+++ b/src/app/GitExtensions/Program.cs
@@ -2,7 +2,6 @@
 using System.Configuration;
 using System.Diagnostics;
 using GitCommands;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -114,7 +113,7 @@ internal static class Program
 
         AppSettings.LoadSettings();
 
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             WebBrowserEmulationMode.SetBrowserFeatureControl();
             FormFixHome.CheckHomePath();
@@ -175,7 +174,7 @@ internal static class Program
             // TODO: remove catch-all
         }
 
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             MouseWheelRedirector.Active = true;
         }

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2689,7 +2689,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
     /// </summary>
     private void FillTerminalTab()
     {
-        if (!EnvUtils.RunningOnWindows() || !AppSettings.ShowConEmuTab.Value)
+        if (!OperatingSystem.IsWindows() || !AppSettings.ShowConEmuTab.Value)
         {
             // ConEmu only works on WinNT
             return;

--- a/src/app/GitUI/CommandsDialogs/FormFileHistoryController.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistoryController.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using GitCommands.Utils;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs;
@@ -30,7 +29,7 @@ public sealed class FormFileHistoryController
         // The section below contains native windows (kernel32) calls
         // and breaks on Linux. Only use it on Windows. Casing is only
         // a Windows problem anyway.
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             // grab the 8.3 file path
             StringBuilder shortPath = new(4096);

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -3,7 +3,6 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.Settings;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -388,7 +387,7 @@ public partial class FormResolveConflicts : GitModuleForm
 
     private bool TryMergeWithScript(string fileName, string? baseFileName, string? localFileName, string? remoteFileName)
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return false;
         }
@@ -719,7 +718,7 @@ public partial class FormResolveConflicts : GitModuleForm
                 }
             }
 
-            if (EnvUtils.RunningOnWindows() && _mergetoolCmd is not null)
+            if (OperatingSystem.IsWindows() && _mergetoolCmd is not null)
             {
                 // This only works when on Windows....
                 const string executablePattern = ".exe";

--- a/src/app/GitUI/CommandsDialogs/FormSettings.cs
+++ b/src/app/GitUI/CommandsDialogs/FormSettings.cs
@@ -2,7 +2,6 @@
 
 using GitCommands;
 using GitCommands.Settings;
-using GitCommands.Utils;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Plugins;
 using GitExtensions.Extensibility.Settings;
@@ -133,7 +132,7 @@ public sealed partial class FormSettings : GitModuleForm, ISettingsPageHost
         settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ScriptsSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Console);
         settingsTreeView.AddSettingsPage(SettingsPageBase.Create<HotkeysSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Hotkey);
 
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ShellExtensionSettingsPage>(this, serviceProvider), gitExtPageRef, Images.ShellExtensions);
         }
@@ -240,7 +239,7 @@ public sealed partial class FormSettings : GitModuleForm, ISettingsPageHost
             _commonLogic.GitConfigSettingsSet.Save();
             _commonLogic.DistributedSettingsSet.Save();
 
-            if (EnvUtils.RunningOnWindows())
+            if (OperatingSystem.IsWindows())
             {
                 FormFixHome.CheckHomePath();
             }

--- a/src/app/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.cs
@@ -1,5 +1,4 @@
 ﻿using GitCommands;
-using GitCommands.Utils;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Infrastructure;
 using GitUI.Shells;
@@ -19,7 +18,7 @@ internal partial class ToolsToolStripMenuItem : ToolStripMenuItemEx
 
         gitBashToolStripMenuItem.Tag = new ShellProvider().GetShell(BashShell.ShellName);
 
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             toolStripSeparator6.Visible = false;
             PuTTYToolStripMenuItem.Visible = false;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -2,7 +2,6 @@
 
 using GitCommands;
 using GitCommands.Git;
-using GitCommands.Utils;
 using GitExtensions.Extensibility.Git;
 using Microsoft.Win32;
 
@@ -20,7 +19,7 @@ public class CheckSettingsLogic
 
     public bool AutoSolveAllSettings()
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return SolveGitCommand();
         }
@@ -50,7 +49,7 @@ public class CheckSettingsLogic
 
     public static bool SolveLinuxToolsDir(string? possibleNewPath = null)
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             AppSettings.LinuxToolsDir = string.Empty;
             return true;
@@ -163,7 +162,7 @@ public class CheckSettingsLogic
 
     public static bool SolveGitCommand(string? possibleNewPath = null)
     {
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             foreach (string command in GetWindowsCommandLocations())
             {

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -4,7 +4,6 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Git;
-using GitCommands.Utils;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Translations;
 using GitExtUtils.GitUI.Theming;
@@ -331,7 +330,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
                 yield return CheckDiffToolConfiguration;
                 yield return CheckTranslationConfigSettings;
 
-                if (EnvUtils.RunningOnWindows())
+                if (OperatingSystem.IsWindows())
                 {
                     yield return CheckGitExtensionsInstall;
                     yield return CheckGitExtensionRegistrySettings;
@@ -508,7 +507,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
 
     private bool CheckGitExtensionRegistrySettings()
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return true;
         }
@@ -534,7 +533,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
 
     private bool CheckGitExtensionsInstall()
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return true;
         }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -7,7 +7,6 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Settings;
-using GitCommands.Utils;
 using GitExtensions.Extensibility.Configurations;
 using GitExtensions.Extensibility.Settings;
 using Microsoft;
@@ -75,7 +74,7 @@ public partial class GitConfigSettingsPage : GitConfigBaseSettingsPage
 
         const string gitCredentialHelperPrefix = "git-credential-";
         string[] linuxCredentialHelpers = ["oauth"];
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             cbxCredentialHelper.Items.AddRange(PathUtil.IsWslPath(Module?.WorkingDir)
                 ? [.. FindGitCredentialHelpers().Select(path => path.ToWslPath().Replace(" ", @"\ ")), .. linuxCredentialHelpers]

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
 using GitCommands;
-using GitCommands.Utils;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.ScriptsEngine;
@@ -159,7 +158,7 @@ Diff selection:
 
     public override void OnPageShown()
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return;
         }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using GitCommands;
-using GitCommands.Utils;
 using GitExtensions.Extensibility.Settings;
 using GitExtUtils.GitUI.Theming;
 using Microsoft.Win32;
@@ -134,7 +133,7 @@ public partial class SshSettingsPage : SettingsPageWithHeader
 
     public bool AutoFindPuttyPaths()
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return false;
         }

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -8,7 +8,6 @@ using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Patches;
 using GitCommands.Settings;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -1891,7 +1890,7 @@ public partial class FileViewer : GitModuleControl
         // TODO Cleanup the handling and separate AllOutput to StandardOutput/StandardError
         ExecutionResult result = Module.GitExecutable.Execute(args, inputWriter => inputWriter.BaseStream.Write(patch), throwOnErrorExit: false);
         string output = result.AllOutput.Trim();
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             // remove file mode warnings
             output = output.RemoveLines(FileModeWarningRegex.IsMatch);

--- a/src/app/GitUI/NBugReports/UIReporter.cs
+++ b/src/app/GitUI/NBugReports/UIReporter.cs
@@ -3,7 +3,6 @@ using System.Text;
 using BugReporter;
 using BugReporter.Serialization;
 using GitCommands;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitUI.CommandsDialogs;
@@ -132,7 +131,7 @@ internal class UIReporter : IBugReporter
         // out: git config --global -add safe.directory "d:/folder/to/repo with space in name"
         static string ReplaceRepoPathQuotes(string command)
         {
-            if (!EnvUtils.RunningOnWindows() || !command.EndsWith('\''))
+            if (!OperatingSystem.IsWindows() || !command.EndsWith('\''))
             {
                 return command;
             }

--- a/src/app/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/src/app/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -1,6 +1,5 @@
 ﻿using System.Drawing.Imaging;
 using GitCommands;
-using GitCommands.Utils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 
@@ -185,7 +184,7 @@ public sealed class SpellCheckEditControl : NativeWindow, IDisposable
 
     private int LineHeight()
     {
-        if (!EnvUtils.RunningOnWindows())
+        if (!OperatingSystem.IsWindows())
         {
             return 12;
         }

--- a/src/app/GitUI/SpellChecker/TextBoxHelper.cs
+++ b/src/app/GitUI/SpellChecker/TextBoxHelper.cs
@@ -1,4 +1,3 @@
-using GitCommands.Utils;
 using GitExtUtils.GitUI;
 
 namespace GitUI.SpellChecker;
@@ -13,7 +12,7 @@ internal static class TextBoxHelper
 
     internal static int GetBaselineOffsetAtCharIndex(TextBoxBase tb, int index)
     {
-        if (tb is not RichTextBox rtb || !EnvUtils.RunningOnWindows())
+        if (tb is not RichTextBox rtb || !OperatingSystem.IsWindows())
         {
             return tb.Font.Height;
         }

--- a/src/app/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/src/app/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -3,7 +3,6 @@ using System.Text.RegularExpressions;
 using ConEmu.WinForms;
 using GitCommands;
 using GitCommands.Logging;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using Microsoft;
 
@@ -35,7 +34,7 @@ public class ConsoleEmulatorOutputControl : ConsoleOutputControl
 
     public override bool IsDisplayingFullProcessOutput => true;
 
-    public static bool IsSupportedInThisEnvironment => EnvUtils.RunningOnWindows();
+    public static bool IsSupportedInThisEnvironment => OperatingSystem.IsWindows();
 
     public override void AppendMessageFreeThreaded(string text)
     {

--- a/src/app/GitUI/UserControls/PathFormatter.cs
+++ b/src/app/GitUI/UserControls/PathFormatter.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text;
 using GitCommands;
-using GitCommands.Utils;
 using GitExtUtils;
 
 namespace GitUI;
@@ -37,7 +36,7 @@ internal sealed class PathFormatter
                 return (prefix, text, suffix);
 
             case TruncatePathMethod.None:
-            case TruncatePathMethod.Compact when !EnvUtils.RunningOnWindows():
+            case TruncatePathMethod.Compact when !OperatingSystem.IsWindows():
                 (prefix, text, suffix) = FormatString(name, oldName, step: 0, isNameTruncated: false);
                 return (prefix, text, suffix);
 
@@ -131,7 +130,7 @@ internal sealed class PathFormatter
             // The win32 method PathCompactPathEx is only supported on Windows
             TruncatePathMethod truncatePathMethod = AppSettings.TruncatePathMethod;
 
-            if (truncatePathMethod == TruncatePathMethod.Compact && EnvUtils.RunningOnWindows())
+            if (truncatePathMethod == TruncatePathMethod.Compact && OperatingSystem.IsWindows())
             {
                 StringBuilder result = new(length);
                 NativeMethods.PathCompactPathEx(result, path, length, 0);

--- a/src/app/GitUI/WindowsJumpListManager.cs
+++ b/src/app/GitUI/WindowsJumpListManager.cs
@@ -71,7 +71,7 @@ public sealed class WindowsJumpListManager : IWindowsJumpListManager
         }
     }
 
-    private static bool IsSupported => EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported;
+    private static bool IsSupported => OperatingSystem.IsWindows() && TaskbarManager.IsPlatformSupported;
     private static bool IsSupportedAndVisible => EnvUtils.RunningOnWindowsWithMainWindow() && TaskbarManager.IsPlatformSupported;
 
     /// <summary>

--- a/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -2,7 +2,6 @@
 using System.Net.Http.Headers;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
-using GitCommands.Utils;
 using GitExtensions.Extensibility.BuildServerIntegration;
 using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Settings;
@@ -22,18 +21,7 @@ public class AppVeyorIntegrationMetadata : BuildServerAdapterMetadataAttribute
     {
     }
 
-    public override string? CanBeLoaded
-    {
-        get
-        {
-            if (EnvUtils.IsNet4FullOrHigher())
-            {
-                return null;
-            }
-
-            return ".NET Framework 4 or higher required";
-        }
-    }
+    public override string? CanBeLoaded => null;
 }
 
 [Export(typeof(IBuildServerAdapter))]

--- a/src/plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/src/plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -5,7 +5,6 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.BuildServerIntegration;
 using GitExtensions.Extensibility.Git;
@@ -27,18 +26,7 @@ public class JenkinsIntegrationMetadata : BuildServerAdapterMetadataAttribute
     {
     }
 
-    public override string? CanBeLoaded
-    {
-        get
-        {
-            if (EnvUtils.IsNet4FullOrHigher())
-            {
-                return null;
-            }
-
-            return ".NET Framework 4 or higher required";
-        }
-    }
+    public override string? CanBeLoaded => null;
 }
 
 [Export(typeof(IBuildServerAdapter))]

--- a/src/plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/src/plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using System.Xml.XPath;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.BuildServerIntegration;
 using GitExtensions.Extensibility.Git;
@@ -29,20 +28,7 @@ public class TeamCityIntegrationMetadataAttribute : BuildServerAdapterMetadataAt
     {
     }
 
-    public override string? CanBeLoaded
-    {
-        get
-        {
-            if (EnvUtils.IsNet4FullOrHigher())
-            {
-                return null;
-            }
-            else
-            {
-                return ".NET Framework 4 or higher required";
-            }
-        }
-    }
+    public override string? CanBeLoaded => null;
 }
 
 [Export(typeof(IBuildServerAdapter))]

--- a/src/plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/src/plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using System.Text;
 using GitCommands;
-using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -64,7 +63,7 @@ public partial class ReleaseNotesGeneratorForm : GitExtensionsFormBase
 
         string result = _gitUiCommands.GitModule.GitExecutable.GetOutput(args);
 
-        if (EnvUtils.RunningOnWindows())
+        if (OperatingSystem.IsWindows())
         {
             result = string.Join(Environment.NewLine, result.Split([Environment.NewLine], StringSplitOptions.None).SelectMany(l => l.Split('\n')));
         }

--- a/tests/app/UnitTests/GitCommands.Tests/EnvironmentPathsProviderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/EnvironmentPathsProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using GitCommands;
-using GitCommands.Utils;
 using NSubstitute;
 
 namespace GitCommandsTests;
@@ -15,7 +14,7 @@ public class EnvironmentPathsProviderTests
     [SetUp]
     public void Setup()
     {
-        _separator = EnvUtils.EnvVariableSeparator.ToString();
+        _separator = Path.PathSeparator.ToString();
 
         _environment = Substitute.For<IEnvironmentAbstraction>();
         _provider = new EnvironmentPathsProvider(_environment);


### PR DESCRIPTION
Replace custom OS-detection and .NET-version-detection methods in EnvUtils with their modern .NET framework counterparts:

- RunningOnWindows() -> OperatingSystem.IsWindows()
- RunningOnUnix() -> !OperatingSystem.IsWindows()
- EnvVariableSeparator -> Path.PathSeparator
- IsNet4FullOrHigher() -> removed (always true on .NET 10)
- IsWindowsVista/7/8/8.1OrGreater() -> removed (unused)
- RunningOnMacOSX() -> removed (unused)

Simplify build server adapter CanBeLoaded properties that checked IsNet4FullOrHigher() to unconditionally return null.

## Test methodology <!-- How did you ensure quality? -->

- Unit tests and manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
