### PR TITLE
refactor: convert JoinableTaskFactory.Run tests to async Task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -304,5 +304,8 @@ csharp_prefer_system_threading_lock = true:suggestion
 # Silent for now, see https://github.com/dotnet/winforms/issues/12476
 dotnet_diagnostic.WFO1000.severity = silent
 
+# VSTHRD103: Call async methods when in an async method
+dotnet_diagnostic.VSTHRD103.severity = warning
+
 # IDE0290: Use primary constructor
 dotnet_diagnostic.IDE0290.severity = none

--- a/tests/app/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
@@ -24,203 +24,182 @@ public sealed class AsyncLoaderTests
     }
 
     [Test]
-    public void Load_should_execute_async_operation_and_callback()
+    public async Task Load_should_execute_async_operation_and_callback()
     {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            SemaphoreSlim loadSignal = new(0);
-            SemaphoreSlim completeSignal = new(0);
+        SemaphoreSlim loadSignal = new(0);
+        SemaphoreSlim completeSignal = new(0);
 
-            int started = 0;
-            int completed = 0;
-            Task task = _loader.LoadAsync(
-                () =>
-                {
-                    started++;
-                    loadSignal.Release();
-                    completeSignal.Wait();
-                },
-                () => completed++);
-
-            (await loadSignal.WaitAsync(1000)).Should().BeTrue();
-
-            started.Should().Be(1);
-            completed.Should().Be(0);
-
-            completeSignal.Release();
-
-            await task;
-
-            started.Should().Be(1);
-            completed.Should().Be(1);
-
-            task.Status.Should().Be(TaskStatus.RanToCompletion);
-        });
-    }
-
-    [Test]
-    public void Load_performed_on_thread_pool_and_result_handled_via_callers_context()
-    {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            Thread callerThread = Thread.CurrentThread;
-            Thread? loadThread = null;
-            Thread? continuationThread = null;
-
-            callerThread.IsThreadPoolThread.Should().BeFalse();
-
-            using AsyncLoader loader = new();
-            await loader.LoadAsync(
-                () => loadThread = Thread.CurrentThread,
-                () => continuationThread = Thread.CurrentThread);
-
-            loadThread!.IsThreadPoolThread.Should().BeTrue();
-            callerThread.Should().NotBeSameAs(loadThread);
-            continuationThread.Should().NotBeSameAs(loadThread);
-        });
-    }
-
-    [Test]
-    public void Cancel_during_load_means_callback_not_fired()
-    {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            SemaphoreSlim loadSignal = new(0);
-            SemaphoreSlim completeSignal = new(0);
-
-            int started = 0;
-            int completed = 0;
-            Task task = _loader.LoadAsync(
-                () =>
-                {
-                    started++;
-                    loadSignal.Release();
-                    completeSignal.Wait();
-                },
-                () => completed++);
-
-            (await loadSignal.WaitAsync(1000)).Should().BeTrue();
-
-            started.Should().Be(1);
-            completed.Should().Be(0);
-
-            _loader.Cancel();
-            completeSignal.Release();
-
-            await task;
-
-            started.Should().Be(1);
-            completed.Should().Be(0, "Should not have called the follow-up action");
-
-            task.Status.Should().Be(TaskStatus.RanToCompletion);
-        });
-    }
-
-    [Test]
-    public void Cancel_during_delay_means_load_not_fired()
-    {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            // Deliberately use a long delay as cancellation should cut it short
-            _loader.Delay = TimeSpan.FromMilliseconds(5000);
-
-            int started = 0;
-            int completed = 0;
-            Task task = _loader.LoadAsync(
-                () => started++,
-                () => completed++);
-
-            await Task.Delay(50);
-
-            started.Should().Be(0);
-            completed.Should().Be(0);
-
-            _loader.Cancel();
-
-            await task;
-
-            started.Should().Be(0);
-            completed.Should().Be(0);
-
-            task.Status.Should().Be(TaskStatus.RanToCompletion);
-        });
-    }
-
-    [Test]
-    public void Dispose_during_load_means_callback_not_fired()
-    {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            SemaphoreSlim loadSignal = new(0);
-            SemaphoreSlim completeSignal = new(0);
-
-            int started = 0;
-            int completed = 0;
-            Task task = _loader.LoadAsync(
-                () =>
-                {
-                    started++;
-                    loadSignal.Release();
-                    completeSignal.Wait();
-                },
-                () => completed++);
-
-            (await loadSignal.WaitAsync(1000)).Should().BeTrue();
-
-            started.Should().Be(1);
-            completed.Should().Be(0);
-
-            _loader.Dispose();
-            completeSignal.Release();
-
-            await task;
-
-            started.Should().Be(1);
-            completed.Should().Be(0, "Should not have called the follow-up action");
-
-            task.Status.Should().Be(TaskStatus.RanToCompletion);
-        });
-    }
-
-    [Test]
-    public void Delay_causes_load_callback_to_be_deferred()
-    {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            _loader.Delay = TimeSpan.FromMilliseconds(200);
-
-            Stopwatch sw = Stopwatch.StartNew();
-
-            await _loader.LoadAsync(
-                () => sw.Stop(),
-                () => { });
-
-            sw.Elapsed.Should().BeGreaterThanOrEqualTo(_loader.Delay - TimeSpan.FromMilliseconds(20));
-        });
-    }
-
-    [Test]
-    public void Error_raised_via_event_and_marked_as_handled_does_not_fault_task()
-    {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            List<Exception> observed = [];
-
-            _loader.LoadingError += (_, e) =>
+        int started = 0;
+        int completed = 0;
+        Task task = _loader.LoadAsync(
+            () =>
             {
-                observed.Add(e.Exception);
-                e.Handled = true;
-            };
+                started++;
+                loadSignal.Release();
+                completeSignal.Wait();
+            },
+            () => completed++);
 
