### PR TITLE
feat(view settings): Add button "save as default"  to "diff viewer" settings page

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -31,6 +31,8 @@ partial class DiffViewerSettingsPage
     private void InitializeComponent()
     {
         tlpnlGeneral = new TableLayoutPanel();
+        btnSaveCurrentViewSettingsAsDefault = new Button();
+        toolTip = new ToolTip();
         chkRememberIgnoreWhiteSpacePreference = new CheckBox();
         chkRememberShowNonPrintingCharsPreference = new CheckBox();
         chkRememberShowEntireFilePreference = new CheckBox();
@@ -66,23 +68,25 @@ partial class DiffViewerSettingsPage
         tlpnlGeneral.ColumnStyles.Add(new ColumnStyle());
         tlpnlGeneral.ColumnStyles.Add(new ColumnStyle());
         tlpnlGeneral.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-        tlpnlGeneral.Controls.Add(chkRememberIgnoreWhiteSpacePreference, 0, 0);
-        tlpnlGeneral.Controls.Add(chkRememberShowNonPrintingCharsPreference, 0, 1);
-        tlpnlGeneral.Controls.Add(chkRememberShowEntireFilePreference, 0, 2);
-        tlpnlGeneral.Controls.Add(chkRememberDiffAppearancePreference, 0, 3);
-        tlpnlGeneral.Controls.Add(chkRememberNumberOfContextLines, 0, 4);
-        tlpnlGeneral.Controls.Add(chkRememberShowSyntaxHighlightingInDiff, 0, 5);
-        tlpnlGeneral.Controls.Add(chkOmitUninterestingDiff, 0, 6);
-        tlpnlGeneral.Controls.Add(chkContScrollToNextFileOnlyWithAlt, 0, 7);
-        tlpnlGeneral.Controls.Add(chkOpenSubmoduleDiffInSeparateWindow, 0, 8);
-        tlpnlGeneral.Controls.Add(chkShowDiffForAllParents, 0, 9);
-        tlpnlGeneral.Controls.Add(chkShowAllCustomDiffTools, 0, 10);
-        tlpnlGeneral.Controls.Add(label1, 0, 11);
-        tlpnlGeneral.Controls.Add(VerticalRulerPosition, 1, 11);
+        tlpnlGeneral.Controls.Add(btnSaveCurrentViewSettingsAsDefault, 0, 0);
+        tlpnlGeneral.Controls.Add(chkRememberIgnoreWhiteSpacePreference, 0, 1);
+        tlpnlGeneral.Controls.Add(chkRememberShowNonPrintingCharsPreference, 0, 2);
+        tlpnlGeneral.Controls.Add(chkRememberShowEntireFilePreference, 0, 3);
+        tlpnlGeneral.Controls.Add(chkRememberDiffAppearancePreference, 0, 4);
+        tlpnlGeneral.Controls.Add(chkRememberNumberOfContextLines, 0, 5);
+        tlpnlGeneral.Controls.Add(chkRememberShowSyntaxHighlightingInDiff, 0, 6);
+        tlpnlGeneral.Controls.Add(chkOmitUninterestingDiff, 0, 7);
+        tlpnlGeneral.Controls.Add(chkContScrollToNextFileOnlyWithAlt, 0, 8);
+        tlpnlGeneral.Controls.Add(chkOpenSubmoduleDiffInSeparateWindow, 0, 9);
+        tlpnlGeneral.Controls.Add(chkShowDiffForAllParents, 0, 10);
+        tlpnlGeneral.Controls.Add(chkShowAllCustomDiffTools, 0, 11);
+        tlpnlGeneral.Controls.Add(label1, 0, 12);
+        tlpnlGeneral.Controls.Add(VerticalRulerPosition, 1, 12);
         tlpnlGeneral.Dock = DockStyle.Fill;
         tlpnlGeneral.Location = new Point(8, 24);
         tlpnlGeneral.Name = "tlpnlGeneral";
-        tlpnlGeneral.RowCount = 12;
+        tlpnlGeneral.RowCount = 13;
+        tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
@@ -96,7 +100,16 @@ partial class DiffViewerSettingsPage
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
-        tlpnlGeneral.Size = new Size(1725, 279);
+        tlpnlGeneral.Size = new Size(1725, 304);
+        // 
+        // btnSaveCurrentViewSettingsAsDefault
+        // 
+        btnSaveCurrentViewSettingsAsDefault.AutoSize = true;
+        btnSaveCurrentViewSettingsAsDefault.Name = "btnSaveCurrentViewSettingsAsDefault";
+        btnSaveCurrentViewSettingsAsDefault.Text = "Save current view settings as default";
+        btnSaveCurrentViewSettingsAsDefault.UseVisualStyleBackColor = true;
+        toolTip.SetToolTip(btnSaveCurrentViewSettingsAsDefault, _saveCurrentViewSettingsAsDefaultTooltip.Text);
+        btnSaveCurrentViewSettingsAsDefault.Click += btnSaveCurrentViewSettingsAsDefault_Click;
         // 
         // chkRememberIgnoreWhiteSpacePreference
         // 
@@ -380,4 +393,6 @@ partial class DiffViewerSettingsPage
     private TableLayoutPanel tlpnlDiffColoring;
     private SettingsCheckBox chkUseGitColoring;
     private SettingsCheckBox chkUseGEThemeGitColoring;
+    private Button btnSaveCurrentViewSettingsAsDefault;
+    private ToolTip toolTip;
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -1,10 +1,19 @@
 ﻿using GitCommands;
 using GitExtensions.Extensibility.Settings;
+using GitUI.UserControls.RevisionGrid;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
 
 public partial class DiffViewerSettingsPage : SettingsPageWithHeader
 {
+    private readonly TranslationString _saveCurrentViewSettingsAsDefaultTooltip = new("""
+        Saves all current view settings as the default for future sessions.
+        Note: The checkboxes 'Remember the "xyz" preference' only affect the running instance
+        as long as the default has not been saved. These preference values are held in memory
+        and must be explicitly saved to become persistent defaults.
+        """);
+
     public DiffViewerSettingsPage(IServiceProvider serviceProvider)
         : base(serviceProvider)
     {
@@ -59,6 +68,11 @@ public partial class DiffViewerSettingsPage : SettingsPageWithHeader
 
     private void chkUseGitColoring_CheckedChanged(object sender, EventArgs e)
         => chkUseGEThemeGitColoring.Enabled = chkUseGitColoring.Checked;
+
+    private void btnSaveCurrentViewSettingsAsDefault_Click(object sender, EventArgs e)
+    {
+        RevisionGridMenuCommands.SaveCurrentViewSettingsAsDefault();
+    }
 
     public static SettingsPageReference GetPageReference()
     {

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -123,6 +123,8 @@ public partial class FileViewer : GitModuleControl
         diffAppearanceToolStripMenuItem.Visible = false;
         SetStateOfContextLinesButtons();
 
+        _ = AppSettings.DiffDisplayAppearance.GetValue(reload: !AppSettings.RememberDiffDisplayAppearance.Value);
+
         automaticContinuousScrollToolStripMenuItem.AdaptImageLightness();
         automaticContinuousScrollToolStripMenuItem.Checked = AppSettings.AutomaticContinuousScroll;
 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1341,6 +1341,24 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>Diff viewer</source>
         <target />
       </trans-unit>
+      <trans-unit id="_saveCurrentViewSettingsAsDefaultTooltip.Text">
+        <source>Saves all current view settings as the default for future sessions.
+Note: The checkboxes 'Remember the "xyz" preference' only affect the running instance
+as long as the default has not been saved. These preference values are held in memory
+and must be explicitly saved to become persistent defaults.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="btnSaveCurrentViewSettingsAsDefault.Text">
+        <source>Save current view settings as default</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="btnSaveCurrentViewSettingsAsDefault.toolTip">
+        <source>Saves all current view settings as the default for future sessions.
+Note: The checkboxes 'Remember the "xyz" preference' only affect the running instance
+as long as the default has not been saved. These preference values are held in memory
+and must be explicitly saved to become persistent defaults.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkContScrollToNextFileOnlyWithAlt.Text">
         <source>Enable automatic continuous scroll (without ALT button)</source>
         <target />

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using GitCommands;
 using GitCommands.Settings;
 using GitExtensions.Extensibility.Git;
@@ -489,7 +489,7 @@ internal class RevisionGridMenuCommands : MenuCommandsBase
             {
                 Name = "SaveAsDefault",
                 Text = "Save current view settings as default",
-                ExecuteAction = SaveAsDefaultViewSettings
+                ExecuteAction = SaveCurrentViewSettingsAsDefault
             }
         };
     }
@@ -538,9 +538,12 @@ internal class RevisionGridMenuCommands : MenuCommandsBase
         }
     }
 
