### PR TITLE
Clean console emulation interface

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -573,18 +573,14 @@ public partial class FormPush : GitModuleForm
 
             if (onRejectedPullAction is not (GitPullAction.Merge or GitPullAction.Rebase))
             {
-                form.AppendOutput(Environment.NewLine +
-                    "Automatical pull can only be performed, when the default pull action is either set to Merge or Rebase." +
-                    Environment.NewLine + Environment.NewLine);
+                MessageBoxes.ShowError(form, "Automatical pull can only be performed, when the default pull action is either set to Merge or Rebase.");
                 return false;
             }
 
             if (IsRebasingMergeCommit())
             {
-                form.AppendOutput(Environment.NewLine +
-                    "Can not perform automatical pull, when the pull action is set to Rebase " + Environment.NewLine +
-                    "and one of the commits that are about to be rebased is a merge commit." +
-                    Environment.NewLine + Environment.NewLine);
+                MessageBoxes.ShowError(form, "Can not perform automatical pull, when the pull action is set to Rebase " +
+                                             "and one of the commits that are about to be rebased is a merge commit.");
                 return false;
             }
 

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
@@ -36,6 +36,12 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
     public event EventHandler<ConsoleProcessExitEventArgs>? CommandProcessExited;
     public event EventHandler? ConsoleHostTerminated;
 
+    private void WriteConsoleOutput(string text)
+    {
+        Validates.NotNull(_terminal);
+        _terminal.RunningSession?.WriteOutputTextAsync(text);
+    }
+
     public void WriteCommandProcessInput(string text)
     {
         Validates.NotNull(_terminal);
@@ -134,12 +140,6 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
             operation.LogProcessEnd(ex);
             throw;
         }
-    }
-
-    private void WriteConsoleOutput(string text)
-    {
-        Validates.NotNull(_terminal);
-        _terminal.RunningSession?.WriteOutputTextAsync(text);
     }
 }
 

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
@@ -38,12 +38,6 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
     public event EventHandler<ConsoleProcessExitEventArgs>? CommandProcessExited;
     public event EventHandler? ConsoleHostTerminated;
 
-    public void WriteConsoleOutput(string text)
-    {
-        Validates.NotNull(_terminal);
-        _terminal.RunningSession?.WriteOutputTextAsync(text);
-    }
-
     public void WriteCommandProcessInput(string text)
     {
         Validates.NotNull(_terminal);
@@ -95,6 +89,8 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
     {
         ProcessOperation operation = CommandLog.LogProcessStart(command, arguments, workDir);
 
+        WriteConsoleOutput($"{(command.Contains(' ') ? command.Quote() : command)} {arguments}{Environment.NewLine}");
+
         try
         {
             string commandLine = new ArgumentBuilder { command.Quote(), arguments }.ToString();
@@ -119,6 +115,7 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
                 _nLastExitCode = args.ExitCode;
                 operation.LogProcessEnd(_nLastExitCode);
                 outputProcessor.Flush();
+                WriteConsoleOutput("Done");
                 CommandProcessExited?.Invoke(this, new ConsoleProcessExitEventArgs(args.ExitCode));
             };
 
@@ -139,6 +136,12 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
             operation.LogProcessEnd(ex);
             throw;
         }
+    }
+
+    public void WriteConsoleOutput(string text)
+    {
+        Validates.NotNull(_terminal);
+        _terminal.RunningSession?.WriteOutputTextAsync(text);
     }
 }
 

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
@@ -32,8 +32,6 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
 
     public Control Control => this;
 
-    public bool IsDisplayingFullProcessOutput => true;
-
     public event EventHandler<ConsoleOutputEventArgs>? CommandOutputReceived;
     public event EventHandler<ConsoleProcessExitEventArgs>? CommandProcessExited;
     public event EventHandler? ConsoleHostTerminated;
