### PR TITLE
ci: publish portable archive artifact from GHA workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -87,6 +87,18 @@ jobs:
     - name: Run tests
       run: dotnet test -c Release --no-restore --no-build --nologo --verbosity q --test-adapter-path:. --logger:trx /bl:artifacts\log\tests.binlog
 
+    - name: Publish
+      shell: pwsh
+      run: |
+        $buildArgs = "/p:ContinuousIntegrationBuild=true $env:BUILD_ARGS".Trim()
+        dotnet publish -c Release --no-build /bl:artifacts\log\publish.binlog $buildArgs.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
+
+    - name: Upload portable archive
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: portable
+        path: 'artifacts\Release\publish\*.zip'
+
     - name: Test report
       # v1 @ 2024-08-30
       uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7


### PR DESCRIPTION
Add publish and artifact upload steps to the GitHub Actions PR Build workflow, producing the same portable zip that AppVeyor previously published.

## Motivation

As discussed in https://github.com/gitextensions/gitextensions/pull/12946#issuecomment-4209503231, the [`gitextensions.extensibility`](https://github.com/gitextensions/gitextensions.extensibility) NuGet package includes a prebuild script ([`Download-GitExtensions.ps1`](https://github.com/gitextensions/gitextensions.extensibility/blob/master/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1)) that downloads the latest master build's portable archive for plugin development. With AppVeyor removed, this source is broken.

This PR restores the portable zip artifact by adding:

1. A **Publish** step (`dotnet publish -c Release --no-build`) that triggers the existing `CreatePortable` MSBuild target, producing the portable zip under `artifacts\Release\publish\`.
2. An **Upload portable archive** step that uploads the zip as a GitHub Actions artifact named `portable`.

## Follow-up work (in `gitextensions.extensibility`)

Once this merges, the extensibility repo will need updates to consume from GHA instead of AppVeyor:

1. **`Download-GitExtensions.ps1`** — add a `GitHubActions` source option that uses the GitHub REST API to find the latest successful workflow run on master and download the `portable` artifact.
2. **`GitExtensions.Extensibility.targets`** — update `ValidateSet` and default for `GitExtensionsReferenceSource` to include `GitHubActions`.
3. The `AppVeyor` source can be deprecated/removed once the transition is complete.

## Test methodology

- Review CI logs

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
