### PR TITLE
perf: add ExplicitCapture to regex options where missing

### DIFF
--- a/src/app/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
+++ b/src/app/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
@@ -5,16 +5,16 @@ namespace GitCommands.Remotes;
 
 public sealed partial class AzureDevOpsRemoteParser : RemoteParser
 {
-    [GeneratedRegex(@"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex VstsHttpsRemoteRegex { get; }
 
-    [GeneratedRegex(@"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex VstsSshRemoteRegex { get; }
 
-    [GeneratedRegex(@"^https:\/\/[^@]*@dev\.azure\.com\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^https:\/\/[^@]*@dev\.azure\.com\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex AzureDevopsHttpsRemoteRegex { get; }
 
-    [GeneratedRegex(@"^git@ssh\.dev\.azure\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^git@ssh\.dev\.azure\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex AzureDevopsSshRemoteRegex { get; }
 
     private static readonly Regex[] _azureDevopsRegexes = [AzureDevopsHttpsRemoteRegex, AzureDevopsSshRemoteRegex, VstsHttpsRemoteRegex, VstsSshRemoteRegex];

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -171,7 +171,7 @@ public sealed partial class FormCommit : GitModuleForm
     /// <summary>
     /// Regex to find message replace pattern: {{ group1 }}[ group2 ]
     /// </summary>
-    [GeneratedRegex(@"\{\{(.*?)\}\}(?:\[(\d+)\])?")]
+    [GeneratedRegex(@"\{\{(?<pattern>.*?)\}\}(?:\[(?<index>\d+)\])?", RegexOptions.ExplicitCapture)]
     private static partial Regex ReplaceMessageRegex();
 
     private CommitKind CommitKind
@@ -1426,10 +1426,10 @@ public sealed partial class FormCommit : GitModuleForm
 
             foreach (Match regexMatch in ReplaceMessageRegex().Matches(message))
             {
-                string pattern = regexMatch.Groups[1].Value;
+                string pattern = regexMatch.Groups["pattern"].Value;
                 int groupIndex = 1;
 
-                if (regexMatch.Groups.Count > 2 && int.TryParse(regexMatch.Groups[2].Value, out int parsedIndex))
+                if (int.TryParse(regexMatch.Groups["index"].Value, out int parsedIndex))
                 {
                     groupIndex = parsedIndex;
                 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -18,7 +18,7 @@ public partial class GitConfigSettingsPage : GitConfigBaseSettingsPage
     private readonly GitConfigSettingsPageController _controller;
     private DiffMergeToolConfigurationManager? _diffMergeToolConfigurationManager;
 
-    [GeneratedRegex(@"\$(LOCAL|REMOTE|BASE|MERGED)")]
+    [GeneratedRegex(@"\$(?:LOCAL|REMOTE|BASE|MERGED)", RegexOptions.ExplicitCapture)]
     private static partial Regex WslRebaseRegex { get; }
 
     public GitConfigSettingsPage(IServiceProvider serviceProvider)

--- a/src/app/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -7,7 +7,7 @@ namespace GitUI.ScriptsEngine;
 public partial class ScriptInfo
 {
     // Match a single '&' (lookahead to not be followed by a second '&')
-    [GeneratedRegex("&(?!&)")]
+    [GeneratedRegex("&(?!&)", RegexOptions.ExplicitCapture)]
     private static partial Regex MnemonicAmpersandRegex { get; }
 
     private Bitmap? _icon;

--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
@@ -17,7 +17,7 @@ public sealed partial class ScriptOptionsParser
 
     private const string head = "HEAD";
 
-    [GeneratedRegex(@"(?<!\\)""")]
+    [GeneratedRegex(@"(?<!\\)""", RegexOptions.ExplicitCapture)]
     private static partial Regex QuoteRegex { get; }
 
     /// <summary>

--- a/src/app/GitUI/UserEnvironmentInformation.cs
+++ b/src/app/GitUI/UserEnvironmentInformation.cs
@@ -17,7 +17,7 @@ public static partial class UserEnvironmentInformation
     private static bool _dirty;
     private static string? _sha;
 
-    [GeneratedRegex(@"^Microsoft\.WindowsDesktop\.App\s+([\w.-]+)\s+.*$", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^Microsoft\.WindowsDesktop\.App\s+(?<version>[\w.-]+)\s+.*$", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
     private static partial Regex DesktopAppRegex { get; }
     [GeneratedRegex(@"^", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
     private static partial Regex LineStartRegex { get; }
@@ -100,7 +100,7 @@ public static partial class UserEnvironmentInformation
         try
         {
             return GetDotnetDesktopRuntimeMatches(versions)
-                .Select(match => Parse(match.Groups[1].Value))
+                .Select(match => Parse(match.Groups["version"].Value))
                 .WhereNotNull();
         }
         catch (Exception ex)

--- a/src/app/ResourceManager/SubmoduleResources.cs
+++ b/src/app/ResourceManager/SubmoduleResources.cs
@@ -11,7 +11,7 @@ namespace ResourceManager;
 public static partial class SubmoduleResources
 {
     private static readonly ICommitDataHeaderRenderer PlainCommitDataHeaderRenderer = new CommitDataHeaderRenderer(new MonospacedHeaderLabelFormatter(), new DateFormatter(), new MonospacedHeaderRenderStyleProvider(), null);
-    [GeneratedRegex(@"^(\s*\S+)\s+", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^(?<prefix>\s*\S+)\s+", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
     private static partial Regex ReplaceTrailingSpacesWithTabRegex { get; }
 
     public static string GetSubmoduleText(IGitModule superproject, string name, string hash)
@@ -199,6 +199,6 @@ public static partial class SubmoduleResources
         }
 
         static string ReplaceTrailingSpacesWithTab(string input)
-            => ReplaceTrailingSpacesWithTabRegex.Replace(input, "$1\t");
+            => ReplaceTrailingSpacesWithTabRegex.Replace(input, "${prefix}\t");
     }
 }

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
@@ -6,10 +6,10 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings;
 
 public partial class GitlabRemoteParser : RemoteParser
 {
-    [GeneratedRegex(@"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git")]
+    [GeneratedRegex(@"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git", RegexOptions.ExplicitCapture)]
     private static partial Regex GitlabSshUrlRegex { get; }
 
-    [GeneratedRegex(@"https?://(?<host>[^/@]+)/(?<owner>.+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
+    [GeneratedRegex(@"https?://(?<host>[^/@]+)/(?<owner>.+)/(?<repo>[\w_\.\-]+)(?:\.git)?", RegexOptions.ExplicitCapture)]
     private static partial Regex GitlabHttpsUrlRegex { get; }
 
     private static readonly Regex[] _gitLabRegexes = [GitlabHttpsUrlRegex, GitlabSshUrlRegex];


### PR DESCRIPTION
Add `RegexOptions.ExplicitCapture` to `[GeneratedRegex]` attributes that were missing it, preventing unnecessary numbered capture group tracking.

Where patterns used numbered groups accessed by index, convert them to named groups:
- **FormCommit** — `Groups[1]`/`Groups[2]` → `Groups["pattern"]`/`Groups["index"]`
- **UserEnvironmentInformation** — `Groups[1]` → `Groups["version"]`
- **SubmoduleResources** — replacement `$1` → `${prefix}`

For **GitConfigSettingsPage**, also convert the unnecessary capturing group to a non-capturing group since the replacement only uses `$&`.

User-provided patterns (`ExternalLinkDefinition`, `TeamCityAdapter`, `JenkinsAdapter`, `FileStatusList`) are intentionally left unchanged as `ExplicitCapture` could break user patterns that rely on numbered groups or backreferences.