### PR TITLE
fix(user scripts): Always provide internal items

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
 using GitCommands;
+using GitExtensions.Extensibility;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.ScriptsEngine;
@@ -163,7 +164,8 @@ Diff selection:
             return;
         }
 
-        if (EmbeddedIcons.Images.Count == 0)
+        bool containsAnyImageWithoutPath = EmbeddedIcons.Images.Keys.Cast<string>().Any(name => !name.ContainsAny(Delimiters.PathSeparators));
+        if (!containsAnyImageWithoutPath)
         {
             System.Resources.ResourceManager rm = new("GitUI.Properties.Images", Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
Fixes #13008

## Proposed changes

`ScriptsSettingsPage`: Load internal items also if external icons have been loaded from user-specified files

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="1009" height="65" alt="image" src="https://github.com/user-attachments/assets/bb9aae08-00b9-49e2-bd69-0cbaeb0205ef" />

### After

<img width="1004" height="88" alt="image" src="https://github.com/user-attachments/assets/fa948618-cf23-4792-8fef-5e661a158c3e" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).