### PR TITLE
feat(UI): add Markdown rendering with WebView2 for commit messages and file previews

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,8 @@
     <PackageVersion Include="GitInfo" Version="2.2.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
+    <PackageVersion Include="Markdig" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3856.49" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
@@ -37,10 +39,10 @@
 
     <!-- Test infra -->
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />    <!-- Required? -->
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" PrivateAssets="all" />
     <PackageVersion Include="NUnit.ConsoleRunner" Version="3.19.2" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -611,6 +611,12 @@ public static partial class AppSettings
         set => SetBool("commitinfoshowtagthiscommitderivesfrom", value);
     }
 
+    public static bool RenderMarkdownPreview
+    {
+        get => GetBool("RenderMarkdownPreview", true);
+        set => SetBool("RenderMarkdownPreview", value);
+    }
+
     #region Avatars
 
     public static string AvatarImageCachePath => Path.Join(LocalApplicationDataPath.Value!, "Images\\");

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormChangeLog.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormChangeLog.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs.BrowseDialog;
+﻿using GitUI.UserControls;
+
+namespace GitUI.CommandsDialogs.BrowseDialog;
 
 partial class FormChangeLog
 {
@@ -28,7 +30,7 @@ partial class FormChangeLog
     /// </summary>
     private void InitializeComponent()
     {
-        ChangeLog = new RichTextBox();
+        ChangeLog = new MarkdownViewer();
         SuspendLayout();
         // 
         // ChangeLog
@@ -36,11 +38,8 @@ partial class FormChangeLog
         ChangeLog.Dock = DockStyle.Fill;
         ChangeLog.Location = new Point(0, 0);
         ChangeLog.Name = "ChangeLog";
-        ChangeLog.ReadOnly = true;
         ChangeLog.Size = new Size(849, 411);
         ChangeLog.TabIndex = 0;
-        ChangeLog.Text = "";
-        ChangeLog.WordWrap = false;
         // 
         // FormChangeLog
         // 
@@ -57,5 +56,5 @@ partial class FormChangeLog
 
     #endregion
 
-    private RichTextBox ChangeLog;
+    private MarkdownViewer ChangeLog;
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormChangeLog.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormChangeLog.cs
@@ -1,4 +1,5 @@
 ﻿using GitUI.Properties;
+using GitUI.UserControls;
 
 namespace GitUI.CommandsDialogs.BrowseDialog;
 
@@ -10,6 +11,6 @@ public partial class FormChangeLog : GitExtensionsForm
         InitializeComponent();
         InitializeComplete();
 
-        Load += (s, e) => ChangeLog.Text = Resources.ChangeLog;
+        Load += (s, e) => ChangeLog.MarkdownText = Resources.ChangeLog;
     }
 }

--- a/src/app/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -23,6 +23,7 @@ partial class CommitInfo
         tableLayout = new TableLayoutPanel();
         pnlCommitMessage = new Panel();
         rtbxCommitMessage = new RichTextBox();
+        mdCommitMessage = new GitUI.UserControls.MarkdownViewer();
         commitInfoContextMenuStrip = new ContextMenuStrip(components);
         copyLinkToolStripMenuItem = new ToolStripMenuItem();
         copyCommitInfoToolStripMenuItem = new ToolStripMenuItem();
@@ -33,6 +34,7 @@ partial class CommitInfo
         showContainedInTagsToolStripMenuItem = new ToolStripMenuItem();
         showMessagesOfAnnotatedTagsToolStripMenuItem = new ToolStripMenuItem();
         showTagThisCommitDerivesFromMenuItem = new ToolStripMenuItem();
+        renderAsMarkdownToolStripMenuItem = new ToolStripMenuItem();
         toolStripSeparator2 = new ToolStripSeparator();
         addNoteToolStripMenuItem = new ToolStripMenuItem();
         commitInfoHeader = new GitUI.CommitInfo.CommitInfoHeader();
@@ -67,6 +69,7 @@ partial class CommitInfo
         pnlCommitMessage.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
         pnlCommitMessage.BackColor = SystemColors.Control;
         pnlCommitMessage.Controls.Add(rtbxCommitMessage);
+        pnlCommitMessage.Controls.Add(mdCommitMessage);
         pnlCommitMessage.Location = new Point(0, 112);
         pnlCommitMessage.Margin = new Padding(0);
         pnlCommitMessage.Name = "pnlCommitMessage";
@@ -91,6 +94,16 @@ partial class CommitInfo
         rtbxCommitMessage.KeyDown += RichTextBox_KeyDown;
         rtbxCommitMessage.MouseDown += _RevisionHeader_MouseDown;
         // 
+        // mdCommitMessage
+        // 
+        mdCommitMessage.Dock = DockStyle.Fill;
+        mdCommitMessage.DisableScrolling = true;
+        mdCommitMessage.Margin = new Padding(0);
+        mdCommitMessage.Name = "mdCommitMessage";
+        mdCommitMessage.Size = new Size(456, 36);
+        mdCommitMessage.TabIndex = 3;
+        mdCommitMessage.Visible = false;
+        // 
         // commitInfoContextMenuStrip
         // 
         commitInfoContextMenuStrip.Items.AddRange(new ToolStripItem[] {
@@ -103,6 +116,7 @@ partial class CommitInfo
         showContainedInTagsToolStripMenuItem,
         showMessagesOfAnnotatedTagsToolStripMenuItem,
         showTagThisCommitDerivesFromMenuItem,
+        renderAsMarkdownToolStripMenuItem,
         toolStripSeparator2,
         addNoteToolStripMenuItem});
         commitInfoContextMenuStrip.Name = "commitInfoContextMenuStrip";
@@ -169,6 +183,13 @@ partial class CommitInfo
         showTagThisCommitDerivesFromMenuItem.Size = new Size(453, 22);
         showTagThisCommitDerivesFromMenuItem.Text = "Show the most recent tag this commit derives from";
         showTagThisCommitDerivesFromMenuItem.Click += showTagThisCommitDerivesFromMenuItem_Click;
