### PR TITLE
feat(worktree): strip common directory prefix from worktree display names

### DIFF
--- a/src/app/GitUI/LeftPanel/WorktreeNode.cs
+++ b/src/app/GitUI/LeftPanel/WorktreeNode.cs
@@ -5,10 +5,11 @@ using GitUI.Properties;
 namespace GitUI.LeftPanel;
 
 [DebuggerDisplay("(Worktree) Path = {Worktree.Path}, Branch = {Worktree.Branch}")]
-internal sealed class WorktreeNode(Tree tree, GitWorktree worktree, bool isCurrent) : Node(tree)
+internal sealed class WorktreeNode(Tree tree, GitWorktree worktree, bool isCurrent, string displayPath) : Node(tree)
 {
     public GitWorktree Worktree { get; } = worktree;
     public bool IsCurrent { get; } = isCurrent;
+    private string DisplayPath { get; } = displayPath;
 
     internal override void OnSelected()
     {
@@ -85,22 +86,8 @@ internal sealed class WorktreeNode(Tree tree, GitWorktree worktree, bool isCurre
     }
 
     protected override string DisplayText()
-    {
-        return Worktree.GetDisplayName(GetRelativePath());
+        => Worktree.GetDisplayName(DisplayPath);
 
-        string GetRelativePath()
-        {
-            string workingDir = Tree.UICommands.Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar);
-            string parentDir = Path.GetDirectoryName(workingDir) ?? workingDir;
-
-            try
-            {
-                return Path.GetRelativePath(parentDir, Worktree.Path);
-            }
-            catch
-            {
-                return Worktree.Path;
-            }
-        }
-    }
+    protected override string NodeName()
+        => Worktree.Path;
 }

--- a/src/app/GitUI/LeftPanel/WorktreeTree.cs
+++ b/src/app/GitUI/LeftPanel/WorktreeTree.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.Buffers;
+using GitCommands;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitUI.CommandsDialogs.WorktreeDialog;
@@ -31,7 +32,20 @@ internal sealed class WorktreeTree(TreeNode treeNode, IGitUICommandsSource uiCom
         Nodes nodes = new(this);
         string currentWorkingDir = Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar);
 
-        foreach (GitWorktree worktree in Module.GetWorktrees())
+        IReadOnlyList<GitWorktree> worktrees = Module.GetWorktrees();
+
+        // Use the main worktree's parent as the reference for relative paths.
+        // Git always lists the main worktree first. Using the main worktree's parent
+        // ensures linked worktrees in a sibling directory produce paths like
+        // "repo.worktrees/feature-a" rather than flat names with no directory component.
+        string mainWorktreePath = worktrees.Count > 0
+            ? worktrees[0].Path.TrimEnd(Path.DirectorySeparatorChar)
+            : currentWorkingDir;
+        string parentDir = Path.GetDirectoryName(mainWorktreePath) ?? mainWorktreePath;
+
+        List<(GitWorktree Worktree, bool IsCurrent, string RelativePath)> worktreeInfos = [];
+
+        foreach (GitWorktree worktree in worktrees)
         {
             token.ThrowIfCancellationRequested();
 
@@ -40,12 +54,123 @@ internal sealed class WorktreeTree(TreeNode treeNode, IGitUICommandsSource uiCom
                 currentWorkingDir,
                 StringComparison.OrdinalIgnoreCase);
 
-            WorktreeNode node = new(this, worktree, isCurrent);
+            string relativePath;
+            try
+            {
+                relativePath = Path.GetRelativePath(parentDir, worktree.Path);
+            }
+            catch
+            {
+                relativePath = worktree.Path;
+            }
+
+            worktreeInfos.Add((worktree, isCurrent, relativePath));
+        }
+
+        // Strip the common directory prefix from non-main worktrees to reduce visual noise.
+        // The first worktree is always the main worktree and is excluded from prefix calculation.
+        string commonPrefix = GetCommonPrefix(
+            worktreeInfos.Skip(1).Select(w => w.RelativePath));
+
+        for (int i = 0; i < worktreeInfos.Count; i++)
+        {
+            token.ThrowIfCancellationRequested();
+
+            (GitWorktree worktree, bool isCurrent, string relativePath) = worktreeInfos[i];
+
+            string displayPath = i > 0
+                && commonPrefix.Length > 0
+                && relativePath.StartsWith(commonPrefix, StringComparison.OrdinalIgnoreCase)
+                ? relativePath[commonPrefix.Length..]
+                : relativePath;
+
+            WorktreeNode node = new(this, worktree, isCurrent, displayPath);
             nodes.AddNode(node);
         }
 
         return nodes;
     }
