### PR TITLE
feat(interactive ref labels): Improve UX

### DIFF
--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -8557,7 +8557,7 @@ help</source>
   <file datatype="plaintext" original="LocalBranchContextMenuProvider" source-language="en">
     <body>
       <trans-unit id="_checkoutBranch.Text">
-        <source>&amp;Checkout this branch</source>
+        <source>Chec&amp;kout this branch</source>
         <target />
       </trans-unit>
       <trans-unit id="_deleteBranch.Text">
@@ -8569,7 +8569,7 @@ help</source>
         <target />
       </trans-unit>
       <trans-unit id="_pushBranch.Text">
-        <source>&amp;Push this branch</source>
+        <source>Pus&amp;h this branch</source>
         <target />
       </trans-unit>
       <trans-unit id="_rebaseOnto.Text">
@@ -8577,7 +8577,7 @@ help</source>
         <target />
       </trans-unit>
       <trans-unit id="_renameBranch.Text">
-        <source>Re&amp;name this branch</source>
+        <source>R&amp;ename this branch</source>
         <target />
       </trans-unit>
     </body>
@@ -8823,7 +8823,7 @@ This will just checkout on the submodule the commit determined by the superproje
   <file datatype="plaintext" original="RefContextMenuComposer" source-language="en">
     <body>
       <trans-unit id="_copyName.Text">
-        <source>Cop&amp;y name to clipboard</source>
+        <source>&amp;Copy name to clipboard</source>
         <target />
       </trans-unit>
     </body>
@@ -8831,7 +8831,7 @@ This will just checkout on the submodule the commit determined by the superproje
   <file datatype="plaintext" original="RemoteBranchContextMenuProvider" source-language="en">
     <body>
       <trans-unit id="_checkoutBranch.Text">
-        <source>&amp;Checkout this branch</source>
+        <source>Chec&amp;kout this branch</source>
         <target />
       </trans-unit>
       <trans-unit id="_deleteBranch.Text">
@@ -10087,15 +10087,15 @@ When OpenSSH is used, command line dialogs are shown!
   <file datatype="plaintext" original="StashRefContextMenuProvider" source-language="en">
     <body>
       <trans-unit id="_applyStash.Text">
-        <source>&amp;Apply stash</source>
+        <source>Appl&amp;y stash</source>
         <target />
       </trans-unit>
       <trans-unit id="_dropStash.Text">
-        <source>Dr&amp;op stash...</source>
+        <source>&amp;Drop stash...</source>
         <target />
       </trans-unit>
       <trans-unit id="_popStash.Text">
-        <source>P&amp;op stash</source>
+        <source>Pop &amp;stash</source>
         <target />
       </trans-unit>
     </body>
@@ -10103,15 +10103,15 @@ When OpenSSH is used, command line dialogs are shown!
   <file datatype="plaintext" original="StashSelectorContextMenuProvider" source-language="en">
     <body>
       <trans-unit id="_applyStash.Text">
-        <source>&amp;Apply stash</source>
+        <source>Appl&amp;y stash</source>
         <target />
       </trans-unit>
       <trans-unit id="_dropStash.Text">
-        <source>Dr&amp;op stash...</source>
+        <source>&amp;Drop stash...</source>
         <target />
       </trans-unit>
       <trans-unit id="_popStash.Text">
-        <source>P&amp;op stash</source>
+        <source>Pop &amp;stash</source>
         <target />
       </trans-unit>
     </body>

--- a/src/app/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -10,6 +10,7 @@ namespace GitUI.UserControls.RevisionGrid;
 public sealed class CopyContextMenuItem : ToolStripMenuItem
 {
     private readonly TranslationString _copyToClipboardText = new("&Copy to clipboard");
+    private Func<IEnumerable<string>, IEnumerable<string>> _filterRefsFunc = refs => refs;
     private Func<IReadOnlyList<GitRevision>>? _revisionFunc;
     private uint _itemNumber;
 
@@ -19,6 +20,11 @@ public sealed class CopyContextMenuItem : ToolStripMenuItem
         Text = _copyToClipboardText.Text;
 
         DropDownOpening += OnDropDownOpening;
+    }
+
+    public void SetFilterRefsFunc(Func<IEnumerable<string>, IEnumerable<string>> filterRefsFunc)
+    {
+        _filterRefsFunc = filterRefsFunc;
     }
 
     public void SetRevisionFunc(Func<IReadOnlyList<GitRevision>> revisionFunc)
