### PR TITLE
feat: compact single-child folder chains in submodule tree

### DIFF
--- a/src/app/GitUI/LeftPanel/Nodes.cs
+++ b/src/app/GitUI/LeftPanel/Nodes.cs
@@ -1,15 +1,10 @@
 ﻿namespace GitUI.LeftPanel;
 
-internal sealed class Nodes : IEnumerable<Node>
+internal sealed class Nodes(Tree? tree) : IReadOnlyCollection<Node>
 {
     private readonly List<Node> _nodesList = [];
 
-    public Tree? Tree { get; }
-
-    public Nodes(Tree? tree)
-    {
-        Tree = tree;
-    }
+    public Tree? Tree { get; } = tree;
 
     /// <summary>
     /// Adds a new node to the collection.
@@ -25,19 +20,32 @@ internal sealed class Nodes : IEnumerable<Node>
         _nodesList.AddRange(nodes);
     }
 
+    public void InsertNode(int index, Node node)
+    {
+        _nodesList.Insert(index, node);
+    }
+
     public void Clear()
     {
         _nodesList.Clear();
     }
 
-    public IEnumerator<Node> GetEnumerator()
-        => _nodesList.GetEnumerator();
+    #region Enumerators
 
-    public void InsertNode(int index, Node node)
-        => _nodesList.Insert(index, node);
+    public List<Node>.Enumerator GetEnumerator()
+    {
+        return _nodesList.GetEnumerator();
+    }
+
+    IEnumerator<Node> IEnumerable<Node>.GetEnumerator()
+    {
+        return _nodesList.GetEnumerator();
+    }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        => GetEnumerator();
+    {
+        return GetEnumerator();
+    }
 
     /// <summary>
     /// Returns all nodes of a given TNode type using depth-first, pre-order method.
@@ -57,6 +65,8 @@ internal sealed class Nodes : IEnumerable<Node>
             }
         }
     }
+
+    #endregion
 
     /// <summary>
     /// This function is responsible for building the TreeNode structure that matches this Nodes's
@@ -105,6 +115,8 @@ internal sealed class Nodes : IEnumerable<Node>
     }
 
     public int Count => _nodesList.Count;
+
+    public Node this[int index] => _nodesList[index];
 
     public Node? LastNode => _nodesList.Count > 0 ? _nodesList[^1] : null;
 }

--- a/src/app/GitUI/LeftPanel/SubmoduleFolderNode.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleFolderNode.cs
@@ -26,4 +26,43 @@ internal sealed class SubmoduleFolderNode : Node
 
     protected override FontStyle GetFontStyle()
         => base.GetFontStyle() | FontStyle.Italic;
+
+    /// <summary>
+    ///  Compacts chains of single-child folder nodes by merging their names with "/" separators.
+    ///  For example, a chain "extension" → "src" → "test" → "assets" becomes
+    ///  a single folder node named "extension/src/test/assets".
+    /// </summary>
+    /// <summary>
+    ///  Compacts chains of single-child folder nodes by merging their names with "/" separators.
+    ///  For example, a chain "extension" → "src" → "test" → "assets" becomes
+    ///  a single folder node named "extension/src/test/assets".
+    /// </summary>
+    internal void CompactSingleChildFolders()
+    {
+        while (Nodes.Count == 1)
+        {
+            SubmoduleFolderNode? childFolder = null;
+            foreach (Node child in Nodes)
+            {
+                childFolder = child as SubmoduleFolderNode;
+            }
+
+            if (childFolder is null)
+            {
+                break;
+            }
+
+            _name += "/" + childFolder._name;
+            List<Node> grandchildren = [.. childFolder.Nodes];
+            Nodes.Clear();
+            Nodes.AddNodes(grandchildren);
+        }
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(SubmoduleFolderNode node)
+    {
+        public string Name => node._name;
+    }
 }