-            Exception ex = new();
+        (await loadSignal.WaitAsync(1000)).Should().BeTrue();
 
-            await _loader.LoadAsync(
-                () => throw ex,
-                Assert.Fail);
+        started.Should().Be(1);
+        completed.Should().Be(0);
 
-            observed.Count.Should().Be(1);
-            observed[0].Should().BeSameAs(ex);
-        });
+        completeSignal.Release();
+
+        await task;
+
+        started.Should().Be(1);
+        completed.Should().Be(1);
+
+        task.Status.Should().Be(TaskStatus.RanToCompletion);
+    }
+
+    [Test]
+    public async Task Load_performed_on_thread_pool_and_result_handled_via_callers_context()
+    {
+        Thread callerThread = Thread.CurrentThread;
+        Thread? loadThread = null;
+        Thread? continuationThread = null;
+
+        callerThread.IsThreadPoolThread.Should().BeFalse();
+
+        using AsyncLoader loader = new();
+        await loader.LoadAsync(
+            () => loadThread = Thread.CurrentThread,
+            () => continuationThread = Thread.CurrentThread);
+
+        loadThread!.IsThreadPoolThread.Should().BeTrue();
+        callerThread.Should().NotBeSameAs(loadThread);
+        continuationThread.Should().NotBeSameAs(loadThread);
+    }
+
+    [Test]
+    public async Task Cancel_during_load_means_callback_not_fired()
+    {
+        SemaphoreSlim loadSignal = new(0);
+        SemaphoreSlim completeSignal = new(0);
+
+        int started = 0;
+        int completed = 0;
+        Task task = _loader.LoadAsync(
+            () =>
+            {
+                started++;
+                loadSignal.Release();
+                completeSignal.Wait();
+            },
+            () => completed++);
+
+        (await loadSignal.WaitAsync(1000)).Should().BeTrue();
+
+        started.Should().Be(1);
+        completed.Should().Be(0);
+
+        _loader.Cancel();
+        completeSignal.Release();
+
+        await task;
+
+        started.Should().Be(1);
+        completed.Should().Be(0, "Should not have called the follow-up action");
+
+        task.Status.Should().Be(TaskStatus.RanToCompletion);
+    }
+
+    [Test]
+    public async Task Cancel_during_delay_means_load_not_fired()
+    {
+        // Deliberately use a long delay as cancellation should cut it short
+        _loader.Delay = TimeSpan.FromMilliseconds(5000);
+
+        int started = 0;
+        int completed = 0;
+        Task task = _loader.LoadAsync(
+            () => started++,
+            () => completed++);
+
+        await Task.Delay(50);
+
+        started.Should().Be(0);
+        completed.Should().Be(0);
+
+        _loader.Cancel();
+
+        await task;
+
+        started.Should().Be(0);
+        completed.Should().Be(0);
+
+        task.Status.Should().Be(TaskStatus.RanToCompletion);
+    }
+
+    [Test]
+    public async Task Dispose_during_load_means_callback_not_fired()
+    {
+        SemaphoreSlim loadSignal = new(0);
+        SemaphoreSlim completeSignal = new(0);
+
+        int started = 0;
+        int completed = 0;
+        Task task = _loader.LoadAsync(
+            () =>
+            {
+                started++;
+                loadSignal.Release();
+                completeSignal.Wait();
+            },
+            () => completed++);
+
+        (await loadSignal.WaitAsync(1000)).Should().BeTrue();
+
+        started.Should().Be(1);
+        completed.Should().Be(0);
+
+        _loader.Dispose();
+        completeSignal.Release();
+
+        await task;
+
+        started.Should().Be(1);
+        completed.Should().Be(0, "Should not have called the follow-up action");
+
+        task.Status.Should().Be(TaskStatus.RanToCompletion);
+    }
+
+    [Test]
+    public async Task Delay_causes_load_callback_to_be_deferred()
+    {
+        _loader.Delay = TimeSpan.FromMilliseconds(200);
+
+        Stopwatch sw = Stopwatch.StartNew();
+
+        await _loader.LoadAsync(
+            () => sw.Stop(),
+            () => { });
+
+        sw.Elapsed.Should().BeGreaterThanOrEqualTo(_loader.Delay - TimeSpan.FromMilliseconds(20));
+    }
+
+    [Test]
+    public async Task Error_raised_via_event_and_marked_as_handled_does_not_fault_task()
+    {
+        List<Exception> observed = [];
+
+        _loader.LoadingError += (_, e) =>
+        {
+            observed.Add(e.Exception);
+            e.Handled = true;
+        };
+
+        Exception ex = new();
+
+        await _loader.LoadAsync(
+            () => throw ex,
+            Assert.Fail);
+
+        observed.Count.Should().Be(1);
+        observed[0].Should().BeSameAs(ex);
     }
 
     [Test]

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -6,7 +6,6 @@ using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
-using GitUI;
 
 namespace GitCommandsTests;
 public sealed partial class GitModuleTests
