### PR TITLE
Allow preconfigure prefix and colour per remote

### DIFF
--- a/src/app/GitCommands/Config/SettingKeyString.cs
+++ b/src/app/GitCommands/Config/SettingKeyString.cs
@@ -27,6 +27,11 @@ public static class SettingKeyString
     public static string RemoteColor = "remote.{0}.color";
 
     /// <summary>
+    /// "remote.{0}.prefix"
+    /// </summary>
+    public static readonly string RemotePrefix = "remote.{0}.prefix";
+
+    /// <summary>
     /// "remote.{0}.push"
     /// </summary>
     public static readonly string RemotePush = "remote.{0}.push";

--- a/src/app/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/src/app/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -5,13 +5,13 @@ using GitExtensions.Extensibility;
 namespace GitCommands.Git;
 
 /// <summary>
-/// Provides ability to ensure compliance with the GIT branch naming conventions.
+///  Provides ability to ensure compliance with the GIT branch naming conventions.
 /// </summary>
 public interface IGitBranchNameNormaliser
 {
     /// <summary>
-    /// Ensures that the branch name meets the GIT branch naming conventions.
-    /// For more details refer to <see href="https://git-scm.com/docs/git-check-ref-format"/>.
+    ///  Ensures that the branch name meets the GIT branch naming conventions.
+    ///  For more details refer to <see href="https://git-scm.com/docs/git-check-ref-format"/>.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
@@ -24,13 +24,16 @@ public interface IGitBranchNameNormaliser
     DESCRIPTION
     Checks if a given refname is acceptable, and exits with a non-zero status if it is not.
 
-    A reference is used in Git to specify branches and tags. A branch head is stored in the refs/heads hierarchy, while a tag is stored in the refs/tags hierarchy of the ref namespace (typically in $GIT_DIR/refs/heads and $GIT_DIR/refs/tags directories or, as entries in file $GIT_DIR/packed-refs if refs are packed by git gc).
+    A reference is used in Git to specify branches and tags. A branch head is stored in the refs/heads hierarchy,
+    while a tag is stored in the refs/tags hierarchy of the ref namespace (typically in $GIT_DIR/refs/heads and $GIT_DIR/refs/tags directories or,
+    as entries in file $GIT_DIR/packed-refs if refs are packed by git gc).
 
     Git imposes the following rules on how references are named:
 
     1. They can include slash '/' for hierarchical (directory) grouping, but no slash-separated component can begin with a dot '.' or end with the sequence '.lock'.
 
-    2. They must contain at least one '/'. This enforces the presence of a category like 'heads/', 'tags/' etc. but the actual names are not restricted. If the --allow-onelevel option is used, this rule is waived.
+    2. They must contain at least one '/'. This enforces the presence of a category like 'heads/', 'tags/' etc. but the actual names are not restricted.
+       If the --allow-onelevel option is used, this rule is waived.
 
     3. They cannot have two consecutive dots '..' anywhere.
 
@@ -48,24 +51,27 @@ public interface IGitBranchNameNormaliser
 
     10. They cannot contain a '\'.
 
-    These rules make it easy for shell script based tools to parse reference names, pathname expansion by the shell when a reference name is used unquoted (by mistake), and also avoids ambiguities in certain reference name expressions (see gitrevisions(7)):
+    These rules make it easy for shell script based tools to parse reference names, pathname expansion by the shell when
+    a reference name is used unquoted (by mistake), and also avoids ambiguities in certain reference name expressions (see gitrevisions(7)):
 
     1. A double-dot '..' is often used as in 'ref1..ref2', and in some contexts this notation means '^ref1 ref2' (i.e. not in 'ref1' and in 'ref2').
 
     2. A tilde '~' and caret '^' are used to introduce the postfix nth parent and peel onion operation.
 
-    3. A colon ':' is used as in 'srcref:dstref' to mean "use srcref\s value and store it in dstref" in fetch and push operations. It may also be used to select a specific object such as with git cat-file': "git cat-file blob v1.3.3:refs.c".
+    3. A colon ':' is used as in 'srcref:dstref' to mean "use srcref\s value and store it in dstref" in fetch and push operations.
+       It may also be used to select a specific object such as with git cat-file': "git cat-file blob v1.3.3:refs.c".
 
     4. at-open-brace '@{' is used as a notation to access a reflog entry.
 
-    With the --branch option, it expands the “previous branch syntax” @{-n}. For example, @{-1} is a way to refer the last branch you were on. This option should be used by porcelains to accept this syntax anywhere a branch name is expected, so they can act as if you typed the branch name.
+    With the --branch option, it expands the “previous branch syntax” @{-n}. For example, @{-1} is a way to refer the last branch you were on.
+    This option should be used by porcelains to accept this syntax anywhere a branch name is expected, so they can act as if you typed the branch name.
 
 */
 
 /// <summary>
-/// Ensures compliance with the GIT branch naming conventions.
+///  Ensures compliance with the GIT branch naming conventions.
 /// </summary>
-public sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
+internal sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
 {
     [GeneratedRegex(@"^(\.)*", RegexOptions.ExplicitCapture)]
     private static partial Regex PeriodRegex { get; }
@@ -85,8 +91,8 @@ public sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
     private static partial Regex Rule10Regex { get; }
 
     /// <summary>
-    /// Ensures that the branch name meets the GIT branch naming conventions.
-    /// For more details refer to <see href="https://www.git-scm.com/docs/git-check-ref-format/1.8.2"/>.
+    ///  Ensures that the branch name meets the GIT branch naming conventions.
+    ///  For more details refer to <see href="https://www.git-scm.com/docs/git-check-ref-format/1.8.2"/>.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
@@ -118,20 +124,11 @@ public sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
     }
 
     /// <summary>
-    /// Indicates whether the given character can be used in a branch name.
-    /// </summary>
-    public static bool IsValidChar(char c)
-    {
-        return c is (> ' ' and < '~' and not ('^' or ':')) &&
-                Array.IndexOf(Path.GetInvalidPathChars(), c) < 0;
-    }
-
-    /// <summary>
-    /// Branch name can include slash '/' for hierarchical (directory) grouping,
-    /// but no slash-separated component can begin with a dot '.' or end with the sequence '.lock'.
+    ///  Branch name can include slash '/' for hierarchical (directory) grouping,
+    ///  but no slash-separated component can begin with a dot '.' or end with the sequence '.lock'.
     /// </summary>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule01(string branchName, GitBranchNameOptions options)
+    internal static string Rule01(string branchName, GitBranchNameOptions options)
     {
         string[] tokens = branchName.Split(Delimiters.ForwardSlash);
         for (int i = 0; i < tokens.Length; i++)
@@ -151,30 +148,30 @@ public sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
     }
 
     /// <summary>
-    /// Branch name cannot have two consecutive dots '..' anywhere.
+    ///  Branch name cannot have two consecutive dots '..' anywhere.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule03(string branchName, GitBranchNameOptions options)
+    internal static string Rule03(string branchName, GitBranchNameOptions options)
     {
         return Rule03Regex.Replace(branchName, options.ReplacementToken);
     }
 
     /// <summary>
-    /// Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \127 'DEL'),
-    /// space, tilde '~', caret '^', or colon ':' anywhere.
-    /// Also allow any valid Unicode letters.
+    ///  Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \127 'DEL'),
+    ///  space, tilde '~', caret '^', or colon ':' anywhere.
+    ///  Also allow any valid Unicode letters.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule04(string branchName, GitBranchNameOptions options)
+    internal static string Rule04(string branchName, GitBranchNameOptions options)
     {
         StringBuilder result = new(branchName.Length);
         foreach (char t in branchName)
         {
-            if (IsValidChar(t) || char.IsLetterOrDigit(t))
+            if (PathUtil.IsValidPathChar(t) || char.IsLetterOrDigit(t))
             {
                 result.Append(t);
             }
@@ -188,22 +185,22 @@ public sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
     }
 
     /// <summary>
-    /// Branch name cannot have question-mark '?', asterisk '*', or open bracket '[' anywhere.
+    ///  Branch name cannot have question-mark '?', asterisk '*', or open bracket '[' anywhere.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule05(string branchName, GitBranchNameOptions options)
+    internal static string Rule05(string branchName, GitBranchNameOptions options)
     {
         return Rule05Regex.Replace(branchName, options.ReplacementToken);
     }
 
     /// <summary>
-    /// Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
+    ///  Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule06(string branchName)
+    internal static string Rule06(string branchName)
     {
         branchName = Rule06Regex.Replace(branchName, "/");
         if (branchName.StartsWith('/'))
@@ -220,45 +217,45 @@ public sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
     }
 
     /// <summary>
-    /// Branch name end with a dot '.'.
+    ///  Branch name end with a dot '.'.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule07(string branchName, GitBranchNameOptions options)
+    internal static string Rule07(string branchName, GitBranchNameOptions options)
     {
         return Rule07Regex.Replace(branchName, options.ReplacementToken);
     }
 
     /// <summary>
-    /// Branch name cannot contain a sequence '@{'.
+    ///  Branch name cannot contain a sequence '@{'.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule08(string branchName, GitBranchNameOptions options)
+    internal static string Rule08(string branchName, GitBranchNameOptions options)
     {
         return Rule08Regex.Replace(branchName, options.ReplacementToken);
     }
 
     /// <summary>
-    /// Branch name cannot be the single character '@'.
+    ///  Branch name cannot be the single character '@'.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule09(string branchName, GitBranchNameOptions options)
+    internal static string Rule09(string branchName, GitBranchNameOptions options)
     {
         return branchName != "@" ? branchName : options.ReplacementToken;
     }
 
     /// <summary>
-    /// Branch name cannot contain a '\'.
+    ///  Branch name cannot contain a '\'.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
     /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal string Rule10(string branchName, GitBranchNameOptions options)
+    internal static string Rule10(string branchName, GitBranchNameOptions options)
     {
         return Rule10Regex.Replace(branchName, options.ReplacementToken);
     }

--- a/src/app/GitCommands/Git/GitBranchNameOptions.cs
+++ b/src/app/GitCommands/Git/GitBranchNameOptions.cs
@@ -1,4 +1,4 @@
-namespace GitCommands.Git;
+﻿namespace GitCommands.Git;
 
 /// <summary>
 /// Options used by <see cref="GitBranchNameNormaliser"/> to ensures compliance with the GIT branch naming conventions.
@@ -14,7 +14,7 @@ public sealed class GitBranchNameOptions
                 throw new ArgumentOutOfRangeException(nameof(replacementToken), "Replacement token must be a single character");
             }
 
-            if (!GitBranchNameNormaliser.IsValidChar(replacementToken[0]))
+            if (!PathUtil.IsValidPathChar(replacementToken[0]))
             {
                 throw new ArgumentOutOfRangeException(nameof(replacementToken), string.Format("Replacement token invalid: '{0}'", replacementToken));
             }

--- a/src/app/GitCommands/PathUtil.cs
+++ b/src/app/GitCommands/PathUtil.cs
@@ -23,6 +23,15 @@ public static partial class PathUtil
     [GeneratedRegex(@"^(\w+):\/\/([\S]+)", RegexOptions.ExplicitCapture)]
     private static partial Regex DriveLetterRegex { get; }
 
+    /// <summary>
+    ///  Indicates whether the given character can be used in a git branch name (and in a file path).
+    /// </summary>
+    public static bool IsValidPathChar(char c)
+    {
+        return c is (> ' ' and < '~' and not ('^' or ':')) &&
+                Array.IndexOf(Path.GetInvalidPathChars(), c) < 0;
+    }
+
     /// <summary>Replaces native path separator with posix path separator (/).</summary>
     [return: NotNullIfNotNull(nameof(path))]
     public static string? ToPosixPath(this string? path)

--- a/src/app/GitCommands/Remotes/ConfigFileRemote.cs
+++ b/src/app/GitCommands/Remotes/ConfigFileRemote.cs
@@ -1,47 +1,54 @@
-using GitCommands.Config;
+﻿using GitCommands.Config;
 
 namespace GitCommands.Remotes;
 
 public class ConfigFileRemote
 {
     /// <summary>
-    /// Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemoteColor"/> key.
+    ///  Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemoteColor"/> key.
     /// </summary>
     public string? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets value indicating whether the remote is enabled or not.
-    /// If remote section is [remote branch] then it is considered enabled, if it is [-remote branch] then it is disabled.
+    ///  Gets or sets value indicating whether the remote is enabled or not.
+    ///  If remote section is [remote branch] then it is considered enabled, if it is [-remote branch] then it is disabled.
     /// </summary>
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the name of the remote branch.
+    ///  Gets or sets the name of the remote branch.
     /// </summary>
     public string? Name { get; set; }
 
     /// <summary>
-    /// Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemotePush"/> key.
+    ///  Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemotePush"/> key.
     /// </summary>
     public IReadOnlyList<string>? Push { get; set; }
 
     /// <summary>
-    /// Gets or sets the prefix stored in .git/config via <see cref="SettingKeyString.RemotePrefix"/> key.
+    ///  Gets or sets an optional prefix stored in <c>.git/config</c> via the
+    ///  <see cref="SettingKeyString.RemotePrefix"/> key (<c>remote.&lt;name&gt;.prefix</c>).
     /// </summary>
+    /// <remarks>
+    ///  When a push has no explicit tracking branch or default push remote configured,
+    ///  this value is prepended to the local branch name to form the remote branch name
+    ///  (e.g. a prefix of <c>"user/"</c> turns local branch <c>feature</c> into remote branch
+    ///  <c>user/feature</c>).
+    /// </remarks>
     public string? Prefix { get; set; }
 
     /// <summary>
-    /// Gets or sets the last pushurl stored in .git/config via <see cref="SettingKeyString.RemotePushUrl"/> key.
+    ///  Gets or sets the last pushurl stored in .git/config via <see cref="SettingKeyString.RemotePushUrl"/> key.
     /// </summary>
     public string? PushUrl { get; set; }
 
     /// <summary>
-    /// Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemotePuttySshKey"/> key.
+    ///  Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemotePuttySshKey"/> key.
     /// </summary>
     public string? PuttySshKey { get; set; }
 
     /// <summary>
-    /// Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemoteUrl"/> key.
+    ///  Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemoteUrl"/> key.
     /// </summary>
     public string? Url { get; set; }
 }

--- a/src/app/GitCommands/Remotes/ConfigFileRemote.cs
+++ b/src/app/GitCommands/Remotes/ConfigFileRemote.cs
@@ -26,6 +26,11 @@ public class ConfigFileRemote
     public IReadOnlyList<string>? Push { get; set; }
 
     /// <summary>
+    /// Gets or sets the prefix stored in .git/config via <see cref="SettingKeyString.RemotePrefix"/> key.
+    /// </summary>
+    public string? Prefix { get; set; }
+
+    /// <summary>
     /// Gets or sets the last pushurl stored in .git/config via <see cref="SettingKeyString.RemotePushUrl"/> key.
     /// </summary>
     public string? PushUrl { get; set; }

--- a/src/app/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/src/app/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -304,10 +304,7 @@ public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
         ConfigFileRemote? remote, string remoteName, string remoteUrl, string? remotePushUrl,
         string remotePuttySshKey, string? remoteColor, string? remotePrefix)
     {
-        if (string.IsNullOrWhiteSpace(remoteName))
-        {
-            throw new ArgumentNullException(nameof(remoteName));
-        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteName);
 
         remoteName = remoteName.Trim();
 
@@ -379,10 +376,7 @@ public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
 
     public void ToggleRemoteState(string remoteName, bool disabled)
     {
-        if (string.IsNullOrWhiteSpace(remoteName))
-        {
-            throw new ArgumentNullException(nameof(remoteName));
-        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteName);
 
         // disabled is the new state, so if the new state is 'false' (=enabled), then the existing state is 'true' (=disabled, i.e. '-remote')
         string sectionName = disabled ? SectionRemote : SectionRemoteDisabled;

--- a/src/app/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/src/app/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -57,8 +57,11 @@ public interface IConfigFileRemoteSettingsManager
     /// <param name="remotePushUrl">An optional alternative remote push URL.</param>
     /// <param name="remotePuttySshKey">An optional Putty SSH key.</param>
     /// <param name="remoteColor">An optional color for the remote.</param>
+    /// <param name="remotePrefix">An optional prefix for the remote.</param>
     /// <returns>Result of the operation.</returns>
-    ConfigFileRemoteSaveResult SaveRemote(ConfigFileRemote? remote, string remoteName, string remoteUrl, string? remotePushUrl, string remotePuttySshKey, string? remoteColor);
+    ConfigFileRemoteSaveResult SaveRemote(
+        ConfigFileRemote? remote, string remoteName, string remoteUrl, string? remotePushUrl,
+        string remotePuttySshKey, string? remoteColor, string? remotePrefix);
 
     /// <summary>
     ///  Marks the remote as enabled or disabled in .git/config file.
@@ -258,6 +261,7 @@ public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
                 Url = module.GetSetting(GetSettingKey(SettingKeyString.RemoteUrl, remote, enabled)),
                 Push = module.GetSettings(GetSettingKey(SettingKeyString.RemotePush, remote, enabled)).ToList(),
                 Color = module.GetSetting(GetSettingKey(SettingKeyString.RemoteColor, remote, enabled)),
+                Prefix = module.GetSetting(GetSettingKey(SettingKeyString.RemotePrefix, remote, enabled)),
 
                 // Note: This only gets the last pushurl
                 PushUrl = module.GetSetting(GetSettingKey(SettingKeyString.RemotePushUrl, remote, enabled)),
@@ -296,7 +300,9 @@ public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
         return GetDisabledRemoteNames().Any(r => r == remoteName);
     }
 
-    public ConfigFileRemoteSaveResult SaveRemote(ConfigFileRemote? remote, string remoteName, string remoteUrl, string? remotePushUrl, string remotePuttySshKey, string? remoteColor)
+    public ConfigFileRemoteSaveResult SaveRemote(
+        ConfigFileRemote? remote, string remoteName, string remoteUrl, string? remotePushUrl,
+        string remotePuttySshKey, string? remoteColor, string? remotePrefix)
     {
         if (string.IsNullOrWhiteSpace(remoteName))
         {
@@ -366,6 +372,7 @@ public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
         UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemotePushUrl, remotePushUrl);
         UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemotePuttySshKey, remotePuttySshKey);
         UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemoteColor, remoteColor);
