### PR TITLE
fix!: worktree with Git < 2.36

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2172,7 +2172,7 @@ public sealed partial class GitModule : IGitModule
         {
             "list",
             "--porcelain",
-            "-z"
+            { GitVersion.SupportWorktreeZ, "-z" },
         };
 
         string output = GitExecutable.GetOutput(args);
@@ -2183,7 +2183,11 @@ public sealed partial class GitModule : IGitModule
         string? branch = null;
         GitWorktreeHeadType headType = GitWorktreeHeadType.Branch;
 
-        foreach (string field in output.LazySplit('\0'))
+        // Note: -z for separator is not configurable before Git 2.36 so paths with \n will fail
+        // Just ignore this case, require Git update (no user feedback other than NBug).
+        char sep = GitVersion.SupportWorktreeZ ? '\0' : '\n';
+
+        foreach (string field in output.LazySplit(sep))
         {
             // Double \0 (empty field) marks the boundary between worktree records
             if (field.Length == 0)

--- a/src/app/GitCommands/Git/GitVersion.cs
+++ b/src/app/GitCommands/Git/GitVersion.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 
@@ -11,6 +11,7 @@ public class GitVersion : IComparable<GitVersion>, IGitVersion
     private static readonly GitVersion _v2_20_0 = new("2.20.0");
     private static readonly GitVersion _v2_32_0 = new("2.32.0");
     private static readonly GitVersion _v2_35_0 = new("2.35.0");
+    private static readonly GitVersion _v2_36_0 = new("2.36.0");
     private static readonly GitVersion _v2_38_0 = new("2.38.0");
     private static readonly GitVersion _v2_42_0 = new("2.42.0");
     private static readonly GitVersion _v2_46_0 = new("2.46.0");
@@ -151,13 +152,14 @@ public class GitVersion : IComparable<GitVersion>, IGitVersion
 
     public bool SupportAmendCommits => this >= _v2_32_0;
     public bool SupportGuiMergeTool => this >= _v2_20_0;
+    public bool SupportLsFilesFormat => this >= _v2_42_0;
     public bool SupportNewGitConfigSyntax => this >= _v2_46_0;
     public bool SupportRangeDiffPath => this >= _v2_38_0;
     public bool SupportRangeDiffTool => this >= _v2_19_0;
     public bool SupportRebaseMerges => this >= _v2_19_0;
     public bool SupportStashStaged => this >= _v2_35_0;
     public bool SupportUpdateRefs => this >= _v2_38_0;
-    public bool SupportLsFilesFormat => this >= _v2_42_0;
+    public bool SupportWorktreeZ => this >= _v2_36_0;
 
     private static int Compare(GitVersion? left, GitVersion? right)
     {

--- a/src/app/GitExtensions.Extensibility/Git/IGitVersion.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitVersion.cs
@@ -5,14 +5,14 @@ public interface IGitVersion : IComparable<IGitVersion>
     bool IsUnknown { get; }
     bool SupportAmendCommits { get; }
     bool SupportGuiMergeTool { get; }
+    bool SupportLsFilesFormat { get; }
     bool SupportNewGitConfigSyntax { get; }
     bool SupportRangeDiffPath { get; }
     bool SupportRangeDiffTool { get; }
     bool SupportRebaseMerges { get; }
     bool SupportStashStaged { get; }
     bool SupportUpdateRefs { get; }
-
-    bool SupportLsFilesFormat { get; }
+    bool SupportWorktreeZ { get; }
 
     string ToString();
 

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitModuleWorktreeTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitModuleWorktreeTests.cs
@@ -13,7 +13,10 @@ public sealed class GitModuleWorktreeTests
     [SetUp]
     public void SetUp()
     {
+        // Clear the static GitVersion cache so the mock executable is always queried for --version.
+        GitVersion.ResetVersion();
         _executable = new MockExecutable();
+        _executable.StageOutput("--version", $"git version {GitVersion.LastRecommendedVersion}");
         _gitModule = GetGitModuleWithExecutable(_executable);
     }
 


### PR DESCRIPTION
## Proposed changes

With Git older than 2.35, it is not possible to load the workspace without getting an NBug.
The official latest supported version is 2.43, but this correction is simple enough.

This changes Git.Extensibility, but so didthe change that introduced this.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
