### PR TITLE
fix(revision grid): always show ref-specific context menu by default

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2087,8 +2087,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             return;
         }
 
-        // If a ref label was right-clicked, show a focused context menu for that ref
-        if (_rightClickedHitInfo is RefLabelHitInfo hitInfo && (ModifierKeys == Keys.Control || (ModifierKeys != Keys.Shift && !AppSettings.AlwaysShowAdvOpt)))
+        // If a ref label was right-clicked, show a focused context menu for that ref (hold Shift for full menu)
+        if (_rightClickedHitInfo is RefLabelHitInfo hitInfo && !ModifierKeys.HasFlag(Keys.Shift))
         {
             e.Cancel = true;
             ShowRefSpecificContextMenu(hitInfo.GitRef, hitInfo.StashReflogSelector);


### PR DESCRIPTION
Right-clicking a ref label now always shows the focused ref-specific context menu regardless of the AlwaysShowAdvOpt setting. Hold Shift to see the full revision context menu instead.

This fixes a regression from #12991 where users with AlwaysShowAdvOpt enabled had to hold Ctrl to get the ref-specific menu.