### PR TITLE
feat: add Copy path and Show in folder to worktree context menu

### DIFF
--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using GitCommands;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.CommandsDialogs;
 using GitUI.LeftPanel.ContextMenu;
@@ -100,12 +101,16 @@ partial class RepoObjectsTree : IMenuItemFactory
         bool isSingleWorktreeSelected = hasSingleSelection && selectedNode is WorktreeNode;
         WorktreeNode? worktreeNode = selectedNode as WorktreeNode;
         bool canActOnWorktree = isSingleWorktreeSelected && worktreeNode is { IsCurrent: false, Worktree.IsDeleted: false };
+        bool worktreePathExists = isSingleWorktreeSelected && worktreeNode is not null && Directory.Exists(worktreeNode.Worktree.Path);
 
         // Always show menu items for any worktree node, but disable for current/deleted
         mnubtnOpenWorktree.Enable(isSingleWorktreeSelected);
         mnubtnOpenWorktree.Enabled = canActOnWorktree;
         mnubtnDeleteWorktree.Enable(isSingleWorktreeSelected);
         mnubtnDeleteWorktree.Enabled = canActOnWorktree;
+        mnubtnCopyWorktreePath.Enable(isSingleWorktreeSelected);
+        mnubtnShowWorktreeInFolder.Enable(isSingleWorktreeSelected);
+        mnubtnShowWorktreeInFolder.Enabled = worktreePathExists;
     }
 
     private void EnableStashContextMenu(bool hasSingleSelection, NodeBase? selectedNode)
@@ -213,6 +218,8 @@ partial class RepoObjectsTree : IMenuItemFactory
         RegisterClick(mnubtnManageWorktreesFromRootNode, () => _worktreeTree.ManageWorktrees(this));
         RegisterClick<WorktreeNode>(mnubtnOpenWorktree, node => node.OpenWorktree());
         RegisterClick<WorktreeNode>(mnubtnDeleteWorktree, node => node.DeleteWorktree());
+        RegisterClick<WorktreeNode>(mnubtnCopyWorktreePath, node => ClipboardUtil.TrySetText(node.Worktree.Path));
+        RegisterClick<WorktreeNode>(mnubtnShowWorktreeInFolder, node => OsShellUtil.OpenWithFileExplorer(node.Worktree.Path));
 
         // Expand / Collapse
         RegisterClick(mnubtnCollapse, () => GetSelectedNodes().HavingChildren().Collapsible().ForEach(node => node.TreeViewNode.Collapse()));

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.Designer.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.Designer.cs
@@ -106,6 +106,9 @@ partial class RepoObjectsTree
         toolStripSeparator12 = new ToolStripSeparator();
         mnubtnOpenWorktree = new ToolStripMenuItem();
         mnubtnDeleteWorktree = new ToolStripMenuItem();
+        toolStripSeparator13 = new ToolStripSeparator();
+        mnubtnCopyWorktreePath = new ToolStripMenuItem();
+        mnubtnShowWorktreeInFolder = new ToolStripMenuItem();
         toolStripSeparator9 = new ToolStripSeparator();
         mnubtnCollapse = new ToolStripMenuItem();
         mnubtnExpand = new ToolStripMenuItem();
@@ -199,6 +202,9 @@ partial class RepoObjectsTree
         toolStripSeparator12,
         mnubtnOpenWorktree,
         mnubtnDeleteWorktree,
+        toolStripSeparator13,
+        mnubtnCopyWorktreePath,
+        mnubtnShowWorktreeInFolder,
         toolStripSeparator9,
         mnubtnCollapse,
         mnubtnExpand,
@@ -544,6 +550,27 @@ partial class RepoObjectsTree
         mnubtnDeleteWorktree.Text = "&Delete worktree...";
         mnubtnDeleteWorktree.ToolTipText = "Delete this worktree";
         // 
+        // toolStripSeparator13
+        // 
+        toolStripSeparator13.Name = "toolStripSeparator13";
+        toolStripSeparator13.Size = new Size(263, 6);
+        // 
+        // mnubtnCopyWorktreePath
+        // 
+        mnubtnCopyWorktreePath.Image = Properties.Images.CopyToClipboard;
+        mnubtnCopyWorktreePath.Name = "mnubtnCopyWorktreePath";
+        mnubtnCopyWorktreePath.Size = new Size(266, 26);
+        mnubtnCopyWorktreePath.Text = "Copy &path";
+        mnubtnCopyWorktreePath.ToolTipText = "Copy the worktree path to clipboard";
+        // 
+        // mnubtnShowWorktreeInFolder
+        // 
+        mnubtnShowWorktreeInFolder.Image = Properties.Images.BrowseFileExplorer;
+        mnubtnShowWorktreeInFolder.Name = "mnubtnShowWorktreeInFolder";
+        mnubtnShowWorktreeInFolder.Size = new Size(266, 26);
+        mnubtnShowWorktreeInFolder.Text = "Show &in folder";
+        mnubtnShowWorktreeInFolder.ToolTipText = "Show the worktree in File Explorer";
+        // 
         // toolStripSeparator9
         // 
         toolStripSeparator9.Name = "toolStripSeparator9";