+        UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemotePrefix, remotePrefix);
 
         return new ConfigFileRemoteSaveResult(output, updateRemoteRequired);
     }

--- a/src/app/GitCommands/ServiceContainerRegistry.cs
+++ b/src/app/GitCommands/ServiceContainerRegistry.cs
@@ -14,5 +14,7 @@ public static class ServiceContainerRegistry
         GitExecutorProvider executorProvider = new(gitDirectoryResolver);
         serviceContainer.AddService<IGitExecutorProvider>(executorProvider);
         serviceContainer.AddService<ISubmoduleStatusProvider>(new SubmoduleStatusProvider(executorProvider));
+
+        serviceContainer.AddService<IGitBranchNameNormaliser>(new GitBranchNameNormaliser());
     }
 }

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -1,7 +1,8 @@
-using GitCommands;
+﻿using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.ScriptsEngine;
 using ResourceManager;
@@ -45,7 +46,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
     public FormCheckoutBranch(IGitUICommands commands, string branch, bool remote, IReadOnlyList<ObjectId>? containRevisions = null)
         : base(commands, true)
     {
-        _branchNameNormaliser = new GitBranchNameNormaliser();
+        _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
         InitializeComponent();
         InitializeComplete();
         _rbResetBranchDefaultText = rbResetBranch.Text;
@@ -544,7 +545,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
 
     private void txtCustomBranchName_Leave(object sender, EventArgs e)
     {
-        if (!AppSettings.AutoNormaliseBranchName || !txtCustomBranchName.Text.Any(GitBranchNameNormaliser.IsValidChar))
+        if (!AppSettings.AutoNormaliseBranchName || !txtCustomBranchName.Text.Any(PathUtil.IsValidPathChar))
         {
             return;
         }

--- a/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -1,8 +1,9 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -15,8 +16,8 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
     private readonly TranslationString _branchNameIsEmpty = new("Enter branch name.");
     private readonly TranslationString _branchNameIsNotValid = new("“{0}” is not valid branch name.");
     private readonly TranslationString _creatingOrphanBranch = new("Creating orphan branch (repository has no commits)");
-    private readonly IGitBranchNameNormaliser _branchNameNormaliser = new GitBranchNameNormaliser();
     private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
+    private readonly IGitBranchNameNormaliser _branchNameNormaliser;
 
     public bool CheckoutAfterCreation { get; set; } = true;
     public bool UserAbleToChangeRevision { get; set; } = true;
@@ -30,6 +31,8 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
         MinimumSize = new Size(Width, PreferredMinimumHeight);
 
         InitializeComplete();
+
+        _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
 
         grpOrphan.AutoSize = true;
 
@@ -82,7 +85,7 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
 
     private void BranchNameTextBox_Leave(object sender, EventArgs e)
     {
-        if (!AppSettings.AutoNormaliseBranchName || !BranchNameTextBox.Text.Any(GitBranchNameNormaliser.IsValidChar))
+        if (!AppSettings.AutoNormaliseBranchName || !BranchNameTextBox.Text.Any(PathUtil.IsValidPathChar))
         {
             return;
         }

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -1,4 +1,4 @@
-using System.Data;
+﻿using System.Data;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Config;
@@ -808,12 +808,13 @@ public partial class FormPush : GitModuleForm
                 }
             }
 
-            if (!RemoteBranch.Items.Contains(_NO_TRANSLATE_Branch.Text))
+            string newRemoteBranchName = $"{_selectedRemote?.Prefix}{_NO_TRANSLATE_Branch.Text}";
+            if (!RemoteBranch.Items.Contains(newRemoteBranchName))
             {
-                RemoteBranch.Items.Add(_NO_TRANSLATE_Branch.Text);
+                RemoteBranch.Items.Add(newRemoteBranchName);
             }
 
-            RemoteBranch.Text = _NO_TRANSLATE_Branch.Text;
+            RemoteBranch.Text = newRemoteBranchName;
         }
     }
 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -87,6 +87,8 @@ partial class FormRemotes
         MergeWith = new DataGridViewTextBoxColumn();
         toolTip1 = new ToolTip(components);
         colorDialog = new ColorDialog();