@@ -410,7 +409,7 @@ public sealed partial class GitModuleTests
     }
 
     [Test]
-    public void GetSuperprojectCurrentCheckout()
+    public async Task GetSuperprojectCurrentCheckout()
     {
         // Create super and sub repo
         using GitModuleTestHelper moduleTestHelperSuper = new("super repo"),
@@ -421,20 +420,16 @@ public sealed partial class GitModuleTests
         IGitModule moduleSub = moduleTestHelperSuper.GetSubmodulesRecursive().ElementAt(0);
 
         // Commit in submodule
-        moduleSub.GitExecutable.GetOutput(@"commit --allow-empty -am ""First commit""");
-        string commitRef = moduleSub.GitExecutable.GetOutput("show HEAD").LazySplit('\n').First().LazySplit(' ').Skip(1).First();
+        await moduleSub.GitExecutable.GetOutputAsync(@"commit --allow-empty -am ""First commit""");
+        string commitRef = (await moduleSub.GitExecutable.GetOutputAsync("show HEAD")).LazySplit('\n').First().LazySplit(' ').Skip(1).First();
 
         // Update ref in superproject
-        moduleTestHelperSuper.Module.GitExecutable.GetOutput(@"add ""sub repo""");
-        moduleTestHelperSuper.Module.GitExecutable.GetOutput(@"commit -am ""Update submodule ref""");
+        await moduleTestHelperSuper.Module.GitExecutable.GetOutputAsync(@"add ""sub repo""");
+        await moduleTestHelperSuper.Module.GitExecutable.GetOutputAsync(@"commit -am ""Update submodule ref""");
 
-        // Assert
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            (char code, ObjectId? commitId) = await moduleSub.GetSuperprojectCurrentCheckoutAsync();
-            code.Should().Be(' ');
-            commitId?.ToString().Should().Be(commitRef);
-        });
+        (char code, ObjectId? commitId) = await moduleSub.GetSuperprojectCurrentCheckoutAsync();
+        code.Should().Be(' ');
+        commitId?.ToString().Should().Be(commitRef);
     }
 
     [TestCase(false, @"stash list")]

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests_Remotes.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests_Remotes.cs
@@ -3,7 +3,6 @@ using CommonTestUtils;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
-using GitUI;
 
 namespace GitCommandsTests;
 
@@ -82,11 +81,9 @@ partial class GitModuleTests
     }
 
     [Test]
