### PR TITLE
feat(UI): add Shift+MouseWheel horizontal scrolling

### DIFF
--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -770,6 +770,24 @@ public partial class FileViewerInternal : GitModuleControl, IFileViewer
 
     private void TextArea_MouseWheel(object? sender, MouseEventArgs e)
     {
+        if (ModifierKeys.HasFlag(Keys.Shift))
+        {
+            int scrollAmount = DpiUtil.Scale(8);
+            HScrollPosition = e.Delta switch
+            {
+                > 0 => Math.Max(0, HScrollPosition - scrollAmount),
+                < 0 => HScrollPosition + scrollAmount,
+                _ => HScrollPosition
+            };
+
+            if (e is HandledMouseEventArgs handled)
+            {
+                handled.Handled = true;
+            }
+
+            return;
+        }
+
         bool isScrollingTowardTop = e.Delta > 0;
         bool isScrollingTowardBottom = e.Delta < 0;
         VScrollBar scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;

--- a/src/app/GitUI/Interops/Messages.cs
+++ b/src/app/GitUI/Interops/Messages.cs
@@ -12,6 +12,7 @@ internal static partial class NativeMethods
     public const int WM_HSCROLL = 276;
     public const int WM_VSCROLL = 0x115;
     public const int WM_MOUSEWHEEL = 0x020A;
+    public const int WM_MOUSEHWHEEL = 0x020E;
     public const int WM_KEYDOWN = 0x0100;
 
     public const int LVM_FIRST = 0x1000;

--- a/src/app/GitUI/UserControls/NativeTreeView.cs
+++ b/src/app/GitUI/UserControls/NativeTreeView.cs
@@ -1,7 +1,11 @@
-﻿namespace GitUI.UserControls;
+﻿using static System.NativeMethods;
+
+namespace GitUI.UserControls;
 
 public class NativeTreeView : TreeView
 {
+    private const int MK_SHIFT = 0x0004;
+
     public NativeTreeView()
     {
         DoubleBuffered = true;
@@ -15,6 +19,64 @@ public class NativeTreeView : TreeView
             // explorer style selection painting in left panel
             // Not needed in dark mode, this is the same for "DarkMode_Explorer"
             NativeMethods.SetWindowTheme(Handle, "explorer", null);
+        }
+    }
+
+    protected override void WndProc(ref Message m)
+    {
+        switch (m.Msg)
+        {
+            case WM_MOUSEWHEEL when (m.WParam.ToInt64() & MK_SHIFT) != 0:
+            {
+                int delta = (short)(m.WParam.ToInt64() >> 16);
+                if (delta != 0)
+                {
+                    // Shift+wheel-up scrolls left, Shift+wheel-down scrolls right
+                    ScrollHorizontally(-delta);
+                }
+
+                return;
+            }
+
+            case WM_MOUSEHWHEEL:
+            {
+                int delta = (short)(m.WParam.ToInt64() >> 16);
+                if (delta != 0)
+                {
+                    // Positive delta = tilt right = scroll right
+                    ScrollHorizontally(delta);
+                }
+
+                return;
+            }
+        }
+
+        base.WndProc(ref m);
+
+        return;
+
+        void ScrollHorizontally(int delta)
+        {
+            SBH direction;
+            int count;
+
+            int scrollLines = SystemInformation.MouseWheelScrollLines;
+            if (scrollLines == -1)
+            {
+                direction = delta > 0 ? SBH.PAGERIGHT : SBH.PAGELEFT;
+                count = 1;
+            }
+            else
+            {
+                direction = delta > 0 ? SBH.LINERIGHT : SBH.LINELEFT;
+                count = Math.Max(1, Math.Abs(delta) * scrollLines * 3 / SystemInformation.MouseWheelScrollDelta);
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                Message hscrollMsg = Message.Create(Handle, WM_HSCROLL, (IntPtr)direction, IntPtr.Zero);
+                DefWndProc(ref hscrollMsg);
+            }
         }
     }
 }


### PR DESCRIPTION
Add horizontal scrolling via Shift+MouseWheel in NativeTreeView (left panel, staged/unstaged file lists) and FileViewerInternal (diff/preview panels). Also handle WM_MOUSEHWHEEL for tilt-wheel and touchpad swipe.

NativeTreeView intercepts WM_MOUSEWHEEL with MK_SHIFT in WndProc and sends WM_HSCROLL via DefWndProc to the native TreeView control. FileViewerInternal adjusts HScrollPosition directly in its existing MouseWheel handler. Both respect system scroll settings.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
