### PR TITLE
feat(GetSelectedBranch): Reduce noise on WSL failure

### DIFF
--- a/src/app/GitCommands/Git/Commands.Execution.cs
+++ b/src/app/GitCommands/Git/Commands.Execution.cs
@@ -90,7 +90,7 @@ public static partial class Commands
         }
         catch (Exception ex)
         {
-            Trace.WriteLine(ex);
+            Trace.WriteLine($"Failed to read repo '{gitExecutor.WorkingDir}': {ex.Message}");
         }
 
         return DetachedHeadParser.UnknownBranchName;

--- a/src/app/GitCommands/Git/Executable.cs
+++ b/src/app/GitCommands/Git/Executable.cs
@@ -146,7 +146,17 @@ public sealed class Executable : IExecutable
 
             try
             {
-                _process.Start();
+                try
+                {
+                    _process.Start();
+                }
+                catch (Exception ex)
+                {
+                    _process.Exited -= OnProcessExit;
+                    _exitHandlerRemoved = true;
+                    _exitTaskCompletionSource.TrySetException(ex);
+                    throw;
+                }
 
                 if (_errorOutputStream is not null)
                 {


### PR DESCRIPTION
Fixes #12966

## Proposed changes

- `GetSelectedBranch`: Do not trace exception backtrace but message with context
- Handle exception from `Process.Start` in `ProcessWrapper`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).