-    public void GetRemotes_should_parse_correctly_configured_remotes()
+    public async Task GetRemotes_should_parse_correctly_configured_remotes()
     {
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            string[] lines =
+        string[] lines =
             [
                 "RussKie\tgit://github.com/RussKie/gitextensions.git (fetch)",
                 "RussKie\tgit://github.com/RussKie/gitextensions.git (push)",
@@ -113,49 +110,48 @@ partial class GitModuleTests
                 "with_option\thttps://github.com/flannelhead/jsmn-stream.git (push) [ignored]"
             ];
 
-            using (_executable.StageOutput("remote -v", string.Join("\n", lines)))
-            {
-                IReadOnlyList<GitExtensions.Extensibility.Git.Remote> remotes = await _gitModule.GetRemotesAsync();
+        using (_executable.StageOutput("remote -v", string.Join("\n", lines)))
+        {
+            IReadOnlyList<GitExtensions.Extensibility.Git.Remote> remotes = await _gitModule.GetRemotesAsync();
 
-                remotes.Count.Should().Be(7);
+            remotes.Count.Should().Be(7);
 
-                remotes[0].Name.Should().Be("RussKie");
-                remotes[0].FetchUrl.Should().Be("git://github.com/RussKie/gitextensions.git");
-                remotes[0].PushUrls.Count.Should().Be(1);
-                remotes[0].PushUrls[0].Should().Be("git://github.com/RussKie/gitextensions.git");
+            remotes[0].Name.Should().Be("RussKie");
+            remotes[0].FetchUrl.Should().Be("git://github.com/RussKie/gitextensions.git");
+            remotes[0].PushUrls.Count.Should().Be(1);
+            remotes[0].PushUrls[0].Should().Be("git://github.com/RussKie/gitextensions.git");
 
-                remotes[1].Name.Should().Be("origin");
-                remotes[1].FetchUrl.Should().Be("git@github.com:drewnoakes/gitextensions.git");
-                remotes[1].PushUrls.Count.Should().Be(1);
-                remotes[1].PushUrls[0].Should().Be("git@github.com:drewnoakes/gitextensions.git");
+            remotes[1].Name.Should().Be("origin");
+            remotes[1].FetchUrl.Should().Be("git@github.com:drewnoakes/gitextensions.git");
+            remotes[1].PushUrls.Count.Should().Be(1);
+            remotes[1].PushUrls[0].Should().Be("git@github.com:drewnoakes/gitextensions.git");
 
-                remotes[2].Name.Should().Be("upstream");
-                remotes[2].FetchUrl.Should().Be("git@github.com:gitextensions/gitextensions.git");
-                remotes[2].PushUrls.Count.Should().Be(1);
-                remotes[2].PushUrls[0].Should().Be("git@github.com:gitextensions/gitextensions.git");
+            remotes[2].Name.Should().Be("upstream");
+            remotes[2].FetchUrl.Should().Be("git@github.com:gitextensions/gitextensions.git");
+            remotes[2].PushUrls.Count.Should().Be(1);
+            remotes[2].PushUrls[0].Should().Be("git@github.com:gitextensions/gitextensions.git");
 
-                remotes[3].Name.Should().Be("asymmetrical");
-                remotes[3].FetchUrl.Should().Be("https://github.com/gitextensions/fetch.git");
-                remotes[3].PushUrls.Count.Should().Be(1);
-                remotes[3].PushUrls[0].Should().Be("https://github.com/gitextensions/push.git");
+            remotes[3].Name.Should().Be("asymmetrical");
+            remotes[3].FetchUrl.Should().Be("https://github.com/gitextensions/fetch.git");
+            remotes[3].PushUrls.Count.Should().Be(1);
+            remotes[3].PushUrls[0].Should().Be("https://github.com/gitextensions/push.git");
 
-                remotes[4].Name.Should().Be("with-space");
-                remotes[4].FetchUrl.Should().Be("c:/Bare Repo");
-                remotes[4].PushUrls.Count.Should().Be(1);
-                remotes[4].PushUrls[0].Should().Be("c:/Bare Repo");
+            remotes[4].Name.Should().Be("with-space");
+            remotes[4].FetchUrl.Should().Be("c:/Bare Repo");
+            remotes[4].PushUrls.Count.Should().Be(1);
+            remotes[4].PushUrls[0].Should().Be("c:/Bare Repo");
 
-                remotes[5].Name.Should().Be("multi");
-                remotes[5].FetchUrl.Should().Be("git@github.com:drewnoakes/gitextensions.git");
-                remotes[5].PushUrls.Count.Should().Be(2);
-                remotes[5].PushUrls[0].Should().Be("git@github.com:drewnoakes/gitextensions.git");
-                remotes[5].PushUrls[1].Should().Be("git@gitlab.com:drewnoakes/gitextensions.git");
+            remotes[5].Name.Should().Be("multi");
+            remotes[5].FetchUrl.Should().Be("git@github.com:drewnoakes/gitextensions.git");
+            remotes[5].PushUrls.Count.Should().Be(2);
+            remotes[5].PushUrls[0].Should().Be("git@github.com:drewnoakes/gitextensions.git");
+            remotes[5].PushUrls[1].Should().Be("git@gitlab.com:drewnoakes/gitextensions.git");
 
-                remotes[6].Name.Should().Be("with_option");
-                remotes[6].FetchUrl.Should().Be("https://github.com/flannelhead/jsmn-stream.git");
-                remotes[6].PushUrls.Count.Should().Be(1);
-                remotes[6].PushUrls[0].Should().Be("https://github.com/flannelhead/jsmn-stream.git");
-            }
-        });
+            remotes[6].Name.Should().Be("with_option");
+            remotes[6].FetchUrl.Should().Be("https://github.com/flannelhead/jsmn-stream.git");
+            remotes[6].PushUrls.Count.Should().Be(1);
+            remotes[6].PushUrls[0].Should().Be("https://github.com/flannelhead/jsmn-stream.git");
+        }
     }
 
     [Test]