@@ -104,8 +110,8 @@ public sealed class CopyContextMenuItem : ToolStripMenuItem
         foreach (GitRevision revision in revisions)
         {
             GitRefListsForRevision refLists = new(revision);
-            branchNames.AddRange(refLists.GetAllBranchNames());
-            tagNames.AddRange(refLists.GetAllTagNames());
+            branchNames.AddRange(_filterRefsFunc(refLists.GetAllBranchNames()));
+            tagNames.AddRange(_filterRefsFunc(refLists.GetAllTagNames()));
         }
 
         _itemNumber = 0;

--- a/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProvider.cs
@@ -10,12 +10,12 @@ namespace GitUI.UserControls.RevisionGrid.RefContextMenus;
 /// </summary>
 internal sealed class LocalBranchContextMenuProvider : Translate, IRefContextMenuProvider
 {
-    private readonly TranslationString _checkoutBranch = new("&Checkout this branch");
+    private readonly TranslationString _checkoutBranch = new("Chec&kout this branch");
     private readonly TranslationString _mergeIntoCurrent = new("&Merge into current branch");
     private readonly TranslationString _rebaseOnto = new("&Rebase current branch onto this");
-    private readonly TranslationString _renameBranch = new("Re&name this branch");
+    private readonly TranslationString _renameBranch = new("R&ename this branch");
     private readonly TranslationString _deleteBranch = new("&Delete this branch");
-    private readonly TranslationString _pushBranch = new("&Push this branch");
+    private readonly TranslationString _pushBranch = new("Pus&h this branch");
 
     public bool Handles(IGitRef? gitRef, string? stashReflogSelector) => gitRef?.IsHead is true;
 
@@ -48,7 +48,10 @@ internal sealed class LocalBranchContextMenuProvider : Translate, IRefContextMen
             menu.Items.Add(rebase);
         }
 
-        menu.Items.Add(new ToolStripSeparator());
+        if (menu.Items.Count > 0)
+        {
+            menu.Items.Add(new ToolStripSeparator());
+        }
 
         ToolStripMenuItem rename = new(_renameBranch.Text, Images.EditFile);
         rename.Click += (_, _) => context.UICommands.StartRenameDialog(context.ParentForm, gitRef.Name);