--- a/src/app/GitUI/LeftPanel/SubmoduleFolderNode.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleFolderNode.cs
@@ -3,19 +3,11 @@
 namespace GitUI.LeftPanel;
 
 // Top-level nodes used to group SubmoduleNodes
-internal sealed class SubmoduleFolderNode : Node
+internal sealed class SubmoduleFolderNode(Tree tree, string name) : Node(tree)
 {
-    private string _name;
-
-    public SubmoduleFolderNode(Tree tree, string name)
-        : base(tree)
-    {
-        _name = name;
-    }
-
     protected override string DisplayText()
     {
-        return string.Format(_name);
+        return name;
     }
 
     public override void ApplyStyle()
@@ -25,13 +17,10 @@ internal sealed class SubmoduleFolderNode : Node
     }
 
     protected override FontStyle GetFontStyle()
-        => base.GetFontStyle() | FontStyle.Italic;
+    {
+        return base.GetFontStyle() | FontStyle.Italic;
+    }
 
-    /// <summary>
-    ///  Compacts chains of single-child folder nodes by merging their names with "/" separators.
-    ///  For example, a chain "extension" → "src" → "test" → "assets" becomes
-    ///  a single folder node named "extension/src/test/assets".
-    /// </summary>
     /// <summary>
     ///  Compacts chains of single-child folder nodes by merging their names with "/" separators.
     ///  For example, a chain "extension" → "src" → "test" → "assets" becomes
@@ -39,23 +28,11 @@ internal sealed class SubmoduleFolderNode : Node
     /// </summary>
     internal void CompactSingleChildFolders()
     {
-        while (Nodes.Count == 1)
+        while (Nodes is [SubmoduleFolderNode childFolder])
         {
-            SubmoduleFolderNode? childFolder = null;
-            foreach (Node child in Nodes)
-            {
-                childFolder = child as SubmoduleFolderNode;
-            }
+            name += "/" + childFolder.DisplayText();
 
-            if (childFolder is null)
-            {
-                break;
-            }
-
-            _name += "/" + childFolder._name;
-            List<Node> grandchildren = [.. childFolder.Nodes];
-            Nodes.Clear();
-            Nodes.AddNodes(grandchildren);
+            Nodes = childFolder.Nodes;
         }
     }
 
@@ -63,6 +40,6 @@ internal sealed class SubmoduleFolderNode : Node
 
     internal readonly struct TestAccessor(SubmoduleFolderNode node)
     {
-        public string Name => node._name;
+        public string Name => node.DisplayText();
     }
 }

--- a/src/app/GitUI/LeftPanel/SubmoduleTree.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleTree.cs
@@ -341,6 +341,9 @@ internal sealed class SubmoduleTree : Tree
             }
         }
 
+        // Compact chains of single-child folder nodes for a cleaner display
+        CompactSingleChildFolderChains(rootNode.Nodes);
+
         Validates.NotNull(result.TopProject);
 
         // Add top-module node, and move children of root to it
@@ -353,6 +356,21 @@ internal sealed class SubmoduleTree : Tree
             result.TopProject.Path);
         topModuleNode.Nodes.AddNodes(rootNode.Nodes);
         nodes.AddNode(topModuleNode);
+
+        return;
+
+        static void CompactSingleChildFolderChains(Nodes nodes)
+        {
+            foreach (Node node in nodes)
+            {
+                if (node is SubmoduleFolderNode folderNode)
+                {
+                    folderNode.CompactSingleChildFolders();
+                }
+
+                CompactSingleChildFolderChains(node.Nodes);
+            }
+        }
     }
 
     public void UpdateSubmodule(IWin32Window owner, SubmoduleNode node)