--- a/tests/app/UnitTests/GitExtUtils.Tests/ComboBoxExtensionsTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/ComboBoxExtensionsTests.cs
@@ -27,7 +27,7 @@ public class ComboBoxExtensionsTests
         // Arrange
         string somewhatLongString = "This is a somewhat long string to force ComboBox drop-down to be adjusted";
 
-        ComboBox comboBox = new();
+        using ComboBox comboBox = new();
         comboBox.Items.Add(somewhatLongString);
 
         int initialWidth = comboBox.Width;
@@ -61,7 +61,7 @@ public class ComboBoxExtensionsTests
         // Arrange
         string veryLongString = string.Join(", ", Enumerable.Repeat("A very long string", 20));
 
-        ToolStripComboBox comboBox = new();
+        using ToolStripComboBox comboBox = new();
         comboBox.Items.Add(veryLongString);
 
         // Act
@@ -77,7 +77,7 @@ public class ComboBoxExtensionsTests
         // Arrange
         string veryLongString = string.Join(", ", Enumerable.Repeat("A very long string", 20));
 
-        ToolStripComboBox comboBox = new();
+        using ToolStripComboBox comboBox = new();
         comboBox.Items.Add(veryLongString);
 
         // Act
@@ -93,7 +93,7 @@ public class ComboBoxExtensionsTests
         // Arrange
         string veryLongString = string.Join(", ", Enumerable.Repeat("A very long string", 20));
 
-        ComboBox comboBox = new()
+        using ComboBox comboBox = new()
         {
             DisplayMember = "Value"
         };
@@ -112,7 +112,7 @@ public class ComboBoxExtensionsTests
         // Arrange
         string veryLongString = string.Join(", ", Enumerable.Repeat("A very long string", 20));
 
-        ComboBox comboBox = new()
+        using ComboBox comboBox = new()
         {
             DisplayMember = "Value"
         };
@@ -131,7 +131,7 @@ public class ComboBoxExtensionsTests
         // Arrange
         string veryLongString = string.Join(", ", Enumerable.Repeat("A very long string", 20));
 
-        ComboBox comboBox = new();
+        using ComboBox comboBox = new();
         comboBox.Items.Add(new ComboBoxItem(Value: "", ToStringValue: veryLongString));
 
         // Act
@@ -147,7 +147,7 @@ public class ComboBoxExtensionsTests
         // Arrange
         string veryLongString = string.Join(", ", Enumerable.Repeat("A very long string", 20));
 
-        ComboBox comboBox = new()
+        using ComboBox comboBox = new()
         {
             DisplayMember = "NonExistentMemberName"
         };