+        lblRemotePrefix = new Label();
+        txtRemotePrefix = new TextBox();
         flowLayoutPanelSsh = new FlowLayoutPanel();
         flowLayoutPanelSsh.SuspendLayout();
         flpnlRemoteColors.SuspendLayout();
@@ -163,11 +165,11 @@ partial class FormRemotes
         flpnlRemoteColors.Controls.Add(btnRemoteColor);
         flpnlRemoteColors.Controls.Add(btnRemoteColorReset);
         flpnlRemoteColors.Dock = DockStyle.Fill;
-        flpnlRemoteColors.Location = new Point(106, 60);
+        flpnlRemoteColors.Location = new Point(106, 89);
         flpnlRemoteColors.Margin = new Padding(0);
         flpnlRemoteColors.Name = "flpnlRemoteColors";
         flpnlRemoteColors.Size = new Size(414, 31);
-        flpnlRemoteColors.TabIndex = 6;
+        flpnlRemoteColors.TabIndex = 8;
         // 
         // btnRemoteColor
         // 
@@ -176,7 +178,7 @@ partial class FormRemotes
         btnRemoteColor.Location = new Point(3, 3);
         btnRemoteColor.Name = "btnRemoteColor";
         btnRemoteColor.Size = new Size(63, 25);
-        btnRemoteColor.TabIndex = 7;
+        btnRemoteColor.TabIndex = 0;
         btnRemoteColor.Text = "Set &color";
         btnRemoteColor.UseVisualStyleBackColor = false;
         btnRemoteColor.Click += btnRemoteColor_Click;