@@ -841,6 +868,9 @@ partial class RepoObjectsTree
     private ToolStripSeparator toolStripSeparator12;
     private ToolStripMenuItem mnubtnOpenWorktree;
     private ToolStripMenuItem mnubtnDeleteWorktree;
+    private ToolStripSeparator toolStripSeparator13;
+    private ToolStripMenuItem mnubtnCopyWorktreePath;
+    private ToolStripMenuItem mnubtnShowWorktreeInFolder;
     private ToolStripSeparator toolStripSeparator9;
     private ToolStripSeparator toolStripSeparator1;
     private ToolStripMenuItem runScriptToolStripMenuItem;

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -8956,6 +8956,14 @@ Reset the filter via View &gt; Show all branches.</source>
         <source>Commit changes in selected submodule</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnCopyWorktreePath.Text">
+        <source>Copy &amp;path</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnCopyWorktreePath.ToolTipText">
+        <source>Copy the worktree path to clipboard</source>
+        <target />
+      </trans-unit>
       <trans-unit id="mnubtnCreateBranch.Text">
         <source>Create Branch...</source>
         <target />
@@ -9146,6 +9154,14 @@ Reset the filter via View &gt; Show all branches.</source>
       </trans-unit>
       <trans-unit id="mnubtnResetSubmodule.ToolTipText">
         <source>Reset selected submodule</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnShowWorktreeInFolder.Text">
+        <source>Show &amp;in folder</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnShowWorktreeInFolder.ToolTipText">
+        <source>Show the worktree in File Explorer</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnStashAllFromRootNode.Text">

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/GitlabAdapter.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/GitlabAdapter.cs
@@ -91,23 +91,17 @@ public sealed class GitlabAdapter : IBuildServerAdapter
                     totalPages = _pagesLimit.Value;
                 }
 
-                Task[] pagesTasks = new Task[totalPages - 1];
+                Task<PagedResponse<GitlabPipeline>>[] pagesTasks = new Task<PagedResponse<GitlabPipeline>>[totalPages - 1];
                 for (int i = 2; i <= totalPages; i++)
                 {
-                    Task<PagedResponse<GitlabPipeline>> pageTask = _apiClient.GetPipelinesAsync(sinceDate, running, i, cancellationToken);
-                    pagesTasks[i - 2] = pageTask.ContinueWith(x =>
-                        {
-                            ProcessLoadedBuilds(x.Result.Items, observer);
-                        },
-                        cancellationToken,
-                        TaskContinuationOptions.None,
-                        TaskScheduler.Current);
+                    pagesTasks[i - 2] = _apiClient.GetPipelinesAsync(sinceDate, running, i, cancellationToken);
                 }
 
-                await Task.Factory.ContinueWhenAll(pagesTasks, t =>
+                PagedResponse<GitlabPipeline>[] pages = await Task.WhenAll(pagesTasks);
+                foreach (PagedResponse<GitlabPipeline> page in pages)
                 {
-                    observer.OnCompleted();
-                }, cancellationToken);
+                    ProcessLoadedBuilds(page.Items, observer);
+                }
             }
             else
             {
@@ -120,9 +114,9 @@ public sealed class GitlabAdapter : IBuildServerAdapter
                     currentPage = await _apiClient.GetPipelinesAsync(sinceDate, running, currentPage.NextPage.Value, cancellationToken);
                     ProcessLoadedBuilds(currentPage.Items, observer);
                 }
-
-                observer.OnCompleted();
             }
+
+            observer.OnCompleted();
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
Add two new context menu items for worktree nodes in the left panel:

- Copy path: copies the worktree path to clipboard (uses ClipboardUtil)
- Show in folder: opens the worktree directory in File Explorer (uses OsShellUtil)

Both items are available on all worktree nodes including the current one. Show in folder is disabled when the directory no longer exists. A separator visually groups these items below Open/Delete. Reuses existing icons (CopyToClipboard, BrowseFileExplorer) and translation patterns (Copy &path, Show &in folder) consistent with the file status list.

<img width="750" height="319" alt="image" src="https://github.com/user-attachments/assets/858ca5ec-48c2-4b96-9a86-cbca4ce3ee46" />

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