@@ -89,7 +87,7 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
     {
         ProcessOperation operation = CommandLog.LogProcessStart(command, arguments, workDir);
 
-        WriteConsoleOutput($"{(command.Contains(' ') ? command.Quote() : command)} {arguments}{Environment.NewLine}");
+        WriteConsoleOutput($"{command.Quote()} {arguments}{Environment.NewLine}");
 
         try
         {
@@ -138,7 +136,7 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
         }
     }
 
-    public void WriteConsoleOutput(string text)
+    private void WriteConsoleOutput(string text)
     {
         Validates.NotNull(_terminal);
         _terminal.RunningSession?.WriteOutputTextAsync(text);

--- a/src/app/GitUI/ConsoleEmulation/IConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/IConsoleCommandRunner.cs
@@ -11,12 +11,6 @@ public interface IConsoleCommandRunner
     Control Control { get; }
 
     /// <summary>
-    ///  Gets a value indicating whether this control renders the full process output, so callers
-    ///  do not need to duplicate selected lines or progress in the window title.
-    /// </summary>
-    bool IsDisplayingFullProcessOutput { get; }
-
-    /// <summary>
     ///  Occurs when the process writes output.
     /// </summary>
     event EventHandler<ConsoleOutputEventArgs> CommandOutputReceived;
@@ -45,11 +39,6 @@ public interface IConsoleCommandRunner
     ///  Starts a new command process inside the console.
     /// </summary>
     void StartCommand(string command, string arguments, string workDir, Dictionary<string, string> envVariables);
-
-    /// <summary>
-    ///  Writes text directly to the console host output.
-    /// </summary>
-    void WriteConsoleOutput(string text);
 
     /// <summary>
     ///  Writes text to the process input stream.

--- a/src/app/GitUI/ConsoleEmulation/PlainText/IPlainTextConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/PlainText/IPlainTextConsoleCommandRunner.cs
@@ -1,0 +1,6 @@
+﻿namespace GitUI.ConsoleEmulation.PlainText;
+
+internal interface IPlainTextConsoleCommandRunner : IConsoleCommandRunner
+{
+    void WriteOutputText(string text);
+}

--- a/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
@@ -124,6 +124,8 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCo
     {
         ProcessOperation operation = CommandLog.LogProcessStart(command, arguments, workDir);
 
+        WriteConsoleOutput($"{(command.Contains(' ') ? command.Quote() : command)} {arguments}{Environment.NewLine}");
+
         try
         {
             EnvironmentConfiguration.SetEnvironmentVariables();
@@ -214,6 +216,7 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCo
 
                         await this.SwitchToMainThreadAsync();
                         operation.LogProcessEnd(exitCode);
+                        WriteConsoleOutput("Done");
                         _process.Dispose();
                         _process = null;
                         await _input!.DisposeAsync();
@@ -251,7 +254,9 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCo
                     nextLineEnd = output.Length;
                 }
 
-                CommandOutputReceived?.Invoke(this, new ConsoleOutputEventArgs(output[startIndex..nextLineEnd]));
+                string outputLine = output[startIndex..nextLineEnd];
+                CommandOutputReceived?.Invoke(this, new ConsoleOutputEventArgs(outputLine));
+
                 startIndex = nextLineEnd;
             }
         }

--- a/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
@@ -15,7 +15,7 @@ namespace GitUI.ConsoleEmulation.PlainText;
 /// <summary>
 ///  Displays redirected process output in an edit box when no embedded terminal is being used.
 /// </summary>
