### PR TITLE
fix(file tree): Avoid split folder

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.StatusSorter.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.StatusSorter.cs
@@ -140,7 +140,7 @@ partial class FileStatusList
                     ("", "") => 0,
                     (_, "") => -1,
                     ("", _) => 1,
-                    _ => StringComparer.InvariantCulture.Compare(l.Path.Value, r.Path.Value)
+                    _ => ComparePath(l.Path.Value.AsSpan(), r.Path.Value.AsSpan())
                 };
 
                 return pathComparison switch
@@ -149,6 +149,37 @@ partial class FileStatusList
                     1 => StartsWith(l.Path, r.Path) ? -1 : 1,
                     _ => StringComparer.InvariantCulture.Compare(l.Name, r.Name)
                 };
+
+                static int ComparePath(ReadOnlySpan<char> l, ReadOnlySpan<char> r)
+                {
+                    if (l.IsEmpty || r.IsEmpty)
+                    {
+                        return l.IsEmpty && r.IsEmpty ? 0 : l.IsEmpty ? -1 : 1;
+                    }
+
+                    Split(l, out ReadOnlySpan<char> topL, out ReadOnlySpan<char> subL);
+                    Split(r, out ReadOnlySpan<char> topR, out ReadOnlySpan<char> subR);
+                    return topL.CompareTo(topR, StringComparison.InvariantCulture) switch
+                    {
+                        -1 => -1,
+                        +1 => +1,
+                        _ => ComparePath(subL, subR)
+                    };
+
+                    static void Split(ReadOnlySpan<char> path, out ReadOnlySpan<char> top, out ReadOnlySpan<char> sub)
+                    {
+                        int separatorIndex = path.IndexOf('/');
+                        if (separatorIndex == -1)
+                        {
+                            top = path;
+                            sub = ReadOnlySpan<char>.Empty;
+                            return;
+                        }
+
+                        top = path[..separatorIndex];
+                        sub = path[(separatorIndex + 1)..];
+                    }
+                }
 
                 static bool StartsWith(RelativePath longPath, RelativePath shortPath)
                 {

--- a/src/app/GitUI/UserControls/FileStatusList.StatusSorter.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.StatusSorter.cs
@@ -1,4 +1,4 @@
-using GitExtensions.Extensibility.Git;
+﻿using GitExtensions.Extensibility.Git;
 using GitUI.UserControls;
 using Microsoft;
 
@@ -161,6 +161,7 @@ partial class FileStatusList
         internal static class TestAccessor
         {
             public static string GetCommonPath(string a, string b) => StatusSorter.GetCommonPath(RelativePath.From(a), RelativePath.From(b)).Value;
+            public static int Compare(string l, string r) => new PathFirstComparer().Compare(new GitItemStatus(l), new GitItemStatus(r));
         }
     }
 }

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/FileStatusListSorterTests.Sort_should_not_split_folders.verified.txt
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/FileStatusListSorterTests.Sort_should_not_split_folders.verified.txt
@@ -1,0 +1,44 @@
+﻿{
+  "Text": "",
+  "Tag": "RelativePath: ",
+  "Nodes": [
+    {
+      "Text": "core",
+      "Tag": "RelativePath: core",
+      "Nodes": [
+        {
+          "Text": "api",
+          "Tag": "RelativePath: core/api",
+          "Nodes": [
+            {
+              "Text": "c_a.0",
+              "Tag": "FileStatusItem: core/api/c_a.0",
+              "Nodes": []
+            }
+          ]
+        },
+        {
+          "Text": "c.1",
+          "Tag": "FileStatusItem: core/c.1",
+          "Nodes": []
+        },
+        {
+          "Text": "c.2",
+          "Tag": "FileStatusItem: core/c.2",
+          "Nodes": []
+        }
+      ]
+    },
+    {
+      "Text": "core.dot",
+      "Tag": "RelativePath: core.dot",
+      "Nodes": [
+        {
+          "Text": "cd.3",
+          "Tag": "FileStatusItem: core.dot/cd.3",
+          "Nodes": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/FileStatusListSorterTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/FileStatusListSorterTests.cs
@@ -20,7 +20,14 @@ public class FileStatusListSorterTests
     }
 
     [Test]
-    public async Task Sort_should_first_add_folders_then_files([Values(false, true)] bool flat, [Values(false, true)] bool mergeSingleItemsWithFolder)
+    public void Compare_should_not_compare_path_separator()
+    {
+        FileStatusList.StatusSorter.TestAccessor.Compare("dir/sub/file", "dir.ext/file").Should().Be(-1);
+        FileStatusList.StatusSorter.TestAccessor.Compare("dir.ext/file", "dir/sub/file").Should().Be(+1);
+    }
+
+    [Test]
+    public async Task Sort_should_first_add_folders_then_files([Values] bool flat, [Values] bool mergeSingleItemsWithFolder)
     {
         const string oldFolder = "oldfolder/of/renamed/file/";
         GitItemStatus[] statuses =
@@ -55,7 +62,23 @@ public class FileStatusListSorterTests
     }
 
     [Test]
-    public async Task Sort_should_not_merge_single_file_with_root_node([Values(false, true)] bool flat)
+    public async Task Sort_should_not_split_folders()
+    {
+        GitItemStatus[] statuses =
+        [
+            new("core/c.1"),
+            new("core/c.2"),
+            new("core.dot/cd.3"),
+            new("core/api/c_a.0"),
+        ];
+
+        FileStatusList.StatusSorter statusSorter = new();
+        TreeNode rootNode = statusSorter.CreateTreeSortedByPath(statuses, flat: false, mergeSingleItemsWithFolder: false, createNode: status => new TreeNode(status.ToString()) { Tag = new FileStatusItem(firstRev: null, secondRev: new GitRevision(ObjectId.WorkTreeId), status) });
+        await Verify(Serialize(rootNode).ToString());
+    }
+
+    [Test]
+    public async Task Sort_should_not_merge_single_file_with_root_node([Values] bool flat)
     {
         GitItemStatus[] statuses =
         [
@@ -68,7 +91,7 @@ public class FileStatusListSorterTests
     }
 
     [Test]
-    public async Task Sort_should_optionally_create_subfolder_nodes_for_single_files([Values(false, true)] bool mergeSingleItemsWithFolder)
+    public async Task Sort_should_optionally_create_subfolder_nodes_for_single_files([Values] bool mergeSingleItemsWithFolder)
     {
         GitItemStatus[] statuses =
         [


### PR DESCRIPTION
Fixes #12988 

## Proposed changes

`FileStatusList.StatusSorter`:
- Add failing tests `Compare_should_not_compare_path_separator` and `Sort_should_not_split_folders`
- Compare paths level by level
- Use shorter `[Values]` syntax for test arguments

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="566" height="160" alt="image" src="https://github.com/user-attachments/assets/4101eb0a-d61d-4ad8-8d01-c450a5c24633" />

### After

<img width="566" height="160" alt="image" src="https://github.com/user-attachments/assets/955bb629-dbb2-45fa-9546-b0a79fef5290" />

## Test methodology <!-- How did you ensure quality? -->

- add testcases
- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).