+        // 
+        // renderAsMarkdownToolStripMenuItem
+        // 
+        renderAsMarkdownToolStripMenuItem.Name = "renderAsMarkdownToolStripMenuItem";
+        renderAsMarkdownToolStripMenuItem.Size = new Size(453, 22);
+        renderAsMarkdownToolStripMenuItem.Text = "Render commit message as Markdown";
+        renderAsMarkdownToolStripMenuItem.Click += renderAsMarkdownToolStripMenuItem_Click;
         // 
         // toolStripSeparator2
         // 
@@ -247,8 +268,10 @@ partial class CommitInfo
     private ToolStripMenuItem addNoteToolStripMenuItem;
     private ToolStripMenuItem showMessagesOfAnnotatedTagsToolStripMenuItem;
     private ToolStripMenuItem showTagThisCommitDerivesFromMenuItem;
+    private ToolStripMenuItem renderAsMarkdownToolStripMenuItem;
     private CommitInfoHeader commitInfoHeader;
     private Panel pnlCommitMessage;
     private RichTextBox rtbxCommitMessage;
+    private UserControls.MarkdownViewer mdCommitMessage;
     private TableLayoutPanel tableLayout;
 }

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -315,6 +315,7 @@ public partial class CommitInfo : GitModuleControl
         showContainedInTagsToolStripMenuItem.Checked = AppSettings.CommitInfoShowContainedInTags;
         showMessagesOfAnnotatedTagsToolStripMenuItem.Checked = AppSettings.ShowAnnotatedTagsMessages;
         showTagThisCommitDerivesFromMenuItem.Checked = AppSettings.CommitInfoShowTagThisCommitDerivesFrom;
+        renderAsMarkdownToolStripMenuItem.Checked = AppSettings.RenderMarkdownPreview;
 
         _showAllBranches = false;
         _showAllTags = false;
@@ -341,21 +342,23 @@ public partial class CommitInfo : GitModuleControl
         }
         else
         {
-            rtbxCommitMessage.SetXHTMLText(GetFixCommitMessage());
+            SetCommitMessage(GetFixCommitMessage());
             RevisionInfo.Clear();
         }
 
         return;
 
-        string GetFixCommitMessage()
+        (string rawBody, string xhtml) GetFixCommitMessage()
         {
             if (_revision is null)
             {
-                return string.Empty;
+                return (string.Empty, string.Empty);
             }
 
             CommitData data = _commitDataManager.CreateFromRevision(_revision, _children);
-            return _commitDataBodyRenderer?.Render(data, showRevisionsAsLinks: false) ?? string.Empty;
+            string rawBody = (GitExtensions.Extensibility.Extensions.UIExtensions.FormatBodyAndNotes(data.Body, data.Notes) ?? "").Trim();
+            string xhtml = _commitDataBodyRenderer?.Render(data, showRevisionsAsLinks: false) ?? string.Empty;
+            return (rawBody, xhtml);
         }
 
         async Task UpdateCommitMessageAsync(CancellationToken cancellationToken)
@@ -378,11 +381,12 @@ public partial class CommitInfo : GitModuleControl
                 return;
             }
 
-            string commitMessage = commitDataBodyRenderer.Render(data, showRevisionsAsLinks: CommandClickedEvent is not null);
+            string rawBody = (GitExtensions.Extensibility.Extensions.UIExtensions.FormatBodyAndNotes(data.Body, data.Notes) ?? "").Trim();
+            string xhtml = commitDataBodyRenderer.Render(data, showRevisionsAsLinks: CommandClickedEvent is not null);
 
             await this.SwitchToMainThreadAsync(cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            rtbxCommitMessage.SetXHTMLText(commitMessage);
+            SetCommitMessage((rawBody, xhtml));
         }
 
         void StartAsyncDataLoad(DistributedSettings settings, CancellationToken cancellationToken)
@@ -728,6 +732,36 @@ public partial class CommitInfo : GitModuleControl
         ReloadCommitInfo();
     }
 
+    private void renderAsMarkdownToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        AppSettings.RenderMarkdownPreview = !AppSettings.RenderMarkdownPreview;
+        ReloadCommitInfo();
+    }
+
+    private void SetCommitMessage((string rawBody, string xhtml) message)
+    {
+        bool useMarkdown = AppSettings.RenderMarkdownPreview;
+
+        rtbxCommitMessage.Visible = !useMarkdown;
+        mdCommitMessage.Visible = useMarkdown;
+
+        if (useMarkdown)
+        {
+            mdCommitMessage.MarkdownText = message.rawBody;
+
+            // WebView2 doesn't fire ContentsResized, so set a reasonable
+            // height based on the text length as a rough heuristic.
+            int lineCount = message.rawBody.Split('\n').Length;
+            int estimatedLineHeight = (int)(16 * DpiUtil.ScaleY);
+            _commitMessageHeight = Math.Max(estimatedLineHeight * lineCount, (int)(60 * DpiUtil.ScaleY));
+            PerformLayout();
+        }
+        else
+        {
+            rtbxCommitMessage.SetXHTMLText(message.xhtml);
+        }
+    }
+
     private void addNoteToolStripMenuItem_Click(object sender, EventArgs e)
     {
         if (_revision is null)
@@ -766,6 +800,13 @@ public partial class CommitInfo : GitModuleControl
 
     private void CommitMessage_ContentsResized(ContentsResizedEventArgs e)
     {
+        // When the WebView2 markdown viewer is active, don't let the hidden
+        // RichTextBox's ContentsResized override the estimated height.
+        if (mdCommitMessage.Visible)
+        {
+            return;
+        }
+
         _commitMessageHeight = e.NewRectangle.Height;
 
         // at scale factor of 150% there is rendering artifact - the last line is almost lost

--- a/src/app/GitUI/Editor/FileViewer.Designer.cs
+++ b/src/app/GitUI/Editor/FileViewer.Designer.cs
@@ -63,7 +63,9 @@ partial class FileViewer
         PictureBox = new PictureBoxEx();
         _NO_TRANSLATE_lblShowPreview = new LinkLabel();
         internalFileViewer = new GitUI.Editor.FileViewerInternal();
+        markdownViewer = new GitUI.UserControls.MarkdownViewer();
         showSyntaxHighlighting = new ToolStripButton();
+        markdownPreviewButton = new ToolStripButton();
         contextMenu.SuspendLayout();
         fileviewerToolbar.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)(PictureBox)).BeginInit();
