### PR TITLE
ci: add workflow_run test report for fork PRs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -99,16 +99,6 @@ jobs:
         name: portable
         path: 'artifacts\Release\publish\*.zip'
 
-    - name: Test report
-      # v1 @ 2024-08-30
-      uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7
-      if: always() && github.event.pull_request.head.repo.full_name == github.repository
-      continue-on-error: true
-      with:
-        name: Test Results
-        path: 'artifacts/**/TestsResults/**/*.trx'
-        reporter: dotnet-trx
-
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -14,7 +14,7 @@ jobs:
   test-report:
     name: Test Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'cancelled'
+    if: github.event.workflow_run.conclusion != 'cancelled' && github.event.workflow_run.event == 'pull_request'
 
     steps:
     - name: Test report

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,28 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows: ["PR Build"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  test-report:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'cancelled'
+
+    steps:
+    - name: Test report
+      # v1 @ 2024-08-30
+      uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7
+      continue-on-error: true
+      with:
+        artifact: test-results
+        name: Test Results
+        path: '**/*.trx'
+        reporter: dotnet-trx

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -7,6 +7,7 @@ on:
       - completed
 
 permissions:
+  actions: read
   contents: read
   checks: write
 


### PR DESCRIPTION
When tests failed a PR build, there wasn't an easy way to view the failure on github.com.

Our test reporter action was nerfed because it requires write permission, and doesn't get a token that allows that on PRs from forks.

We could make this work for PRs within this repo, but better to have it work well for all contributors.

This change moves test reporting from an inline step in PR Build to a dedicated workflow_run workflow. This runs in the base repo context with checks:write permission, so test results now appear as Check Runs for fork PRs too.

---

I agree that the maintainer squash merge this PR (if the commit message is clear).

---

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