@@ -188,11 +190,11 @@ partial class FormRemotes
         btnRemoteColorReset.Location = new Point(72, 3);
         btnRemoteColorReset.Name = "btnRemoteColorReset";
         btnRemoteColorReset.Size = new Size(85, 25);
-        btnRemoteColorReset.TabIndex = 8;
+        btnRemoteColorReset.TabIndex = 1;
         btnRemoteColorReset.Text = "Default color";
         btnRemoteColorReset.UseVisualStyleBackColor = false;
-        btnRemoteColorReset.Click += btnRemoteColorReset_Click;
         btnRemoteColorReset.Visible = false;
+        btnRemoteColorReset.Click += btnRemoteColorReset_Click;
         // 
         // flpnlRemoteManagement
         // 
@@ -210,7 +212,7 @@ partial class FormRemotes
         flpnlRemoteManagement.RowStyles.Add(new RowStyle());
         flpnlRemoteManagement.RowStyles.Add(new RowStyle());
         flpnlRemoteManagement.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        flpnlRemoteManagement.Size = new Size(564, 309);
+        flpnlRemoteManagement.Size = new Size(564, 338);
         flpnlRemoteManagement.TabIndex = 0;
         // 
         // pnlMgtDetails
@@ -222,7 +224,7 @@ partial class FormRemotes
         pnlMgtDetails.Location = new Point(3, 3);
         pnlMgtDetails.Name = "pnlMgtDetails";
         pnlMgtDetails.Padding = new Padding(0, 0, 0, 8);
-        pnlMgtDetails.Size = new Size(558, 169);
+        pnlMgtDetails.Size = new Size(558, 198);
         pnlMgtDetails.TabIndex = 0;
         pnlMgtDetails.Text = "Details";
         // 
@@ -238,21 +240,24 @@ partial class FormRemotes
         tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 0);
         tblpnlMgtDetails.Controls.Add(label1, 0, 1);
         tblpnlMgtDetails.Controls.Add(RemoteName, 1, 1);
-        tblpnlMgtDetails.Controls.Add(lblRemoteColor, 0, 2);
-        tblpnlMgtDetails.Controls.Add(flpnlRemoteColors, 1, 2);
-        tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 3);
-        tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 4);
-        tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 4);
-        tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 4);
+        tblpnlMgtDetails.Controls.Add(lblRemotePrefix, 0, 2);
+        tblpnlMgtDetails.Controls.Add(txtRemotePrefix, 1, 2);
+        tblpnlMgtDetails.Controls.Add(lblRemoteColor, 0, 3);
+        tblpnlMgtDetails.Controls.Add(flpnlRemoteColors, 1, 3);
+        tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 4);
+        tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 5);
+        tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 5);
+        tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 5);
         tblpnlMgtDetails.Location = new Point(16, 11);
         tblpnlMgtDetails.Name = "tblpnlMgtDetails";
-        tblpnlMgtDetails.RowCount = 5;
+        tblpnlMgtDetails.RowCount = 6;
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
         tblpnlMgtDetails.RowStyles.Add(new RowStyle());
-        tblpnlMgtDetails.Size = new Size(520, 147);
+        tblpnlMgtDetails.RowStyles.Add(new RowStyle());
+        tblpnlMgtDetails.Size = new Size(520, 176);
         tblpnlMgtDetails.TabIndex = 11;
         // 
         // label2
@@ -316,10 +321,10 @@ partial class FormRemotes
         // 
         lblRemoteColor.AutoSize = true;
         lblRemoteColor.Dock = DockStyle.Fill;
-        lblRemoteColor.Location = new Point(3, 60);
+        lblRemoteColor.Location = new Point(3, 89);
         lblRemoteColor.Name = "lblRemoteColor";
         lblRemoteColor.Size = new Size(100, 31);
-        lblRemoteColor.TabIndex = 5;
+        lblRemoteColor.TabIndex = 7;
         lblRemoteColor.Text = "Color";
         lblRemoteColor.TextAlign = ContentAlignment.MiddleLeft;
         // 
@@ -328,7 +333,7 @@ partial class FormRemotes
         checkBoxSepPushUrl.AutoSize = true;
         tblpnlMgtDetails.SetColumnSpan(checkBoxSepPushUrl, 2);
         checkBoxSepPushUrl.Dock = DockStyle.Fill;
-        checkBoxSepPushUrl.Location = new Point(3, 94);
+        checkBoxSepPushUrl.Location = new Point(3, 123);
         checkBoxSepPushUrl.Name = "checkBoxSepPushUrl";
         checkBoxSepPushUrl.Padding = new Padding(24, 0, 0, 0);
         checkBoxSepPushUrl.Size = new Size(354, 19);
@@ -341,7 +346,7 @@ partial class FormRemotes
         // 
         labelPushUrl.AutoSize = true;
         labelPushUrl.Dock = DockStyle.Fill;
