### PR TITLE
feat: add type icons and condensed remote labels to revision grid ref labels

### DIFF
--- a/src/app/GitExtUtils/GitUI/RectangleExtensions.cs
+++ b/src/app/GitExtUtils/GitUI/RectangleExtensions.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.Contracts;
+
+namespace GitUI;
+
+/// <summary>
+/// Extension methods for <see cref="Rectangle"/>.
+/// </summary>
+public static class RectangleExtensions
+{
+    /// <summary>
+    /// Returns a new rectangle with its left edge moved right by <paramref name="offset"/>,
+    /// reducing the width accordingly.
+    /// </summary>
+    [Pure]
+    public static Rectangle ReduceLeft(this Rectangle rect, int offset)
+    {
+        return new Rectangle(
+            rect.Left + offset,
+            rect.Top,
+            rect.Width - offset,
+            rect.Height);
+    }
+
+    /// <summary>
+    /// Returns a new rectangle with its width reduced from the right by <paramref name="offset"/>.
+    /// </summary>
+    [Pure]
+    public static Rectangle ReduceRight(this Rectangle rect, int offset)
+    {
+        return new Rectangle(
+            rect.Left,
+            rect.Top,
+            rect.Width - offset,
+            rect.Height);
+    }
+}

--- a/src/app/GitExtUtils/GitUI/Theming/AppColor.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/AppColor.cs
@@ -29,6 +29,7 @@ public enum AppColor
     RemoteBranch,
     Tag,
     OtherTag,
+    Stash,
     DiffSection,
     AnsiTerminalBlackForeNormal,
     AnsiTerminalBlackBackNormal,

--- a/src/app/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
@@ -27,6 +27,7 @@ public static class AppColorDefaults
             { AppColor.RemoteBranch, Color.FromArgb(0x8b, 0x00, 0x09) },
             { AppColor.Tag, Color.DarkBlue },
             { AppColor.OtherTag, Color.Gray },
+            { AppColor.Stash, Color.FromArgb(0x9a, 0x72, 0x00) },
             { AppColor.DiffSection, Color.FromArgb(230, 230, 230) },
             { AppColor.AnsiTerminalBlackForeNormal, Color.FromArgb(0x00, 0x00, 0x00) },
             { AppColor.AnsiTerminalBlackBackNormal, Color.FromArgb(0x60, 0x60, 0x60) },