--- a/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/RefContextMenuComposer.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/RefContextMenuComposer.cs
@@ -11,7 +11,7 @@ namespace GitUI.UserControls.RevisionGrid.RefContextMenus;
 /// </summary>
 internal sealed class RefContextMenuComposer : Translate
 {
-    private readonly TranslationString _copyName = new("Cop&y name to clipboard");
+    private readonly TranslationString _copyName = new("&Copy name to clipboard");
 
     private readonly IReadOnlyList<IRefContextMenuProvider> _providers;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProvider.cs
@@ -10,7 +10,7 @@ namespace GitUI.UserControls.RevisionGrid.RefContextMenus;
 /// </summary>
 internal sealed class RemoteBranchContextMenuProvider : Translate, IRefContextMenuProvider
 {
-    private readonly TranslationString _checkoutBranch = new("&Checkout this branch");
+    private readonly TranslationString _checkoutBranch = new("Chec&kout this branch");
     private readonly TranslationString _mergeIntoCurrent = new("&Merge into current branch");
     private readonly TranslationString _rebaseOnto = new("&Rebase current branch onto this");
     private readonly TranslationString _deleteBranch = new("&Delete this branch");

--- a/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/StashRefContextMenuProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/StashRefContextMenuProvider.cs
@@ -10,9 +10,9 @@ namespace GitUI.UserControls.RevisionGrid.RefContextMenus;
 /// </summary>
 internal sealed class StashRefContextMenuProvider : Translate, IRefContextMenuProvider
 {
-    private readonly TranslationString _applyStash = new("&Apply stash");
-    private readonly TranslationString _popStash = new("P&op stash");
-    private readonly TranslationString _dropStash = new("Dr&op stash...");
+    private readonly TranslationString _applyStash = new("Appl&y stash");
+    private readonly TranslationString _popStash = new("Pop &stash");
+    private readonly TranslationString _dropStash = new("&Drop stash...");
 
     public bool Handles(IGitRef? gitRef, string? stashReflogSelector) => gitRef?.IsStash is true;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/StashSelectorContextMenuProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/StashSelectorContextMenuProvider.cs
@@ -13,9 +13,9 @@ namespace GitUI.UserControls.RevisionGrid.RefContextMenus;
 /// </summary>
 internal sealed class StashSelectorContextMenuProvider : Translate, IRefContextMenuProvider
 {
-    private readonly TranslationString _applyStash = new("&Apply stash");
-    private readonly TranslationString _popStash = new("P&op stash");
-    private readonly TranslationString _dropStash = new("Dr&op stash...");
+    private readonly TranslationString _applyStash = new("Appl&y stash");
+    private readonly TranslationString _popStash = new("Pop &stash");
+    private readonly TranslationString _dropStash = new("&Drop stash...");
 
     public bool Handles(IGitRef? gitRef, string? stashReflogSelector) => gitRef is null && stashReflogSelector is not null;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2088,13 +2088,21 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         }
 
         // If a ref label was right-clicked, show a focused context menu for that ref
-        if (_rightClickedHitInfo is { } hitInfo)
+        if (_rightClickedHitInfo is RefLabelHitInfo hitInfo && (ModifierKeys == Keys.Control || (ModifierKeys != Keys.Shift && !AppSettings.AlwaysShowAdvOpt)))
         {
             e.Cancel = true;
             ShowRefSpecificContextMenu(hitInfo.GitRef, hitInfo.StashReflogSelector);
             _rightClickedHitInfo = null;
             return;
         }
+
+        IGitRef? clickedRef = _rightClickedHitInfo?.GitRef;
+        Func<IEnumerable<IGitRef>, IEnumerable<IGitRef>> filterRefs = clickedRef is null
+            ? refs => refs
+            : refs => refs.Where(r => r == clickedRef);
+        copyToClipboardToolStripMenuItem.SetFilterRefsFunc(clickedRef is null
+            ? refNames => refNames
+            : refNames => refNames.Where(r => r == clickedRef.Name));
 
         bool inTheMiddleOfBisect = Module.InTheMiddleOfBisect();
         SetEnabled(markRevisionAsBadToolStripMenuItem, inTheMiddleOfBisect);
@@ -2115,7 +2123,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         GitRefListsForRevision gitRefListsForRevision = new(revision);
         _rebaseOnTopOf = null;
 
-        foreach (IGitRef head in gitRefListsForRevision.AllTags)
+        foreach (IGitRef head in filterRefs(gitRefListsForRevision.AllTags))
         {
             AddBranchMenuItem(deleteTagDropDown, head, delegate { UICommands.StartDeleteTagDialog(ParentForm, head.Name); });
             AddBranchMenuItem(selectInLeftPanelDropDown, head, SelectInLeftPanel_Click);
@@ -2128,10 +2136,9 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         // For now there is no action that could be done on currentBranch
         string currentBranchRef = GitRefName.RefsHeadsPrefix + CurrentBranch.Value;
-        IReadOnlyList<IGitRef> branchesWithNoIdenticalRemotes = gitRefListsForRevision.BranchesWithNoIdenticalRemotes;
 
         bool currentBranchPointsToRevision = false;
-        foreach (IGitRef head in branchesWithNoIdenticalRemotes)
+        foreach (IGitRef head in filterRefs(gitRefListsForRevision.BranchesWithNoIdenticalRemotes))
         {
             if (head.CompleteName == currentBranchRef)
             {
@@ -2161,7 +2168,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             _rebaseOnTopOf ??= toolStripItem.Tag as string;
         }
 
-        IReadOnlyList<IGitRef> allBranches = gitRefListsForRevision.AllBranches;
+        IReadOnlyList<IGitRef> allBranches = [.. filterRefs(gitRefListsForRevision.AllBranches)];
         bool isHeadOfCurrentBranch = false;
         bool firstRemoteBranchForCheckout = false;
         foreach (IGitRef head in allBranches)

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProviderTests.cs
@@ -87,7 +87,7 @@ public class LocalBranchContextMenuProviderTests
 
         menu.Items.Cast<ToolStripItem>()
             .Where(i => i is not ToolStripSeparator)
-            .Select(i => i.Text)
+            .Select(i => i.Text?.Replace("&", ""))
             .Should().Contain(t => t.Contains("Checkout"));
     }
 
@@ -190,7 +190,7 @@ public class LocalBranchContextMenuProviderTests
 
         menu.Items.Cast<ToolStripItem>()
             .Where(i => i is not ToolStripSeparator)
-            .Select(i => i.Text)
+            .Select(i => i.Text?.Replace("&", ""))
             .Should().Contain(t => t.Contains("Push"));
     }
 

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProviderTests.cs
@@ -77,7 +77,7 @@ public class RemoteBranchContextMenuProviderTests
 
         menu.Items.Cast<ToolStripItem>()
             .Where(i => i is not ToolStripSeparator)
-            .Select(i => i.Text)
+            .Select(i => i.Text?.Replace("&", ""))
             .Should().Contain(t => t.Contains("Checkout"));
     }
 

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/StashRefContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/StashRefContextMenuProviderTests.cs
@@ -65,10 +65,10 @@ public class StashRefContextMenuProviderTests
 
         _provider.Populate(menu, gitRef, stashReflogSelector: null, _context);
 
-        IEnumerable<string> texts = menu.Items.Cast<ToolStripItem>().Select(i => i.Text!);
+        IEnumerable<string> texts = menu.Items.Cast<ToolStripItem>().Select(i => i.Text!.Replace("&", ""));
         texts.Should().Contain(t => t.Contains("Apply"));
-        texts.Should().Contain(t => t.Contains("op stash") && !t.Contains("Drop") && !t.Contains("Dr"));
-        texts.Should().Contain(t => t.StartsWith("Dr"));
+        texts.Should().Contain(t => t.Contains("Pop"));
+        texts.Should().Contain(t => t.Contains("Drop"));
     }
 
     [Test]

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/StashSelectorContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/StashSelectorContextMenuProviderTests.cs
@@ -74,10 +74,10 @@ public class StashSelectorContextMenuProviderTests
 
         _provider.Populate(menu, gitRef: null, stashReflogSelector: "stash@{0}", context);
 
-        IEnumerable<string> texts = menu.Items.Cast<ToolStripItem>().Select(i => i.Text!);
+        IEnumerable<string> texts = menu.Items.Cast<ToolStripItem>().Select(i => i.Text!.Replace("&", ""));
         texts.Should().Contain(t => t.Contains("Apply"));
-        texts.Should().Contain(t => t.StartsWith("P") && t.Contains("op stash"));
-        texts.Should().Contain(t => t.StartsWith("Dr"));
+        texts.Should().Contain(t => t.Contains("Pop"));
+        texts.Should().Contain(t => t.Contains("Drop"));
         menu.Items.Count.Should().Be(3);
     }
 
