### PR TITLE
chore(rebase): Bypass false debug assertion

### DIFF
--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -340,7 +340,7 @@ public partial class PatchGrid : GitModuleControl
         Validates.NotNull(PatchFiles);
 
         IReadOnlyList<PatchFile> updatedPatches = GetPatches();
-        if (updatedPatches.Count != PatchFiles.Count)
+        if (updatedPatches.Count != PatchFiles.Count && !_isManagingRebase)
         {
             // Fail for popup in Debug
             string s = $"PatchGrid: RefreshGrid: PatchFiles count {PatchFiles.Count} is different from updatedPatches count {updatedPatches.Count}. This should not happen.";


### PR DESCRIPTION
When a rebase is finished
(after a conflict on one of the commits rebased),
this assertion is false.

updatedPatches.Count: 0
vs
PatchFiles.Count: number of remaining patch files to apply when conflict occured

So bypassing when in rebase...

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
