### PR TITLE
ci: exclude test code from SonarQube analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+# Exclude test projects from SonarQube analysis
+sonar.exclusions=tests/**/*


### PR DESCRIPTION
Add `sonar-project.properties` to exclude the `tests/` directory from SonarQube analysis, avoiding noise from unit test code.