@@ -94,7 +94,7 @@ public class StashSelectorContextMenuProviderTests
         _provider.Populate(menu, gitRef: null, stashReflogSelector: "stash@{0}", context);
 
         menu.Items.Count.Should().Be(1);
-        menu.Items[0].Text.Should().Contain("Apply");
+        menu.Items[0].Text?.Replace("&", "").Should().Contain("Apply");
     }
 
     private RefContextMenuContext CreateContext(Func<GitRevision?> getLatestSelectedRevision)


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/12951#issuecomment-4195351501

## Proposed changes

- use the same mnemonics as in the revision context menu
- force revision context menu by holding `Shift`
- force ref-specific context menu by holding `Ctrl`
- default to revision context menu if `AlwaysShowAdvOpt`
- filter revision context menu to clicked ref

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

Before | After
-- | --
<img width="662" height="476" alt="image" src="https://github.com/user-attachments/assets/59c5f71e-01b5-40e7-bb84-40f34e02d923" /> | <img width="732" height="474" alt="image" src="https://github.com/user-attachments/assets/c26d52d0-f20d-458a-a0d2-c71565760d3b" />
<img width="228" height="99" alt="image" src="https://github.com/user-attachments/assets/858da545-c0de-4ae3-b1be-9a20cb70aff8" /> | <img width="221" height="95" alt="image" src="https://github.com/user-attachments/assets/680722bd-41be-46ba-a482-0b6236ac8e63" />
<img width="349" height="97" alt="image" src="https://github.com/user-attachments/assets/fec5a4af-e0ad-4754-a872-4056ed95bc6c" /> | <img width="307" height="100" alt="image" src="https://github.com/user-attachments/assets/f19802dd-d877-4123-b8a8-e7af4c83851c" />
<img width="238" height="108" alt="image" src="https://github.com/user-attachments/assets/e488bcb7-95bf-4e2d-a9dc-ca0b48c8b043" /> | <img width="228" height="114" alt="image" src="https://github.com/user-attachments/assets/f12f39dc-a182-4d41-a653-3bdf6c001fb8" /> <img width="316" height="151" alt="image" src="https://github.com/user-attachments/assets/4a561d64-d12a-4073-85f9-e8c5fc9a9153" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).