@@ -315,6 +317,7 @@ partial class FileViewer
         showEntireFileButton,
         showNonPrintChars,
         showSyntaxHighlighting,
+        markdownPreviewButton,
         ignoreWhitespaceAtEol,
         ignoreWhiteSpaces,
         ignoreAllWhitespaces,
@@ -483,11 +486,32 @@ partial class FileViewer
         showSyntaxHighlighting.ToolTipText = "Show syntax highlighting";
         showSyntaxHighlighting.Click += ShowSyntaxHighlighting_Click;
         // 
+        // markdownPreviewButton
+        // 
+        markdownPreviewButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
+        markdownPreviewButton.Image = Properties.Images.Preview;
+        markdownPreviewButton.Name = "markdownPreviewButton";
+        markdownPreviewButton.Size = new Size(23, 22);
+        markdownPreviewButton.ToolTipText = "Toggle Markdown preview";
+        markdownPreviewButton.Visible = false;
+        markdownPreviewButton.Click += MarkdownPreviewButton_Click;
+        // 
+        // markdownViewer
+        // 
+        markdownViewer.Dock = DockStyle.Fill;
+        markdownViewer.Location = new Point(0, 0);
+        markdownViewer.Margin = new Padding(0);
+        markdownViewer.Name = "markdownViewer";
+        markdownViewer.Size = new Size(757, 518);
+        markdownViewer.TabIndex = 8;
+        markdownViewer.Visible = false;
+        // 
         // FileViewer
         // 
         AutoScaleDimensions = new SizeF(96F, 96F);
         AutoScaleMode = AutoScaleMode.Dpi;
         Controls.Add(_NO_TRANSLATE_lblShowPreview);
+        Controls.Add(markdownViewer);
         Controls.Add(internalFileViewer);
         Controls.Add(PictureBox);
         Controls.Add(fileviewerToolbar);
@@ -550,4 +574,6 @@ partial class FileViewer
     private ToolStripMenuItem ignoreAllWhitespaceChangesToolStripMenuItem;
     private LinkLabel _NO_TRANSLATE_lblShowPreview;
     private ToolStripButton showSyntaxHighlighting;
+    private ToolStripButton markdownPreviewButton;
+    private UserControls.MarkdownViewer markdownViewer;
 }

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -64,6 +64,7 @@ public partial class FileViewer : GitModuleControl
     private Encoding? _encoding;
     private Func<Task>? _deferShowFunc;
     private FileStatusItem? _viewItem;
+    private bool _isMarkdownFile;
 
     [GeneratedRegex(@"warning: .*has type .* expected .*", RegexOptions.ExplicitCapture)]
     private static partial Regex FileModeWarningRegex { get; }
@@ -154,6 +155,23 @@ public partial class FileViewer : GitModuleControl
             }
         };
         internalFileViewer.MouseLeave += (_, e) =>
+        {
+            if (GetChildAtPoint(PointToClient(MousePosition)) != fileviewerToolbar &&
+                fileviewerToolbar is not null)
+            {
+                fileviewerToolbar.Visible = false;
+            }
+        };
+        markdownViewer.MouseMove += (_, e) =>
+        {
+            if (!fileviewerToolbar.Visible)
+            {
+                fileviewerToolbar.Visible = true;
+                fileviewerToolbar.Location = new Point(Width - fileviewerToolbar.Width - 40, 0);
+                fileviewerToolbar.BringToFront();
+            }
+        };
+        markdownViewer.MouseLeave += (_, e) =>
         {
             if (GetChildAtPoint(PointToClient(MousePosition)) != fileviewerToolbar &&
                 fileviewerToolbar is not null)
@@ -640,6 +658,13 @@ public partial class FileViewer : GitModuleControl
                         internalFileViewer.SetText(string.Format(_binaryFileDetected.Text, fileName), openWithDifftool);
                     }
                 }
