### PR TITLE
ci: name portable artifact with version and commit hash

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -93,10 +93,17 @@ jobs:
         $buildArgs = "/p:ContinuousIntegrationBuild=true $env:BUILD_ARGS".Trim()
         dotnet publish -c Release --no-build /bl:artifacts\log\publish.binlog $buildArgs.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
 
+    - name: Resolve portable archive name
+      id: portable-name
+      shell: pwsh
+      run: |
+        $zip = Get-ChildItem artifacts\Release\publish\*.zip | Select-Object -First 1
+        "name=$($zip.BaseName)" >> $env:GITHUB_OUTPUT
+
     - name: Upload portable archive
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: portable
+        name: ${{ steps.portable-name.outputs.name }}
         path: 'artifacts\Release\publish\*.zip'
 
     - name: Upload test results


### PR DESCRIPTION
Name the portable archive GHA artifact with the version, build number, and short commit hash (e.g. `GitExtensions-Portable-x64-7.0.0.61-1b6954a`) instead of the generic `portable`.

The artifact name is derived from the actual zip filename produced by the `CreatePortable` MSBuild target, so it always matches the zip content.

Addresses @mstv's feedback in #12983.

## Test methodology

- Review CI logs

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
