### PR TITLE
ci: avoid duplicate runs on PR branches

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,10 +2,9 @@ name: PR Build
 
 on:
   push:
-    branches-ignore:
-      - configdata
-      - gh-pages
-      - 'translations_*'
+    branches:
+      - master
+      - 'release/**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Previously both 'push' and 'pull_request' triggers fired for every commit on a PR branch, causing two concurrent check runs. Restrict 'push' to master and release branches only — these are the post-merge confirmation runs. PRs are covered exclusively by the 'pull_request' trigger.