+                else if (_viewMode == ViewMode.MarkdownPreview)
+                {
+                    markdownViewer.MarkdownText = text;
+
+                    // Also keep the text in the internal viewer so toggling back works
+                    internalFileViewer.SetText(text, openWithDifftool, ViewMode.Text, useGitColoring: false, contentIdentification: fileName);
+                }
                 else
                 {
                     // If the file seem to be a diff, color with escape sequences if they exist
@@ -1024,6 +1049,9 @@ public partial class FileViewer : GitModuleControl
         ignoreWhiteSpaces.Visible = diffCanBeModified;
         ignoreAllWhitespaces.Visible = diffCanBeModified;
 
+        markdownPreviewButton.Visible = _isMarkdownFile || viewMode == ViewMode.MarkdownPreview;
+        markdownPreviewButton.Checked = viewMode == ViewMode.MarkdownPreview;
+
         return;
 
         void SetDifftasticEnabled()
@@ -1174,6 +1202,12 @@ public partial class FileViewer : GitModuleControl
 
         _viewMode = viewMode;
         _viewItem = item;
+        _isMarkdownFile = IsReadOnly
+            && _viewMode == ViewMode.Text
+            && !string.IsNullOrEmpty(fileName)
+            && (fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+                || fileName.EndsWith(".markdown", StringComparison.OrdinalIgnoreCase));
+
         if (_viewMode == ViewMode.Text
             && !string.IsNullOrEmpty(fileName)
             && (fileName.EndsWith(".diff", StringComparison.OrdinalIgnoreCase)
@@ -1181,6 +1215,11 @@ public partial class FileViewer : GitModuleControl
         {
             // Override the set view mode
             _viewMode = ViewMode.FixedDiff;
+        }
+
+        if (_isMarkdownFile && AppSettings.RenderMarkdownPreview)
+        {
+            _viewMode = ViewMode.MarkdownPreview;
         }
 
         SupportLinePatching =
@@ -1201,7 +1240,18 @@ public partial class FileViewer : GitModuleControl
         SetVisibilityDiffContextMenu(_viewMode);
         ClearImage();
         PictureBox.Visible = _viewMode == ViewMode.Image;
-        internalFileViewer.Visible = _viewMode != ViewMode.Image;
+        markdownViewer.Visible = _viewMode == ViewMode.MarkdownPreview;
+        internalFileViewer.Visible = _viewMode is not (ViewMode.Image or ViewMode.MarkdownPreview);
+
+        // In markdown preview mode, always show the toolbar so the user can
+        // toggle back to source. WebView2 doesn't bubble WinForms mouse events,
+        // so the hover-based toolbar approach doesn't work.
+        if (_viewMode == ViewMode.MarkdownPreview)
+        {
+            fileviewerToolbar.Visible = true;
+            fileviewerToolbar.Location = new Point(Width - fileviewerToolbar.Width - 40, 0);
+            fileviewerToolbar.BringToFront();
+        }
 
         if (((ShowSyntaxHighlightingInDiff && _viewMode.IsPartialTextView()) || _viewMode == ViewMode.Text) && fileName is not null)
         {
@@ -1483,6 +1533,33 @@ public partial class FileViewer : GitModuleControl
         showSyntaxHighlightingToolStripMenuItem.Checked = ShowSyntaxHighlightingInDiff;
         AppSettings.ShowSyntaxHighlightingInDiff.Value = ShowSyntaxHighlightingInDiff;
         OnExtraDiffArgumentsChanged();
+    }
+
+    private void MarkdownPreviewButton_Click(object sender, EventArgs e)
+    {
+        bool showPreview = _viewMode != ViewMode.MarkdownPreview;
+
+        if (showPreview)
+        {
+            _viewMode = ViewMode.MarkdownPreview;
+            markdownViewer.MarkdownText = internalFileViewer.GetText();
+        }
+        else
+        {
+            _viewMode = ViewMode.Text;
+        }
+
+        markdownViewer.Visible = showPreview;
+        internalFileViewer.Visible = !showPreview;
+        SetVisibilityDiffContextMenu(_viewMode);
+
+        // Keep toolbar visible in preview mode (WebView2 can't hover-show it)
+        if (showPreview)
+        {
+            fileviewerToolbar.Visible = true;
+            fileviewerToolbar.Location = new Point(Width - fileviewerToolbar.Width - 40, 0);
+            fileviewerToolbar.BringToFront();
+        }
     }
 
     private void ShowEntireFileToolStripMenuItemClick(object sender, EventArgs e)

--- a/src/app/GitUI/Editor/MarkdownToHtmlConverter.cs
+++ b/src/app/GitUI/Editor/MarkdownToHtmlConverter.cs
@@ -1,0 +1,264 @@
+﻿using System.Text;
+using GitExtUtils.GitUI.Theming;
+using Markdig;
+
+namespace GitUI.Editor;
+
+/// <summary>
+///  Converts Markdown text to a full HTML document with embedded CSS,
+///  suitable for rendering in a WebView2 control.
+/// </summary>
+internal static class MarkdownToHtmlConverter
+{
+    private static readonly MarkdownPipeline _pipeline = new MarkdownPipelineBuilder()
+        .UseAutoLinks()
+        .UseEmphasisExtras()
+        .UseTaskLists()
+        .Build();
+
+    /// <summary>
+    ///  Converts the specified Markdown text to a complete HTML document
+    ///  with inline CSS that adapts to the current theme.
+    /// </summary>
+    /// <param name="markdown"> The markdown source text.</param>
+    /// <param name="disableScrolling">
+    ///  When <see langword="true"/>, adds <c>overflow: hidden</c> to the body and
+    ///  injects JavaScript to forward wheel events to the host via
+    ///  <c>window.chrome.webview.postMessage</c>. Use when the WebView2 is embedded
+    ///  in a scrollable WinForms container (e.g. CommitInfo).
+    /// </param>
+    public static string Convert(string markdown, bool disableScrolling = false)
+    {
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return string.Empty;
+        }
+
+        // Strip BOM that prevents Markdig from recognising headings at the start
+        if (markdown[0] == '\uFEFF')
+        {
+            markdown = markdown[1..];
+        }
+
+        string bodyHtml = Markdown.ToHtml(markdown, _pipeline);
+        return WrapInHtmlDocument(bodyHtml, disableScrolling);
+    }
+
+    private static string WrapInHtmlDocument(string bodyHtml, bool disableScrolling)
+    {
+        bool isDark = Application.IsDarkModeEnabled;
+
+        Color background = SystemColors.Window;
+        Color foreground = SystemColors.WindowText;
+        Color codeBg = background.MakeBackgroundDarkerBy(isDark ? -0.08 : 0.05);
+        Color borderColor = background.MakeBackgroundDarkerBy(isDark ? -0.15 : 0.15);
+        Color blockquoteFg = isDark
+            ? Color.FromArgb(145, 152, 161)
+            : Color.FromArgb(101, 109, 118);
+        Color blockquoteBorder = isDark
+            ? Color.FromArgb(61, 68, 77)
+            : Color.FromArgb(208, 215, 222);
+        Color linkColor = isDark
+            ? Color.FromArgb(68, 147, 248)
+            : Color.FromArgb(3, 102, 214);
+        Color ruleColor = borderColor;
+        Color tableRowAlt = background.MakeBackgroundDarkerBy(isDark ? -0.04 : 0.02);
+        Color h6Color = isDark
+            ? Color.FromArgb(145, 152, 161)
+            : Color.FromArgb(101, 109, 118);
+
+        StringBuilder sb = new();
+
+        // GitHub-flavoured markdown CSS, adapted from github-markdown-css (MIT license).
+        // Colours are computed from SystemColors for theme integration.
+        sb.Append($$"""
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <meta charset="utf-8">
+            <style>
+            * { box-sizing: border-box; }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+                font-size: 12px;
+                color: {{FormatColor(foreground)}};
+                background: {{FormatColor(background)}};
+                margin: 8px 16px;
+                line-height: 1.5;
+                word-wrap: break-word;{{(disableScrolling ? "\n                overflow: hidden;" : "")}}
+            }
+            body > *:first-child { margin-top: 0 !important; }
+            body > *:last-child { margin-bottom: 0 !important; }
+            h1, h2, h3, h4, h5, h6 {
+                margin-top: 1.5rem;
+                margin-bottom: 1rem;
+                font-weight: 600;
+                line-height: 1.25;
+            }
+            h1 {
+                font-size: 2em;
+                padding-bottom: 0.3em;
+                border-bottom: 1px solid {{FormatColor(borderColor)}};
+            }
+            h2 {
+                font-size: 1.5em;
+                padding-bottom: 0.3em;
+                border-bottom: 1px solid {{FormatColor(borderColor)}};
+            }
+            h3 { font-size: 1.25em; }
+            h4 { font-size: 1em; }
+            h5 { font-size: 0.875em; }
+            h6 { font-size: 0.85em; color: {{FormatColor(h6Color)}}; }
+            p, blockquote, ul, ol, dl, table, pre, details {
+                margin-top: 0;
+                margin-bottom: 1rem;
+            }
+            ul, ol {
+                padding-left: 2em;
+            }
+            ul ul, ul ol, ol ol, ol ul {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
+            ol ol, ul ol {
+                list-style-type: lower-roman;
+            }
+            ul ul ol, ul ol ol, ol ul ol, ol ol ol {
+                list-style-type: lower-alpha;
+            }
+            li + li {
+                margin-top: 0.25em;
+            }
+            li > p {
+                margin-top: 1rem;
+            }
+            b, strong {
+                font-weight: 600;
+            }
+            a {
+                color: {{FormatColor(linkColor)}};
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+            code, tt, samp {
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+                font-size: 85%;
+            }
+            code, tt {
+                padding: 0.2em 0.4em;
+                margin: 0;
+                white-space: break-spaces;
+                background-color: {{FormatColor(codeBg)}};
+                border-radius: 6px;
+            }
+            pre {
+                padding: 1rem;
+                overflow: auto;
+                font-size: 85%;
+                line-height: 1.45;
+                background-color: {{FormatColor(codeBg)}};
+                border-radius: 6px;
+                margin-top: 0;
+                margin-bottom: 1rem;
+            }
+            pre code, pre tt {
+                display: inline;
+                padding: 0;
+                margin: 0;
+                background: transparent;
+                border: 0;
+                white-space: pre;
+                word-wrap: normal;
+                font-size: 100%;
+            }
+            blockquote {
+                margin: 0 0 1rem 0;
+                padding: 0 1em;
+                color: {{FormatColor(blockquoteFg)}};
+                border-left: 0.25em solid {{FormatColor(blockquoteBorder)}};
+            }
+            blockquote > :first-child { margin-top: 0; }
+            blockquote > :last-child { margin-bottom: 0; }
+            hr {
+                height: 0.25em;
+                padding: 0;
+                margin: 1.5rem 0;
+                background-color: {{FormatColor(ruleColor)}};
+                border: 0;
+            }
+            table {
+                border-spacing: 0;
+                border-collapse: collapse;
+                display: block;
+                width: max-content;
+                max-width: 100%;
+                overflow: auto;
+            }
+            table th {
+                font-weight: 600;
+            }
+            table th, table td {
+                padding: 6px 13px;
+                border: 1px solid {{FormatColor(borderColor)}};
+            }
+            table tr {
+                background-color: {{FormatColor(background)}};
+                border-top: 1px solid {{FormatColor(borderColor)}};
+            }
+            table tr:nth-child(2n) {
+                background-color: {{FormatColor(tableRowAlt)}};
+            }
+            img {
+                max-width: 100%;
+                border-style: none;
+            }
+            .task-list-item {
+                list-style-type: none;
+            }
+            .task-list-item input[type="checkbox"] {
+                margin: 0 0.35em 0.25em -1.6em;
+                vertical-align: middle;
+            }
+            dl dt {
+                padding: 0;
+                margin-top: 1rem;
+                font-size: 1em;
+                font-style: italic;
+                font-weight: 600;
+            }
+            dl dd {
+                padding: 0 1rem;
+                margin-bottom: 1rem;
+            }
+            </style>
+            """);
+
+        if (disableScrolling)
+        {
+            sb.Append("""
+                <script>
+                document.addEventListener('wheel', function(e) {
+                    e.preventDefault();
+                    window.chrome.webview.postMessage(Math.round(e.deltaY));
+                }, { passive: false });
+                </script>
+                """);
+        }
+
+        sb.Append("""
+            </head>
+            <body>
+            """);
+        sb.Append(bodyHtml);
+        sb.Append("""
+            </body>
+            </html>
+            """);
+
+        return sb.ToString();
+
+        static string FormatColor(Color c) => $"rgb({c.R},{c.G},{c.B})";
+    }
+}

--- a/src/app/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/src/app/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1445,6 +1445,8 @@ internal static class RichTextBoxXhtmlSupportExtension
                 cs.scf.Push(cs.cf);
                 string strFont = cs.cf.szFaceName;
                 int crFont = cs.cf.crTextColor;
+                int crBack = cs.cf.crBackColor;
+                bool hasBackColor = false;
                 int yHeight = cs.cf.yHeight;
 
                 while (reader.MoveToNextAttribute())
@@ -1477,6 +1479,24 @@ internal static class RichTextBoxXhtmlSupportExtension
                             }
 
                             break;
+                        case "bgcolor":
+                            cs.cf.dwMask |= CFM.BACKCOLOR;
+                            hasBackColor = true;
+                            string bgText = reader.Value;
+                            if (bgText.StartsWith('#'))
+                            {
+                                string strBg = bgText[1..];
+                                int nBg = Convert.ToInt32(strBg, 16);
+                                Color bgColor = Color.FromArgb(nBg);
+                                crBack = GetCOLORREF(bgColor);
+                            }
+                            else if (!int.TryParse(bgText, out crBack))
+                            {
+                                Color bgColor = Color.FromName(bgText);
+                                crBack = GetCOLORREF(bgColor);
+                            }
+
+                            break;
                     }
                 }
 