--- a/tests/app/UnitTests/GitUI.Tests/LeftPanel/SubmoduleFolderNodeTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/LeftPanel/SubmoduleFolderNodeTests.cs
@@ -1,0 +1,94 @@
+﻿using AwesomeAssertions;
+using GitUI.LeftPanel;
+
+namespace GitUITests.LeftPanel;
+
+[TestFixture]
+public sealed class SubmoduleFolderNodeTests
+{
+    [Test]
+    public void CompactSingleChildFolders_should_merge_chain_of_single_child_folders()
+    {
+        SubmoduleFolderNode root = CreateFolder("extension");
+        SubmoduleFolderNode child1 = CreateFolder("src");
+        SubmoduleFolderNode child2 = CreateFolder("test");
+        SubmoduleFolderNode child3 = CreateFolder("assets");
+
+        root.Nodes.AddNode(child1);
+        child1.Nodes.AddNode(child2);
+        child2.Nodes.AddNode(child3);
+
+        root.CompactSingleChildFolders();
+
+        root.GetTestAccessor().Name.Should().Be("extension/src/test/assets");
+        root.Nodes.Count.Should().Be(0);
+    }
+
+    [Test]
+    public void CompactSingleChildFolders_should_stop_at_non_folder_child()
+    {
+        SubmoduleFolderNode root = CreateFolder("a");
+        SubmoduleFolderNode child = CreateFolder("b");
+        DummyNode leaf = new();
+
+        root.Nodes.AddNode(child);
+        child.Nodes.AddNode(leaf);
+
+        root.CompactSingleChildFolders();
+
+        root.GetTestAccessor().Name.Should().Be("a/b");
+        root.Nodes.Count.Should().Be(1);
+    }
+
+    [Test]
+    public void CompactSingleChildFolders_should_not_compact_when_multiple_children()
+    {
+        SubmoduleFolderNode root = CreateFolder("Externals");
+        SubmoduleFolderNode child1 = CreateFolder("a");
+        SubmoduleFolderNode child2 = CreateFolder("b");
+
+        root.Nodes.AddNode(child1);
+        root.Nodes.AddNode(child2);
+
+        root.CompactSingleChildFolders();
+
+        root.GetTestAccessor().Name.Should().Be("Externals");
+        root.Nodes.Count.Should().Be(2);
+    }
+
+    [Test]
+    public void CompactSingleChildFolders_should_not_compact_when_no_children()
+    {
+        SubmoduleFolderNode root = CreateFolder("empty");
+
+        root.CompactSingleChildFolders();
+
+        root.GetTestAccessor().Name.Should().Be("empty");
+        root.Nodes.Count.Should().Be(0);
+    }
+
+    [Test]
+    public void CompactSingleChildFolders_should_preserve_grandchildren_of_multi_child_node()
+    {
+        SubmoduleFolderNode root = CreateFolder("a");
+        SubmoduleFolderNode child = CreateFolder("b");
+        SubmoduleFolderNode grandchild = CreateFolder("c");
+        DummyNode leaf1 = new();
+        DummyNode leaf2 = new();
+
+        root.Nodes.AddNode(child);
+        child.Nodes.AddNode(grandchild);
+        grandchild.Nodes.AddNode(leaf1);
+        grandchild.Nodes.AddNode(leaf2);
+
+        root.CompactSingleChildFolders();
+
+        root.GetTestAccessor().Name.Should().Be("a/b/c");
+        root.Nodes.Count.Should().Be(2);
+    }
+
+    private static SubmoduleFolderNode CreateFolder(string name)
+    {
+        return new SubmoduleFolderNode(tree: null!, name);
+    }
+}


### PR DESCRIPTION
When intermediate folder nodes in the submodule tree have only a single child, collapse them into one node with a combined path (e.g. "extension/src/test/assets" instead of four nested nodes).

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="432" height="233" alt="image" src="https://github.com/user-attachments/assets/fc177085-b692-4751-830b-a460f4831d1a" />

### After

<img width="345" height="152" alt="image" src="https://github.com/user-attachments/assets/49f77bcd-bc42-48e5-a23e-60ee570400c8" />

## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