-public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCommandRunner
+public sealed class PlainTextConsoleCommandRunner : ContainerControl, IPlainTextConsoleCommandRunner
 {
     private readonly RichTextBox _editbox;
 
@@ -61,9 +61,8 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCo
 
     public Control Control => this;
 
-    public bool IsDisplayingFullProcessOutput => false;
-
     public event EventHandler<ConsoleOutputEventArgs>? CommandOutputReceived;
+
     public event EventHandler<ConsoleProcessExitEventArgs>? CommandProcessExited;
 
     // Editbox-based output never terminates independently; event is required by the interface.
@@ -71,7 +70,7 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCo
     public event EventHandler? ConsoleHostTerminated;
 #pragma warning restore CS0067
 
-    public void WriteConsoleOutput(string text)
+    public void WriteOutputText(string text)
     {
         _outputThrottle?.Append(text);
     }
@@ -124,7 +123,7 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCo
     {
         ProcessOperation operation = CommandLog.LogProcessStart(command, arguments, workDir);
 
-        WriteConsoleOutput($"{(command.Contains(' ') ? command.Quote() : command)} {arguments}{Environment.NewLine}");
+        WriteOutputText($"{command.Quote()} {arguments}{Environment.NewLine}");
 
         try
         {
@@ -216,7 +215,7 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IConsoleCo
 
                         await this.SwitchToMainThreadAsync();
                         operation.LogProcessEnd(exitCode);
-                        WriteConsoleOutput("Done");
+                        WriteOutputText("Done");
                         _process.Dispose();
                         _process = null;
                         await _input!.DisposeAsync();

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -104,13 +104,6 @@ public partial class FormProcess : FormStatus
     private void ProcessStart(FormStatus form)
     {
         BeforeProcessStart();
-        string quotedProcessString = ProcessString!;
-        if (quotedProcessString.Contains(' '))
-        {
-            quotedProcessString = quotedProcessString.Quote();
-        }
-
-        AppendMessage($"{quotedProcessString} {ProcessArguments}{Environment.NewLine}");
 
         try
         {
@@ -128,7 +121,7 @@ public partial class FormProcess : FormStatus
         }
         catch (Exception e)
         {
-            AppendMessage($"{Environment.NewLine}{e.ToStringWithData()}{Environment.NewLine}");
+            MessageBoxes.ShowError(this, $"{Environment.NewLine}{e.ToStringWithData()}", "Failed to run command");
             OnExit(1);
         }
     }
@@ -199,29 +192,17 @@ public partial class FormProcess : FormStatus
             const string ansiSuffix = "\u001B[K";
             string line = e.Text.Replace(ansiSuffix, "");
 
-            if (ConsoleCommandRunner.IsDisplayingFullProcessOutput)
+            // To the internal log (which can be then retrieved as full text from this form)
+            OutputLog.Append(line);
+
+            if (!ConsoleCommandRunner.IsDisplayingFullProcessOutput)
             {
-                OutputLog.Append(line); // To the log only, display control displays it by itself
-            }
-            else
-            {
-                AppendOutput(line); // Both to log and display control
+                // To the display control
+                AppendMessage(line);
             }
         }
 
         DataReceived(sender!, e);
-    }
-
-    /// <summary>
-    /// Appends a line of text (CRLF added automatically) both to the logged output (<see cref="FormStatus.GetOutputString"/>) and to the display console control.
-    /// </summary>
-    public void AppendOutput(string line)
-    {
-        // To the internal log (which can be then retrieved as full text from this form)
-        OutputLog.Append(line);
-
-        // To the display control
-        AppendMessage(line);
     }
 
     public static bool IsOperationAborted(string dialogResult)

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -122,7 +122,7 @@ public partial class FormProcess : FormStatus
         }
         catch (Exception e)
         {
-            MessageBoxes.ShowError(this, $"{Environment.NewLine}{e.ToStringWithData()}", "Failed to run command");
+            MessageBoxes.ShowError(this, e.ToStringWithData(), "Failed to run command");
             OnExit(1);
         }
     }

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -3,6 +3,7 @@ using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 using GitUI.ConsoleEmulation;
+using GitUI.ConsoleEmulation.PlainText;
 
 namespace GitUI.HelperDialogs;
 
@@ -195,10 +196,22 @@ public partial class FormProcess : FormStatus
             // To the internal log (which can be then retrieved as full text from this form)
             OutputLog.Append(line);
 