-        labelPushUrl.Location = new Point(3, 116);
+        labelPushUrl.Location = new Point(3, 145);
         labelPushUrl.Name = "labelPushUrl";
         labelPushUrl.Size = new Size(100, 31);
         labelPushUrl.TabIndex = 10;
@@ -355,7 +360,7 @@ partial class FormRemotes
         comboBoxPushUrl.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
         comboBoxPushUrl.AutoCompleteSource = AutoCompleteSource.ListItems;
         comboBoxPushUrl.FormattingEnabled = true;
-        comboBoxPushUrl.Location = new Point(109, 120);
+        comboBoxPushUrl.Location = new Point(109, 149);
         comboBoxPushUrl.Name = "comboBoxPushUrl";
         comboBoxPushUrl.Size = new Size(298, 23);
         comboBoxPushUrl.TabIndex = 11;
@@ -367,7 +372,7 @@ partial class FormRemotes
         folderBrowserButtonPushUrl.AutoSize = true;
         folderBrowserButtonPushUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         folderBrowserButtonPushUrl.Dock = DockStyle.Fill;
-        folderBrowserButtonPushUrl.Location = new Point(413, 119);
+        folderBrowserButtonPushUrl.Location = new Point(413, 148);
         folderBrowserButtonPushUrl.MinimumSize = new Size(104, 25);
         folderBrowserButtonPushUrl.Name = "folderBrowserButtonPushUrl";
         folderBrowserButtonPushUrl.PathShowingControl = comboBoxPushUrl;
@@ -384,7 +389,7 @@ partial class FormRemotes
         pnlMgtPuttySsh.Controls.Add(lblMgtPuttyPanelHeader);
         pnlMgtPuttySsh.Controls.Add(lblHeaderLine2);
         pnlMgtPuttySsh.Dock = DockStyle.Top;
-        pnlMgtPuttySsh.Location = new Point(3, 178);
+        pnlMgtPuttySsh.Location = new Point(3, 207);
         pnlMgtPuttySsh.Name = "pnlMgtPuttySsh";
         pnlMgtPuttySsh.Padding = new Padding(0, 0, 0, 8);
         pnlMgtPuttySsh.Size = new Size(558, 91);
@@ -474,7 +479,7 @@ partial class FormRemotes
         flowLayoutPanel2.Controls.Add(Save);
         flowLayoutPanel2.Dock = DockStyle.Top;
         flowLayoutPanel2.FlowDirection = FlowDirection.RightToLeft;
-        flowLayoutPanel2.Location = new Point(3, 275);
+        flowLayoutPanel2.Location = new Point(3, 304);
         flowLayoutPanel2.Name = "flowLayoutPanel2";
         flowLayoutPanel2.Padding = new Padding(0, 0, 20, 0);
         flowLayoutPanel2.Size = new Size(558, 31);
@@ -782,6 +787,26 @@ partial class FormRemotes
         colorDialog.AnyColor = true;
         colorDialog.FullOpen = true;
         // 
+        // lblRemotePrefix
+        // 
+        lblRemotePrefix.AutoSize = true;
+        lblRemotePrefix.Dock = DockStyle.Fill;
+        lblRemotePrefix.Location = new Point(3, 60);
+        lblRemotePrefix.Name = "lblRemotePrefix";
+        lblRemotePrefix.Size = new Size(100, 29);
+        lblRemotePrefix.TabIndex = 5;
+        lblRemotePrefix.Text = "Prefix";
+        lblRemotePrefix.TextAlign = ContentAlignment.MiddleLeft;
+        // 
+        // txtRemotePrefix
+        // 
+        txtRemotePrefix.Dock = DockStyle.Fill;
+        txtRemotePrefix.Location = new Point(109, 63);
+        txtRemotePrefix.MaxLength = 100;
+        txtRemotePrefix.Name = "txtRemotePrefix";
+        txtRemotePrefix.Size = new Size(298, 23);
+        txtRemotePrefix.TabIndex = 6;
+        // 
         // FormRemotes
         // 
         AutoScaleDimensions = new SizeF(96F, 96F);
@@ -883,4 +908,6 @@ partial class FormRemotes
     private ColorDialog colorDialog;
     private Button btnRemoteColorReset;
     private FlowLayoutPanel flpnlRemoteColors;
+    private Label lblRemotePrefix;
+    private TextBox txtRemotePrefix;
 }

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -1,9 +1,11 @@
 ﻿using GitCommands;
 using GitCommands.Config;
+using GitCommands.Git;
 using GitCommands.Remotes;
 using GitCommands.UserRepositoryHistory;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Infrastructure;
@@ -29,6 +31,7 @@ public partial class FormRemotes : GitModuleForm
 
     private readonly FormRemotesController _formRemotesController = new();
     private IConfigFileRemoteSettingsManager? _remotesManager;
+    private IGitBranchNameNormaliser _branchNameNormaliser;
     private ConfigFileRemote? _selectedRemote;
     private readonly ListViewGroup _lvgEnabled;
     private readonly ListViewGroup _lvgDisabled;
@@ -106,6 +109,9 @@ Inactive remote is completely invisible to git.");
     {
         InitializeComponent();
         InitializeComplete();
+
+        _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
+        txtRemotePrefix.Leave += (sender, e) => txtRemotePrefix.Text = _branchNameNormaliser.Normalise(txtRemotePrefix.Text, new(AppSettings.AutoNormaliseSymbol));
 
         btnRemoteColor.BackColor = Color.Transparent;
 
@@ -486,7 +492,7 @@ Inactive remote is completely invisible to git.");
         string remoteUrl = Url.Text.Trim();
         string remotePushUrl = comboBoxPushUrl.Text.Trim();
         bool creatingNew = _selectedRemote is null;
-        string remotePrefix = txtRemotePrefix.Text.Trim(); // TODO: validate/sanitize the prefix
+        string remotePrefix = txtRemotePrefix.Text;
 
         string? color = null;
         if (btnRemoteColor.BackColor != Color.Transparent)

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -891,4 +891,23 @@ Inactive remote is completely invisible to git.");
             RemoteName.SelectAll();
         }
     }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor
+    {
+        private readonly FormRemotes _form;
+
+        public TestAccessor(FormRemotes form)
+        {
+            _form = form;
+        }
+
+        public Button Delete => _form.Delete;
+        public TextBox RemoteName => _form.RemoteName;
+        public TextBox RemotePrefix => _form.txtRemotePrefix;
+        public Button Save => _form.Save;
+        public TabControl TabControl => _form.tabControl1;
+        public Button ToggleState => _form.btnToggleState;
+    }
 }

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -395,6 +395,9 @@ Inactive remote is completely invisible to git.");
         {
             lblRemoteColor.Visible = false;
             flpnlRemoteColors.Visible = false;
+
+            lblRemotePrefix.Visible = false;
+            txtRemotePrefix.Visible = false;
         }
 
         // if Putty SSH isn't enabled, reduce the minimum height of the form
@@ -483,6 +486,7 @@ Inactive remote is completely invisible to git.");
         string remoteUrl = Url.Text.Trim();
         string remotePushUrl = comboBoxPushUrl.Text.Trim();
         bool creatingNew = _selectedRemote is null;
+        string remotePrefix = txtRemotePrefix.Text.Trim(); // TODO: validate/sanitize the prefix
 
         string? color = null;
         if (btnRemoteColor.BackColor != Color.Transparent)