+
+    /// <summary>
+    ///  Finds the longest common prefix among the given relative paths, snapping to a word boundary.
+    /// </summary>
+    /// <remarks>
+    ///  Word boundaries are directory separators and the characters <c>_</c>, <c>-</c>, <c>.</c>, and space.
+    ///  This ensures names like "apricot" and "apple" are not truncated to "pricot" and "pple".
+    /// </remarks>
+    /// <returns>
+    ///  The common prefix including its trailing delimiter, or an empty string if there is no common prefix.
+    /// </returns>
+    internal static string GetCommonPrefix(IEnumerable<string> paths)
+    {
+        ReadOnlySpan<char> prefix = default;
+        bool hasDirectorySeparator = false;
+        int count = 0;
+
+        foreach (string path in paths)
+        {
+            ReadOnlySpan<char> span = path.AsSpan();
+            count++;
+
+            if (count == 1)
+            {
+                prefix = span;
+                hasDirectorySeparator = span.ContainsAny(DirectorySeparatorChars);
+                continue;
+            }
+
+            hasDirectorySeparator = hasDirectorySeparator || span.ContainsAny(DirectorySeparatorChars);
+
+            // Find the longest character-for-character match.
+            int limit = Math.Min(prefix.Length, span.Length);
+            int matchLength = 0;
+            for (int i = 0; i < limit; i++)
+            {
+                if (char.ToUpperInvariant(prefix[i]) != char.ToUpperInvariant(span[i]))
+                {
+                    break;
+                }
+
+                matchLength = i + 1;
+            }
+
+            prefix = prefix[..matchLength];
+        }
+
+        if (count < 2 || prefix.Length == 0)
+        {
+            return "";
+        }
+
+        // Snap to the last directory separator in the common prefix.
+        int dirSepIndex = prefix.LastIndexOfAny(DirectorySeparatorChars);
+        if (dirSepIndex >= 0)
+        {
+            return prefix[..(dirSepIndex + 1)].ToString();
+        }
+
+        // Fall back to word-boundary characters only when none of the paths contain
+        // directory separators. This handles the case where all worktrees are flat
+        // siblings in the same directory (e.g. "repo_dev", "repo_test").
+        if (hasDirectorySeparator)
+        {
+            return "";
+        }
+
+        int boundaryIndex = prefix.LastIndexOfAny(WordBoundaryChars);
+        if (boundaryIndex < 0)
+        {
+            return "";
+        }
+
+        return prefix[..(boundaryIndex + 1)].ToString();
+    }
+
+    private static readonly SearchValues<char> DirectorySeparatorChars = SearchValues.Create(
+        [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]);
+
+    private static readonly SearchValues<char> WordBoundaryChars = SearchValues.Create(
+        ['_', '-', '.', ' ']);
 
     protected override void PostFillTreeViewNode(bool firstTime)
     {

--- a/tests/app/UnitTests/GitUI.Tests/LeftPanel/WorktreeTreeTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/LeftPanel/WorktreeTreeTests.cs
@@ -1,0 +1,193 @@
+﻿using AwesomeAssertions;
+using GitUI.LeftPanel;
+
+namespace GitUITests.LeftPanel;
+
+[TestFixture]
+public sealed class WorktreeTreeTests
+{
+    private static readonly char Sep = Path.DirectorySeparatorChar;
+
+    [Test]
+    public void GetCommonPrefix_should_return_empty_for_no_paths()
+    {
+        string result = WorktreeTree.GetCommonPrefix([]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_return_empty_for_single_path()
+    {
+        // A single path has nothing to compare against — no common prefix to strip.
+        string[] paths = [$"worktrees{Sep}feature-a"];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_return_common_prefix_for_sibling_paths()
+    {
+        string[] paths =
+        [
+            $"my-repo.worktrees{Sep}feature-a",
+            $"my-repo.worktrees{Sep}feature-b",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be($"my-repo.worktrees{Sep}");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_return_empty_when_paths_share_no_directory_prefix()
+    {
+        string[] paths =
+        [
+            $"folder-a{Sep}feature-a",
+            $"folder-b{Sep}feature-b",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_return_partial_prefix_for_mixed_depth()
+    {
+        string[] paths =
+        [
+            $"root{Sep}team-a{Sep}feature-1",
+            $"root{Sep}team-a{Sep}feature-2",
+            $"root{Sep}team-b{Sep}feature-3",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be($"root{Sep}");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_handle_nested_common_prefix()
+    {
+        string[] paths =
+        [
+            $"root{Sep}sub{Sep}feature-1",
+            $"root{Sep}sub{Sep}feature-2",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be($"root{Sep}sub{Sep}");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_be_case_insensitive()
+    {
+        string[] paths =
+        [
+            $"Worktrees{Sep}feature-a",
+            $"worktrees{Sep}feature-b",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be($"Worktrees{Sep}");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_strip_underscore_delimited_prefix()
+    {
+        string[] paths =
+        [
+            "gitextensions3_configdata",
+            "gitextensions3_dev",
+            "gitextensions3_test",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be("gitextensions3_");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_strip_hyphen_delimited_prefix()
+    {
+        string[] paths =
+        [
+            "my-repo-feature-a",
+            "my-repo-feature-b",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be("my-repo-feature-");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_strip_dot_delimited_prefix()
+    {
+        string[] paths =
+        [
+            "repo.worktrees.alpha",
+            "repo.worktrees.beta",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be("repo.worktrees.");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_strip_space_delimited_prefix()
+    {
+        string[] paths =
+        [
+            "my repo feature-a",
+            "my repo feature-b",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be("my repo feature-");
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_not_split_mid_word()
+    {
+        string[] paths = ["apricot", "apple"];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_return_empty_for_single_path_without_boundary()
+    {
+        string[] paths = ["worktree"];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetCommonPrefix_should_snap_to_directory_separator_over_word_boundary()
+    {
+        // When paths contain directory separators, the prefix snaps to the last
+        // directory separator even when word boundaries exist beyond it.
+        string[] paths =
+        [
+            $"shared{Sep}gitextensions3_configdata",
+            $"shared{Sep}gitextensions3_dev",
+        ];
+
+        string result = WorktreeTree.GetCommonPrefix(paths);
+
+        result.Should().Be($"shared{Sep}");
+    }
+}


### PR DESCRIPTION
When all non-main worktrees share a common parent directory (e.g. my-repo.worktrees/), strip that prefix from the display text in the left panel so only the distinguishing folder name is visible. The full path is still shown in the tooltip.

The prefix calculation uses ReadOnlySpan<char> segment comparison to avoid intermediate allocations.

## Screenshots

### Before

<img width="682" height="399" alt="image" src="https://github.com/user-attachments/assets/a211fa12-ce54-42f3-ac0a-a30a9f075486" />

### After

<img width="684" height="398" alt="image" src="https://github.com/user-attachments/assets/36f7169c-140f-4803-b19c-32a756d0a934" />

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
