### PR TITLE
feat: scroll revision grid to worktree commit on selection

### DIFF
--- a/src/app/GitUI/LeftPanel/BaseBranchLeafNode.cs
+++ b/src/app/GitUI/LeftPanel/BaseBranchLeafNode.cs
@@ -69,13 +69,9 @@ internal abstract class BaseBranchLeafNode : BaseRevisionNode
 
     protected override void SelectRevision()
     {
-        TreeViewNode.TreeView?.BeginInvoke(() =>
-        {
-            string branch = RelatedBranch is null || !Control.ModifierKeys.HasFlag(Keys.Alt)
-                ? FullPath
-                : RelatedBranch;
-            UICommands.BrowseRepo?.GoToRef(branch, showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
-            TreeViewNode.TreeView?.Focus();
-        });
+        string branch = RelatedBranch is null || !Control.ModifierKeys.HasFlag(Keys.Alt)
+            ? FullPath
+            : RelatedBranch;
+        GoToRevision(branch);
     }
 }

--- a/src/app/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/src/app/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -111,15 +111,9 @@ internal abstract class BaseRevisionNode : Node
 
     protected virtual void SelectRevision()
     {
-        if (ObjectId is null)
+        if (ObjectId is not null)
         {
-            return;
+            GoToRevision(ObjectId.ToString());
         }
-
-        TreeViewNode.TreeView?.BeginInvoke(() =>
-        {
-            UICommands.BrowseRepo?.GoToRef(ObjectId.ToString(), showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
-            TreeViewNode.TreeView?.Focus();
-        });
     }
 }

--- a/src/app/GitUI/LeftPanel/Node.cs
+++ b/src/app/GitUI/LeftPanel/Node.cs
@@ -75,6 +75,22 @@ internal abstract class Node : NodeBase, INode
         }
     }
 
+    /// <summary>
+    ///  Navigates the revision grid to the specified ref (commit SHA, branch name, tag, etc.)
+    ///  and returns focus to the tree view.
+    /// </summary>
+    protected void GoToRevision(string @ref)
+    {
+        TreeView? treeView = TreeViewNode.TreeView;
+        bool toggleSelection = Control.ModifierKeys.HasFlag(Keys.Control);
+
+        treeView?.BeginInvoke(() =>
+        {
+            UICommands.BrowseRepo?.GoToRef(@ref, showNoRevisionMsg: true, toggleSelection: toggleSelection);
+            treeView.Focus();
+        });
+    }
+
     internal virtual void OnSelected()
     {
     }

--- a/src/app/GitUI/LeftPanel/WorktreeNode.cs
+++ b/src/app/GitUI/LeftPanel/WorktreeNode.cs
@@ -10,6 +10,19 @@ internal sealed class WorktreeNode(Tree tree, GitWorktree worktree, bool isCurre
     public GitWorktree Worktree { get; } = worktree;
     public bool IsCurrent { get; } = isCurrent;
 
+    internal override void OnSelected()
+    {
+        if (Tree.IgnoreSelectionChangedEvent)
+        {
+            return;
+        }
+
+        if (Worktree.Sha1 is not null)
+        {
+            GoToRevision(Worktree.Sha1);
+        }
+    }
+
     internal override void OnDoubleClick()
     {
         if (!IsCurrent && !Worktree.IsDeleted)


### PR DESCRIPTION
When a worktree is selected in the left panel, navigate the revision grid to the commit that worktree's HEAD points to. This follows the same pattern used by branch, tag, and stash nodes.

Refactor tree nodes a bit to avoid duplicating code.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