@@ -514,7 +518,8 @@ Inactive remote is completely invisible to git.");
                                                    remoteUrl,
                                                    checkBoxSepPushUrl.Checked ? remotePushUrl : null,
                                                    PuttySshKey.Text,
-                                                   color);
+                                                   color,
+                                                   remotePrefix);
 
             if (!string.IsNullOrEmpty(result.UserMessage))
             {
@@ -733,6 +738,8 @@ Inactive remote is completely invisible to git.");
         checkBoxSepPushUrl.Checked = false;
         PuttySshKey.Text = string.Empty;
         gbMgtPanel.Text = _gbMgtPanelHeaderNew.Text;
+        txtRemotePrefix.Text = string.Empty;
+        SetRemoteColor(Color.Transparent);
 
         if (Remotes.SelectedIndices.Count < 1)
         {
@@ -758,6 +765,7 @@ Inactive remote is completely invisible to git.");
         BindBtnToggleState(_selectedRemote.Disabled);
         btnToggleState.Visible = true;
         flpnlRemoteManagement.Enabled = !_selectedRemote.Disabled;
+        txtRemotePrefix.Text = _selectedRemote.Prefix;
 
         if (string.IsNullOrWhiteSpace(_selectedRemote.Color))
         {

--- a/src/app/GitUI/CommandsDialogs/FormRenameBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRenameBranch.cs
@@ -2,8 +2,8 @@
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils;
 using GitUI.HelperDialogs;
-using ResourceManager;
 
 namespace GitUI.CommandsDialogs;
 
@@ -16,7 +16,7 @@ public sealed partial class FormRenameBranch : GitModuleForm
     public FormRenameBranch(IGitUICommands commands, string defaultBranch)
         : base(commands)
     {
-        _branchNameNormaliser = new GitBranchNameNormaliser();
+        _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
 
         InitializeComponent();
         InitializeComplete();
@@ -26,7 +26,7 @@ public sealed partial class FormRenameBranch : GitModuleForm
 
     private void BranchNameTextBox_Leave(object sender, EventArgs e)
     {
-        if (!AppSettings.AutoNormaliseBranchName || !BranchNameTextBox.Text.Any(GitBranchNameNormaliser.IsValidChar))
+        if (!AppSettings.AutoNormaliseBranchName || !BranchNameTextBox.Text.Any(PathUtil.IsValidPathChar))
         {
             return;
         }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -6766,6 +6766,10 @@ Value has been reset to empty value.</source>
         <source>Color</source>
         <target />
       </trans-unit>
+      <trans-unit id="lblRemotePrefix.Text">
+        <source>Prefix</source>
+        <target />
+      </trans-unit>
       <trans-unit id="pnlMgtDetails.Text">
         <source>Details</source>
         <target />

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
@@ -1,4 +1,5 @@
-﻿using AwesomeAssertions;
+﻿using System.ComponentModel.Design;
+using AwesomeAssertions;
 using CommonTestUtils;
 using GitCommands;
 using GitCommands.Git;
@@ -14,7 +15,6 @@ public class FormRemotesTests
 {
     private ReferenceRepository _referenceRepository = null!;
     private GitUICommands _commands = null!;
-    private IGitBranchNameNormaliser _branchNameNormaliser = null!;
     private bool _originalAlwaysShowAdvOpt;
 
     [SetUp]
@@ -23,10 +23,8 @@ public class FormRemotesTests
         _originalAlwaysShowAdvOpt = AppSettings.AlwaysShowAdvOpt;
 
         _referenceRepository = new ReferenceRepository();
-        _branchNameNormaliser = Substitute.For<IGitBranchNameNormaliser>();
 
-        System.ComponentModel.Design.ServiceContainer serviceContainer = GlobalServiceContainer.CreateDefaultMockServiceContainer();
-        serviceContainer.AddService(_branchNameNormaliser);
+        ServiceContainer serviceContainer = GlobalServiceContainer.CreateDefaultMockServiceContainer();
 
         _commands = new GitUICommands(serviceContainer, _referenceRepository.Module);
     }
@@ -106,7 +104,9 @@ public class FormRemotesTests
     public void Should_normalise_remote_prefix_on_leave()
     {
         AppSettings.AlwaysShowAdvOpt = true;
-        _branchNameNormaliser.Normalise("invalid branch name", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-name");
+
+        IGitBranchNameNormaliser branchNameNormaliser = _commands.GetRequiredService<IGitBranchNameNormaliser>();
+        branchNameNormaliser.Normalise("invalid branch name", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-name");
 
         RunFormTest(
             form =>

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
@@ -1,0 +1,145 @@
+﻿using AwesomeAssertions;
+using CommonTestUtils;
+using GitCommands;
+using GitCommands.Git;
+using GitExtUtils;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NSubstitute;
+
+namespace GitExtensions.UITests.CommandsDialogs;
+
+[Apartment(ApartmentState.STA)]
+public class FormRemotesTests
+{
+    private ReferenceRepository _referenceRepository = null!;
+    private GitUICommands _commands = null!;
+    private IGitBranchNameNormaliser _branchNameNormaliser = null!;
+    private bool _originalAlwaysShowAdvOpt;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _originalAlwaysShowAdvOpt = AppSettings.AlwaysShowAdvOpt;
+
+        _referenceRepository = new ReferenceRepository();
+        _branchNameNormaliser = Substitute.For<IGitBranchNameNormaliser>();
+
+        System.ComponentModel.Design.ServiceContainer serviceContainer = GlobalServiceContainer.CreateDefaultMockServiceContainer();
+        serviceContainer.AddService(_branchNameNormaliser);
+
+        _commands = new GitUICommands(serviceContainer, _referenceRepository.Module);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        AppSettings.AlwaysShowAdvOpt = _originalAlwaysShowAdvOpt;
+        _referenceRepository.Dispose();
+    }
+
+    [Test]
+    public void Should_display_remotes_tab_by_default()
+    {
+        RunFormTest(
+            form =>
+            {
+                FormRemotes.TestAccessor accessor = form.GetTestAccessor();
+                accessor.TabControl.SelectedTab.Should().NotBeNull();
+                accessor.TabControl.SelectedIndex.Should().Be(0);
+            });
+    }
+
+    [Test]
+    public void Should_stay_on_remotes_tab_when_preselecting_local_without_remotes()
+    {
+        // Tab switch to "Default pull behaviors" only occurs when remotes are configured
+        RunFormTest(
+            form =>
+            {
+                FormRemotes.TestAccessor accessor = form.GetTestAccessor();
+                accessor.TabControl.SelectedIndex.Should().Be(0);
+            },
+            preselectLocal: "master");
+    }
+
+    [Test]
+    public void Should_enable_save_button_when_remote_name_is_entered()
+    {
+        RunFormTest(
+            form =>
+            {
+                FormRemotes.TestAccessor accessor = form.GetTestAccessor();
+
+                accessor.RemoteName.Text = "origin";
+                accessor.Save.Enabled.Should().BeTrue();
+
+                accessor.RemoteName.Text = string.Empty;
+                accessor.Save.Enabled.Should().BeFalse();
+            });
+    }
+
+    [Test]
+    public void Should_disable_delete_and_toggle_buttons_when_no_remotes_configured()
+    {
+        RunFormTest(
+            form =>
+            {
+                FormRemotes.TestAccessor accessor = form.GetTestAccessor();
+                accessor.Delete.Enabled.Should().BeFalse();
+                accessor.ToggleState.Enabled.Should().BeFalse();
+            });
+    }
+
+    [Test]
+    public void Should_show_empty_remote_name_when_no_remotes_configured()
+    {
+        RunFormTest(
+            form =>
+            {
+                FormRemotes.TestAccessor accessor = form.GetTestAccessor();
+                accessor.RemoteName.Text.Should().BeEmpty();
+            });
+    }
+
+    [Test]
+    public void Should_normalise_remote_prefix_on_leave()
+    {
+        AppSettings.AlwaysShowAdvOpt = true;
+        _branchNameNormaliser.Normalise("invalid branch name", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-name");
+
+        RunFormTest(
+            form =>
+            {
+                FormRemotes.TestAccessor accessor = form.GetTestAccessor();
+
+                accessor.RemotePrefix.Focus();
+                accessor.RemotePrefix.Text = "invalid branch name";
+                accessor.RemoteName.Focus();
+
+                accessor.RemotePrefix.Text.Should().Be("invalid-branch-name");
+            });
+    }
+
+    private void RunFormTest(Action<FormRemotes> testDriver, string? preselectRemote = null, string? preselectLocal = null)
+    {
+        RunFormTest(
+            form =>
+            {
+                testDriver(form);
+                return Task.CompletedTask;
+            },
+            preselectRemote,
+            preselectLocal);
+    }
+
+    private void RunFormTest(Func<FormRemotes, Task> testDriverAsync, string? preselectRemote = null, string? preselectLocal = null)
+    {
+        UITest.RunForm(
+            () =>
+            {
+                _commands.StartRemotesDialog(owner: null, preselectRemote: preselectRemote, preselectLocal: preselectLocal);
+            },
+            testDriverAsync);
+    }
+}

--- a/tests/app/IntegrationTests/UI.IntegrationTests/GlobalServiceContainer.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/GlobalServiceContainer.cs
@@ -37,6 +37,11 @@ public static class GlobalServiceContainer
 
         serviceContainer.AddService(Substitute.For<ISubmoduleStatusProvider>());
 
+        IGitBranchNameNormaliser branchNameNormaliser = Substitute.For<IGitBranchNameNormaliser>();
+        branchNameNormaliser.Normalise(Arg.Any<string?>(), Arg.Any<GitBranchNameOptions>())
+            .Returns(callInfo => callInfo.Arg<string?>());
+        serviceContainer.AddService(branchNameNormaliser);
+
         serviceContainer.AddService<IGitExecutorProvider>(new GitExecutorProvider(new GitDirectoryResolver()));
 
         return serviceContainer;

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitBranchNameNormaliserTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitBranchNameNormaliserTest.cs
@@ -39,7 +39,7 @@ public sealed class GitBranchNameNormaliserTest
     [TestCase("hierarchy/sher.lok/foo", "hierarchy/sher.lok/foo")]
     public void Normalise_rule01(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule01(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule01(input, _gitBranchNameOptions).Should().Be(expected);
     }
 
     // They cannot have two consecutive dots .. anywhere.
@@ -61,7 +61,7 @@ public sealed class GitBranchNameNormaliserTest
     [TestCase("hier.....archy/sher...lok/fo..o", "hier_archy/sher_lok/fo_o")]
     public void Normalise_rule03(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule03(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule03(input, _gitBranchNameOptions).Should().Be(expected);
     }
 
     // Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \127 'DEL'),
@@ -77,7 +77,7 @@ public sealed class GitBranchNameNormaliserTest
     [TestCase("Anhörung`!@#$%", "Anhörung`!@#$%")]
     public void Normalise_rule04(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule04(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule04(input, _gitBranchNameOptions).Should().Be(expected);
     }
 
     // Branch name cannot have question-mark '?', asterisk '*', or open bracket '[' anywhere.
@@ -92,7 +92,7 @@ public sealed class GitBranchNameNormaliserTest
     [TestCase("testing?[*]*test", "testing___]_test")]
     public void Normalise_rule05(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule05(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule05(input, _gitBranchNameOptions).Should().Be(expected);
     }
 
     // Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
@@ -103,7 +103,7 @@ public sealed class GitBranchNameNormaliserTest
     [TestCase("///test///test///", "test/test")]
     public void Normalise_rule06(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule06(input).Should().Be(expected);
+        GitBranchNameNormaliser.Rule06(input).Should().Be(expected);
     }
 
     // Branch name end with a dot '.'.
@@ -112,7 +112,7 @@ public sealed class GitBranchNameNormaliserTest
     [TestCase("test...", "test_")]
     public void Normalise_rule07(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule07(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule07(input, _gitBranchNameOptions).Should().Be(expected);
     }
 
     // Branch name cannot contain a sequence '@{'.
@@ -122,20 +122,20 @@ public sealed class GitBranchNameNormaliserTest
     [TestCase("test@{bla}", "test_bla}")]
     public void Normalise_rule08(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule08(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule08(input, _gitBranchNameOptions).Should().Be(expected);
     }
 
     // Branch name cannot be the single character '@'.
     [TestCase(@"@", "_")]
     public void Normalise_rule09(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule09(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule09(input, _gitBranchNameOptions).Should().Be(expected);
     }
 
     // Branch name cannot contain a '\'.
     [TestCase(@"test\foo\\bar\", "test_foo_bar_")]
     public void Normalise_rule10(string input, string expected)
     {
-        _gitBranchNameNormaliser.Rule10(input, _gitBranchNameOptions).Should().Be(expected);
+        GitBranchNameNormaliser.Rule10(input, _gitBranchNameOptions).Should().Be(expected);
     }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -6,6 +6,61 @@ namespace GitCommandsTests.Helpers;
 [TestFixture]
 public class PathUtilTest
 {
+    [TestCase('a', true)]
+    [TestCase('z', true)]
+    [TestCase('A', true)]
+    [TestCase('Z', true)]
+    [TestCase('0', true)]
+    [TestCase('9', true)]
+    [TestCase('-', true)]
+    [TestCase('_', true)]
+    [TestCase('.', true)]
+    [TestCase('/', true)]
+    [TestCase('!', true)]
+    [TestCase('}', true)]
+    [TestCase('@', true)]
+    [TestCase(' ', false)]
+    [TestCase('~', false)]
+    [TestCase('^', false)]
+    [TestCase(':', false)]
+    [TestCase('\0', false)]
+    [TestCase('\t', false)]
+    [TestCase('\n', false)]
+    [TestCase('\r', false)]
+    [TestCase('\x7F', false)]
+    public void IsValidPathChar_should_return_expected(char c, bool expected)
+    {
+        PathUtil.IsValidPathChar(c).Should().Be(expected);
+    }
+
+    [Test]
+    public void IsValidPathChar_should_return_false_for_all_invalid_path_chars()
+    {
+        foreach (char c in Path.GetInvalidPathChars())
+        {
+            PathUtil.IsValidPathChar(c).Should().BeFalse($"character U+{(int)c:X4} should be invalid");
+        }
+    }
+
+    [Test]
+    public void IsValidPathChar_should_accept_all_ascii_letters_and_digits()
+    {
+        for (char c = 'a'; c <= 'z'; c++)
+        {
+            PathUtil.IsValidPathChar(c).Should().BeTrue();
+        }
+
+        for (char c = 'A'; c <= 'Z'; c++)
+        {
+            PathUtil.IsValidPathChar(c).Should().BeTrue();
+        }
+
+        for (char c = '0'; c <= '9'; c++)
+        {
+            PathUtil.IsValidPathChar(c).Should().BeTrue();
+        }
+    }
+
     [Test]
     public void ToPosixPathTest()
     {

--- a/tests/app/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
@@ -106,11 +106,11 @@ internal class ConfigFileRemoteSettingsManagerTests
     [Test]
     public void SaveRemote_should_throw_if_remoteName_is_null_or_empty()
     {
-        ((Action)(() => _remotesManager.SaveRemote(null, null!, "b", "c", "d", "e"))).Should().Throw<ArgumentNullException>()
+        ((Action)(() => _remotesManager.SaveRemote(null, null!, "b", "c", "d", "e", "f"))).Should().Throw<ArgumentNullException>()
             .WithMessage("Value cannot be null. (Parameter 'remoteName')");
-        ((Action)(() => _remotesManager.SaveRemote(null, "", "b", "c", "d", "e"))).Should().Throw<ArgumentNullException>()
+        ((Action)(() => _remotesManager.SaveRemote(null, "", "b", "c", "d", "e", "f"))).Should().Throw<ArgumentNullException>()
             .WithMessage("Value cannot be null. (Parameter 'remoteName')");
-        ((Action)(() => _remotesManager.SaveRemote(null, "  ", "b", "c", "d", "e"))).Should().Throw<ArgumentNullException>()
+        ((Action)(() => _remotesManager.SaveRemote(null, "  ", "b", "c", "d", "e", "f"))).Should().Throw<ArgumentNullException>()
             .WithMessage("Value cannot be null. (Parameter 'remoteName')");
     }
 
@@ -122,7 +122,7 @@ internal class ConfigFileRemoteSettingsManagerTests
         const string output = "";
         _module.AddRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, null, null!, null);
+        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, null, null!, null, null);
 
         result.UserMessage.Should().Be(output);
         result.ShouldUpdateRemote.Should().BeTrue();
@@ -137,10 +137,11 @@ internal class ConfigFileRemoteSettingsManagerTests
         const string remotePushUrl = "c";
         const string remotePuttySshKey = "";
         const string remoteColor = "";
+        const string remotePrefix = "";
         const string output = "";
         _module.AddRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, remotePushUrl, remotePuttySshKey, remoteColor);
+        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(null, remoteName, remoteUrl, remotePushUrl, remotePuttySshKey, remoteColor, remotePrefix);
 
         result.UserMessage.Should().Be(output);
         result.ShouldUpdateRemote.Should().BeTrue();
@@ -159,7 +160,7 @@ internal class ConfigFileRemoteSettingsManagerTests
         ConfigFileRemote gitRemote = new() { Name = "old", Url = remoteUrl };
         _module.RenameRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null!, null);
+        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null!, null, null);
 
         result.UserMessage.Should().Be(output);
         result.ShouldUpdateRemote.Should().BeFalse();
@@ -175,23 +176,24 @@ internal class ConfigFileRemoteSettingsManagerTests
         ConfigFileRemote gitRemote = new() { Name = "old", Url = "old" };
         _module.RenameRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
-        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null!, null);
+        ConfigFileRemoteSaveResult result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null!, null, null);
 
         result.UserMessage.Should().Be(output);
         result.ShouldUpdateRemote.Should().BeTrue();
         _module.Received(1).RenameRemote(gitRemote.Name, remoteName);
     }
 
-    [TestCase(null, null, null, null)]
-    [TestCase("a", null, null, null)]
-    [TestCase("a", "b", null, null)]
-    [TestCase("a", "b", "c", null)]
-    [TestCase("a", "b", "c", "d")]
-    public void SaveRemote_should_update_settings(string? remoteUrl, string? remotePushUrl, string? remotePuttySshKey, string? remoteColor)
+    [TestCase(null, null, null, null, null)]
+    [TestCase("a", null, null, null, null)]
+    [TestCase("a", "b", null, null, null)]
+    [TestCase("a", "b", "c", null, null)]
+    [TestCase("a", "b", "c", "d", null)]
+    [TestCase("a", "b", "c", "d", "e")]
+    public void SaveRemote_should_update_settings(string? remoteUrl, string? remotePushUrl, string? remotePuttySshKey, string? remoteColor, string? remotePrefix)
     {
         ConfigFileRemote remote = new() { Name = "bla", Url = remoteUrl };
 
-        _remotesManager.SaveRemote(remote, remote.Name, remoteUrl!, remotePushUrl, remotePuttySshKey!, remoteColor);
+        _remotesManager.SaveRemote(remote, remote.Name, remoteUrl!, remotePushUrl, remotePuttySshKey!, remoteColor, remotePrefix);
 
         void Ensure(string setting, string value)
         {

--- a/tests/app/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
@@ -108,10 +108,10 @@ internal class ConfigFileRemoteSettingsManagerTests
     {
         ((Action)(() => _remotesManager.SaveRemote(null, null!, "b", "c", "d", "e", "f"))).Should().Throw<ArgumentNullException>()
             .WithMessage("Value cannot be null. (Parameter 'remoteName')");
-        ((Action)(() => _remotesManager.SaveRemote(null, "", "b", "c", "d", "e", "f"))).Should().Throw<ArgumentNullException>()
-            .WithMessage("Value cannot be null. (Parameter 'remoteName')");
-        ((Action)(() => _remotesManager.SaveRemote(null, "  ", "b", "c", "d", "e", "f"))).Should().Throw<ArgumentNullException>()
-            .WithMessage("Value cannot be null. (Parameter 'remoteName')");
+        ((Action)(() => _remotesManager.SaveRemote(null, "", "b", "c", "d", "e", "f"))).Should().Throw<ArgumentException>()
+            .WithMessage("The value cannot be an empty string or composed entirely of whitespace. (Parameter 'remoteName')");
+        ((Action)(() => _remotesManager.SaveRemote(null, "  ", "b", "c", "d", "e", "f"))).Should().Throw<ArgumentException>()
+            .WithMessage("The value cannot be an empty string or composed entirely of whitespace. (Parameter 'remoteName')");
     }
 
     [Test]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Most of the time I work in monorepos where everyone is working against the trunk. There are also policies that enforce branch naming, e.g., branch must start with `dev/<username>/`. It's rather bothersome to constantly type the prefixes, and it takes unnecessary space in the revision grid.

This change allows to preconfigure prefixes per remote. It also allows apply different colours, which is useful in the context of Git Extensions, where I often track remotes from other contributors.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

* Prefix  
<img width="1204" height="509" alt="image" src="https://github.com/user-attachments/assets/e29a8b0a-ff6f-42de-a7ad-7d8e694ba30e" />  
<img width="879" height="562" alt="image" src="https://github.com/user-attachments/assets/2b6252f4-e9e5-42cd-941f-026e85225418" />

* Colours  
<img width="1215" height="787" alt="image" src="https://github.com/user-attachments/assets/7b1cb4fc-f2c3-4a87-bc73-b3398970877c" />



<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