-    private void SaveAsDefaultViewSettings()
+    /// <summary>
+    ///  Saves all <see cref="IRuntimeSetting"/> values as the default for future sessions.
+    /// </summary>
+    public static void SaveCurrentViewSettingsAsDefault()
     {
-        foreach (FieldInfo staticAppSettingField in typeof(AppSettings).GetFields(BindingFlags.Public | BindingFlags.NonPublic | System.Reflection.BindingFlags.Static))
+        foreach (FieldInfo staticAppSettingField in typeof(AppSettings).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
         {
             IRuntimeSetting? runtimeSetting = staticAppSettingField.GetValue(null) as IRuntimeSetting;
             runtimeSetting?.Save();


### PR DESCRIPTION
Fixes #12634

## Proposed changes

- `DiffViewerSettingsPage`: Add `btnSaveCurrentViewSettingsAsDefault` with tooltip also explaining 'Remember the "xyz" preference'
   implements https://github.com/gitextensions/gitextensions/issues/12634#issuecomment-3499086563 ff.
- `FileViewer`: Apply `AppSettings.RememberDiffDisplayAppearance` to `AppSettings.DiffDisplayAppearance`
   fixes https://github.com/gitextensions/gitextensions/issues/12634#issuecomment-3881683235

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="827" height="549" alt="image" src="https://github.com/user-attachments/assets/fe85a56c-567f-446a-ba5f-1849a5df3557" />

### After

<img width="911" height="569" alt="image" src="https://github.com/user-attachments/assets/50488c4f-c75e-45a5-bc96-32b6ee0d55f2" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).