-            if (!ConsoleCommandRunner.IsDisplayingFullProcessOutput)
+            if (ConsoleCommandRunner is IPlainTextConsoleCommandRunner plainTextRunner)
             {
-                // To the display control
-                AppendMessage(line);
+                // Plain text emulator is not emitting process output, so do it manually
+                plainTextRunner.WriteOutputText(line);
+
+                if (!line.EndsWith(Delimiters.LineFeed))
+                {
+                    this.InvokeAndForget(() =>
+                    {
+                        if (ShowPassword.CheckState == CheckState.Unchecked)
+                        {
+                            ShowPassword.CheckState = CheckState.Indeterminate;
+                            PasswordInput.Focus();
+                        }
+                    });
+                }
             }
         }
 

--- a/src/app/GitUI/HelperDialogs/FormStatus.cs
+++ b/src/app/GitUI/HelperDialogs/FormStatus.cs
@@ -120,9 +120,10 @@ public partial class FormStatus : GitExtensionsDialog
         form.Text = text;
         if (output?.Length > 0)
         {
+            IPlainTextConsoleCommandRunner commandRunner = (IPlainTextConsoleCommandRunner)form.ConsoleCommandRunner;
             foreach (string line in output)
             {
-                form.AppendMessage(line);
+                commandRunner.WriteOutputText(line);
             }
         }
 
@@ -155,26 +156,6 @@ public partial class FormStatus : GitExtensionsDialog
         if (!_errorOccurred)
         {
             Start();
-        }
-    }
-
-    /// <summary>
-    /// Adds a message to the console display control ONLY, <see cref="GetOutputString" /> will not list it.
-    /// </summary>
-    private protected void AppendMessage(string text)
-    {
-        ConsoleCommandRunner.WriteConsoleOutput(text);
-
-        if (!text.EndsWith(Delimiters.LineFeed))
-        {
-            this.InvokeAndForget(() =>
-            {
-                if (ShowPassword.CheckState == CheckState.Unchecked)
-                {
-                    ShowPassword.CheckState = CheckState.Indeterminate;
-                    PasswordInput.Focus();
-                }
-            });
         }
     }
 
@@ -251,7 +232,7 @@ public partial class FormStatus : GitExtensionsDialog
         }
 
         // Show last progress message in the title, unless it's showing in the control body already
-        if (!ConsoleCommandRunner.IsDisplayingFullProcessOutput)
+        if (ConsoleCommandRunner is IPlainTextConsoleCommandRunner)
         {
             Text = text;
         }

--- a/src/app/GitUI/HelperDialogs/FormStatus.cs
+++ b/src/app/GitUI/HelperDialogs/FormStatus.cs
@@ -194,7 +194,6 @@ public partial class FormStatus : GitExtensionsDialog
                 Trace.WriteLine(exception);
             }
 
-            AppendMessage("Done");
             ShowPassword.Visible = false;
             PasswordInput.Visible = false;
             ProgressBar.Visible = false;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Currently the `IConsoleCommandRunner` contains API which allows to append text to the console output. While that works perfectly fine with PlainText emulator and ConEmu, it creates complications when implementing other consoles like Mintty. It is still possible to do that by e.g. using a socket and passing text around - but it's complexity and a bit of a delay and overhead. So I decided to simplify the implementation.

I've spent a bit of time analyzing the API usage and refactored it, so that we don't have that API anymore. I left the special handling for PlainText emulator which relies on external output management. Apart from that the code right now shall be equivalent to how it was before.

Internal changes:
- Now console itself is responsible for printing command line args and `Done` at the end. It allows to implement that nicely with Mintty and add custom coloring
- Cleaned `IConsoleCommandRunner` interface
- Added special handling for `IPlainTextConsoleCommandRunner` - as that's the only case where we have special case
- [Minor] Always quote command path instead of doing it conditionally. Doesn't change anything in reality, as real path is always containing spaces.

## Behavior change
When we have push error, we now show error dialog instead of embedding error into the console output:

<img width="567" height="359" alt="image" src="https://github.com/user-attachments/assets/f00c434d-e78a-4912-ba45-f3972e41140c" />

I think it's not a big deal and it's actually nicer to differentiate between command output and GitExtensions errors.


I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
