### PR TITLE
fix(test): fix flaky CancellationTokenSequence concurrency test

### DIFF
--- a/tests/app/UnitTests/GitUI.Tests/CancellationTokenSequenceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CancellationTokenSequenceTests.cs
@@ -128,8 +128,6 @@ public sealed class CancellationTokenSequenceTests
             completed == allTasks,
             "Test should have completed within a reasonable amount of time");
 
-        await allTasks;
-
         ClassicAssert.AreEqual(loopCount, completedCount);
 
         await Console.Out.WriteLineAsync("Winner by index: " + string.Join(",", winnerByIndex));

--- a/tests/app/UnitTests/GitUI.Tests/CancellationTokenSequenceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CancellationTokenSequenceTests.cs
@@ -105,29 +105,30 @@ public sealed class CancellationTokenSequenceTests
     [Test]
     public async Task Concurrent_callers_to_Next_only_result_in_one_non_cancelled_token_being_issued()
     {
-        const int loopCount = 10000;
+        const int loopCount = 1000;
 
         int logicalProcessorCount = Environment.ProcessorCount;
-        int threadCount = Math.Max(2, logicalProcessorCount);
+
+        // Cap threads to avoid O(n²) CAS contention in Next() on high-core-count machines
+        int threadCount = Math.Min(8, Math.Max(2, logicalProcessorCount));
 
         using CancellationTokenSequence sequence = new();
         using Barrier barrier = new(threadCount);
-        using CountdownEvent countdown = new(loopCount * threadCount);
         int completedCount = 0;
-
-        using CancellationTokenSource completionTokenSource = new();
-        CancellationToken completionToken = completionTokenSource.Token;
         int[] winnerByIndex = new int[threadCount];
 
         List<Task> tasks = [.. Enumerable
             .Range(0, threadCount)
-            .Select(i => Task.Run(() => ThreadMethodAsync(i)))];
+            .Select(i => Task.Run(() => ThreadMethod(i)))];
+
+        Task allTasks = Task.WhenAll(tasks);
+        Task completed = await Task.WhenAny(allTasks, Task.Delay(TimeSpan.FromSeconds(10)));
 
         ClassicAssert.True(
-            countdown.Wait(TimeSpan.FromSeconds(10)),
+            completed == allTasks,
             "Test should have completed within a reasonable amount of time");
 
-        await Task.WhenAll(tasks);
+        await allTasks;
 
         ClassicAssert.AreEqual(loopCount, completedCount);
 
@@ -141,16 +142,11 @@ public sealed class CancellationTokenSequenceTests
 
         return;
 
-        async Task ThreadMethodAsync(int i)
+        void ThreadMethod(int i)
         {
-            while (true)
+            for (int j = 0; j < loopCount; j++)
             {
                 barrier.SignalAndWait();
-
-                if (completionToken.IsCancellationRequested)
-                {
-                    return;
-                }
 
                 CancellationToken token = sequence.Next();
 
@@ -160,11 +156,6 @@ public sealed class CancellationTokenSequenceTests
                 {
                     Interlocked.Increment(ref completedCount);
                     Interlocked.Increment(ref winnerByIndex[i]);
-                }
-
-                if (countdown.Signal())
-                {
-                    await completionTokenSource.CancelAsync();
                 }
             }
         }


### PR DESCRIPTION
Fixes a flaky test seen on a recent AppVeyor build.

On high-core-count machines (e.g. 28 logical processors), using all processors as thread count caused O(n²) CAS contention per round in the Next() compare-exchange loop. Cap thread count at 8 for sufficient concurrency coverage without excessive contention.

Also reduce loop count from 10,000 to 1,000 (still 8,000 concurrent Next() calls — plenty for race detection) and simplify the loop from while+CountdownEvent+CancellationTokenSource to a plain for-loop, eliminating two synchronization primitives of overhead per round.

## Test methodology <!-- How did you ensure quality? -->

- Unit test runs

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