@@ -1484,9 +1504,15 @@ internal static class RichTextBoxXhtmlSupportExtension
 
                 cs.cf.szFaceName = strFont;
                 cs.cf.crTextColor = crFont;
+                cs.cf.crBackColor = crBack;
                 cs.cf.yHeight = yHeight;
 
                 cs.cf.dwEffects &= ~CFE.AUTOCOLOR;
+                if (hasBackColor)
+                {
+                    cs.cf.dwEffects &= ~CFE.AUTOBACKCOLOR;
+                }
+
                 cs.charFormatChanged = true;
                 break;
         }

--- a/src/app/GitUI/Editor/ViewMode.cs
+++ b/src/app/GitUI/Editor/ViewMode.cs
@@ -28,5 +28,8 @@ public enum ViewMode
     Grep,
 
     // Image viewer
-    Image
+    Image,
+
+    // Rendered Markdown preview
+    MarkdownPreview
 }

--- a/src/app/GitUI/GitUI.csproj
+++ b/src/app/GitUI/GitUI.csproj
@@ -24,6 +24,8 @@
     <PackageReference Include="Microsoft-WindowsAPICodePack-Core" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" />
     <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="Markdig" />
+    <PackageReference Include="Microsoft.Web.WebView2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -957,6 +957,10 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>Copy link</source>
         <target />
       </trans-unit>
