### PR TITLE
feat: auto-detect Azure DevOps for build status and PR creation

### DIFF
--- a/src/app/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
+++ b/src/app/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
@@ -5,7 +5,7 @@ namespace GitCommands.Remotes;
 
 public sealed partial class AzureDevOpsRemoteParser : RemoteParser
 {
-    [GeneratedRegex(@"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
+    [GeneratedRegex(@"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com(?:\/DefaultCollection)?\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex VstsHttpsRemoteRegex { get; }
 
     [GeneratedRegex(@"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
@@ -40,4 +40,48 @@ public sealed partial class AzureDevOpsRemoteParser : RemoteParser
         repository = m.Groups["repo"].Value;
         return true;
     }
+
+    /// <summary>
+    ///  Constructs the Azure DevOps project web URL from a remote URL and extracted owner/project names.
+    /// </summary>
+    /// <returns>The project URL, or <see langword="null"/> if the remote host is not recognized.</returns>
+    public static string? BuildProjectUrl(string remoteUrl, string owner, string project)
+    {
+        if (IsDevAzureCom(remoteUrl))
+        {
+            return $"https://dev.azure.com/{owner}/{project}";
+        }
+
+        if (IsVisualStudioCom(remoteUrl))
+        {
+            return $"https://{owner}.visualstudio.com/{project}";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///  Constructs the Azure DevOps repository web URL from a remote URL and extracted components.
+    /// </summary>
+    /// <returns>The repository URL, or <see langword="null"/> if the remote host is not recognized.</returns>
+    public static string? BuildRepositoryUrl(string remoteUrl, string owner, string project, string repository)
+    {
+        if (IsDevAzureCom(remoteUrl))
+        {
+            return $"https://dev.azure.com/{owner}/{project}/_git/{repository}";
+        }
+
+        if (IsVisualStudioCom(remoteUrl))
+        {
+            return $"https://{owner}.visualstudio.com/{project}/_git/{repository}";
+        }
+
+        return null;
+    }
+
+    private static bool IsDevAzureCom(string remoteUrl)
+        => remoteUrl.Contains("dev.azure.com", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsVisualStudioCom(string remoteUrl)
+        => remoteUrl.Contains("visualstudio.com", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/src/app/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -12,6 +12,7 @@ using GitCommands.Settings;
 using GitExtensions.Extensibility.BuildServerIntegration;
 using GitExtensions.Extensibility.Configurations;
 using GitExtensions.Extensibility.Git;
+using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUI.HelperDialogs;
@@ -68,10 +69,17 @@ public sealed class BuildServerWatcher : IBuildServerWatcher, IDisposable
         _buildServerAdapter = buildServerAdapter;
 
         // When a build server adapter is available (including auto-detected),
-        // ensure the column visibility reflects the user's display preferences
+        // ensure the column visibility and width reflect the user's display preferences
         if (buildServerAdapter is not null)
         {
-            ColumnProvider.Column.Visible = AppSettings.ShowBuildStatusIconColumn || AppSettings.ShowBuildStatusTextColumn;
+            bool showIcon = AppSettings.ShowBuildStatusIconColumn;
+            bool showText = AppSettings.ShowBuildStatusTextColumn;
+            ColumnProvider.Column.Visible = showIcon || showText;
+
+            if (showIcon && !showText)
+            {
+                ColumnProvider.Column.Width = DpiUtil.Scale(16);
+            }
         }
 
         await TaskScheduler.Default;
@@ -364,11 +372,8 @@ public sealed class BuildServerWatcher : IBuildServerWatcher, IDisposable
             }
         }
 
-        // For GitHub Actions with explicit config, ensure owner/repo are populated from remotes
-        if (buildServerName == "GitHub Actions")
-        {
-            TryAutoDetectBuildServerType(buildServerSettings.SettingsSource);
-        }
+        // When explicitly configured, let the matching detector populate settings from remotes
+        TryPopulateSettingsForBuildServer(buildServerName, buildServerSettings.SettingsSource);
 
         IEnumerable<Lazy<IBuildServerAdapter, IBuildServerTypeMetadata>> exports = ManagedExtensibility.GetExports<IBuildServerAdapter, IBuildServerTypeMetadata>();
         Lazy<IBuildServerAdapter, IBuildServerTypeMetadata>? export = exports.SingleOrDefault(x => x.Metadata.BuildServerType == buildServerName);
@@ -411,9 +416,9 @@ public sealed class BuildServerWatcher : IBuildServerWatcher, IDisposable
     }
 
     /// <summary>
-    ///  Attempts to detect the build server type from the repository's remote URLs.
-    ///  Currently detects GitHub-hosted repositories and returns "GitHub Actions".
-    ///  When detected, writes the owner and repository to <paramref name="settingsSource"/>
+    ///  Attempts to detect the build server type from the repository's remote URLs
+    ///  by querying registered <see cref="IBuildServerAutoDetector"/> exports.
+    ///  When detected, writes adapter-specific settings to <paramref name="settingsSource"/>
     ///  (if not already set) so the adapter can use them without re-parsing.
     ///  Respects <see cref="AppSettings.PrioritizedBuildServerRemoteNames"/> for remote ordering,
     ///  so that forks resolve to the upstream project's CI rather than the fork's.
@@ -422,40 +427,17 @@ public sealed class BuildServerWatcher : IBuildServerWatcher, IDisposable
     {
         try
         {
-            GitHubRemoteParser parser = new();
-            IGitModule module = _module();
-            IReadOnlyList<string> remoteNames = module.GetRemoteNames();
-
-            string[] prioritizedNames = AppSettings.PrioritizedBuildServerRemoteNames
-                .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-            IEnumerable<string> orderedRemotes = remoteNames
-                .OrderBy(r =>
-                {
-                    int index = Array.FindIndex(prioritizedNames, n => string.Equals(n, r, StringComparison.OrdinalIgnoreCase));
-                    return index >= 0 ? index : prioritizedNames.Length;
-                });
-
-            foreach (string remoteName in orderedRemotes)
+            List<string> remoteUrls = GetOrderedRemoteUrls();
+            if (remoteUrls.Count == 0)
             {
-                string remoteUrl = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remoteName));
-                if (!string.IsNullOrWhiteSpace(remoteUrl)
-                    && parser.TryExtractGitHubDataFromRemoteUrl(remoteUrl, out string? owner, out string? repository))
+                return null;
+            }
+
+            foreach (Lazy<IBuildServerAutoDetector> export in ManagedExtensibility.GetExports<IBuildServerAutoDetector>())
+            {
+                if (export.Value.TryDetect(remoteUrls, settingsSource))
                 {
-                    if (settingsSource is not null)
-                    {
-                        if (string.IsNullOrWhiteSpace(settingsSource.GetString("GitHubActionsOwner", null)))
-                        {
-                            settingsSource.SetString("GitHubActionsOwner", owner);
-                        }
-
-                        if (string.IsNullOrWhiteSpace(settingsSource.GetString("GitHubActionsRepository", null)))
-                        {
-                            settingsSource.SetString("GitHubActionsRepository", repository);
-                        }
-                    }
-
-                    return "GitHub Actions";
+                    return export.Value.BuildServerType;
                 }
             }
         }
@@ -465,6 +447,67 @@ public sealed class BuildServerWatcher : IBuildServerWatcher, IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///  For an explicitly configured build server, runs the matching auto-detector
+    ///  to populate adapter-specific settings from remote URLs.
+    /// </summary>
+    private void TryPopulateSettingsForBuildServer(string buildServerName, GitExtensions.Extensibility.Settings.SettingsSource settingsSource)
+    {
+        try
+        {
+            List<string> remoteUrls = GetOrderedRemoteUrls();
+            if (remoteUrls.Count == 0)
+            {
+                return;
+            }
+
+            foreach (Lazy<IBuildServerAutoDetector> export in ManagedExtensibility.GetExports<IBuildServerAutoDetector>())
+            {
+                if (export.Value.BuildServerType == buildServerName)
+                {
+                    export.Value.TryDetect(remoteUrls, settingsSource);
+                    return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.Write($"Populate build server settings failed: {ex}");
+        }
+    }
+
+    /// <summary>
+    ///  Collects remote URLs from the current module, ordered by
+    ///  <see cref="AppSettings.PrioritizedBuildServerRemoteNames"/>.
+    /// </summary>
+    private List<string> GetOrderedRemoteUrls()
+    {
+        IGitModule module = _module();
+        IReadOnlyList<string> remoteNames = module.GetRemoteNames();
+
+        string[] prioritizedNames = AppSettings.PrioritizedBuildServerRemoteNames
+            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        IEnumerable<string> orderedRemotes = remoteNames
+            .OrderBy(r =>
+            {
+                int index = Array.FindIndex(prioritizedNames, n => string.Equals(n, r, StringComparison.OrdinalIgnoreCase));
+                return index >= 0 ? index : prioritizedNames.Length;
+            });
+
+        List<string> remoteUrls = [];
+        foreach (string remoteName in orderedRemotes)
+        {
+            string remoteUrl = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remoteName));
+            if (!string.IsNullOrWhiteSpace(remoteUrl))
+            {
+                remoteUrls.Add(remoteUrl);
+            }
+        }
+
+        return remoteUrls;
     }
 
     public void Dispose()

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -472,7 +472,14 @@ public partial class FormPush : GitModuleForm
             ScriptsRunner.RunEventScripts(ScriptEvent.AfterPush, this);
             if (_createPullRequestCB.Checked)
             {
-                UICommands.StartCreatePullRequest(owner);
+                if (PluginRegistry.TryGetGitHosterForModule(Module) is not null)
+                {
+                    UICommands.StartCreatePullRequest(owner);
+                }
+                else
+                {
+                    TryOpenAzureDevOpsPullRequestInBrowser();
+                }
             }
 
             return true;
@@ -825,7 +832,7 @@ public partial class FormPush : GitModuleForm
         Text = string.Concat(_pushCaption.Text, " (", Module.WorkingDir, ")");
 
         IRepositoryHostPlugin? gitHoster = PluginRegistry.TryGetGitHosterForModule(Module);
-        _createPullRequestCB.Enabled = gitHoster is not null;
+        _createPullRequestCB.Enabled = gitHoster is not null || HasAzureDevOpsRemote();
     }
 
     private void AddRemoteClick(object sender, EventArgs e)
@@ -1275,6 +1282,56 @@ public partial class FormPush : GitModuleForm
 
             pushCheckBox.Value = willPush(row);
         }
+    }
+
+    /// <summary>
+    ///  Checks whether any configured remote points to an Azure DevOps repository.
+    /// </summary>
+    private bool HasAzureDevOpsRemote()
+    {
+        AzureDevOpsRemoteParser parser = new();
+        foreach (string remoteName in Module.GetRemoteNames())
+        {
+            string remoteUrl = Module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remoteName));
+            if (!string.IsNullOrWhiteSpace(remoteUrl) && parser.IsValidRemoteUrl(remoteUrl))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Opens the Azure DevOps "create pull request" page in the default browser
+    ///  for the currently selected remote and branch.
+    /// </summary>
+    private void TryOpenAzureDevOpsPullRequestInBrowser()
+    {
+        string? remoteUrl = _selectedRemote?.Url;
+        if (string.IsNullOrWhiteSpace(remoteUrl))
+        {
+            return;
+        }
+
+        AzureDevOpsRemoteParser parser = new();
+        if (!parser.TryExtractAzureDevopsDataFromRemoteUrl(remoteUrl, out string? owner, out string? project, out string? repo))
+        {
+            return;
+        }
+
+        string? repoWebUrl = AzureDevOpsRemoteParser.BuildRepositoryUrl(remoteUrl, owner, project, repo);
+        if (repoWebUrl is null)
+        {
+            return;
+        }
+
+        string branch = _selectedBranch is not null and not HeadText and not AllRefs
+            ? _selectedBranch
+            : Module.GetSelectedBranch();
+
+        string pullRequestUrl = $"{repoWebUrl}/pullrequestcreate?sourceRef={Uri.EscapeDataString(branch)}";
+        OsShellUtil.OpenUrlInDefaultBrowser(pullRequestUrl);
     }
 
     internal TestAccessor GetTestAccessor() => new(this);

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -12,42 +12,117 @@ namespace AzureDevOpsIntegration;
 /// </summary>
 public sealed class ApiClient : IDisposable
 {
-    private const string BuildDefinitionsUrl = "build/definitions?api-version=2.0";
     private const string Properties = "properties=sourceVersion,status,buildNumber,result,definition,_links,startTime,finishTime";
     private readonly HttpClient _httpClient;
 
     /// <summary>
-    /// Creates a new API client instance for the given Azure DevOps / TFS project, that uses the given authentication token.
+    ///  Creates a new API client for the given Azure DevOps / TFS project.
     /// </summary>
     /// <param name="projectUrl">
-    /// The home page url of the project the API client should provide access to.
+    ///  The home page url of the project the API client should provide access to.
     /// </param>
     /// <param name="apiToken">
-    /// The authentication token that is required and used to access the REST API of the Azure DevOps / TFS instance.
+    ///  A Personal Access Token for Basic auth. When <see langword="null"/> or empty,
+    ///  the client attempts to obtain a Bearer token from Git Credential Manager, and
+    ///  falls back to default Windows credentials (NTLM/Negotiate) for on-premises TFS.
     /// </param>
-    public ApiClient(string projectUrl, string apiToken)
+    /// <param name="gitExecutable">
+    ///  Path to the git executable, used to invoke <c>git credential fill</c> when
+    ///  no PAT is provided. When <see langword="null"/>, defaults to <c>"git"</c>.
+    /// </param>
+    public ApiClient(string projectUrl, string? apiToken, string? gitExecutable = null)
     {
-        _httpClient = new HttpClient();
-        InitializeHttpClient(projectUrl, apiToken);
+        if (!string.IsNullOrWhiteSpace(apiToken))
+        {
+            _httpClient = new HttpClient();
+            SetBasicAuth(apiToken);
+        }
+        else
+        {
+            string? bearerToken = TryGetBearerTokenFromGcm(projectUrl, gitExecutable);
+            if (bearerToken is not null)
+            {
+                _httpClient = new HttpClient();
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+            }
+            else
+            {
+                _httpClient = new HttpClient(new HttpClientHandler { UseDefaultCredentials = true });
+            }
+        }
+
+        _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        _httpClient.BaseAddress = new Uri(projectUrl.EndsWith('/') ? projectUrl + "_apis/" : projectUrl + "/_apis/");
+    }
+
+    private void SetBasicAuth(string apiToken)
+    {
+        string apiTokenHeaderValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{apiToken}"));
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", apiTokenHeaderValue);
     }
 
     /// <summary>
-    /// Configures the <see cref="HttpClient"/> of the API client instance, so that API requests can be made with it.
+    ///  Attempts to obtain a Bearer token from Git Credential Manager via <c>git credential fill</c>.
     /// </summary>
-    /// <param name="projectUrl">
-    /// The home page url of the Azure DevOps / TFS project the API client should provide access to.
-    /// </param>
-    /// <param name="apiToken">
-    /// The authentication token that is required and used to access the REST API of the Azure DevOps / TFS instance.
-    /// </param>
-    private void InitializeHttpClient(string projectUrl, string apiToken)
+    private static string? TryGetBearerTokenFromGcm(string projectUrl, string? gitExecutable)
     {
-        _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        try
+        {
+            if (!Uri.TryCreate(projectUrl, UriKind.Absolute, out Uri? uri))
+            {
+                return null;
+            }
 
-        string apiTokenHeaderValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{apiToken}"));
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", apiTokenHeaderValue);
+            string input = $"protocol={uri.Scheme}\nhost={uri.Host}\npath={uri.AbsolutePath.TrimStart('/')}\n\n";
 
-        _httpClient.BaseAddress = new Uri(projectUrl.EndsWith('/') ? projectUrl + "_apis/" : projectUrl + "/_apis/");
+            using System.Diagnostics.Process process = new()
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = gitExecutable ?? "git",
+                    Arguments = "credential fill",
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+
+            process.Start();
+            process.StandardInput.Write(input);
+            process.StandardInput.Close();
+
+            string output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(TimeSpan.FromSeconds(30));
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            foreach (string line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                // Split on the first '=' only to handle tokens containing '='
+                int separatorIndex = line.IndexOf('=');
+                if (separatorIndex > 0)
+                {
+                    string key = line[..separatorIndex].Trim();
+                    string value = line[(separatorIndex + 1)..].Trim();
+
+                    if (key == "password" && !string.IsNullOrWhiteSpace(value))
+                    {
+                        return value;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // GCM not available or failed — fall back to default credentials
+        }
+
+        return null;
     }
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
@@ -69,11 +144,23 @@ public sealed class ApiClient : IDisposable
         return JsonSerializer.Deserialize<T>(json, _jsonOptions)!;
     }
 
-    public async Task<string?> GetBuildDefinitionsAsync(string buildDefinitionNameFilter)
+    public async Task<string?> GetBuildDefinitionsAsync(string buildDefinitionNameFilter, string? repositoryName = null)
     {
         bool isNotFiltered = string.IsNullOrWhiteSpace(buildDefinitionNameFilter);
         string buildDefinitionUriFilter = isNotFiltered ? string.Empty : "&name=" + buildDefinitionNameFilter;
-        ListWrapper<BuildDefinition> buildDefinitions = await HttpGetAsync<ListWrapper<BuildDefinition>>(BuildDefinitionsUrl + buildDefinitionUriFilter);
+
+        string repositoryFilter = "";
+        if (!string.IsNullOrWhiteSpace(repositoryName))
+        {
+            string? repositoryId = await GetRepositoryIdAsync(repositoryName);
+            if (repositoryId is not null)
+            {
+                repositoryFilter = $"&repositoryId={repositoryId}&repositoryType=TfsGit";
+            }
+        }
+
+        string url = $"build/definitions?api-version=6.0{buildDefinitionUriFilter}{repositoryFilter}";
+        ListWrapper<BuildDefinition> buildDefinitions = await HttpGetAsync<ListWrapper<BuildDefinition>>(url);
         if (buildDefinitions.Count != 0)
         {
             return GetBuildDefinitionsIds(buildDefinitions.Value);
@@ -84,9 +171,25 @@ public sealed class ApiClient : IDisposable
             return null;
         }
 
-        buildDefinitions = await HttpGetAsync<ListWrapper<BuildDefinition>>(BuildDefinitionsUrl);
+        buildDefinitions = await HttpGetAsync<ListWrapper<BuildDefinition>>($"build/definitions?api-version=6.0{repositoryFilter}");
 
         return GetBuildDefinitionsIds(buildDefinitions.Value?.Where(b => b.Name is not null && Regex.IsMatch(b.Name, buildDefinitionNameFilter)));
+    }
+
+    /// <summary>
+    ///  Resolves a repository name to its GUID via the Azure DevOps Git API.
+    /// </summary>
+    private async Task<string?> GetRepositoryIdAsync(string repositoryName)
+    {
+        try
+        {
+            GitRepository repo = await HttpGetAsync<GitRepository>($"git/repositories/{Uri.EscapeDataString(repositoryName)}?api-version=6.0");
+            return repo.Id;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static string? GetBuildDefinitionsIds(IEnumerable<BuildDefinition>? buildDefinitions)
@@ -158,9 +261,15 @@ internal class Project
     public string? Url { get; set; }
 }
 
-public class BuildDefinition
+internal class GitRepository
 {
     public string? Id { get; set; }
+    public string? Name { get; set; }
+}
+
+public class BuildDefinition
+{
+    public int Id { get; set; }
     public string? Name { get; set; }
     public string? Url { get; set; }
 }

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -85,21 +85,24 @@ Detail of the error:");
 
         if (!_settings.IsValid())
         {
-            return;
+            throw new InvalidOperationException("Azure DevOps integration settings are incomplete (project URL missing).");
         }
 
         _projectUrl = _buildServerWatcher.ReplaceVariables(_settings.ProjectUrl);
 
-        if (!Uri.IsWellFormedUriString(_projectUrl, UriKind.Absolute) || string.IsNullOrWhiteSpace(_settings.ApiToken))
+        if (!Uri.IsWellFormedUriString(_projectUrl, UriKind.Absolute))
         {
-            return;
+            throw new InvalidOperationException("Azure DevOps project URL is not a valid absolute URI.");
         }
 
         _apiClient = new ApiClient(_projectUrl, _settings.ApiToken);
         if (_buildsCache is null || _buildsCache.Id != CacheKey)
         {
             _buildsCache = null;
-            _buildDefinitionsTask = ThreadHelper.JoinableTaskFactory.RunAsync(() => _apiClient.GetBuildDefinitionsAsync(_settings.BuildDefinitionFilter));
+            _buildDefinitionsTask = ThreadHelper.JoinableTaskFactory.RunAsync(
+                () => _apiClient.GetBuildDefinitionsAsync(
+                    _settings.BuildDefinitionFilter,
+                    string.IsNullOrWhiteSpace(_settings.RepositoryName) ? null : _settings.RepositoryName));
         }
         else
         {

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAutoDetector.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAutoDetector.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.Composition;
+using GitCommands.Remotes;
+using GitExtensions.Extensibility.Settings;
+using GitUIPluginInterfaces.BuildServerIntegration;
+
+namespace AzureDevOpsIntegration;
+
+[Export(typeof(IBuildServerAutoDetector))]
+internal sealed class AzureDevOpsAutoDetector : IBuildServerAutoDetector
+{
+    public string BuildServerType => AzureDevOpsAdapter.PluginName;
+
+    public bool TryDetect(IReadOnlyList<string> remoteUrls, SettingsSource? settingsSource)
+    {
+        AzureDevOpsRemoteParser parser = new();
+
+        foreach (string remoteUrl in remoteUrls)
+        {
+            if (parser.TryExtractAzureDevopsDataFromRemoteUrl(remoteUrl, out string? owner, out string? project, out string? repository))
+            {
+                if (settingsSource is not null)
+                {
+                    if (string.IsNullOrWhiteSpace(settingsSource.GetString("ProjectUrl", null)))
+                    {
+                        string? projectUrl = AzureDevOpsRemoteParser.BuildProjectUrl(remoteUrl, owner, project);
+                        if (projectUrl is not null)
+                        {
+                            settingsSource.SetString("ProjectUrl", projectUrl);
+                        }
+                    }
+
+                    if (string.IsNullOrWhiteSpace(settingsSource.GetString("RepositoryName", null)))
+                    {
+                        settingsSource.SetString("RepositoryName", repository);
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/IntegrationSettings.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/IntegrationSettings.cs
@@ -11,6 +11,7 @@ public class IntegrationSettings
     private const string ProjectUrlKey = "ProjectUrl";
     private const string BuildDefinitionFilterKey = "BuildDefinitionNameFilter";
     private const string ApiTokenKey = "RestApiToken";
+    private const string RepositoryNameKey = "RepositoryName";
 
     /// <summary>
     /// Reads these settings from the given <see cref="SettingsSource"/>
@@ -20,12 +21,14 @@ public class IntegrationSettings
         string projectUrl = config?.GetString(ProjectUrlKey, "") ?? "";
         string buildDefinitionFilter = config?.GetString(BuildDefinitionFilterKey, "") ?? "";
         string apiToken = config?.GetString(ApiTokenKey, "") ?? "";
+        string repositoryName = config?.GetString(RepositoryNameKey, "") ?? "";
 
         return new IntegrationSettings()
         {
             ProjectUrl = projectUrl,
             BuildDefinitionFilter = buildDefinitionFilter,
             ApiToken = apiToken,
+            RepositoryName = repositoryName,
         };
     }
 
@@ -45,6 +48,11 @@ public class IntegrationSettings
     public string ApiToken { get; set; } = "";
 
     /// <summary>
+    ///  The repository name, used to scope build definition queries to the correct repository.
+    /// </summary>
+    public string RepositoryName { get; set; } = "";
+
+    /// <summary>
     /// Writes these settings to the given <see cref="SettingsSource"/>
     /// </summary>
     public void WriteTo(SettingsSource config)
@@ -52,13 +60,15 @@ public class IntegrationSettings
         config.SetString(ProjectUrlKey, ProjectUrl);
         config.SetString(BuildDefinitionFilterKey, BuildDefinitionFilter);
         config.SetString(ApiTokenKey, ApiToken);
+        config.SetString(RepositoryNameKey, RepositoryName);
     }
 
     /// <summary>
     /// Validates if these settings are valid and good to use.
+    /// A PAT is optional — when absent, default Windows credentials are used.
     /// </summary>
     public bool IsValid()
     {
-        return !(string.IsNullOrWhiteSpace(ProjectUrl) || string.IsNullOrWhiteSpace(ApiToken)) && BuildServerSettingsHelper.IsRegexValid(BuildDefinitionFilter);
+        return !string.IsNullOrWhiteSpace(ProjectUrl) && BuildServerSettingsHelper.IsRegexValid(BuildDefinitionFilter);
     }
 }

--- a/src/plugins/BuildServerIntegration/GitHubActionsIntegration/GitHubActionsAutoDetector.cs
+++ b/src/plugins/BuildServerIntegration/GitHubActionsIntegration/GitHubActionsAutoDetector.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.Composition;
+using GitCommands.Remotes;
+using GitExtensions.Extensibility.Settings;
+using GitUIPluginInterfaces.BuildServerIntegration;
+
+namespace GitExtensions.Plugins.GitHubActionsIntegration;
+
+[Export(typeof(IBuildServerAutoDetector))]
+internal sealed class GitHubActionsAutoDetector : IBuildServerAutoDetector
+{
+    public string BuildServerType => GitHubActionsAdapter.PluginName;
+
+    public bool TryDetect(IReadOnlyList<string> remoteUrls, SettingsSource? settingsSource)
+    {
+        GitHubRemoteParser parser = new();
+
+        foreach (string remoteUrl in remoteUrls)
+        {
+            if (parser.TryExtractGitHubDataFromRemoteUrl(remoteUrl, out string? owner, out string? repository))
+            {
+                if (settingsSource is not null)
+                {
+                    if (string.IsNullOrWhiteSpace(settingsSource.GetString(GitHubActionsAdapter.SettingOwner, null)))
+                    {
+                        settingsSource.SetString(GitHubActionsAdapter.SettingOwner, owner);
+                    }
+
+                    if (string.IsNullOrWhiteSpace(settingsSource.GetString(GitHubActionsAdapter.SettingRepository, null)))
+                    {
+                        settingsSource.SetString(GitHubActionsAdapter.SettingRepository, repository);
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerAutoDetector.cs
+++ b/src/plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerAutoDetector.cs
@@ -1,0 +1,26 @@
+using GitExtensions.Extensibility.Settings;
+
+namespace GitUIPluginInterfaces.BuildServerIntegration;
+
+/// <summary>
+///  Allows a build server adapter to participate in automatic detection
+///  based on the repository's remote URLs. Implement this interface and
+///  export it via MEF alongside <see cref="IBuildServerAdapter"/>.
+/// </summary>
+public interface IBuildServerAutoDetector
+{
+    /// <summary>
+    ///  The build server type name, matching <see cref="IBuildServerTypeMetadata.BuildServerType"/>.
+    /// </summary>
+    string BuildServerType { get; }
+
+    /// <summary>
+    ///  Attempts to detect this build server from the given remote URLs.
+    ///  When detected and <paramref name="settingsSource"/> is not <see langword="null"/>,
+    ///  populates adapter-specific settings (e.g. project URL, owner, repository).
+    /// </summary>
+    /// <param name="remoteUrls">Remote URLs ordered by priority.</param>
+    /// <param name="settingsSource">Optional settings to populate when detected.</param>
+    /// <returns><see langword="true"/> if this build server was detected.</returns>
+    bool TryDetect(IReadOnlyList<string> remoteUrls, SettingsSource? settingsSource);
+}

--- a/tests/app/UnitTests/GitCommands.Tests/Remote/AzureDevOpsRemoteParserTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Remote/AzureDevOpsRemoteParserTests.cs
@@ -19,6 +19,17 @@ public class AzureDevOpsRemoteParserTests
     }
 
     [Test]
+    public void Should_succeed_in_parsing_visualstudio_url_with_DefaultCollection()
+    {
+        AzureDevOpsRemoteParser azureDevOpsRemoteParser = new();
+        string url = "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/vs-green";
+        azureDevOpsRemoteParser.TryExtractAzureDevopsDataFromRemoteUrl(url, out string? owner, out string? project, out string? repository).Should().BeTrue();
+        owner.Should().Be("devdiv");
+        project.Should().Be("DevDiv");
+        repository.Should().Be("vs-green");
+    }
+
+    [Test]
     public void Should_fail_in_parsing_invalid_url()
     {
         AzureDevOpsRemoteParser azureDevOpsRemoteParser = new();
@@ -29,5 +40,35 @@ public class AzureDevOpsRemoteParserTests
         repository.Should().BeNull();
 
         azureDevOpsRemoteParser.IsValidRemoteUrl(url).Should().BeFalse();
+    }
+
+    [TestCase("https://owner@dev.azure.com/myorg/myproject/_git/myrepo", "myorg", "myproject", "https://dev.azure.com/myorg/myproject")]
+    [TestCase("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo", "myorg", "myproject", "https://dev.azure.com/myorg/myproject")]
+    [TestCase("https://myorg.visualstudio.com/myproject/_git/myrepo", "myorg", "myproject", "https://myorg.visualstudio.com/myproject")]
+    [TestCase("myorg@vs-ssh.visualstudio.com:v3/myorg/myproject/myrepo", "myorg", "myproject", "https://myorg.visualstudio.com/myproject")]
+    public void BuildProjectUrl_should_return_expected_url(string remoteUrl, string owner, string project, string expectedUrl)
+    {
+        AzureDevOpsRemoteParser.BuildProjectUrl(remoteUrl, owner, project).Should().Be(expectedUrl);
+    }
+
+    [Test]
+    public void BuildProjectUrl_should_return_null_for_unknown_host()
+    {
+        AzureDevOpsRemoteParser.BuildProjectUrl("https://github.com/owner/repo.git", "owner", "repo").Should().BeNull();
+    }
+
+    [TestCase("https://owner@dev.azure.com/myorg/myproject/_git/myrepo", "myorg", "myproject", "myrepo", "https://dev.azure.com/myorg/myproject/_git/myrepo")]
+    [TestCase("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo", "myorg", "myproject", "myrepo", "https://dev.azure.com/myorg/myproject/_git/myrepo")]
+    [TestCase("https://myorg.visualstudio.com/myproject/_git/myrepo", "myorg", "myproject", "myrepo", "https://myorg.visualstudio.com/myproject/_git/myrepo")]
+    [TestCase("myorg@vs-ssh.visualstudio.com:v3/myorg/myproject/myrepo", "myorg", "myproject", "myrepo", "https://myorg.visualstudio.com/myproject/_git/myrepo")]
+    public void BuildRepositoryUrl_should_return_expected_url(string remoteUrl, string owner, string project, string repository, string expectedUrl)
+    {
+        AzureDevOpsRemoteParser.BuildRepositoryUrl(remoteUrl, owner, project, repository).Should().Be(expectedUrl);
+    }
+
+    [Test]
+    public void BuildRepositoryUrl_should_return_null_for_unknown_host()
+    {
+        AzureDevOpsRemoteParser.BuildRepositoryUrl("https://github.com/owner/repo.git", "owner", "project", "repo").Should().BeNull();
     }
 }


### PR DESCRIPTION
Build status column:

- Auto-detect Azure DevOps from remote URLs (dev.azure.com, visualstudio.com, including /DefaultCollection/ paths) via new IBuildServerAutoDetector extensibility point.
- Authenticate using Git Credential Manager (same OAuth token as git fetch) — no PAT required. Falls back to default Windows credentials for on-premises TFS, or PAT when configured.
- Scope build definition queries to the repository via its GUID, avoiding irrelevant results in large projects.
- Show icon-only column (16px) by default for auto-detected adapters.

Create pull request on push:

- Enable the 'Create pull request' checkbox in FormPush for Azure DevOps repositories. Opens the create-PR page in the default browser with sourceRef pre-populated after a successful push.

Architecture:

- Introduce IBuildServerAutoDetector interface in GitUIPluginInterfaces, exported via MEF. BuildServerWatcher iterates registered detectors instead of hard-coding adapter names and remote-parsing logic.
- Implement GitHubActionsAutoDetector and AzureDevOpsAutoDetector in their respective plugin assemblies.
- Consolidate Azure DevOps URL construction in AzureDevOpsRemoteParser.BuildProjectUrl/BuildRepositoryUrl.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

I can't include any from work, but with this change GE automatically detects Azure DevOps as a build server and shows build results in the column.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