--- a/src/app/GitUI/Themes/dark.css
+++ b/src/app/GitUI/Themes/dark.css
@@ -63,6 +63,7 @@ WindowText: fff0f0f0
 .RemoteBranch.colorblind { color: #0080ff; } /* hsl(210, 100%, 50%) */
 .Tag { color: #40BAF7; }
 .OtherTag { color: #cfb3b3; }
+.Stash { color: #e8c040; }
 .DiffSection { color: #5f5e5e; }
 
 /* translation of terminal (cli) ansi color output sequences */

--- a/src/app/GitUI/Themes/invariant.css
+++ b/src/app/GitUI/Themes/invariant.css
@@ -61,6 +61,7 @@
 .RemoteBranch.colorblind { color: #0600a8; }
 .Tag { color: #00008b; }
 .OtherTag { color: #808080; }
+.Stash { color: #9a7200; }
 .DiffSection { color: #e6e6e6; }
 
 /* translation of terminal (cli) ansi color output sequences */

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -114,12 +114,26 @@ internal sealed class MessageColumnProvider : ColumnProvider
         if (revision.Refs.Count != 0)
         {
             IReadOnlyList<IGitRef> gitRefs = SortRefs(revision.Refs.Where(FilterRef));
+            Dictionary<string, List<IGitRef>> trackedRemotes = BuildTrackedRemoteMap(gitRefs);
+            HashSet<IGitRef> suppressedRemotes = [];
+            foreach (List<IGitRef> remotes in trackedRemotes.Values)
+            {
+                suppressedRemotes.UnionWith(remotes);
+            }
+
             foreach (IGitRef gitRef in gitRefs)
             {
                 if (offset > messageBounds.Width)
                 {
                     // Stop drawing refs if we run out of room
                     break;
+                }
+
+                // Remote refs that are tracked by a local branch in this row are drawn
+                // condensed immediately after that local branch instead.
+                if (suppressedRemotes.Contains(gitRef))
+                {
+                    continue;
                 }
 
                 IGitRef? superprojectRef = superprojectRefs.FirstOrDefault(superGitRef => gitRef.CompleteName == superGitRef.CompleteName);
@@ -129,6 +143,15 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 }
 
                 bool isHighlighted = _highlightedRowIndex == e.RowIndex && ReferenceEquals(_highlightedRef, gitRef);
+
+                // If this branch has tracked remotes, draw the group with correct z-order:
+                // remotes first (behind), then the branch on top.
+                if (gitRef.IsHead && trackedRemotes.TryGetValue(gitRef.Name, out List<IGitRef>? remotes) && remotes.Count > 0)
+                {
+                    DrawBranchWithNestledRemotes(e, gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, remotes, ref hitInfos);
+                    continue;
+                }
+
                 Rectangle refRect = DrawRef(e, gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted);
                 if (refRect != Rectangle.Empty)
                 {
@@ -148,8 +171,8 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 style.NormalFont,
                 ref offset,
                 revision.IsAutostash ? revision.Subject : (revision.ReflogSelector ?? throw new InvalidOperationException($"{nameof(revision.ReflogSelector)} must not be null"))[5..],
-                AppColor.OtherTag.GetThemeColor(),
-                RefArrowType.None,
+                AppColor.Stash.GetThemeColor(),
+                RefLabelIcon.Stash,
                 messageBounds,
                 e.Graphics,
                 dashedLine: false,
@@ -261,7 +284,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
             ref offset,
             revision.Subject,
             AppColor.OtherTag.GetThemeColor(),
-            RefArrowType.None,
+            RefLabelIcon.None,
             messageBounds,
             graphics,
             dashedLine: false,
@@ -271,13 +294,27 @@ internal sealed class MessageColumnProvider : ColumnProvider
             TextRenderer.MeasureText(ResourceManager.TranslatedStrings.Workspace, style.NormalFont).Width,
             TextRenderer.MeasureText(ResourceManager.TranslatedStrings.Index, style.NormalFont).Width);
 
-        offset = baseOffset + max + DpiUtil.Scale(6);
+        // Align icons consistently across both artificial commit rows.
+        // Decompose the capsule layout to stay in sync if ref label sizing changes:
+        // paddingLeft(6) + textWidth + paddingRight(6) - borderAdjustment(1) + marginRight(5) + breathingRoom(4).
+        int refLabelHorizontalPadding = DpiUtil.Scale(6);
+        int refLabelBorderAdjustment = DpiUtil.Scale(1);
+        int refLabelTrailingMargin = DpiUtil.Scale(5);
+        int iconBreathingRoom = DpiUtil.Scale(4);
+        int refLabelWidth = max + (refLabelHorizontalPadding * 2) - refLabelBorderAdjustment;
+        offset = baseOffset + refLabelWidth + refLabelTrailingMargin + iconBreathingRoom;
 
         // Summary of changes
         if (!_settings.ShowGitStatusForArtificialCommits || _grid.GetChangeCount(revision.ObjectId) is not ArtificialCommitChangeCount changeCount)
         {
             return;
         }
+
+        // Compute capsule height metrics so icons align with the capsule's vertical extent.
+        int paddingTopBottom = DpiUtil.Scale(2);
+        int textHeight = TextRenderer.MeasureText(graphics, " ", style.NormalFont, Size.Empty, TextFormatFlags.NoPadding).Height;
+        int capsuleHeight = textHeight + (paddingTopBottom * 2) - 1;
+        int capsuleTopOffset = (e.CellBounds.Height - capsuleHeight) / 2;
 
         if (changeCount.DataValid)
         {
@@ -311,12 +348,14 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 return;
             }
 
-            int imageVerticalPadding = DpiUtil.Scale(6);
             int textHorizontalPadding = DpiUtil.Scale(4);
-            int imageSize = e.CellBounds.Height - imageVerticalPadding - imageVerticalPadding;
+
+            // Keep original icon size; centre it within the capsule's vertical extent.
+            int imageSize = e.CellBounds.Height - DpiUtil.Scale(12);
+            int imageTop = capsuleTopOffset + ((capsuleHeight - imageSize) / 2);
             Rectangle imageRect = new(
                 messageBounds.Left + offset,
-                e.CellBounds.Top + imageVerticalPadding,
+                e.CellBounds.Top + imageTop,
                 imageSize,
                 imageSize);
 
@@ -347,11 +386,11 @@ internal sealed class MessageColumnProvider : ColumnProvider
             Color headColor = RevisionGridRefRenderer.GetHeadColor(gitRef);
             string gitRefName = i < (MaxSuperprojectRefs - 1) ? gitRef.Name : "…";
 
-            RefArrowType arrowType = gitRef.IsSelected
-                ? RefArrowType.Filled
+            RefLabelIcon icon = gitRef.IsSelected
+                ? RefLabelIcon.ArrowFilled
                 : gitRef.IsSelectedHeadMergeSource
-                    ? RefArrowType.NotFilled
-                    : RefArrowType.None;
+                    ? RefLabelIcon.ArrowNotFilled
+                    : RefLabelIcon.None;
             Font font = gitRef.IsSelected ? style.BoldFont : style.NormalFont;
 
             RevisionGridRefRenderer.DrawRef(
@@ -360,7 +399,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 ref offset,
                 gitRefName,
                 headColor,
-                arrowType,
+                icon,
                 messageBounds,
                 e.Graphics!,
                 dashedLine: true);
@@ -403,7 +442,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 ref currentOffset,
                 label,
                 headColor: Color.OrangeRed.AdaptTextColor(),
-                isSelected ? RefArrowType.Filled : RefArrowType.NotFilled,
+                isSelected ? RefLabelIcon.ArrowFilled : RefLabelIcon.ArrowNotFilled,
                 messageBounds,
                 e.Graphics!,
                 dashedLine: true);
@@ -439,11 +478,13 @@ internal sealed class MessageColumnProvider : ColumnProvider
             headColor = RevisionGridRefRenderer.GetHeadColor(gitRef);
         }
 
-        RefArrowType arrowType = gitRef.IsSelected
-            ? RefArrowType.Filled
-            : gitRef.IsSelectedHeadMergeSource
-                ? RefArrowType.NotFilled
-                : RefArrowType.None;
+        RefLabelIcon icon = gitRef.IsSelected
+            ? RefLabelIcon.Head
+            : gitRef.IsTag
+                ? RefLabelIcon.Tag
+                : gitRef.IsRemote
+                    ? RefLabelIcon.Remote
+                    : RefLabelIcon.Branch;
 
         Font font = gitRef.IsSelected
             ? style.BoldFont
@@ -464,12 +505,172 @@ internal sealed class MessageColumnProvider : ColumnProvider
             ref offset,
             name,
             headColor,
-            arrowType,
+            icon,
             messageBounds,
             e.Graphics!,
             dashedLine: superprojectRef is not null,
             fill: _settings.FillRefLabels,
             highlight: highlight);
+    }
+
+    /// <summary>
+    /// Draws a local branch capsule with its tracked remote capsules nestled against it,
+    /// appearing as a single visual group.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each remote is a D-shape (neck + right semicircle) drawn behind the branch.
+    /// Drawing order is back-to-front: remote[N-1] first, then … remote[0], then the branch on top.
+    /// This way each shape's right rounded cap covers the left neck of the shape in front of it,
+    /// revealing only each remote's semicircle as a "right-half-capsule".
+    /// </para>
+    /// <para>
+    /// The combined outer outline — branch left cap + shared straight top/bottom edges + last
+    /// remote's right cap — is itself a capsule shape.
+    /// </para>
+    /// </remarks>
+    private void DrawBranchWithNestledRemotes(
+        DataGridViewCellPaintingEventArgs e,
+        IGitRef gitRef,
+        IGitRef? superprojectRef,
+        CellStyle style,
+        Rectangle messageBounds,
+        ref int offset,
+        bool isHighlighted,
+        List<IGitRef> remotes,
+        ref List<RefLabelHitInfo>? hitInfos)
+    {
+        RefLabelIcon branchIcon = gitRef.IsSelected ? RefLabelIcon.Head : RefLabelIcon.Branch;
+        Font branchFont = gitRef.IsSelected ? style.BoldFont : style.NormalFont;
+        (int branchIdealWidth, int backgroundHeight) = RevisionGridRefRenderer.MeasureRef(branchFont, gitRef.Name, branchIcon, e.Graphics!);
+
+        int branchWidth = Math.Min(messageBounds.Width - offset, branchIdealWidth);
+        if (branchWidth <= 0)
+        {
+            return;
+        }
+
+        // Absolute x where the branch capsule's right edge will be.
+        int branchRight = messageBounds.X + offset + branchWidth;
+        int diameter = backgroundHeight;
+
+        // capsuleTop: y-coordinate of the capsule top edge (same formula as DrawRef uses).
+        int outerMarginTopBottom = (messageBounds.Height - backgroundHeight) / 2;
+        int capsuleTop = messageBounds.Y + outerMarginTopBottom;
+
+        // Count how many remotes fit within the cell width.
+        int remoteCount = 0;
+        for (int i = 0; i < remotes.Count; i++)
+        {
+            if ((branchRight + ((i + 1) * diameter)) - messageBounds.X > messageBounds.Width)
+            {
+                break;
+            }
+
+            remoteCount++;
+        }
+
+        // Draw remotes back-to-front so each covers the neck of the one behind it.
+        // remote[N-1] is drawn first (furthest back), remote[0] last (just behind branch).
+        Rectangle[] remoteRects = new Rectangle[remoteCount];
+        for (int i = remoteCount - 1; i >= 0; i--)
+        {
+            IGitRef remote = remotes[i];
+            bool isRemoteHighlighted = _highlightedRowIndex == e.RowIndex && ReferenceEquals(_highlightedRef, remote);
+
+            if (!style.RemoteColors.TryGetValue(remote.Remote, out Color remoteColor))
+            {
+                remoteColor = RevisionGridRefRenderer.GetHeadColor(remote);
+            }
+
+            // Each remote[i] anchors at branchRight + i*diameter.
+            int precedingRight = branchRight + (i * diameter);
+
+            remoteRects[i] = RevisionGridRefRenderer.DrawNestledRemoteRef(
+                e.State.HasFlag(DataGridViewElementStates.Selected),
+                remoteColor,
+                precedingRight,
+                capsuleTop,
+                backgroundHeight,
+                e.Graphics!,
+                highlight: isRemoteHighlighted);
+        }
+
+        // Draw the branch on top so its solid fill fully hides the D-shape necks.
+        Rectangle branchRect = DrawRef(e, gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted);
+
+        // Advance offset past the last remote's right edge.
+        offset = (branchRight + (remoteCount * diameter)) - messageBounds.X + DpiUtil.Scale(5);
+
+        // Register hit-boxes.
+        if (branchRect != Rectangle.Empty)
+        {
+            hitInfos ??= RentHitInfoList();
+            hitInfos.Add(new RefLabelHitInfo(branchRect, gitRef, StashReflogSelector: null));
+        }
+
+        for (int i = 0; i < remoteCount; i++)
+        {
+            if (remoteRects[i] == Rectangle.Empty)
+            {
+                continue;
+            }
+
+            // Each remote's visible area is exactly its semicircle region.
+            int hitLeft = branchRight + (i * diameter);
+            hitInfos ??= RentHitInfoList();
+            hitInfos.Add(new RefLabelHitInfo(
+                remoteRects[i] with { X = hitLeft, Width = diameter },
+                remotes[i],
+                StashReflogSelector: null));
+        }
+    }
+
+    /// <summary>
+    /// Builds a map of local branch name → remote refs that appear to track it,
+    /// based on the remote ref's <see cref="IGitRef.LocalName"/> matching the local
+    /// branch name. No I/O is performed.
+    /// </summary>
+    private static Dictionary<string, List<IGitRef>> BuildTrackedRemoteMap(IReadOnlyList<IGitRef> refs)
+    {
+        // Collect all local branch names (including the checked-out HEAD branch, which
+        // still benefits from condensed remote tracking even though it uses a target icon).
+        HashSet<string> localBranchNames = [];
+        foreach (IGitRef r in refs)
+        {
+            if (r.IsHead)
+            {
+                localBranchNames.Add(r.Name);
+            }
+        }
+
+        if (localBranchNames.Count == 0)
+        {
+            return [];
+        }
+
+        Dictionary<string, List<IGitRef>> map = [];
+        foreach (IGitRef r in refs)
+        {
+            if (!r.IsRemote)
+            {
+                continue;
+            }
+
+            string localName = r.LocalName;
+            if (localBranchNames.Contains(localName))
+            {
+                if (!map.TryGetValue(localName, out List<IGitRef>? list))
+                {
+                    list = [];
+                    map[localName] = list;
+                }
+
+                list.Add(r);
+            }
+        }
+
+        return map;
     }
 
     private static void DrawImage(

--- a/src/app/GitUI/UserControls/RevisionGrid/RefArrowType.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefArrowType.cs
@@ -1,8 +1,0 @@
-namespace GitUI.UserControls.RevisionGrid;
-
-internal enum RefArrowType
-{
-    None,
-    Filled,
-    NotFilled
-}

--- a/src/app/GitUI/UserControls/RevisionGrid/RefLabelIcon.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefLabelIcon.cs
@@ -1,0 +1,31 @@
+﻿namespace GitUI.UserControls.RevisionGrid;
+
+/// <summary>
+/// Specifies the icon drawn inside a ref label in the revision grid.
+/// </summary>
+internal enum RefLabelIcon
+{
+    /// <summary>No icon is displayed.</summary>
+    None,
+
+    /// <summary>Solid filled arrow for the selected superproject ref.</summary>
+    ArrowFilled,
+
+    /// <summary>Hollow arrow outline for the superproject merge source ref.</summary>
+    ArrowNotFilled,
+
+    /// <summary>Target/crosshair icon for the checked-out branch.</summary>
+    Head,
+
+    /// <summary>Fork icon for local branches.</summary>
+    Branch,
+
+    /// <summary>Cloud icon for remote tracking branches.</summary>
+    Remote,
+
+    /// <summary>Tag-shaped background for tags, with the tag name written directly on the shape.</summary>
+    Tag,
+
+    /// <summary>Drawer/box icon for stashes.</summary>
+    Stash
+}

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.Contracts;
-using System.Drawing.Drawing2D;
+﻿using System.Drawing.Drawing2D;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
@@ -17,118 +16,477 @@ internal static class RevisionGridRefRenderer
     ///  Draws a ref label and returns the painted rectangle in the same coordinate space as <paramref name="bounds"/>.
     /// </summary>
     /// <returns>The bounding rectangle of the drawn ref label in DataGridView client coordinates, or <see cref="Rectangle.Empty"/> if nothing was drawn.</returns>
-    public static Rectangle DrawRef(bool isRowSelected, Font font, ref int offset, string name, Color headColor, RefArrowType arrowType, in Rectangle bounds, Graphics graphics, bool dashedLine = false, bool fill = false, bool highlight = false)
+    public static Rectangle DrawRef(bool isRowSelected, Font font, ref int offset, string name, Color headColor, RefLabelIcon icon, in Rectangle bounds, Graphics graphics, bool dashedLine = false, bool fill = false, bool highlight = false)
     {
-        int paddingLeftRight = !string.IsNullOrEmpty(name) ? DpiUtil.Scale(4) : DpiUtil.Scale(1);
-        int paddingTopBottom = DpiUtil.Scale(2);
-        int marginRight = DpiUtil.Scale(7);
+        // Copy ref/in parameters to locals so they can be captured by local functions.
+        Rectangle boundsLocal = bounds;
+        int offsetLocal = offset;
 
-        Color textColor = fill ? headColor : ColorHelper.Lerp(headColor, Color.Black, 0.25F);
+        int paddingLeftRight = !string.IsNullOrEmpty(name) ? DpiUtil.Scale(6) : DpiUtil.Scale(3);
+        int paddingTopBottom = DpiUtil.Scale(2);
+        int marginRight = DpiUtil.Scale(5);
+
+        // Solid-fill capsules: choose contrasting text colour for readability.
+        // Use 0.40 as the luminance threshold — this ensures green hues (which are perceptually
+        // bright despite having luminance ~0.45) get dark text rather than white.
+        float luminanceForText = ((0.299f * headColor.R) + (0.587f * headColor.G) + (0.114f * headColor.B)) / 255f;
+        Color textColor = luminanceForText > 0.40f ? Color.FromArgb(30, 30, 30) : Color.White;
 
         Size textSize = !string.IsNullOrEmpty(name)
             ? TextRenderer.MeasureText(graphics, name, font, Size.Empty, TextFormatFlags.NoPadding)
-            : new(0, TextRenderer.MeasureText(graphics, " ", font, Size.Empty, TextFormatFlags.NoPadding).Height);
+            : new(width: 0, height: TextRenderer.MeasureText(graphics, " ", font, Size.Empty, TextFormatFlags.NoPadding).Height);
 
-        int arrowWidth = arrowType == RefArrowType.None ? 0 : bounds.Height / 2;
+        int backgroundHeight = textSize.Height + (paddingTopBottom * 2) - 1;
+        int outerMarginTopBottom = (boundsLocal.Height - backgroundHeight) / 2;
 
-        int backgroundHeight = textSize.Height + paddingTopBottom + paddingTopBottom - 1;
-        int outerMarginTopBottom = (bounds.Height - backgroundHeight) / 2;
+        // Tags use a custom tag-shaped background rather than a capsule with an icon inside.
+        if (icon == RefLabelIcon.Tag)
+        {
+            Rectangle tagResult = DrawTagRef();
+            offset = offsetLocal;
+            return tagResult;
+        }
+
+        bool hasArrow = icon is RefLabelIcon.ArrowFilled or RefLabelIcon.ArrowNotFilled;
+        bool hasIcon = icon is RefLabelIcon.Head or RefLabelIcon.Branch or RefLabelIcon.Remote or RefLabelIcon.Stash;
+
+        // | left padding | icon (optional) | gap (if icon and text) | text | arrow (optional) | right padding |
+        //                |__|    icon   |__|
+        //                  \______________\___ padding
+
+        int arrowWidth = hasArrow ? boundsLocal.Height / 2 : 0;
+        int iconSize = hasIcon ? textSize.Height - (paddingTopBottom * 2) : 0;
+        int iconGap = 0;
+
+        // When there is no text and only an icon (e.g. a condensed remote cloud label), force the
+        // rect to be square so the fully-rounded capsule path renders as a true circle.
+        int naturalWidth = textSize.Width + arrowWidth + iconSize + iconGap + paddingLeftRight + paddingLeftRight - 1;
+        int idealWidth = string.IsNullOrEmpty(name) && hasIcon && !hasArrow ? backgroundHeight : naturalWidth;
 
         Rectangle rect = new(
-            bounds.X + offset,
-            bounds.Y + outerMarginTopBottom,
-            Math.Min(bounds.Width - offset, textSize.Width + arrowWidth + paddingLeftRight + paddingLeftRight - 1),
+            boundsLocal.X + offsetLocal,
+            boundsLocal.Y + outerMarginTopBottom,
+            width: Math.Min(boundsLocal.Width - offsetLocal, idealWidth),
             backgroundHeight);
-        if (rect.Width == 0 || rect.Height == 0)
+
+        if (rect.Width <= 0 || rect.Height <= 0)
         {
             // it may happen, as observe in #5396
             return Rectangle.Empty;
         }
 
-        DrawRefBackground(
-            isRowSelected,
-            graphics,
-            headColor,
-            rect,
-            radius: 3, arrowType, dashedLine, fill, highlight);
+        DrawRefBackground(isRowSelected, headColor, rect, icon, dashedLine, fill, highlight);
+
+        if (hasIcon)
+        {
+            // When there is no text, centre the icon in the (circular) rect.
+            // When text follows, left-align the icon just after the left padding.
+            float iconX = string.IsNullOrEmpty(name)
+                ? rect.X + ((rect.Width - iconSize) / 2f)
+                : rect.X + (paddingLeftRight / 2f) + 1;
+            float iconY = rect.Y + ((rect.Height - iconSize) / 2f);
+
+            DrawRefIcon(iconX, iconY);
+        }
 
         Rectangle textBounds = new(
-            rect.X + arrowWidth + paddingLeftRight,
+            rect.X + arrowWidth + paddingLeftRight + iconSize + iconGap,
             rect.Y + paddingTopBottom - 1,
-            Math.Min(bounds.Width - offset - paddingLeftRight - paddingLeftRight, textSize.Width),
+            Math.Min(boundsLocal.Width - offsetLocal - paddingLeftRight - paddingLeftRight, textSize.Width),
             textSize.Height);
 
         TextRenderer.DrawText(graphics, name, font, textBounds, textColor, TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding);
 
         offset += rect.Width + marginRight;
         return rect;
+
+        void FillFrameAndHighlight(GraphicsPath path, Rectangle bounds, Color color, bool dashedLine, bool fill, bool isRowSelected, bool highlight)
+        {
+            using SolidBrush brush = new(color);
+            graphics.FillPath(brush, path);
+
+            bool isDark = SystemColors.Window.GetBrightness() < 0.5f;
+
+            if (dashedLine)
+            {
+                // Dashed border indicates a superproject ref — always visible so the dashes read.
+                Color dashColor = isDark
+                    ? ColorHelper.Lerp(color, Color.White, 0.5f)
+                    : ColorHelper.Lerp(color, Color.Black, 0.5f);
+                using Pen dashPen = new(dashColor);
+                dashPen.DashPattern = _dashPattern;
+                graphics.DrawPath(dashPen, path);
+            }
+
+            if (highlight)
+            {
+                // On hover: border becomes lighter (dark theme) or darker (light theme).
+                Color borderColor = isDark
+                    ? ColorHelper.Lerp(color, Color.White, 0.6f)
+                    : ColorHelper.Lerp(color, Color.Black, 0.4f);
+                using Pen highlightPen = new(borderColor, 2f);
+                graphics.DrawPath(highlightPen, path);
+            }
+        }
+
+        Rectangle DrawTagRef()
+        {
+            // The tag shape has a pointed notch on the left and a flat right edge,
+            // with slightly rounded corners (chamfered notch corners, small arcs on the right).
+            // Use tighter padding than the standard capsule: less height and less right padding.
+            int tagPaddingTopBottom = Math.Max(1, paddingTopBottom - 1);
+            int tagPaddingRight = DpiUtil.Scale(2);
+            int tagHeight = textSize.Height + (tagPaddingTopBottom * 2) - 1;
+            int tagOuterMargin = (boundsLocal.Height - tagHeight) / 2;
+            int notchWidth = tagHeight / 2;
+
+            Rectangle tagRect = new(
+                boundsLocal.X + offsetLocal,
+                boundsLocal.Y + tagOuterMargin,
+                width: Math.Min(boundsLocal.Width - offsetLocal, textSize.Width + notchWidth + paddingLeftRight + tagPaddingRight - 1),
+                tagHeight);
+
+            if (tagRect.Width == 0 || tagRect.Height == 0)
+            {
+                return Rectangle.Empty;
+            }
+
+            float l = tagRect.X;
+            float t = tagRect.Y;
+            float r = tagRect.Right;
+            float b = tagRect.Bottom;
+            float midY = t + (tagRect.Height / 2f);
+            float notchX = l + notchWidth;
+
+            // Small corner radius for the right corners; chamfer size for the 45° notch corners.
+            float cr = Math.Max(2f, backgroundHeight * 0.12f);
+            float chamfer = cr * 0.707f;
+
+            SmoothingMode oldMode = graphics.SmoothingMode;
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+            try
+            {
+                using GraphicsPath path = new();
+                path.AddLine(l, midY, notchX - chamfer, t + chamfer);              // tip → near top-notch corner
+                path.AddLine(notchX - chamfer, t + chamfer, notchX + chamfer, t);  // chamfer the top-notch corner
+                path.AddLine(notchX + chamfer, t, r - cr, t);                      // top edge
+                path.AddArc(r - (2 * cr), t, 2 * cr, 2 * cr, 270, 90);            // top-right rounded corner
+                path.AddArc(r - (2 * cr), b - (2 * cr), 2 * cr, 2 * cr, 0, 90);   // bottom-right rounded corner
+                path.AddLine(r - cr, b, notchX + chamfer, b);                      // bottom edge
+                path.AddLine(notchX + chamfer, b, notchX - chamfer, b - chamfer);  // chamfer the bottom-notch corner
+                path.CloseFigure();                                                 // back to tip
+
+                FillFrameAndHighlight(path, tagRect, headColor, dashedLine, fill, isRowSelected, highlight);
+
+                // Cut-out dot in the notch: filled with the row background so it appears as a hole.
+                // Positioned towards the text side of the notch so the tip has breathing room.
+                float dotDiameter = Math.Max(3f, tagRect.Height * 0.26f);
+                float dotX = l + (notchWidth * 0.72f) - (dotDiameter / 2f);
+                Color dotFill = isRowSelected ? SystemColors.Highlight : SystemColors.Window;
+                using SolidBrush dotBrush = new(dotFill);
+                graphics.FillEllipse(dotBrush, dotX, midY - (dotDiameter / 2f), dotDiameter, dotDiameter);
+            }
+            finally
+            {
+                graphics.SmoothingMode = oldMode;
+            }
+
+            Rectangle textBounds = new(
+                tagRect.X + notchWidth + DpiUtil.Scale(4),
+                tagRect.Y + tagPaddingTopBottom - 1,
+                Math.Min(boundsLocal.Width - offsetLocal - notchWidth - tagPaddingRight, textSize.Width),
+                textSize.Height);
+
+            TextRenderer.DrawText(graphics, name, font, textBounds, textColor, TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding);
+
+            offsetLocal += tagRect.Width + marginRight;
+            return tagRect;
+        }
+
+        void DrawRefBackground(bool isRowSelected, Color color, Rectangle bounds, RefLabelIcon icon, bool dashedLine, bool fill, bool highlight)
+        {
+            SmoothingMode oldMode = graphics.SmoothingMode;
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+            try
+            {
+                using GraphicsPath path = CreateRoundRectPath();
+
+                FillFrameAndHighlight(path, bounds, color, dashedLine, fill, isRowSelected, highlight);
+
+                // arrow for superproject ref indicators
+                if (icon is RefLabelIcon.ArrowFilled or RefLabelIcon.ArrowNotFilled)
+                {
+                    DrawArrow(graphics, bounds.X, bounds.Y, bounds.Height, color, filled: icon == RefLabelIcon.ArrowFilled);
+                }
+            }
+            finally
+            {
+                graphics.SmoothingMode = oldMode;
+            }
+
+            return;
+
+            GraphicsPath CreateRoundRectPath()
+            {
+                int left = bounds.X;
+                int top = bounds.Y;
+                int right = left + bounds.Width;
+                int bottom = top + bounds.Height;
+                int diameter = Math.Min(bounds.Width, bounds.Height);
+
+                GraphicsPath path = new();
+                path.AddArc(left, top, diameter, diameter, startAngle: 180, sweepAngle: 90);
+                path.AddArc(right - diameter, top, diameter, diameter, 270, 90);
+                path.AddArc(right - diameter, bottom - diameter, diameter, diameter, 0, 90);
+                path.AddArc(left, bottom - diameter, diameter, diameter, 90, 90);
+                path.CloseFigure();
+
+                return path;
+            }
+        }
+
+        void DrawRefIcon(float x, float y)
+        {
+            SmoothingMode oldMode = graphics.SmoothingMode;
+            graphics.SmoothingMode = SmoothingMode.HighQuality;
+
+            try
+            {
+                switch (icon)
+                {
+                    case RefLabelIcon.Head:
+                        DrawHeadIcon();
+                        break;
+                    case RefLabelIcon.Branch:
+                        DrawBranchIcon();
+                        break;
+                    case RefLabelIcon.Remote:
+                        DrawRemoteIcon();
+                        break;
+                    case RefLabelIcon.Stash:
+                        DrawStashIcon();
+                        break;
+                }
+            }
+            finally
+            {
+                graphics.SmoothingMode = oldMode;
+            }
+
+            return;
+
+            void DrawHeadIcon()
+            {
+                float penWidth = Math.Max(1f, iconSize * 0.08f);
+                using Pen pen = new(textColor, penWidth);
+                using SolidBrush brush = new(textColor);
+
+                float cx = x + (iconSize / 2f);
+                float cy = y + (iconSize / 2f);
+                float outerDiameter1 = iconSize * 1f;
+                float outerDiameter2 = iconSize * 0.5f;
+                float dotDiameter = Math.Max(2f, iconSize * 0.15f);
+
+                graphics.DrawEllipse(pen, cx - (outerDiameter1 / 2f), cy - (outerDiameter1 / 2f), outerDiameter1, outerDiameter1);
+                graphics.DrawEllipse(pen, cx - (outerDiameter2 / 2f), cy - (outerDiameter2 / 2f), outerDiameter2, outerDiameter2);
+                graphics.FillEllipse(brush, cx - (dotDiameter / 2f), cy - (dotDiameter / 2f), dotDiameter, dotDiameter);
+            }
+
+            void DrawBranchIcon()
+            {
+                float penWidth = Math.Max(1f, iconSize * 0.08f);
+                using Pen pen = new(textColor, penWidth);
+
+                float dotRadius = iconSize * 0.1f;
+                float dotDiameter = dotRadius * 2;
+
+                float mainX = MathF.Round(x + (iconSize * 0.35f));
+                float topY = y + (iconSize * 0.15f);
+                float bottomY = y + (iconSize * 0.85f);
+                float branchStartY = y + (iconSize * 0.7f);
+                float branchEndX = x + (iconSize * 0.75f);
+                float branchEndY = y + (iconSize * 0.4f);
+                float branchMidY = branchStartY + ((branchEndY - branchStartY) / 2f);
+
+                graphics.DrawLine(pen, mainX, topY + dotRadius, mainX, bottomY - dotRadius);
+
+                graphics.DrawBezier(
+                    pen,
+                    mainX, branchStartY,
+                    mainX, branchMidY,
+                    branchEndX, branchMidY,
+                    branchEndX, branchEndY + dotRadius);
+
+                graphics.DrawEllipse(pen, mainX - dotRadius, topY - dotRadius, dotDiameter, dotDiameter);
+                graphics.DrawEllipse(pen, mainX - dotRadius, bottomY - dotRadius, dotDiameter, dotDiameter);
+                graphics.DrawEllipse(pen, branchEndX - dotRadius, branchEndY - dotRadius, dotDiameter, dotDiameter);
+            }
+
+            void DrawRemoteIcon()
+            {
+                DrawCloudIcon(graphics, textColor, x, y, iconSize);
+            }
+
+            void DrawStashIcon()
+            {
+                float penWidth = Math.Max(1f, iconSize * 0.08f);
+                using Pen pen = new(textColor, penWidth);
+
+                float padding = iconSize * 0.15f;
+                float left = x + padding;
+                float right = x + iconSize - padding;
+                float top = y + padding;
+                float bottom = y + iconSize - padding;
+                float width = right - left;
+                float height = bottom - top;
+
+                // Drawer front face
+                graphics.DrawRectangle(pen, left, top + (height * 0.3f), width, height * 0.7f);
+
+                // Lid/top edge
+                graphics.DrawLine(pen, left, top + (height * 0.3f), left + (width * 0.5f), top);
+                graphics.DrawLine(pen, left + (width * 0.5f), top, right, top + (height * 0.3f));
+            }
+        }
     }
 
-    private static void DrawRefBackground(bool isRowSelected, Graphics graphics, Color color, Rectangle bounds, int radius, RefArrowType arrowType, bool dashedLine, bool fill, bool highlight)
+    /// <summary>
+    /// Computes the ideal rendered size of a ref label without drawing it.
+    /// Returns the capsule's ideal width and height given the same inputs as <see cref="DrawRef"/>.
+    /// Does not account for clipping to available cell width.
+    /// </summary>
+    public static (int idealWidth, int backgroundHeight) MeasureRef(Font font, string name, RefLabelIcon icon, Graphics graphics)
     {
+        int paddingLeftRight = !string.IsNullOrEmpty(name) ? DpiUtil.Scale(6) : DpiUtil.Scale(3);
+        int paddingTopBottom = DpiUtil.Scale(2);
+
+        int textHeight = TextRenderer.MeasureText(graphics, " ", font, Size.Empty, TextFormatFlags.NoPadding).Height;
+        int textWidth = !string.IsNullOrEmpty(name)
+            ? TextRenderer.MeasureText(graphics, name, font, Size.Empty, TextFormatFlags.NoPadding).Width
+            : 0;
+
+        int backgroundHeight = textHeight + (paddingTopBottom * 2) - 1;
+        bool hasIcon = icon is RefLabelIcon.Head or RefLabelIcon.Branch or RefLabelIcon.Remote or RefLabelIcon.Stash;
+        int iconSize = hasIcon ? textHeight - (paddingTopBottom * 2) : 0;
+
+        int naturalWidth = textWidth + iconSize + (paddingLeftRight * 2) - 1;
+        int idealWidth = string.IsNullOrEmpty(name) && hasIcon ? backgroundHeight : naturalWidth;
+
+        return (idealWidth, backgroundHeight);
+    }
+
+    /// <summary>
+    /// Draws a remote ref label as a D-shape (neck rectangle + right semicircle) nestled
+    /// against the right edge of a preceding branch capsule.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The D-shape's left neck aligns with the branch's straight top/bottom edges, so the
+    /// combined outline of branch + remote looks like a single capsule. The branch is drawn
+    /// on top afterwards — its right rounded cap provides the curved visual boundary between
+    /// the two colours.
+    /// </para>
+    /// <para>
+    /// Geometry: given <paramref name="precedingRight"/> as the absolute x of the previous
+    /// shape's right edge and <c>R = backgroundHeight / 2</c>:
+    /// <list type="bullet">
+    ///   <item>Neck left edge: precedingRight − R</item>
+    ///   <item>Semicircle centre: precedingRight + R</item>
+    ///   <item>Shape right edge: precedingRight + 2R (= precedingRight + backgroundHeight)</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    /// <param name="precedingRight">Absolute x-coordinate of the right edge of the preceding capsule.</param>
+    /// <param name="capsuleTop">Absolute y-coordinate of the capsule top edge.</param>
+    /// <param name="backgroundHeight">Capsule height (must equal the branch capsule's height).</param>
+    /// <returns>Full D-shape bounding rectangle (left half will be covered by the branch drawn on top).</returns>
+    public static Rectangle DrawNestledRemoteRef(
+        bool isRowSelected,
+        Color headColor,
+        int precedingRight,
+        int capsuleTop,
+        int backgroundHeight,
+        Graphics graphics,
+        bool highlight)
+    {
+        int diameter = backgroundHeight;
+        int radius = diameter / 2;
+
+        // D-shape bounding box.
+        int shapeLeft = precedingRight - radius;
+        int shapeTop = capsuleTop;
+        int shapeBottom = capsuleTop + backgroundHeight;
+        float midY = shapeTop + radius;
+
+        // Total width = neck(radius) + semicircle(diameter) = 3*radius.
+        Rectangle shapeBounds = new(shapeLeft, shapeTop, 3 * radius, backgroundHeight);
+
+        if (shapeBounds.Width <= 0 || shapeBounds.Height <= 0)
+        {
+            return Rectangle.Empty;
+        }
+
         SmoothingMode oldMode = graphics.SmoothingMode;
         graphics.SmoothingMode = SmoothingMode.AntiAlias;
 
         try
         {
-            using GraphicsPath path = CreateRoundRectPath(bounds, radius);
-            if (fill)
-            {
-                Color color1 = ColorHelper.Lerp(color, SystemColors.Window, 0.92F);
-                Color color2 = ColorHelper.Lerp(color1, SystemColors.Window, 0.9f);
-                using LinearGradientBrush brush = new(bounds, color1, color2, angle: 90);
-                graphics.FillPath(brush, path);
-            }
-            else if (isRowSelected)
-            {
-                graphics.FillPath(SystemBrushes.Window, path);
-            }
+            // Fill path: full closed D-shape (neck rect + right semicircle).
+            // Top edge ends at the semicircle centre; AddArc begins there.
+            using GraphicsPath fillPath = new();
+            fillPath.AddLine(shapeLeft, shapeTop, shapeLeft + (2 * radius), shapeTop);
+            fillPath.AddArc(precedingRight, shapeTop, diameter, diameter, -90, 180);
+            fillPath.AddLine(shapeLeft + (2 * radius), shapeBottom, shapeLeft, shapeBottom);
+            fillPath.CloseFigure();
 
-            // frame
-            using Pen pen = new(ColorHelper.Lerp(color, SystemColors.Window, fill ? 0.83F : 0.5F));
-            if (dashedLine)
-            {
-                pen.DashPattern = _dashPattern;
-            }
+            using SolidBrush fillBrush = new(headColor);
+            graphics.FillPath(fillBrush, fillPath);
 
-            graphics.DrawPath(pen, path);
+            // Stroke path: top edge + right arc + bottom edge only (no left vertical edge —
+            // it is hidden under the branch capsule drawn on top).
+            using GraphicsPath strokePath = new();
+            strokePath.AddLine(shapeLeft, shapeTop, shapeLeft + (2 * radius), shapeTop);
+            strokePath.AddArc(precedingRight, shapeTop, diameter, diameter, -90, 180);
+            strokePath.AddLine(shapeLeft + (2 * radius), shapeBottom, shapeLeft, shapeBottom);
 
             if (highlight)
             {
-                using Pen highlightPen = new(color, 2f);
-                graphics.DrawPath(highlightPen, path);
-            }
-
-            // arrow if the head is the current branch
-            if (arrowType != RefArrowType.None)
-            {
-                DrawArrow(graphics, bounds.X, bounds.Y, bounds.Height, color, filled: arrowType == RefArrowType.Filled);
+                bool isDark = SystemColors.Window.GetBrightness() < 0.5f;
+                Color borderColor = isDark
+                    ? ColorHelper.Lerp(headColor, Color.White, 0.6f)
+                    : ColorHelper.Lerp(headColor, Color.Black, 0.4f);
+                using Pen highlightPen = new(borderColor, 2f);
+                graphics.DrawPath(highlightPen, strokePath);
             }
         }
         finally
         {
             graphics.SmoothingMode = oldMode;
         }
-    }
 
-    [Pure]
-    public static Rectangle ReduceLeft(this Rectangle rect, int offset)
-    {
-        return new Rectangle(
-            rect.Left + offset,
-            rect.Top,
-            rect.Width - offset,
-            rect.Height);
-    }
+        // Cloud icon centred in the semicircle, using a contrasting colour for readability.
+        float luminance = ((0.299f * headColor.R) + (0.587f * headColor.G) + (0.114f * headColor.B)) / 255f;
+        Color iconColor = luminance > 0.40f ? Color.FromArgb(30, 30, 30) : Color.White;
 
-    [Pure]
-    public static Rectangle ReduceRight(this Rectangle rect, int offset)
-    {
-        return new Rectangle(
-            rect.Left,
-            rect.Top,
-            rect.Width - offset,
-            rect.Height);
+        int paddingTopBottom = DpiUtil.Scale(2);
+        int iconSize = Math.Max(4, backgroundHeight - (paddingTopBottom * 4) + 1);
+        float iconX = (precedingRight + radius) - (iconSize / 2f);
+        float iconY = midY - (iconSize / 2f);
+
+        SmoothingMode iconOldMode = graphics.SmoothingMode;
+        graphics.SmoothingMode = SmoothingMode.HighQuality;
+        try
+        {
+            DrawCloudIcon(graphics, iconColor, iconX, iconY, iconSize);
+        }
+        finally
+        {
+            graphics.SmoothingMode = iconOldMode;
+        }
+
+        return shapeBounds;
     }
 
     public static Color GetHeadColor(IGitRef gitRef)
@@ -148,7 +506,85 @@ internal static class RevisionGridRefRenderer
             return AppColor.RemoteBranch.GetThemeColor();
         }
 
+        if (gitRef.IsStash)
+        {
+            return AppColor.Stash.GetThemeColor();
+        }
+
         return AppColor.OtherTag.GetThemeColor();
+    }
+
+    private static void DrawCloudIcon(Graphics graphics, Color color, float x, float y, float iconSize)
+    {
+        float penWidth = Math.Max(1f, iconSize * 0.08f);
+        using Pen pen = new(color, penWidth) { LineJoin = LineJoin.Round };
+        using GraphicsPath path = new();
+
+        float s = iconSize;
+
+        // Bezier curves traced from a cloud SVG (72×72 viewBox), normalized to 0–1.
+        // Three bumps: left (small), middle (medium), right (large).
+
+        // Left bump, descending left side
+        path.AddBezier(
+            x + (0.221f * s), y + (0.420f * s),
+            x + (0.139f * s), y + (0.439f * s),
+            x + (0.083f * s), y + (0.510f * s),
+            x + (0.083f * s), y + (0.596f * s));
+
+        // Bottom-left rounded corner
+        path.AddBezier(
+            x + (0.083f * s), y + (0.596f * s),
+            x + (0.083f * s), y + (0.687f * s),
+            x + (0.146f * s), y + (0.760f * s),
+            x + (0.224f * s), y + (0.760f * s));
+
+        // Flat bottom
+        path.AddLine(
+            x + (0.224f * s), y + (0.760f * s),
+            x + (0.762f * s), y + (0.760f * s));
+
+        // Bottom-right rounded corner
+        path.AddBezier(
+            x + (0.762f * s), y + (0.760f * s),
+            x + (0.847f * s), y + (0.760f * s),
+            x + (0.917f * s), y + (0.682f * s),
+            x + (0.917f * s), y + (0.586f * s));
+
+        // Right bump, ascending right side
+        path.AddBezier(
+            x + (0.917f * s), y + (0.586f * s),
+            x + (0.917f * s), y + (0.494f * s),
+            x + (0.853f * s), y + (0.419f * s),
+            x + (0.773f * s), y + (0.413f * s));
+
+        // Right bump top arc
+        path.AddBezier(
+            x + (0.773f * s), y + (0.413f * s),
+            x + (0.743f * s), y + (0.309f * s),
+            x + (0.660f * s), y + (0.240f * s),
+            x + (0.561f * s), y + (0.240f * s));
+
+        // Right bump descending to middle valley
+        path.AddBezier(
+            x + (0.561f * s), y + (0.240f * s),
+            x + (0.498f * s), y + (0.240f * s),
+            x + (0.441f * s), y + (0.269f * s),
+            x + (0.404f * s), y + (0.315f * s));
+
+        // Middle valley across to left bump top
+        path.AddLine(
+            x + (0.404f * s), y + (0.315f * s),
+            x + (0.343f * s), y + (0.310f * s));
+
+        // Left bump top arc, back to start
+        path.AddBezier(
+            x + (0.343f * s), y + (0.310f * s),
+            x + (0.280f * s), y + (0.310f * s),
+            x + (0.228f * s), y + (0.358f * s),
+            x + (0.221f * s), y + (0.420f * s));
+
+        graphics.DrawPath(pen, path);
     }
 
     private static void DrawArrow(Graphics graphics, float x, float y, float rowHeight, Color color, bool filled)
@@ -179,22 +615,5 @@ internal static class RevisionGridRefRenderer
             using Pen pen = new(color);
             graphics.DrawPolygon(pen, _arrowPoints);
         }
-    }
-
-    internal static GraphicsPath CreateRoundRectPath(Rectangle rect, int radius)
-    {
-        int left = rect.X;
-        int top = rect.Y;
-        int right = left + rect.Width;
-        int bottom = top + rect.Height;
-
-        GraphicsPath path = new();
-        path.AddArc(left, top, radius, radius, startAngle: 180, sweepAngle: 90);
-        path.AddArc(right - radius, top, radius, radius, 270, 90);
-        path.AddArc(right - radius, bottom - radius, radius, radius, 0, 90);
-        path.AddArc(left, bottom - radius, radius, radius, 90, 90);
-        path.CloseFigure();
-
-        return path;
     }
 }


### PR DESCRIPTION
## feat: add type icons and condensed remote labels to revision grid ref labels

### What's new

**Ref label icons**

Each ref label in the revision grid now shows a small vector icon to the left of the name, visually identifying the ref type at a glance.

The shape of refs has changed too, making them a little smoother, with rounded ends.

Tags are rendered differently from all other labels: rather than a capsule with an icon inside, they use a physical price-tag shape (pointed notch on the left, semicircle on the right) with the tag name written directly on the shape.

All icons are vector-drawn at runtime and scale correctly with DPI.

**Condensed remote tracking refs**

When a local branch and its remote tracking counterpart(s) appear on the same commit row, the remote ref is collapsed into a compact circular cloud label immediately after the local branch label:

- **One tracking remote** → single cloud circle with no text: `(master) (☁)`
- **Multiple tracking remotes** → cloud circle with count: `(master) (☁×2)`

Standalone remote refs (no matching local branch in the row) continue to render in full. The cell tooltip still lists all ref names in full, so collapsed remotes remain discoverable on hover. Single-remote condensed labels support hover highlight and the normal right-click context menu.

Remote condensing uses pure string matching (`remoteRef.LocalName == localBranch.Name`) — no git config I/O in the render path.

## Screenshots

### Before

<img width="898" height="447" alt="image" src="https://github.com/user-attachments/assets/14f0957d-f364-4f88-a672-b66bea8416d4" />

<img width="509" height="122" alt="image" src="https://github.com/user-attachments/assets/51ce843b-3761-4d83-9672-ae97eb691e97" />

<img width="494" height="113" alt="image" src="https://github.com/user-attachments/assets/49f7d734-c525-4916-8d19-59831c31c78a" />

### After

<img width="895" height="441" alt="image" src="https://github.com/user-attachments/assets/2713f6dc-9eb7-48f3-8b4c-c2778a909c70" />

<img width="491" height="119" alt="image" src="https://github.com/user-attachments/assets/6154b8f5-df55-440d-8fea-8eb7fee2d5a9" />

<img width="495" height="112" alt="image" src="https://github.com/user-attachments/assets/b92c132c-4740-4132-9c76-92faa2858faf" />


<img width="895" height="438" alt="image" src="https://github.com/user-attachments/assets/1cca1a09-fbbc-42b0-baaa-efc3f92bab1b" />

<img width="493" height="120" alt="image" src="https://github.com/user-attachments/assets/8ef61778-acaa-40de-ad71-91b71408356b" />

<img width="536" height="118" alt="image" src="https://github.com/user-attachments/assets/0b053442-116b-4659-a5e7-549923cbe556" />


Note that condensing only occurs when the local and remote branches are at the same commit. If a remote branch differs from its local counterpart, it's full name is displayed:

<img width="330" height="56" alt="image" src="https://github.com/user-attachments/assets/3b872412-5a3c-4eb0-9782-ac6595f2e809" />

## Test methodology <!-- How did you ensure quality? -->

- Manual tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