+      <trans-unit id="renderAsMarkdownToolStripMenuItem.Text">
+        <source>Render commit message as Markdown</source>
+        <target />
+      </trans-unit>
       <trans-unit id="showContainedInBranchesRemoteIfNoLocalToolStripMenuItem.Text">
         <source>Show remote branches only when no local branch contains this commit</source>
         <target />
@@ -2004,6 +2008,10 @@ Suitable for some config files modified locally.</source>
       </trans-unit>
       <trans-unit id="increaseNumberOfLinesToolStripMenuItem.Text">
         <source>&amp;Increase the number of lines of context</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="markdownPreviewButton.ToolTipText">
+        <source>Toggle Markdown preview</source>
         <target />
       </trans-unit>
       <trans-unit id="nextChangeButton.ToolTipText">

--- a/src/app/GitUI/UserControls/MarkdownViewer.cs
+++ b/src/app/GitUI/UserControls/MarkdownViewer.cs
@@ -1,0 +1,166 @@
+using GitCommands;
+using GitExtUtils.GitUI;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+
+namespace GitUI.UserControls;
+
+/// <summary>
+///  A read-only control that renders Markdown text in a WebView2 control
+///  using <see cref="Editor.MarkdownToHtmlConverter"/>.
+/// </summary>
+public class MarkdownViewer : UserControl
+{
+    private readonly WebView2 _webView;
+    private string _markdownText = string.Empty;
+    private string? _pendingHtml;
+    private bool _isWebViewReady;
+    private bool _isInitializing;
+
+    public MarkdownViewer()
+    {
+        _webView = new WebView2
+        {
+            Dock = DockStyle.Fill,
+            DefaultBackgroundColor = SystemColors.Window,
+        };
+
+        _webView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
+        _webView.NavigationStarting += WebView_NavigationStarting;
+
+        // Bubble mouse events so the floating toolbar in FileViewer works.
+        _webView.MouseMove += (s, e) => OnMouseMove(e);
+        _webView.MouseLeave += (s, e) => OnMouseLeave(e);
+
+        Controls.Add(_webView);
+    }
+
+    /// <summary>
+    ///  Gets or sets the Markdown text to render.
+    /// </summary>
+    public string MarkdownText
+    {
+        get => _markdownText;
+        set
+        {
+            _markdownText = value ?? string.Empty;
+            RenderMarkdown();
+        }
+    }
+
+    /// <summary>
+    ///  When <see langword="true"/>, the WebView2 does not scroll internally and
+    ///  forwards wheel events to the nearest scrollable WinForms parent.
+    ///  Use for embedded panels like CommitInfo. Default is <see langword="false"/>.
+    /// </summary>
+    public bool DisableScrolling { get; set; }
+
+    private async Task EnsureInitializedAsync()
+    {
+        if (_isWebViewReady || _isInitializing)
+        {
+            return;
+        }
+
+        _isInitializing = true;
+
+        CoreWebView2Environment environment = await CoreWebView2Environment.CreateAsync(
+            userDataFolder: Path.Combine(Path.GetTempPath(), "GitExtensions_WebView2"));
+        await _webView.EnsureCoreWebView2Async(environment);
+    }
+
+    private void WebView_CoreWebView2InitializationCompleted(object? sender, CoreWebView2InitializationCompletedEventArgs e)
+    {
+        if (!e.IsSuccess)
+        {
+            return;
+        }
+
+        _isWebViewReady = true;
+
+        CoreWebView2Settings settings = _webView.CoreWebView2.Settings;
+        settings.AreDefaultContextMenusEnabled = false;
+        settings.AreDevToolsEnabled = false;
+        settings.IsStatusBarEnabled = false;
+        settings.IsZoomControlEnabled = false;
+
+        // Forward mouse wheel events to the parent scroll container.
+        // WebView2 is a separate HWND that captures wheel events, preventing
+        // the WinForms parent (e.g. CommitInfo with AutoScroll) from scrolling.
+        _webView.CoreWebView2.WebMessageReceived += (s, args) =>
+        {
+            if (int.TryParse(args.WebMessageAsJson, out int delta))
+            {
+                ScrollableControl? scrollParent = FindScrollParent();
+                if (scrollParent is not null)
+                {
+                    Point pos = scrollParent.AutoScrollPosition;
+                    scrollParent.AutoScrollPosition = new Point(-pos.X, -pos.Y + delta);
+                }
+            }
+        };
+
+        if (_pendingHtml is not null)
+        {
+            _webView.NavigateToString(_pendingHtml);
+            _pendingHtml = null;
+        }
+    }
+
+    private void WebView_NavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
+    {
+        // Allow initial content load (about:blank and data URIs) but open
+        // clicked links in the default browser instead of navigating.
+        if (e.Uri is not null
+            && !e.Uri.StartsWith("about:", StringComparison.OrdinalIgnoreCase)
+            && !e.Uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            e.Cancel = true;
+            OsShellUtil.OpenUrlInDefaultBrowser(e.Uri);
+        }
+    }
+
+    private void RenderMarkdown()
+    {
+        string html = Editor.MarkdownToHtmlConverter.Convert(_markdownText, DisableScrolling);
+
+        if (_isWebViewReady)
+        {
+            _webView.NavigateToString(html);
+        }
+        else
+        {
+            _pendingHtml = html;
+
+            // EnsureCoreWebView2Async must run on the UI thread (STA).
+            // RenderMarkdown is called from property setters on the UI thread,
+            // so we can safely fire-and-forget here.
+            EnsureInitializedAsync().FileAndForget();
+        }
+    }
+
+    private ScrollableControl? FindScrollParent()
+    {
+        for (Control? current = Parent; current is not null; current = current.Parent)
+        {
+            if (current is ScrollableControl { AutoScroll: true } scrollable)
+            {
+                return scrollable;
+            }
+        }
+
+        return null;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _webView.CoreWebView2InitializationCompleted -= WebView_CoreWebView2InitializationCompleted;
+            _webView.NavigationStarting -= WebView_NavigationStarting;
+            _webView.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/app/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
+++ b/src/app/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
@@ -13,7 +13,13 @@ public interface ICommitDataBodyRenderer
     /// <summary>
     /// Render the body of a commit message.
     /// </summary>
-    string Render(CommitData commitData, bool showRevisionsAsLinks);
+    /// <param name="commitData"> The commit data to render.</param>
+    /// <param name="showRevisionsAsLinks"> Whether to linkify commit hashes.</param>
+    /// <param name="markdownConverter">
+    ///  An optional function that converts Markdown text to XHTML. When provided,
+    ///  the raw body is passed through this function instead of being HTML-encoded.
+    /// </param>
+    string Render(CommitData commitData, bool showRevisionsAsLinks, Func<string, string>? markdownConverter = null);
 }
 
 /// <summary>
@@ -33,11 +39,15 @@ public sealed class CommitDataBodyRenderer : ICommitDataBodyRenderer
     /// <summary>
     /// Render the body of a commit message.
     /// </summary>
-    public string Render(CommitData commitData, bool showRevisionsAsLinks)
+    public string Render(CommitData commitData, bool showRevisionsAsLinks, Func<string, string>? markdownConverter = null)
     {
         ArgumentNullException.ThrowIfNull(commitData);
 
-        string body = WebUtility.HtmlEncode((UIExtensions.FormatBodyAndNotes(commitData.Body, commitData.Notes) ?? "").Trim());
+        string rawBody = (UIExtensions.FormatBodyAndNotes(commitData.Body, commitData.Notes) ?? "").Trim();
+
+        string body = markdownConverter is not null
+            ? markdownConverter(rawBody)
+            : WebUtility.HtmlEncode(rawBody);
 
         if (showRevisionsAsLinks)
         {

--- a/tests/app/UnitTests/GitUI.Tests/Editor/MarkdownRenderingIntegrationTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/MarkdownRenderingIntegrationTests.cs
@@ -1,0 +1,215 @@
+using AwesomeAssertions;
+using GitUI.Editor;
+
+namespace GitUITests.Editor;
+
+/// <summary>
+/// Tests that verify the HTML output from <see cref="MarkdownToHtmlConverter"/>
+/// used for WebView2 rendering of markdown in CommitInfo and FileViewer.
+/// </summary>
+[TestFixture]
+public class MarkdownRenderingIntegrationTests
+{
+    [Test]
+    public void Convert_should_return_empty_for_null()
+    {
+        MarkdownToHtmlConverter.Convert(null!).Should().BeEmpty();
+    }
+
+    [Test]
+    public void Convert_should_return_empty_for_empty_string()
+    {
+        MarkdownToHtmlConverter.Convert(string.Empty).Should().BeEmpty();
+    }
+
+    [Test]
+    public void Convert_should_produce_html_document()
+    {
+        string html = MarkdownToHtmlConverter.Convert("Hello");
+        html.Should().Contain("<!DOCTYPE html>");
+        html.Should().Contain("<body>");
+        html.Should().Contain("</body>");
+    }
+
+    [Test]
+    public void Convert_two_item_list_should_have_li_for_each_item()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            Hello
+
+            - Yes
+            - Please
+            """);
+
+        html.Should().Contain("<li>Yes</li>");
+        html.Should().Contain("<li>Please</li>");
+    }
+
+    [Test]
+    public void Convert_three_item_list_should_have_all_items()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            - First
+            - Second
+            - Third
+            """);
+
+        html.Should().Contain("<li>First</li>");
+        html.Should().Contain("<li>Second</li>");
+        html.Should().Contain("<li>Third</li>");
+    }
+
+    [Test]
+    public void Convert_nested_list_should_have_nested_ul()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            - Parent
+              - Child 1
+              - Child 2
+            """);
+
+        html.Should().Contain("<li>Parent");
+        html.Should().Contain("<li>Child 1</li>");
+        html.Should().Contain("<li>Child 2</li>");
+        html.Should().Contain("<ul>").And.Contain("</ul>");
+    }
+
+    [Test]
+    public void Convert_paragraph_after_list_should_be_outside_ul()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            - Item
+
+            After the list
+            """);
+
+        html.Should().Contain("</ul>");
+        int listEnd = html.IndexOf("</ul>");
+        int afterStart = html.IndexOf("After the list");
+        afterStart.Should().BeGreaterThan(listEnd, "paragraph should come after the list");
+    }
+
+    [Test]
+    public void Convert_should_not_render_html_comments_as_list_items()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            - Item one
+            - Item two
+            <!-- GitOpsUserAgent=something -->
+            """);
+
+        // HTML comments may be present in output but should not create extra <li> tags
+        html.Split("<li>").Length.Should().Be(3, "should be 2 <li> tags, not 3");
+    }
+
+    [Test]
+    public void Convert_consecutive_paragraphs_should_be_separate_p_tags()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            First paragraph.
+
+            Second paragraph.
+            """);
+
+        html.Should().Contain("<p>First paragraph.</p>");
+        html.Should().Contain("<p>Second paragraph.</p>");
+    }
+
+    [Test]
+    public void Convert_inline_code_should_use_code_tag()
+    {
+        string html = MarkdownToHtmlConverter.Convert("Use `code` here");
+        html.Should().Contain("<code>code</code>");
+    }
+
+    [Test]
+    public void Convert_fenced_code_block_should_use_pre_and_code()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            ```
+            code block
+            ```
+            """);
+
+        html.Should().Contain("<pre><code>");
+        html.Should().Contain("code block");
+    }
+
+    [Test]
+    public void Convert_headings_should_produce_h_tags()
+    {
+        MarkdownToHtmlConverter.Convert("# H1").Should().Contain("<h1>");
+        MarkdownToHtmlConverter.Convert("## H2").Should().Contain("<h2>");
+        MarkdownToHtmlConverter.Convert("### H3").Should().Contain("<h3>");
+    }
+
+    [Test]
+    public void Convert_bold_should_produce_strong()
+    {
+        MarkdownToHtmlConverter.Convert("**bold**").Should().Contain("<strong>bold</strong>");
+    }
+
+    [Test]
+    public void Convert_italic_should_produce_em()
+    {
+        MarkdownToHtmlConverter.Convert("*italic*").Should().Contain("<em>italic</em>");
+    }
+
+    [Test]
+    public void Convert_links_should_produce_a_tags()
+    {
+        string html = MarkdownToHtmlConverter.Convert("[text](https://example.com)");
+        html.Should().Contain("<a href=\"https://example.com\">text</a>");
+    }
+
+    [Test]
+    public void Convert_blockquote_should_produce_blockquote_tag()
+    {
+        string html = MarkdownToHtmlConverter.Convert("> quoted text");
+        html.Should().Contain("<blockquote>");
+        html.Should().Contain("quoted text");
+    }
+
+    [Test]
+    public void Convert_thematic_break_should_produce_hr()
+    {
+        MarkdownToHtmlConverter.Convert("---").Should().Contain("<hr />");
+    }
+
+    [Test]
+    public void Convert_list_continuation_should_stay_in_same_li()
+    {
+        string html = MarkdownToHtmlConverter.Convert("""
+            - Replace ulong.TryParse/Utf8Parser with Convert.FromHexString for both char and byte
+              overloads, which is SSSE3-vectorized
+            - Second item
+            """);
+
+        // The continuation should be inside the first <li>, not a separate one
+        int overloadsPos = html.IndexOf("overloads");
+        int secondLiPos = html.IndexOf("<li>Second");
+
+        overloadsPos.Should().BeLessThan(secondLiPos, "continuation should be before second <li>");
+
+        // Only 2 <li> tags
+        html.Split("<li>").Length.Should().Be(3, "should be 2 <li> tags (3 parts when split)");
+    }
+
+    [Test]
+    public void Convert_css_should_include_theme_colors()
+    {
+        string html = MarkdownToHtmlConverter.Convert("test");
+        html.Should().Contain("<style>");
+        html.Should().Contain("rgb(");
+        html.Should().Contain("font-family");
+    }
+
+    [Test]
+    public void Convert_html_entities_should_be_escaped()
+    {
+        string html = MarkdownToHtmlConverter.Convert("1 < 2 & 3 > 0");
+        html.Should().Contain("&lt;");
+        html.Should().Contain("&amp;");
+        html.Should().Contain("&gt;");
+    }
+}


### PR DESCRIPTION
Fixes #6509

(WIP while a few bugs get ironed out. Putting up for early feedback.)

Add the ability to render Markdown content throughout Git Extensions using Markdig for parsing and WebView2 for display. This replaces raw text display with properly formatted output including headings, lists, code blocks, links, tables, and more.

Components:

-  MarkdownToHtmlConverter: Converts Markdown to a complete HTML document with theme-aware CSS adapted from github-markdown-css (MIT). Colours are computed from SystemColors so the output integrates seamlessly with both light and dark WinForms themes. Strips UTF-8 BOM to avoid heading parsing failures.

- MarkdownViewer: A UserControl hosting a WebView2 control that renders Markdown via MarkdownToHtmlConverter. Handles lazy WebView2 init on the UI thread, intercepts link clicks to open in the default browser, and forwards mouse-wheel events to the parent scroll container via JavaScript postMessage (WebView2 is a separate HWND that otherwise captures wheel input).

- CommitInfo integration: When the RenderMarkdownPreview setting is enabled (default: true), commit message bodies render through MarkdownViewer instead of the RichTextBox XHTML path. A context-menu toggle ('Render commit message as Markdown') allows switching at runtime. The hidden RichTextBox ContentsResized event is guarded to prevent it from collapsing the panel height.

- FileViewer integration: Files with .md/.markdown extensions can be previewed as rendered Markdown. A toolbar toggle button (preview icon) appears for Markdown files, allowing users to switch between source and rendered views. The toolbar stays always-visible in preview mode since WebView2 cannot trigger hover-based show/hide. ViewMode enum extended with MarkdownPreview.

- FormChangeLog: Now uses MarkdownViewer so the changelog renders with proper formatting instead of raw Markdown source.

- RichTextBoxXhtmlSupportExtension: Added bgcolor attribute support for the <font> tag, using CHARFORMAT2 crBackColor field.

- CommitDataBodyRenderer: Extended Render() with an optional markdownConverter delegate parameter so the ResourceManager layer stays free of Markdig/WebView2 references.

New setting: AppSettings.RenderMarkdownPreview (default: true)

New dependencies:
  - Markdig 1.1.2 (Markdown parser, MIT license)
  - Microsoft.Web.WebView2 1.0.3856.49 (Chromium renderer, ships with Windows 10+)

Tests: 20 tests covering MarkdownToHtmlConverter output including lists, nested lists, headings, code blocks, links, paragraphs, blockquotes, HTML comment suppression, continuations, and theme CSS.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

<img width="1663" height="1361" alt="image" src="https://github.com/user-attachments/assets/d766b351-76a6-492c-afe1-ab551af718e2" />

<img width="1663" height="1361" alt="image" src="https://github.com/user-attachments/assets/8242a8d1-990f-4a67-8ef3-baf23481a790" />

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