--- a/tests/app/UnitTests/GitExtUtils.Tests/ControlTagExtensionTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/ControlTagExtensionTests.cs
@@ -6,7 +6,7 @@ public class ControlTagExtensionTests
     [Test]
     public void Multiple_values_can_be_set()
     {
-        Control control = new();
+        using Control control = new();
 
         control.SetTag(1);
         control.SetTag(2f);
@@ -20,7 +20,7 @@ public class ControlTagExtensionTests
     [Test]
     public void When_tag_field_is_occupied_GetTag_returns_default()
     {
-        Control control = new()
+        using Control control = new()
         {
             Tag = new object()
         };
@@ -32,7 +32,7 @@ public class ControlTagExtensionTests
     [Test]
     public void When_tag_field_is_occupied_SetTag_replaces_existing_tag()
     {
-        Control control = new()
+        using Control control = new()
         {
             Tag = new object()
         };
@@ -46,7 +46,7 @@ public class ControlTagExtensionTests
     [Test]
     public void When_another_type_is_stored_at_key_GetTag_return_default()
     {
-        Control control = new();
+        using Control control = new();
         control.SetTag("key", 1);
         control.SetTag("key", 2f);
 

--- a/tests/app/UnitTests/GitExtUtils.Tests/TableLayoutPanelExtensionsTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/TableLayoutPanelExtensionsTests.cs
@@ -22,7 +22,7 @@ public class TableLayoutPanelExtensionsTests
     [Test]
     public void AdjustWidthToSize_should_throw_if_index_outside_table_columns_count()
     {
-        TableLayoutPanel table = new()
+        using TableLayoutPanel table = new()
         {
             ColumnCount = 3
         };
@@ -35,7 +35,7 @@ public class TableLayoutPanelExtensionsTests
     [Test]
     public void AdjustWidthToSize_should_throw_if_no_widths_given()
     {
-        TableLayoutPanel table = new()
+        using TableLayoutPanel table = new()
         {
             ColumnCount = 3
         };
@@ -45,7 +45,7 @@ public class TableLayoutPanelExtensionsTests
     [Test]
     public void AdjustWidthToSize_should_throw_if_no_widths_given1()
     {
-        TableLayoutPanel table = new()
+        using TableLayoutPanel table = new()
         {
             ColumnCount = 3
         };
@@ -56,7 +56,7 @@ public class TableLayoutPanelExtensionsTests
     [Test]
     public void AdjustWidthToSize_should_set_width_to_largest_value()
     {
-        TableLayoutPanel table = new()
+        using TableLayoutPanel table = new()
         {
             ColumnCount = 3
         };

--- a/tests/app/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
@@ -16,6 +16,12 @@ public class ControlThreadingExtensionsTests
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
         await form.SwitchToMainThreadAsync();
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ControlSwitchToMainThreadOnMainThread_with_cancellation_token()
+    {
+        Form form = new();
 
         using CancellationTokenSource cancellationTokenSource = new();
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
@@ -53,6 +59,12 @@ public class ControlThreadingExtensionsTests
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
         await form.SwitchToMainThreadAsync();
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ControlSwitchToMainThreadOnBackgroundThread_with_cancellation_token()
+    {
+        Form form = new();
 
         using CancellationTokenSource cancellationTokenSource = new();
         await TaskScheduler.Default;

--- a/tests/app/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
@@ -9,24 +9,18 @@ namespace GitUITests;
 public class ControlThreadingExtensionsTests
 {
     [Test]
-    public void ControlSwitchToMainThreadOnMainThread()
+    public async Task ControlSwitchToMainThreadOnMainThread()
     {
         Form form = new();
 
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
-            await form.SwitchToMainThreadAsync();
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
-        });
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
+        await form.SwitchToMainThreadAsync();
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
 
         using CancellationTokenSource cancellationTokenSource = new();
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
-            await form.SwitchToMainThreadAsync(cancellationTokenSource.Token);
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
-        });
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
+        await form.SwitchToMainThreadAsync(cancellationTokenSource.Token);
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
     }
 
     [Test]
@@ -51,26 +45,20 @@ public class ControlThreadingExtensionsTests
     }
 
     [Test]
-    public void ControlSwitchToMainThreadOnBackgroundThread()
+    public async Task ControlSwitchToMainThreadOnBackgroundThread()
     {
         Form form = new();
 
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            await TaskScheduler.Default;
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
-            await form.SwitchToMainThreadAsync();
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
-        });
+        await TaskScheduler.Default;
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
+        await form.SwitchToMainThreadAsync();
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
 
         using CancellationTokenSource cancellationTokenSource = new();
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            await TaskScheduler.Default;
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
-            await form.SwitchToMainThreadAsync(cancellationTokenSource.Token);
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
-        });
+        await TaskScheduler.Default;
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
+        await form.SwitchToMainThreadAsync(cancellationTokenSource.Token);
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
     }
 
     [Test]

--- a/tests/app/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
@@ -11,7 +11,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task ControlSwitchToMainThreadOnMainThread()
     {
-        Form form = new();
+        using Form form = new();
 
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
         await form.SwitchToMainThreadAsync();
@@ -21,7 +21,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task ControlSwitchToMainThreadOnMainThread_with_cancellation_token()
     {
-        Form form = new();
+        using Form form = new();
 
         using CancellationTokenSource cancellationTokenSource = new();
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
@@ -32,7 +32,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public void ControlSwitchToMainThreadOnMainThreadCompletesSynchronously()
     {
-        Form form = new();
+        using Form form = new();
 
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
 
@@ -53,7 +53,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task ControlSwitchToMainThreadOnBackgroundThread()
     {
-        Form form = new();
+        using Form form = new();
 
         await TaskScheduler.Default;
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
@@ -64,7 +64,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task ControlSwitchToMainThreadOnBackgroundThread_with_cancellation_token()
     {
-        Form form = new();
+        using Form form = new();
 
         using CancellationTokenSource cancellationTokenSource = new();
         await TaskScheduler.Default;
@@ -87,7 +87,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task TokenCancelledBeforeSwitchOnMainThread()
     {
-        Form form = new();
+        using Form form = new();
         using CancellationTokenSource cancellationTokenSource = new();
         await cancellationTokenSource.CancelAsync();
 
@@ -129,7 +129,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task TokenCancelledAfterSwitchOnMainThread()
     {
-        Form form = new();
+        using Form form = new();
         using CancellationTokenSource cancellationTokenSource = new();
 
         ControlThreadingExtensions.ControlMainThreadAwaitable awaitable = form.SwitchToMainThreadAsync(cancellationTokenSource.Token);
@@ -157,7 +157,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task TokenCancelledBeforeSwitchOnBackgroundThread()
     {
-        Form form = new();
+        using Form form = new();
 
         await TaskScheduler.Default;
 
@@ -192,7 +192,7 @@ public class ControlThreadingExtensionsTests
     [Test]
     public async Task TokenCancelledAfterSwitchOnBackgroundThread()
     {
-        Form form = new();
+        using Form form = new();
 
         await TaskScheduler.Default;
 

--- a/tests/app/UnitTests/GitUI.Tests/ControlUtilTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ControlUtilTests.cs
@@ -23,7 +23,7 @@ public sealed class ControlUtilTests
     [Test]
     public void FindDescendants()
     {
-        Control root = CreateTestHierarchy();
+        using Control root = CreateTestHierarchy();
 
         // child1, child2, child3, grandchild1, grandchild2
         root.FindDescendants().Count().Should().Be(5);
@@ -33,7 +33,7 @@ public sealed class ControlUtilTests
     [Test]
     public void FindDescendantsOfType()
     {
-        Control root = CreateTestHierarchy();
+        using Control root = CreateTestHierarchy();
 
         root.FindDescendantsOfType<TextBox>().Count().Should().Be(1);
         root.FindDescendantsOfType<Button>().Count().Should().Be(1);
@@ -43,7 +43,7 @@ public sealed class ControlUtilTests
     [Test]
     public void FindDescendantsOfTypeWithPredicate()
     {
-        Control root = CreateTestHierarchy();
+        using Control root = CreateTestHierarchy();
 
         Button? foundButton = root.FindDescendantOfType<Button>(t => t.Text == "Click me");
         foundButton.Should().NotBeNull();

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
@@ -90,7 +90,7 @@ public class DiffHighlightServiceTests
     [Test]
     public async Task MarkInlineGap()
     {
-        TextEditorControl textEditor = new();
+        using TextEditorControl textEditor = new();
         DiffViewerLineNumberControl diffViewerLineNumber = new(textEditor.ActiveTextAreaControl.TextArea);
         string testDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
         string text = File.ReadAllText(Path.Combine(testDataDir, "gaps.diff"));

--- a/tests/app/UnitTests/GitUI.Tests/LeftPanel/GitRefMenuItemsTest.cs
+++ b/tests/app/UnitTests/GitUI.Tests/LeftPanel/GitRefMenuItemsTest.cs
@@ -28,6 +28,15 @@ public class GitRefMenuItemsTest
         Enumerable.Range(0, expectedMenuItems).ForEach(_ => _factoryQueue.Enqueue(new ToolStripMenuItem()));
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        while (_factoryQueue.Count > 0)
+        {
+            _factoryQueue.Dequeue().Dispose();
+        }
+    }
+
     [Test]
     public void WithInactiveLocalBranch_HasAllMenuItems()
     {

--- a/tests/app/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
@@ -25,7 +25,7 @@ public sealed class RepositoryHistoryUIServiceTests
     [Test]
     public void PopulateRecentRepositoriesMenu_should_add_new_item()
     {
-        ToolStripMenuItem containerMenu = new();
+        using ToolStripMenuItem containerMenu = new();
 
         const string path = "";
         const string caption = "CAPTION";
@@ -39,7 +39,7 @@ public sealed class RepositoryHistoryUIServiceTests
     [Test]
     public void AddRecentRepositories_should_set_properties_correctly()
     {
-        ToolStripMenuItem containerMenu = new();
+        using ToolStripMenuItem containerMenu = new();
 
         const string path = "";
         const string caption = "CAPTION";
@@ -61,7 +61,7 @@ public sealed class RepositoryHistoryUIServiceTests
     {
         _branchNameCache.GetCachedBranchName(Arg.Any<string>()).Returns(string.IsNullOrWhiteSpace(branch) ? null : branch);
 
-        ToolStripMenuItem containerMenu = new();
+        using ToolStripMenuItem containerMenu = new();
 
         const string path = "somepath";
         const string caption = "CAPTION";
@@ -83,7 +83,7 @@ public sealed class RepositoryHistoryUIServiceTests
     [Test]
     public void ChangeWorkingDir_should_promt_user_to_delete_invalid_repo()
     {
-        ToolStripMenuItem containerMenu = new();
+        using ToolStripMenuItem containerMenu = new();
 
         const string path = "";
         const string caption = "CAPTION";
@@ -100,7 +100,7 @@ public sealed class RepositoryHistoryUIServiceTests
     [Test]
     public void PopulateFavouriteRepositoriesMenu_should_order_favourites_alphabetically()
     {
-        ToolStripMenuItem tsmiFavouriteRepositories = new();
+        using ToolStripMenuItem tsmiFavouriteRepositories = new();
         List<Repository> repositoryHistory =
         [
             new Repository(@"c:\") { Category = "D" },

--- a/tests/app/UnitTests/GitUI.Tests/ThreadHelperTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ThreadHelperTests.cs
@@ -45,33 +45,31 @@ public sealed class ThreadHelperTests
     }
 
     [Test]
-    public void ThrowIfNotOnUIThread()
+    public async Task ThrowIfNotOnUIThread()
     {
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
+#pragma warning disable VSTHRD109 // Switch instead of assert in async methods -- intentionally testing ThrowIfNotOnUIThread
         ThreadHelper.ThrowIfNotOnUIThread();
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            await TaskScheduler.Default;
+#pragma warning restore VSTHRD109
 
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
+        await TaskScheduler.Default;
 
-            ((Action)(() => ThreadHelper.ThrowIfNotOnUIThread())).Should().Throw<COMException>();
-        });
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
+
+        ((Action)(() => ThreadHelper.ThrowIfNotOnUIThread())).Should().Throw<COMException>();
     }
 
     [Test]
-    public void ThrowIfOnUIThread()
+    public async Task ThrowIfOnUIThread()
     {
         ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeTrue();
         ((Action)(() => ThreadHelper.ThrowIfOnUIThread())).Should().Throw<COMException>();
-        ThreadHelper.JoinableTaskFactory.Run(async () =>
-        {
-            await TaskScheduler.Default;
 
-            ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
+        await TaskScheduler.Default;
 
-            ThreadHelper.ThrowIfOnUIThread();
-        });
+        ThreadHelper.JoinableTaskContext.IsOnMainThread.Should().BeFalse();
+
+        ThreadHelper.ThrowIfOnUIThread();
     }
 
     [Test]

--- a/tests/app/UnitTests/GitUI.Tests/ToolStripUtilTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ToolStripUtilTests.cs
@@ -6,7 +6,7 @@ public sealed class ToolStripUtilTests
     [Test]
     public void FindToolStripItems()
     {
-        ToolStrip root = new()
+        using ToolStrip root = new()
         {
             Items =
             {

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
@@ -36,6 +36,7 @@ public class FilterToolBarTests
     [TearDown]
     public void TearDown()
     {
+        _filterToolBar.Dispose();
         AppSettings.ShowOnlyFirstParent = _originalShowOnlyFirstParent;
         AppSettings.ShowReflogReferences.Value = _originalShowReflogReferences;
     }

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/InteractiveGitActionControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/InteractiveGitActionControlTests.cs
@@ -5,12 +5,20 @@ namespace GitUITests.UserControls;
 [Apartment(ApartmentState.STA)]
 public class InteractiveGitActionControlTests
 {
+    private InteractiveGitActionControl _control = null!;
     private InteractiveGitActionControl.TestAccessor _accessor;
 
     [SetUp]
     public void SetUp()
     {
-        _accessor = new InteractiveGitActionControl().GetTestAccessor();
+        _control = new InteractiveGitActionControl();
+        _accessor = _control.GetTestAccessor();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _control.Dispose();
     }
 
     [TestCase(InteractiveGitActionControl.GitAction.Rebase, false)]


### PR DESCRIPTION
NUnit natively supports async Task test methods, making the JoinableTaskFactory.Run(async () => { ... }) wrapper unnecessary in most cases. The NUnit STA runner pumps Win32 messages while awaiting, so JoinableTaskFactory.SwitchToMainThreadAsync() (used internally by AsyncLoader and ControlThreadingExtensions) continues to work correctly.

Converted 13 test methods across 5 files:
- AsyncLoaderTests (7 tests)
- ControlThreadingExtensionsTests (2 tests)
- ThreadHelperTests (2 tests)
- GitModuleTests_Remotes (1 test)
- GitModuleTests (1 test)

Removed unused 'using GitUI' from files that no longer reference ThreadHelper. Added VSTHRD109 suppression in ThrowIfNotOnUIThread test since the test intentionally validates thread-checking behavior.