### PR TITLE
fix: ShowError MessageBoxes in plugins

### DIFF
--- a/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/src/plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -137,7 +137,7 @@ public sealed partial class DeleteUnusedBranchesForm : GitExtensionsFormBase
 
         if (!result.ExitedSuccessfully)
         {
-            MessageBoxes.Show(this, result.AllOutput, $"git {args}", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, result.AllOutput, $"git {args}");
             return [];
         }
 

--- a/src/plugins/Gource/GourceStart.cs
+++ b/src/plugins/Gource/GourceStart.cs
@@ -52,7 +52,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
         }
         catch (Exception e)
         {
-            MessageBoxes.ShowError(this, e.Message, "Error");
+            MessageBoxes.ShowError(this, e.Message);
         }
     }
 

--- a/src/plugins/Gource/GourceStart.cs
+++ b/src/plugins/Gource/GourceStart.cs
@@ -52,7 +52,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
         }
         catch (Exception e)
         {
-            MessageBoxes.Show(this, e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, e.Message, "Error");
         }
     }
 
@@ -62,7 +62,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
 
         if (!File.Exists(GourcePath.Text))
         {
-            MessageBoxes.Show(this, "Cannot find Gource.\nPlease download Gource and set the correct path.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBoxes.ShowError(this, "Cannot find Gource.\nPlease download Gource and set the correct path.", "Error");
             return;
         }
 

--- a/src/plugins/Gource/GourceStart.cs
+++ b/src/plugins/Gource/GourceStart.cs
@@ -62,7 +62,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
 
         if (!File.Exists(GourcePath.Text))
         {
-            MessageBoxes.ShowError(this, "Cannot find Gource.\nPlease download Gource and set the correct path.", "Error");
+            MessageBoxes.ShowError(this, "Cannot find Gource.\nPlease download Gource and set the correct path.");
             return;
         }
 


### PR DESCRIPTION
## Proposed changes

After a recent cleanup were a couple of MessageBoxes call missed, not using ShowError()

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
