### PR TITLE
fix(commit):fix hideous resize of status bar when staging

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -247,7 +247,7 @@ partial class FormCommit
         toolStripProgressBar1.Margin = new Padding(0);
         toolStripProgressBar1.Name = "toolStripProgressBar1";
         toolStripProgressBar1.Overflow = ToolStripItemOverflow.Never;
-        toolStripProgressBar1.Size = new Size(150, 27);
+        toolStripProgressBar1.Size = new Size(150, 15);
         toolStripProgressBar1.Visible = false;
         // 
         // toolbarSelectionFilter


### PR DESCRIPTION
for the first time
because the progress bar is larger than status bar

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

![pb_probress_bar](https://github.com/user-attachments/assets/19eba121-515a-48c9-a905-198ed8c8ba38)

### After
![pb_probress_bar_solved](https://github.com/user-attachments/assets/0aa8e8f6-04f2-41b2-8cae-ae3e491ff9ac)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
