### PR TITLE
Adopt fore colors

### DIFF
--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -57,58 +57,6 @@ public static class ColorHelper
     }
 
     /// <summary>
-    ///  Get a color to be used instead of SystemColors.GrayText
-    ///  when background is SystemColors.Highlight or SystemColors.MenuHighlight.
-    /// </summary>
-    /// <remarks>
-    ///  Consider a transformation of color range [SystemColors.ControlText, SystemColors.Control] to
-    ///  [SystemColors.HighlightText, SystemColors.Highlight].
-    ///  What result would such transformation produce given SystemColors.GrayText as input?
-    ///  First we calculate transformed GrayText color relative to InvariantTheme.
-    ///  Then we apply transformation from InvariantTheme to current theme by calling AdaptTextColor.
-    ///  Only used in Light mode.
-    /// </remarks>
-    public static Color GetHighlightGrayTextColor(
-        KnownColor backgroundColorName,
-        KnownColor textColorName,
-        KnownColor highlightColorName,
-        float degreeOfGrayness = 1f)
-    {
-        HslColor grayTextHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
-        HslColor textHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
-        HslColor highlightTextHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.HighlightText));
-        HslColor backgroundHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(backgroundColorName));
-        HslColor highlightBackgroundHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(highlightColorName));
-
-        double grayTextL = textHsl.L + (degreeOfGrayness * (grayTextHsl.L - textHsl.L));
-
-        double highlightGrayTextL = Transform(
-            grayTextL,
-            textHsl.L, backgroundHsl.L,
-            highlightTextHsl.L, highlightBackgroundHsl.L);
-
-        HslColor highlightGrayTextHsl = grayTextHsl.WithLuminosity(highlightGrayTextL);
-        return AdaptColor(highlightGrayTextHsl.ToColor(), isForeground: true);
-    }
-
-    /// <summary>
-    ///  Get a color to be used instead of <see cref="SystemColors.GrayText"/> which is more or less gray than
-    ///  the usual <see cref="SystemColors.GrayText"/>.
-    ///  Only used in Light mode.
-    /// </summary>
-    /// <param name="textColorName">The name of the text color to base the grayness on.</param>
-    /// <param name="degreeOfGrayness">How gray the result should be; 1.0 is full gray, 0.0 is same as text.</param>
-    public static Color GetGrayTextColor(KnownColor textColorName, float degreeOfGrayness = 1f)
-    {
-        HslColor grayTextHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
-        HslColor textHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
-
-        double grayTextL = textHsl.L + (degreeOfGrayness * (grayTextHsl.L - textHsl.L));
-        HslColor highlightGrayTextHsl = grayTextHsl.WithLuminosity(grayTextL);
-        return AdaptColor(highlightGrayTextHsl.ToColor(), isForeground: true);
-    }
-
-    /// <summary>
     ///  Adapt invariant background colors to the current theme,
     ///  by comparing to Text/Background color pairs in the invariant theme.
     ///  Note that <see cref="SystemColors"/> and <see cref="AppColor"/> should not be adapted.
@@ -116,9 +64,6 @@ public static class ColorHelper
     /// <param name="original">The original <see cref="Color"/></param>
     /// <returns>The adapted color.</returns>
     public static Color AdaptBackColor(this Color original)
-        => AdaptColor(original, isForeground: false);
-
-    private static Color AdaptColor(Color original, bool isForeground)
     {
         if (IsDefaultTheme)
         {
@@ -129,14 +74,11 @@ public static class ColorHelper
 
         int index = Enumerable.Range(0, BackForeExamples.Length)
             .Min(i => (
-                 distance: DistanceTo(
-                    isForeground ? BackForeExamples[i].fore : BackForeExamples[i].back),
+                 distance: DistanceTo(BackForeExamples[i].back),
                  index: i)).index;
 
         (KnownColor back, KnownColor fore) option = BackForeExamples[index];
-        return isForeground
-            ? AdaptColor(original, option.fore, option.back)
-            : AdaptColor(original, option.back, option.fore);
+        return AdaptColor(original, option.back, option.fore);
 
         double DistanceTo(KnownColor c2)
         {

--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -1,7 +1,11 @@
-﻿namespace GitExtUtils.GitUI.Theming;
+﻿using System.Collections.Concurrent;
+
+namespace GitExtUtils.GitUI.Theming;
 
 public static class ColorHelper
 {
+    private static readonly ConcurrentDictionary<(Color fore, Color back), Color> _foreColorForBackColors = new();
+
     private static readonly (KnownColor back, KnownColor fore)[] BackForeExamples =
     [
         (KnownColor.Window, KnownColor.WindowText),
@@ -26,45 +30,43 @@ public static class ColorHelper
         return Color.FromArgb(color.A, r, g, b);
     }
 
-    public static void SetForeColorForBackColor(this Control control) =>
-        control.ForeColor = GetForeColorForBackColor(control.BackColor);
+    public static void SetForeColorForBackColor(this Control control)
+        => control.ForeColor = control.ForeColor.AdaptForeColor(control.BackColor);
 
-    public static Color GetForeColorForBackColor(Color backColor)
+    public static Color GetTextColor(this Color backColor)
+        => ThemeSettings.Theme.GetNonEmptyColor(KnownColor.WindowText).AdaptForeColor(backColor);
+
+    public static Color AdaptForeColor(
+        this Color original, Color backColor)
     {
-        HslColor hsl1 = backColor.ToPerceptedHsl();
-
-        (double distance, int index) closestBack = Enumerable.Range(0, BackForeExamples.Length)
-            .Select(i => (Distance: DistanceTo(BackForeExamples[i].back), Index: i))
-            .Min();
-
-        (double distance, int index) closestFore = Enumerable.Range(0, BackForeExamples.Length)
-            .Select(i => (Distance: DistanceTo(BackForeExamples[i].fore), Index: i))
-            .Min();
-
-        return ThemeSettings.Theme.GetNonEmptyColor(closestBack.distance <= closestFore.distance * 1.25 // prefer back-fore combination
-            ? BackForeExamples[closestBack.index].fore
-            : BackForeExamples[closestFore.index].back);
-
-        double DistanceTo(KnownColor c2)
+        if (backColor == Color.Empty)
         {
-            HslColor hsl2 = ThemeSettings.Theme.GetNonEmptyColor(c2).ToPerceptedHsl();
-            return
-                Math.Abs(hsl1.L - hsl2.L) +
-                (0.25 * Math.Abs(hsl1.S - hsl2.S)) +
-                (0.25 * (hsl1.H - hsl2.H).Modulo(1));
+            backColor = ThemeSettings.Theme.GetColor(AppColor.PanelBackground);
         }
+
+        (Color fore, Color back) key = (original, backColor);
+
+        if (_foreColorForBackColors.TryGetValue(key, out Color cachedColor))
+        {
+            return cachedColor;
+        }
+
+        Color foreColor = EnsureContrast(backColor, original);
+        _foreColorForBackColors[key] = foreColor;
+        return foreColor;
     }
 
     /// <summary>
-    /// Get a color to be used instead of SystemColors.GrayText
-    /// when background is SystemColors.Highlight or SystemColors.MenuHighlight.
+    ///  Get a color to be used instead of SystemColors.GrayText
+    ///  when background is SystemColors.Highlight or SystemColors.MenuHighlight.
     /// </summary>
     /// <remarks>
-    /// Consider a transformation of color range [SystemColors.ControlText, SystemColors.Control] to
-    /// [SystemColors.HighlightText, SystemColors.Highlight].
-    /// What result would such transformation produce given SystemColors.GrayText as input?
-    /// First we calculate transformed GrayText color relative to InvariantTheme.
-    /// Then we apply transformation from InvariantTheme to current theme by calling AdaptTextColor.
+    ///  Consider a transformation of color range [SystemColors.ControlText, SystemColors.Control] to
+    ///  [SystemColors.HighlightText, SystemColors.Highlight].
+    ///  What result would such transformation produce given SystemColors.GrayText as input?
+    ///  First we calculate transformed GrayText color relative to InvariantTheme.
+    ///  Then we apply transformation from InvariantTheme to current theme by calling AdaptTextColor.
+    ///  Only used in Light mode.
     /// </remarks>
     public static Color GetHighlightGrayTextColor(
         KnownColor backgroundColorName,
@@ -86,13 +88,16 @@ public static class ColorHelper
             highlightTextHsl.L, highlightBackgroundHsl.L);
 
         HslColor highlightGrayTextHsl = grayTextHsl.WithLuminosity(highlightGrayTextL);
-        return AdaptTextColor(highlightGrayTextHsl.ToColor());
+        return AdaptColor(highlightGrayTextHsl.ToColor(), isForeground: true);
     }
 
     /// <summary>
-    /// Get a color to be used instead of SystemColors.GrayText which is more or less gray than
-    /// the usual SystemColors.GrayText.
+    ///  Get a color to be used instead of <see cref="SystemColors.GrayText"/> which is more or less gray than
+    ///  the usual <see cref="SystemColors.GrayText"/>.
+    ///  Only used in Light mode.
     /// </summary>
+    /// <param name="textColorName">The name of the text color to base the grayness on.</param>
+    /// <param name="degreeOfGrayness">How gray the result should be; 1.0 is full gray, 0.0 is same as text.</param>
     public static Color GetGrayTextColor(KnownColor textColorName, float degreeOfGrayness = 1f)
     {
         HslColor grayTextHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
@@ -100,23 +105,20 @@ public static class ColorHelper
 
         double grayTextL = textHsl.L + (degreeOfGrayness * (grayTextHsl.L - textHsl.L));
         HslColor highlightGrayTextHsl = grayTextHsl.WithLuminosity(grayTextL);
-        return AdaptTextColor(highlightGrayTextHsl.ToColor());
+        return AdaptColor(highlightGrayTextHsl.ToColor(), isForeground: true);
     }
 
-    public static Color AdaptTextColor(this Color original) =>
-        AdaptColor(original, isForeground: true);
-
-    public static Color AdaptBackColor(this Color original) =>
-        AdaptColor(original, isForeground: false);
-
     /// <summary>
-    /// Adapt invariant colors to the current theme, by comparing to Text/Background color pairs in the invariant theme.
-    /// Note that <see cref="SystemColors"/> and <see cref="AppColor"/> should not be adapted.
+    ///  Adapt invariant background colors to the current theme,
+    ///  by comparing to Text/Background color pairs in the invariant theme.
+    ///  Note that <see cref="SystemColors"/> and <see cref="AppColor"/> should not be adapted.
     /// </summary>
     /// <param name="original">The original <see cref="Color"/></param>
-    /// <param name="isForeground"><see ref="true"/> if foreground/text, <see ref="false"/> if background.</param>
     /// <returns>The adapted color.</returns>
-    public static Color AdaptColor(Color original, bool isForeground)
+    public static Color AdaptBackColor(this Color original)
+        => AdaptColor(original, isForeground: false);
+
+    private static Color AdaptColor(Color original, bool isForeground)
     {
         if (IsDefaultTheme)
         {
@@ -126,11 +128,10 @@ public static class ColorHelper
         HslColor hsl1 = original.ToPerceptedHsl();
 
         int index = Enumerable.Range(0, BackForeExamples.Length)
-            .Select(i => (
-                distance: DistanceTo(
+            .Min(i => (
+                 distance: DistanceTo(
                     isForeground ? BackForeExamples[i].fore : BackForeExamples[i].back),
-                index: i))
-            .Min().index;
+                 index: i)).index;
 
         (KnownColor back, KnownColor fore) option = BackForeExamples[index];
         return isForeground
@@ -362,17 +363,24 @@ public static class ColorHelper
     /// Get contrast color (Black or White) of a background color to use as a foreground color (not using the theme settings).
     /// </summary>
     /// <param name="backgroundColor">the background color</param>
-    /// <param name="luminanceThreshold">a custom luminance threshold to let the caller determine the boundary.</param>
+    /// <param name="luminanceThreshold">
+    ///  scaled to the WCAG relative luminance threshold; so 0.5 corresponds to 0.18,
+    ///  which is approximately the WCAG equal-contrast midpoint between black and white.
+    ///  Therefore "force all" to white is about 5.5.
+    ///  Note that the rgb midpoint is closer to 77 than 7f, not linear.
+    /// </param>
     /// <returns>the black or white color to use as foreground</returns>
-    public static Color GetContrastColor(this Color backgroundColor, float luminanceThreshold = 0.5f)
+    public static Color GetContrastColor(this Color backgroundColor, float luminanceThreshold)
     {
-        // (Loosely) Based on https://stackoverflow.com/a/3943023
-        // Calculate the luminance of the background color
-        double luminance = ((0.2126 * backgroundColor.R) + (0.7152 * backgroundColor.G) + (0.0722 * backgroundColor.B)) / 255;
-
-        // Use the threshold value to determine whether to use black or white as the foreground color
-        return (luminance > luminanceThreshold) ? Color.Black : Color.White;
+        // scale so 0.5 corresponds to the WCAG equal-contrast midpoint between black and white
+        const float wcagEqualContrastMidpoint = 0.185f;
+        luminanceThreshold = luminanceThreshold * (wcagEqualContrastMidpoint * 2.0f);
+        double luminance = WcagRelativeLuminance(backgroundColor);
+        return luminance > luminanceThreshold ? Color.Black : Color.White;
     }
+
+    private static double WcagRelativeLuminance(Color c) =>
+        (0.2126 * SrgbLinearize(c.R)) + (0.7152 * SrgbLinearize(c.G)) + (0.0722 * SrgbLinearize(c.B));
 
     private static double SrgbLinearize(byte channel)
     {
@@ -386,12 +394,82 @@ public static class ColorHelper
         return (byte)Math.Round(Math.Clamp(normalized * 255.0, 0.0, 255.0));
     }
 
+    private static double WcagContrastRatio(Color c1, Color c2)
+    {
+        double l1 = WcagRelativeLuminance(c1);
+        double l2 = WcagRelativeLuminance(c2);
+        return l1 > l2 ? (l1 + 0.05) / (l2 + 0.05) : (l2 + 0.05) / (l1 + 0.05);
+    }
+
+    /// <summary>
+    ///  Adjusts <paramref name="foreground"/> luminance until <paramref name="ratio"/> contrast is met against
+    ///  <paramref name="background"/>, mirroring the xterm.js algorithm used by VS Code.
+    ///  If neither direction reaches the target, the result with the higher contrast ratio is returned.
+    /// </summary>
+    private static Color EnsureContrast(Color background, Color foreground, double ratio = 4.5)
+    {
+        if (WcagContrastRatio(background, foreground) >= ratio)
+        {
+            return foreground;
+        }
+
+        double foregroundLuminance = WcagRelativeLuminance(foreground);
+        double backgroundLuminance = WcagRelativeLuminance(background);
+
+        Color resultA = foregroundLuminance < backgroundLuminance
+            ? ReduceLuminance(background, foreground, ratio)
+            : IncreaseLuminance(background, foreground, ratio);
+
+        if (WcagContrastRatio(background, resultA) >= ratio)
+        {
+            return resultA;
+        }
+
+        Color resultB = foregroundLuminance < backgroundLuminance
+            ? IncreaseLuminance(background, foreground, ratio)
+            : ReduceLuminance(background, foreground, ratio);
+
+        return WcagContrastRatio(background, resultA) >= WcagContrastRatio(background, resultB)
+            ? resultA
+            : resultB;
+    }
+
+    private static Color ReduceLuminance(Color background, Color foreground, double ratio)
+    {
+        int r = foreground.R, g = foreground.G, b = foreground.B;
+        Color current = foreground;
+        while (WcagContrastRatio(background, current) < ratio && (r > 0 || g > 0 || b > 0))
+        {
+            r -= (int)Math.Ceiling(r * 0.1);
+            g -= (int)Math.Ceiling(g * 0.1);
+            b -= (int)Math.Ceiling(b * 0.1);
+            current = Color.FromArgb(foreground.A, r, g, b);
+        }
+
+        return current;
+    }
+
+    private static Color IncreaseLuminance(Color background, Color foreground, double ratio)
+    {
+        int r = foreground.R, g = foreground.G, b = foreground.B;
+        Color current = foreground;
+        while (WcagContrastRatio(background, current) < ratio && (r < 255 || g < 255 || b < 255))
+        {
+            r = Math.Min(255, r + (int)Math.Ceiling((255 - r) * 0.1));
+            g = Math.Min(255, g + (int)Math.Ceiling((255 - g) * 0.1));
+            b = Math.Min(255, b + (int)Math.Ceiling((255 - b) * 0.1));
+            current = Color.FromArgb(foreground.A, r, g, b);
+        }
+
+        return current;
+    }
+
     internal static class TestAccessor
     {
         public static double Transform(double orig, double exampleOrig, double oppositeOrig, double example, double opposite) =>
             ColorHelper.Transform(orig, exampleOrig, oppositeOrig, example, opposite);
 
-        public static Color GetContrastColor(Color backgroundColor, float luminanceThreshold = 0.5f) =>
-            ColorHelper.GetContrastColor(backgroundColor, luminanceThreshold);
+        public static Color GetContrastColor(Color backgroundColor, float luminanceThreshold) =>
+            backgroundColor.GetContrastColor(luminanceThreshold);
     }
 }

--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -14,15 +14,16 @@ public static class ColorHelper
     public static ThemeSettings ThemeSettings { private get; set; } = ThemeSettings.Default;
 
     /// <summary>
-    ///  Blends the color with the default Editor background color, halves each value first.
-    ///  Keep the original alpha, SystemColors.Window.A==255 and we do not want rounding errors.
+    ///  Blends the color with the current editor background color at 50% in linear light (sRGB gamma-corrected) space,
+    ///  producing a perceptually correct midpoint. The original alpha is preserved.
     /// </summary>
-    public static Color DimColor(Color color)
+    public static Color DimColor(this Color color)
     {
-        const uint maskWithoutLeastSignificantBits = 0xFE_FE_FE_FE;
-        uint defaultBackground = (uint)ThemeSettings.Theme.GetColor(AppColor.EditorBackground).ToArgb();
-        int dimCode = (int)((((uint)color.ToArgb() & maskWithoutLeastSignificantBits) >> 1) + ((defaultBackground & maskWithoutLeastSignificantBits) >> 1));
-        return Color.FromArgb(color.A, (dimCode >> 16) & 0xff, (dimCode >> 8) & 0xff, dimCode & 0xff);
+        Color background = ThemeSettings.Theme.GetColor(AppColor.EditorBackground);
+        byte r = SrgbDelinearize((SrgbLinearize(color.R) + SrgbLinearize(background.R)) * 0.5);
+        byte g = SrgbDelinearize((SrgbLinearize(color.G) + SrgbLinearize(background.G)) * 0.5);
+        byte b = SrgbDelinearize((SrgbLinearize(color.B) + SrgbLinearize(background.B)) * 0.5);
+        return Color.FromArgb(color.A, r, g, b);
     }
 
     public static void SetForeColorForBackColor(this Control control) =>
@@ -371,6 +372,18 @@ public static class ColorHelper
 
         // Use the threshold value to determine whether to use black or white as the foreground color
         return (luminance > luminanceThreshold) ? Color.Black : Color.White;
+    }
+
+    private static double SrgbLinearize(byte channel)
+    {
+        double normalized = channel / 255.0;
+        return normalized <= 0.04045 ? normalized / 12.92 : Math.Pow((normalized + 0.055) / 1.055, 2.4);
+    }
+
+    private static byte SrgbDelinearize(double linear)
+    {
+        double normalized = linear <= 0.0031308 ? 12.92 * linear : (1.055 * Math.Pow(linear, 1.0 / 2.4)) - 0.055;
+        return (byte)Math.Round(Math.Clamp(normalized * 255.0, 0.0, 255.0));
     }
 
     internal static class TestAccessor

--- a/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -145,7 +145,7 @@ public static class ColorHelper
     }
 
     /// <remarks>0.05 is subtle. 0.3 is quite strong.</remarks>
-    public static Color MakeBackgroundDarkerBy(this Color color, double amount) =>
+    public static Color MakeDarkerBy(this Color color, double amount) =>
         color.TransformHsl(l: l => l - amount);
 
     public static void AdaptImageLightness(this ToolStripItem item) =>

--- a/src/app/GitExtUtils/GitUI/Theming/OtherColors.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/OtherColors.cs
@@ -7,7 +7,10 @@ public static class OtherColors
     public static readonly Color MergeConflictsColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
     public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
     public static readonly Color PanelMessageWarningColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
-    public static readonly Color BrightGreen = Color.FromArgb(128, 255, 128);
-    public static readonly Color BrightYellow = Color.FromArgb(255, 255, 128);
-    public static readonly Color BrightRed = Color.FromArgb(255, 128, 128);
+    public static readonly Color BrightGreen = Color.FromArgb(128, 255, 128).DimDarkModeColor();
+    public static readonly Color BrightYellow = Color.FromArgb(255, 255, 128).DimDarkModeColor();
+    public static readonly Color BrightRed = Color.FromArgb(255, 128, 128).DimDarkModeColor();
+
+    public static Color DimDarkModeColor(this Color color)
+        => Application.IsDarkModeEnabled ? color.DimColor() : color;
 }

--- a/src/app/GitExtUtils/GitUI/Theming/ThemeFix.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/ThemeFix.cs
@@ -58,17 +58,21 @@ public static class ThemeFix
     private static void SetupLinkLabel(this LinkLabel label)
     {
         // e.g. FormAbout
-        label.LinkColor = Application.IsDarkModeEnabled ? Color.CornflowerBlue : label.LinkColor.AdaptTextColor();
-        label.VisitedLinkColor = label.VisitedLinkColor.AdaptTextColor();
-        label.ActiveLinkColor = label.ActiveLinkColor.AdaptTextColor();
+        // Use the parent control's BackColor when the label's own BackColor is empty (inherited).
+        Color effectiveBackColor = label.BackColor.IsEmpty ? label.Parent?.BackColor ?? SystemColors.Control : label.BackColor;
+        label.LinkColor = label.LinkColor.AdaptForeColor(effectiveBackColor);
+        label.VisitedLinkColor = label.VisitedLinkColor.AdaptForeColor(effectiveBackColor);
+        label.ActiveLinkColor = label.ActiveLinkColor.AdaptForeColor(effectiveBackColor);
     }
 
     private static void SetupToolStripStatusLabel(this ToolStripLabel label)
     {
         // e.g. FormCommit
-        label.LinkColor = Application.IsDarkModeEnabled ? Color.CornflowerBlue : label.LinkColor.AdaptTextColor();
-        label.VisitedLinkColor = label.VisitedLinkColor.AdaptTextColor();
-        label.ActiveLinkColor = label.ActiveLinkColor.AdaptTextColor();
+        // Use the owning strip's BackColor when the label's own BackColor is empty (inherited).
+        Color effectiveBackColor = label.BackColor.IsEmpty ? label.Owner?.BackColor ?? SystemColors.Control : label.BackColor;
+        label.LinkColor = label.LinkColor.AdaptForeColor(effectiveBackColor);
+        label.VisitedLinkColor = label.VisitedLinkColor.AdaptForeColor(effectiveBackColor);
+        label.ActiveLinkColor = label.ActiveLinkColor.AdaptForeColor(effectiveBackColor);
     }
 
     private static void SetupButton(this Button button)

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using GitCommands;
 using GitCommands.UserRepositoryHistory;
@@ -88,7 +88,7 @@ public partial class UserRepositoriesList : GitExtensionsControl
 
         _secondaryFont = new Font(AppSettings.Font.FontFamily, AppSettings.Font.SizeInPoints - 1f);
         lblRecentRepositories.Font = new Font(AppSettings.Font.FontFamily, AppSettings.Font.SizeInPoints + 5.5f);
-        lblRecentRepositories.ForeColor.AdaptTextColor();
+        lblRecentRepositories.SetForeColorForBackColor();
 
         textBoxSearch.PlaceholderText = _repositorySearchPlaceholder.Text;
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -157,7 +157,7 @@ public partial class FormRecentReposSettings : GitExtensionsForm
 
         if (!Directory.Exists(repo.Repo.Path))
         {
-            item.ForeColor = Color.Red.AdaptTextColor();
+            item.ForeColor = Color.Red.AdaptForeColor(item.BackColor);
         }
 
         return item;

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Drawing2D;
 using GitCommands;
@@ -1833,7 +1833,10 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
                 bool isBranchVisible = ((ICheckRefs)RevisionGridControl).Contains(branch.ObjectId);
 
                 ToolStripItem toolStripItem = branchSelect.DropDownItems.Add(branch.Name);
-                toolStripItem.ForeColor = isBranchVisible ? branchSelect.ForeColor : Color.Silver.AdaptTextColor();
+                Color effectiveBackColor = toolStripItem.BackColor.IsEmpty
+                    ? toolStripItem.GetCurrentParent()?.BackColor ?? branchSelect.DropDown.BackColor
+                    : toolStripItem.BackColor;
+                toolStripItem.ForeColor = isBranchVisible ? branchSelect.ForeColor : Color.Silver.AdaptForeColor(effectiveBackColor);
                 toolStripItem.Image = (isBranchVisible ? Images.Branch : Images.EyeClosed).AdaptLightness();
                 toolStripItem.Click += (s, e) => UICommands.StartCheckoutBranch(this, toolStripItem.Text!);
             }

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -1,4 +1,4 @@
-using GitCommands;
+﻿using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.UserRepositoryHistory;
@@ -345,14 +345,14 @@ public partial class FormClone : GitExtensionsDialog
         if (destinationUnfilled || subDirectoryUnfilled)
         {
             Info.Text = newRepositoryLocationInfo;
-            Info.ForeColor = Color.Red.AdaptTextColor();
+            Info.ForeColor = Color.Red.AdaptForeColor(Info.BackColor);
             return;
         }
 
         if (Directory.Exists(destinationPath) && Directory.EnumerateFileSystemEntries(destinationPath).Any())
         {
             Info.Text = $@"{newRepositoryLocationInfo} {_infoDirectoryExists.Text}";
-            Info.ForeColor = Color.Red.AdaptTextColor();
+            Info.ForeColor = Color.Red.AdaptForeColor(Info.BackColor);
             return;
         }
 

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -2378,7 +2378,7 @@ public sealed partial class FormCommit : GitModuleForm
                         len = lineLength - offset;
                         if (len > 0)
                         {
-                            Message.ChangeTextColor(line, offset, len, Color.Red.AdaptTextColor());
+                            Message.ChangeTextColor(line, offset, len, Color.Red.AdaptForeColor(Message.BackColor));
                         }
                     }
                 }

--- a/src/app/GitUI/CommandsDialogs/FormReflog.cs
+++ b/src/app/GitUI/CommandsDialogs/FormReflog.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
@@ -40,7 +40,7 @@ public partial class FormReflog : GitModuleForm
         : base(uiCommands)
     {
         InitializeComponent();
-        lblDirtyWorkingDirectory.ForeColor.AdaptTextColor();
+        lblDirtyWorkingDirectory.SetForeColorForBackColor();
         InitializeComplete();
 
         gridReflog.RowTemplate.Height = DpiUtil.Scale(24);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -585,7 +585,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     private static void RenderSettingSet(Button settingButton, Button settingFixButton, string text)
     {
         settingButton.BackColor = OtherColors.BrightGreen;
-        settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
+        settingButton.SetForeColorForBackColor();
         settingButton.Text = text;
         settingFixButton.Visible = false;
     }
@@ -596,7 +596,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     private static void RenderSettingUnset(Button settingButton, Button settingFixButton, string text)
     {
         settingButton.BackColor = OtherColors.BrightRed;
-        settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
+        settingButton.SetForeColorForBackColor();
         settingButton.Text = text;
         settingFixButton.Visible = true;
     }
@@ -604,7 +604,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     private static void RenderSettingNotRecommended(Button settingButton, Button settingFixButton, string text)
     {
         settingButton.BackColor = OtherColors.BrightYellow;
-        settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
+        settingButton.SetForeColorForBackColor();
         settingButton.Text = text;
         settingFixButton.Visible = true;
     }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
@@ -54,7 +54,7 @@ internal partial class ControlHotkeys : GitExtensionsControl
     public ControlHotkeys()
     {
         InitializeComponent();
-        txtHotkey.ForeColor.AdaptTextColor();
+        txtHotkey.SetForeColorForBackColor();
         InitializeComplete();
 
         cmbSettings.DisplayMember = nameof(HotkeySettings.Name);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
@@ -38,7 +38,7 @@ public class TextboxHotkey : TextBox
             if (_keyData != Keys.None)
             {
                 // TODO: do not change text color on already assigned keys, which occur only once
-                ForeColor = HotkeySettingsManager.IsUniqueKey(_keyData) ? Color.Red.AdaptTextColor() : SystemColors.WindowText;
+                ForeColor = HotkeySettingsManager.IsUniqueKey(_keyData) ? Color.Red.AdaptForeColor(BackColor) : SystemColors.WindowText;
             }
 
             Text = _keyData.ToText();

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -104,7 +104,7 @@ public partial class CommitInfo : GitModuleControl
         _gitRevisionExternalLinksParser = new GitRevisionExternalLinksParser(_effectiveLinkDefinitionsProvider, _externalLinkRevisionParser);
         _gitDescribeProvider = new GitDescribeProvider(() => Module);
 
-        Color messageBackground = SystemColors.Window.MakeBackgroundDarkerBy(0.04);
+        Color messageBackground = SystemColors.Window.MakeDarkerBy(0.04);
         pnlCommitMessage.BackColor = messageBackground;
         rtbxCommitMessage.BackColor = messageBackground;
 

--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -513,7 +513,7 @@ public partial class AnsiEscapeUtilities
 
         if (dim)
         {
-            color = ColorHelper.DimColor(color);
+            color = color.DimColor();
         }
 
         return color;

--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -508,7 +508,7 @@ public partial class AnsiEscapeUtilities
 
         if (extraBold)
         {
-            color = color.MakeBackgroundDarkerBy(-0.1);
+            color = color.MakeDarkerBy(-0.1);
         }
 
         if (dim)

--- a/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/src/app/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -402,9 +402,9 @@ public partial class AnsiEscapeUtilities
             backColor = Get8bitColor(currentBack, fore: false, bold, dim);
         }
 
-        if (backColor is not null && foreColor is null)
+        if (backColor is Color back && foreColor is null)
         {
-            foreColor = ColorHelper.GetForeColorForBackColor((Color)backColor);
+            foreColor = back.GetTextColor();
         }
 
         // Set result if there are changes

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -412,8 +412,8 @@ public abstract class DiffHighlightService : TextHighlightService
             ? CreateTextMarker(offset, length, (isRemoved ? _removedBackColor : _addedBackColor).DimColor().DimColor())
             : new(offset, length, TextMarkerType.SolidBlock, AppColor.EditorBackground.GetThemeColor(), (isRemoved ? _removedForeColor : _addedForeColor).DimColor());
 
-    private static TextMarker CreateTextMarker(int offset, int length, Color color)
-        => new(offset, length, TextMarkerType.SolidBlock, color, ColorHelper.GetForeColorForBackColor(color));
+    private static TextMarker CreateTextMarker(int offset, int length, Color backColor)
+        => new(offset, length, TextMarkerType.SolidBlock, backColor, backColor.GetTextColor());
 
     internal class TestAccessor
     {

--- a/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/src/app/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -409,8 +409,8 @@ public abstract class DiffHighlightService : TextHighlightService
 
     private static TextMarker CreateDimmedMarker(int offset, int length, bool isRemoved, bool dimBackground)
         => dimBackground
-            ? CreateTextMarker(offset, length, ColorHelper.DimColor(ColorHelper.DimColor(isRemoved ? _removedBackColor : _addedBackColor)))
-            : new(offset, length, TextMarkerType.SolidBlock, AppColor.EditorBackground.GetThemeColor(), ColorHelper.DimColor(isRemoved ? _removedForeColor : _addedForeColor));
+            ? CreateTextMarker(offset, length, (isRemoved ? _removedBackColor : _addedBackColor).DimColor().DimColor())
+            : new(offset, length, TextMarkerType.SolidBlock, AppColor.EditorBackground.GetThemeColor(), (isRemoved ? _removedForeColor : _addedForeColor).DimColor());
 
     private static TextMarker CreateTextMarker(int offset, int length, Color color)
         => new(offset, length, TextMarkerType.SolidBlock, color, ColorHelper.GetForeColorForBackColor(color));

--- a/src/app/GitUI/Editor/FileViewerInternal.cs
+++ b/src/app/GitUI/Editor/FileViewerInternal.cs
@@ -142,7 +142,7 @@ public partial class FileViewerInternal : GitModuleControl, IFileViewer
 
                 TextMarker textMarker = new(indexMatch,
                     word.Length, TextMarkerType.SolidBlock, highlightColor,
-                    ColorHelper.GetForeColorForBackColor(highlightColor));
+                    highlightColor.GetTextColor());
 
                 selectionMarkers.Add(textMarker);
             }

--- a/src/app/GitUI/Editor/FindAndReplaceForm.cs
+++ b/src/app/GitUI/Editor/FindAndReplaceForm.cs
@@ -543,9 +543,8 @@ public sealed class TextEditorSearcher : IDisposable
     public void SetScanRegion(int offset, int length)
     {
         Validates.NotNull(_document);
-        Color bkgColor = _document.HighlightingStrategy.GetColorFor("Default").BackgroundColor.AdaptBackColor();
         _region = new TextMarker(offset, length, TextMarkerType.SolidBlock,
-                                 Globals.HalfMix(bkgColor, Color.FromArgb(160, 160, 160).AdaptTextColor()));
+                                 Color.FromArgb(160, 160, 160).AdaptBackColor().DimColor());
         _document.MarkerStrategy.AddMarker(_region);
         _document.TextContentChanged += DocumentOnTextContentChanged;
         ScanRegionChanged?.Invoke(this, EventArgs.Empty);
@@ -766,14 +765,5 @@ public static class Globals
     public static bool IsInRange(int x, int lo, int hi)
     {
         return x >= lo && x <= hi;
-    }
-
-    public static Color HalfMix(Color one, Color two)
-    {
-        return Color.FromArgb(
-            (one.A + two.A) >> 1,
-            (one.R + two.R) >> 1,
-            (one.G + two.G) >> 1,
-            (one.B + two.B) >> 1);
     }
 }

--- a/src/app/GitUI/GitExtensionsDialog.cs
+++ b/src/app/GitUI/GitExtensionsDialog.cs
@@ -12,7 +12,7 @@ namespace GitUI;
 /// <remarks>Includes support for font, hotkey, icon, translation, and position restore.</remarks>
 public partial class GitExtensionsDialog : GitModuleForm
 {
-    private static readonly Pen FooterDividerPen = new(SystemColors.ControlLight.MakeBackgroundDarkerBy(0.04));
+    private static readonly Pen FooterDividerPen = new(SystemColors.ControlLight.MakeDarkerBy(0.04));
 
     /// <summary>Creates a new <see cref="GitExtensionsForm"/> indicating position restore.</summary>
     /// <param name="enablePositionRestore">Indicates whether the <see cref="Form"/>'s position
@@ -23,7 +23,7 @@ public partial class GitExtensionsDialog : GitModuleForm
         InitializeComponent();
 
         // Lighten up the control panel
-        ControlsPanel.BackColor = SystemColors.ControlLight.MakeBackgroundDarkerBy(-0.04);
+        ControlsPanel.BackColor = SystemColors.ControlLight.MakeDarkerBy(-0.04);
         MainPanel.BackColor = AppColor.PanelBackground.GetThemeColor();
 
         // Draw a separator line at the top of the footer panel, similar to what Task Dialog does

--- a/src/app/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/src/app/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -151,7 +151,7 @@ public sealed class SpellCheckEditControl : NativeWindow, IDisposable
 
     private void DrawWave(Point start, Point end)
     {
-        using Pen pen = new(Color.Red.AdaptTextColor(), DpiUtil.ScaleX);
+        using Pen pen = new(Color.Red.AdaptForeColor(_richTextBox.BackColor), DpiUtil.ScaleX);
         int waveWidth = DpiUtil.Scale(4);
         int waveHalfWidth = waveWidth >> 1;
         if ((end.X - start.X) > waveWidth)

--- a/src/app/GitUI/Themes/dark+.css
+++ b/src/app/GitUI/Themes/dark+.css
@@ -6,7 +6,7 @@
 .PanelBackground { color: #191a1b; }
 .EditorBackground { color: #121314; }
 .LineNumberBackground { color: #252526; }
-.AuthoredHighlight { color: #232c00; }
+.AuthoredHighlight { color: #282800; }
 .Selection { color: #2d6981; }
 .HighlightAllOccurences { color: #1a475a; }
 .InactiveSelectionHighlight { color: #1e3d4b; }

--- a/src/app/GitUI/Themes/dark+.css
+++ b/src/app/GitUI/Themes/dark+.css
@@ -8,7 +8,7 @@
 .LineNumberBackground { color: #252526; }
 .AuthoredHighlight { color: #282800; }
 .Selection { color: #2d6981; }
-.HighlightAllOccurences { color: #1a475a; }
+.HighlightAllOccurences { color: #173440; }
 .InactiveSelectionHighlight { color: #1e3d4b; }
 
 .Branch { color: #00d76b; }

--- a/src/app/GitUI/Themes/dark+.css
+++ b/src/app/GitUI/Themes/dark+.css
@@ -9,6 +9,6 @@
 .AuthoredHighlight { color: #282800; }
 .Selection { color: #2d6981; }
 .HighlightAllOccurences { color: #1a475a; }
-.InactiveSelectionHighlight { color: #1e3d4b; }
+.InactiveSelectionHighlight { color: #171e25; }
 
 .Branch { color: #00d76b; }

--- a/src/app/GitUI/Theming/HighlightingExtension.cs
+++ b/src/app/GitUI/Theming/HighlightingExtension.cs
@@ -7,13 +7,19 @@ internal static class HighlightingExtension
 {
     public static HighlightColor Transform(this HighlightColor original)
     {
-        Color backReplacement = Adapt(original.BackgroundColor, isForeground: false);
-        Color replacement = Adapt(original.Color, isForeground: true);
-        return new HighlightColor(original, replacement, backReplacement);
+        Color originalBackColor = original.BackgroundColor;
+        bool hasNoBackground = originalBackColor.IsEmpty || originalBackColor.A == 0;
+        Color backColor = !original.Adaptable || originalBackColor.IsSystemColor || hasNoBackground
+            ? originalBackColor
+            : ColorHelper.AdaptBackColor(originalBackColor);
 
-        Color Adapt(Color c, bool isForeground) =>
-            !original.Adaptable || c.IsSystemColor
-                ? c
-                : ColorHelper.AdaptColor(c, isForeground);
+        Color effectiveBackColor = hasNoBackground
+            ? AppColor.EditorBackground.GetThemeColor()
+            : originalBackColor;
+        Color foreColor = !original.Adaptable || original.Color.IsSystemColor
+            ? original.Color
+            : original.Color.AdaptForeColor(hasNoBackground ? effectiveBackColor : backColor);
+
+        return new HighlightColor(original, foreColor, backColor);
     }
 }

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -81,7 +81,7 @@ public sealed partial class BlameControl : GitModuleControl
 
         CommitInfo.CommandClicked += commitInfo_CommandClicked;
 
-        _commitHighlightColor = Application.IsDarkModeEnabled ? AppColor.EditorBackground.GetThemeColor().MakeBackgroundDarkerBy(-0.06) : SystemColors.ControlLight;
+        _commitHighlightColor = Application.IsDarkModeEnabled ? AppColor.EditorBackground.GetThemeColor().MakeDarkerBy(-0.06) : SystemColors.ControlLight;
         _gitRevisionSummaryBuilder = new GitRevisionSummaryBuilder();
         _gitBlameParser = new GitBlameParser(() => UICommands.Module);
     }

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reactive.Linq;
@@ -46,11 +46,6 @@ public sealed partial class FileStatusList : GitModuleControl
     private readonly ToolStripItem _sortBySeparator = new ToolStripSeparator();
     private readonly SolidBrush _inactiveSelectionHighlightBrush = new(AppColor.InactiveSelectionHighlight.GetThemeColor());
     private readonly SolidBrush _backgroundBrush = new(AppColor.PanelBackground.GetThemeColor());
-    private readonly Color _grayTextColor = ColorHelper.GetHighlightGrayTextColor(
-        backgroundColorName: KnownColor.Window,
-        textColorName: KnownColor.WindowText,
-        highlightColorName: KnownColor.Highlight);
-
     private GitItemStatus? _nextItemToSelect = null;
     private bool _enableSelectedIndexChangeEvent = true;
     private bool _flatList = false;
@@ -1733,7 +1728,7 @@ public sealed partial class FileStatusList : GitModuleControl
         Rectangle textRect = new(item.Bounds.X - 1, item.Bounds.Top - 1, item.Bounds.Width, item.Bounds.Height);
 
         Color grayTextColor = selected && Focused && !Application.IsDarkModeEnabled
-            ? _grayTextColor
+            ? Color.FromArgb(192, 192, 192)
             : SystemColors.GrayText;
 
         Color textColor = selected && Focused

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -46,6 +46,10 @@ public sealed partial class FileStatusList : GitModuleControl
     private readonly ToolStripItem _sortBySeparator = new ToolStripSeparator();
     private readonly SolidBrush _inactiveSelectionHighlightBrush = new(AppColor.InactiveSelectionHighlight.GetThemeColor());
     private readonly SolidBrush _backgroundBrush = new(AppColor.PanelBackground.GetThemeColor());
+    private readonly Color _grayTextColor = ColorHelper.GetHighlightGrayTextColor(
+        backgroundColorName: KnownColor.Window,
+        textColorName: KnownColor.WindowText,
+        highlightColorName: KnownColor.Highlight);
 
     private GitItemStatus? _nextItemToSelect = null;
     private bool _enableSelectedIndexChangeEvent = true;
@@ -1729,10 +1733,7 @@ public sealed partial class FileStatusList : GitModuleControl
         Rectangle textRect = new(item.Bounds.X - 1, item.Bounds.Top - 1, item.Bounds.Width, item.Bounds.Height);
 
         Color grayTextColor = selected && Focused && !Application.IsDarkModeEnabled
-            ? ColorHelper.GetHighlightGrayTextColor(
-                backgroundColorName: KnownColor.Window,
-                textColorName: KnownColor.WindowText,
-                highlightColorName: KnownColor.Highlight)
+            ? _grayTextColor
             : SystemColors.GrayText;
 
         Color textColor = selected && Focused

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -371,7 +371,7 @@ public partial class PatchGrid : GitModuleControl
         {
             Patches.ClearSelection();
             DataGridViewRow dataGridViewRow = Patches.Rows[shouldSelectIndex];
-            dataGridViewRow.DefaultCellStyle.ForeColor = Color.OrangeRed.AdaptTextColor();
+            dataGridViewRow.DefaultCellStyle.ForeColor = Color.OrangeRed.AdaptForeColor(dataGridViewRow.InheritedStyle.BackColor);
             dataGridViewRow.Selected = true;
         }
     }

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using GitCommands;
 using GitCommands.Settings;
 using GitExtensions.Extensibility.BuildServerIntegration;
@@ -91,6 +91,8 @@ internal sealed class BuildStatusColumnProvider : ColumnProvider
 
         _grid.DrawColumnText(e, text, _fontWithUnicodeCache, GetColor(style.ForeColor), bounds: e.CellBounds);
 
+        return;
+
         Color GetColor(Color foreColor)
         {
             bool isSelected = _gridView.Rows[e.RowIndex].Selected;
@@ -119,7 +121,18 @@ internal sealed class BuildStatusColumnProvider : ColumnProvider
                     break;
             }
 
-            return customColor.AdaptTextColor();
+            return customColor.AdaptForeColor(GetResolvedBackColor());
+        }
+
+        Color GetResolvedBackColor()
+        {
+            Color backColor = e?.CellStyle?.BackColor ?? Theme.Default.GetColor(AppColor.PanelBackground);
+            if (backColor == Color.Empty && e is not null)
+            {
+                return _gridView.Rows[e.RowIndex].Cells[e.ColumnIndex].InheritedStyle.BackColor;
+            }
+
+            return backColor;
         }
     }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -397,12 +397,14 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
         void DrawSuperProjectRef(string label, ref int currentOffset, bool isSelected)
         {
+            // Rectangle does not have a BackColor property. Use the cell's background color instead.
+            Color backColor = e.CellStyle?.BackColor ?? ThemeSettings.Default.Theme.GetColor(AppColor.EditorBackground);
             RevisionGridRefRenderer.DrawRef(
                 e.State.HasFlag(DataGridViewElementStates.Selected),
                 style.NormalFont,
                 ref currentOffset,
                 label,
-                headColor: Color.OrangeRed.AdaptTextColor(),
+                headColor: Color.OrangeRed.AdaptForeColor(backColor),
                 isSelected ? RefArrowType.Filled : RefArrowType.NotFilled,
                 messageBounds,
                 e.Graphics!,

--- a/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -177,7 +177,7 @@ internal sealed class QuickSearchProvider
         }
         else
         {
-            _label.ForeColor = Color.DarkRed.AdaptTextColor();
+            _label.ForeColor = Color.DarkRed.AdaptForeColor(_label.BackColor);
         }
 
         int? SearchForward()

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -107,27 +107,30 @@ public sealed partial class RevisionDataGridView : DataGridView
         _authoredHighlightBrush = new SolidBrush(AppColor.AuthoredHighlight.GetThemeColor());
         _inactiveSelectionHighlightBrush = new SolidBrush(AppColor.InactiveSelectionHighlight.GetThemeColor());
 
+        // subject/body colors are hardcoded to be correct relative each other,
+        // subject color should be emphasied compared to body, selected vs unselected etc.
+
         // relativeNonSelectedSubject: SystemColors.ControlText
         _relativeNonSelectedSubjectColor = Application.IsDarkModeEnabled
             ? SystemColors.ControlText
             : SystemColors.HighlightText;
         _nonRelativeNonSelectedSubjectColor = Application.IsDarkModeEnabled
-            ? Color.FromArgb(192, 192, 192)
+            ? Color.FromArgb(192, 192, 192) // de-emphasised light grey on dark background
             : SystemColors.GrayText;
         _nonRelativeSelectedSubjectColor = Application.IsDarkModeEnabled
-            ? Color.FromArgb(235, 235, 215)
-            : GetHighlightedGrayTextColor(degreeOfGrayness: 1f);
+            ? Color.FromArgb(235, 235, 215) // near-white with warm tint on blue selection
+            : Color.FromArgb(188, 188, 188);
 
         // relativeNonSelectedBody: SystemColors.GrayText
         _relativeSelectedBodyColor = Application.IsDarkModeEnabled
-            ? Color.FromArgb(170, 170, 150)
-            : _nonRelativeSelectedSubjectColor;
+            ? Color.FromArgb(170, 170, 150) // warm mid-grey on blue selection
+            : Color.FromArgb(188, 188, 188); // same as _nonRelativeSelectedSubjectColor
         _nonRelativeNonSelectedBodyColor = Application.IsDarkModeEnabled
-            ? Color.FromArgb(130, 130, 130)
-            : ColorHelper.GetGrayTextColor(textColorName: KnownColor.ControlText, degreeOfGrayness: 1.4f);
+            ? Color.FromArgb(130, 130, 130) // darker grey than subject, further de-emphasised
+            : Color.FromArgb(152, 152, 152);
         _nonRelativeSelectedBodyColor = Application.IsDarkModeEnabled
-            ? Color.FromArgb(170, 170, 150)
-            : GetHighlightedGrayTextColor(degreeOfGrayness: 1.4f);
+            ? Color.FromArgb(170, 170, 150) // same as relativeSelectedBody — consistent on selection
+            : Color.FromArgb(161, 161, 161);
 
         UpdateRowHeight();
 
@@ -162,13 +165,6 @@ public sealed partial class RevisionDataGridView : DataGridView
         Clear();
 
         return;
-
-        static Color GetHighlightedGrayTextColor(float degreeOfGrayness = 1f) =>
-            ColorHelper.GetHighlightGrayTextColor(
-                backgroundColorName: KnownColor.Control,
-                textColorName: KnownColor.ControlText,
-                highlightColorName: KnownColor.Highlight,
-                degreeOfGrayness);
 
         void InitializeComponent()
         {

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -1,4 +1,4 @@
-using System.Collections.Frozen;
+﻿using System.Collections.Frozen;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -164,11 +164,11 @@ public sealed partial class RevisionDataGridView : DataGridView
         return;
 
         static Color GetHighlightedGrayTextColor(float degreeOfGrayness = 1f) =>
-        ColorHelper.GetHighlightGrayTextColor(
-            backgroundColorName: KnownColor.Control,
-            textColorName: KnownColor.ControlText,
-            highlightColorName: KnownColor.Highlight,
-            degreeOfGrayness);
+            ColorHelper.GetHighlightGrayTextColor(
+                backgroundColorName: KnownColor.Control,
+                textColorName: KnownColor.ControlText,
+                highlightColorName: KnownColor.Highlight,
+                degreeOfGrayness);
 
         void InitializeComponent()
         {
@@ -448,7 +448,8 @@ public sealed partial class RevisionDataGridView : DataGridView
             columnProvider.Clear();
         }
 
-        // Reload settings that will be used during drawing
+        // Reload settings that will be used during drawing.
+        // Theme related settings are only loaded at startup.
         _revisionGraphDrawNonRelativesTextGray = AppSettings.RevisionGraphDrawNonRelativesTextGray;
 
         _highlightAuthoredRevisions = AppSettings.HighlightAuthoredRevisions;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -107,6 +107,28 @@ public sealed partial class RevisionDataGridView : DataGridView
         _authoredHighlightBrush = new SolidBrush(AppColor.AuthoredHighlight.GetThemeColor());
         _inactiveSelectionHighlightBrush = new SolidBrush(AppColor.InactiveSelectionHighlight.GetThemeColor());
 
+        // relativeNonSelectedSubject: SystemColors.ControlText
+        _relativeNonSelectedSubjectColor = Application.IsDarkModeEnabled
+            ? SystemColors.ControlText
+            : SystemColors.HighlightText;
+        _nonRelativeNonSelectedSubjectColor = Application.IsDarkModeEnabled
+            ? Color.FromArgb(192, 192, 192)
+            : SystemColors.GrayText;
+        _nonRelativeSelectedSubjectColor = Application.IsDarkModeEnabled
+            ? Color.FromArgb(235, 235, 215)
+            : GetHighlightedGrayTextColor(degreeOfGrayness: 1f);
+
+        // relativeNonSelectedBody: SystemColors.GrayText
+        _relativeSelectedBodyColor = Application.IsDarkModeEnabled
+            ? Color.FromArgb(170, 170, 150)
+            : _nonRelativeSelectedSubjectColor;
+        _nonRelativeNonSelectedBodyColor = Application.IsDarkModeEnabled
+            ? Color.FromArgb(130, 130, 130)
+            : ColorHelper.GetGrayTextColor(textColorName: KnownColor.ControlText, degreeOfGrayness: 1.4f);
+        _nonRelativeSelectedBodyColor = Application.IsDarkModeEnabled
+            ? Color.FromArgb(170, 170, 150)
+            : GetHighlightedGrayTextColor(degreeOfGrayness: 1.4f);
+
         UpdateRowHeight();
 
         SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
@@ -140,6 +162,13 @@ public sealed partial class RevisionDataGridView : DataGridView
         Clear();
 
         return;
+
+        static Color GetHighlightedGrayTextColor(float degreeOfGrayness = 1f) =>
+        ColorHelper.GetHighlightGrayTextColor(
+            backgroundColorName: KnownColor.Control,
+            textColorName: KnownColor.ControlText,
+            highlightColorName: KnownColor.Highlight,
+            degreeOfGrayness);
 
         void InitializeComponent()
         {
@@ -421,16 +450,6 @@ public sealed partial class RevisionDataGridView : DataGridView
 
         // Reload settings that will be used during drawing
         _revisionGraphDrawNonRelativesTextGray = AppSettings.RevisionGraphDrawNonRelativesTextGray;
-
-        // relativeNonSelectedSubject: SystemColors.ControlText
-        _relativeNonSelectedSubjectColor = Application.IsDarkModeEnabled ? SystemColors.ControlText : SystemColors.HighlightText;
-        _nonRelativeNonSelectedSubjectColor = Application.IsDarkModeEnabled ? Color.FromArgb(192, 192, 192) : SystemColors.GrayText;
-        _nonRelativeSelectedSubjectColor = Application.IsDarkModeEnabled ? Color.FromArgb(235, 235, 215) : GetHighlightedGrayTextColor(degreeOfGrayness: 1f);
-
-        // relativeNonSelectedBody: SystemColors.GrayText
-        _relativeSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(170, 170, 150) : _nonRelativeSelectedSubjectColor;
-        _nonRelativeNonSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(130, 130, 130) : GetGrayControlTextColor(degreeOfGrayness: 1.4f);
-        _nonRelativeSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(170, 170, 150) : GetHighlightedGrayTextColor(degreeOfGrayness: 1.4f);
 
         _highlightAuthoredRevisions = AppSettings.HighlightAuthoredRevisions;
         _revisionGraphDrawAlternateBackColor = AppSettings.RevisionGraphDrawAlternateBackColor;
@@ -1015,14 +1034,4 @@ public sealed partial class RevisionDataGridView : DataGridView
         _boldFont = new Font(_normalFont, FontStyle.Bold);
         _monospaceFont = AppSettings.MonospaceFont;
     }
-
-    private static Color GetHighlightedGrayTextColor(float degreeOfGrayness = 1f) =>
-        ColorHelper.GetHighlightGrayTextColor(
-            backgroundColorName: KnownColor.Control,
-            textColorName: KnownColor.ControlText,
-            highlightColorName: KnownColor.Highlight,
-            degreeOfGrayness);
-
-    private static Color GetGrayControlTextColor(float degreeOfGrayness = 1f) =>
-        ColorHelper.GetGrayTextColor(textColorName: KnownColor.ControlText, degreeOfGrayness);
 }

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -103,7 +103,7 @@ public sealed partial class RevisionDataGridView : DataGridView
         DoubleBuffered = true;
 
         _rowBackgroundBrush = new SolidBrush(AppColor.PanelBackground.GetThemeColor());
-        _alternatingRowBackgroundBrush = new SolidBrush(_rowBackgroundBrush.Color.MakeBackgroundDarkerBy(Application.IsDarkModeEnabled ? -0.018 : 0.025));
+        _alternatingRowBackgroundBrush = new SolidBrush(_rowBackgroundBrush.Color.MakeDarkerBy(Application.IsDarkModeEnabled ? -0.018 : 0.025));
         _authoredHighlightBrush = new SolidBrush(AppColor.AuthoredHighlight.GetThemeColor());
         _inactiveSelectionHighlightBrush = new SolidBrush(AppColor.InactiveSelectionHighlight.GetThemeColor());
 

--- a/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
@@ -32,7 +32,7 @@ public partial class SettingsUserControl : GitExtensionsControl, IBuildServerSet
     public SettingsUserControl()
     {
         InitializeComponent();
-        labelRegexError.ForeColor.AdaptTextColor();
+        labelRegexError.SetForeColorForBackColor();
         InitializeComplete();
 
         Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top;

--- a/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
+++ b/src/plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
@@ -28,7 +28,7 @@ public partial class TeamCitySettingsUserControl : GitExtensionsControl, IBuildS
     public TeamCitySettingsUserControl()
     {
         InitializeComponent();
-        labelRegexError.ForeColor.AdaptTextColor();
+        labelRegexError.SetForeColorForBackColor();
         InitializeComplete();
 
         Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top;

--- a/tests/app/UnitTests/GitExtUtils.Tests/ColorTransformationTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/ColorTransformationTests.cs
@@ -48,8 +48,8 @@ public class ColorTransformationTests
     }
 
     [TestCase("#000000", 0.5f)]
-    [TestCase("#777777", 0.5f)]
-    [TestCase("#999999", 0.6f)] // the threshold has been increased to still write in black on a darker color
+    [TestCase("#757575", 0.5f)]
+    [TestCase("#999999", 1.0f)] // write white on a lighter background with increased threshold
     public void Should_return_white_when_color_is_dark(string backgroundColor, float luminanceThreshold)
     {
         Color correspondingForeColor = ColorHelper.TestAccessor.GetContrastColor(ColorTranslator.FromHtml(backgroundColor), luminanceThreshold);
@@ -59,7 +59,7 @@ public class ColorTransformationTests
 
     [TestCase("#FFFFFF", 0.5f)]
     [TestCase("#999999", 0.5f)]
-    [TestCase("#777777", 0.4f)] // the threshold has been lower to still write in white on a lighter color
+    [TestCase("#777777", 0.4f)] // write black on a lighter background with decreased threshold
     public void Should_return_black_when_color_is_light(string backgroundColor, float luminanceThreshold)
     {
         Color correspondingForeColor = ColorHelper.TestAccessor.GetContrastColor(ColorTranslator.FromHtml(backgroundColor), luminanceThreshold);

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesGet8bitColorTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesGet8bitColorTests.cs
@@ -1,35 +1,8 @@
-﻿using GitCommands;
-using GitExtUtils.GitUI.Theming;
-using GitUI.Editor.Diff;
-using GitUI.Theming;
+﻿using GitUI.Editor.Diff;
 
 namespace GitUITests.Editor.Diff;
-public class AnsiEscapeUtilitiesTest_Get8bitColor
+public class AnsiEscapeUtilitiesGet8bitColorTests : AnsiEscapeUtilitiesTestBase
 {
-    private const int _redId = 1;
-    private readonly List<Color> _redAnsiTheme = [Color.FromArgb(211, 0, 11), Color.FromArgb(232, 127, 132), Color.FromArgb(255, 94, 94), Color.FromArgb(254, 174, 174),
-        Color.FromArgb(255, 200, 200), Color.FromArgb(254, 227, 227), Color.FromArgb(255, 165, 165), Color.FromArgb(254, 209, 209)];
-
-    private ThemeId _themeId;
-    private string[] _themeVariations = null!;
-
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        _themeId = AppSettings.ThemeId;
-        _themeVariations = AppSettings.ThemeVariations;
-        AppSettings.ThemeId = ThemeId.DefaultLight;
-        AppSettings.ThemeVariations = ThemeVariations.None;
-        ThemeModule.Load();
-    }
-
-    [OneTimeTearDown]
-    public void OneTimeTearDown()
-    {
-        AppSettings.ThemeId = _themeId;
-        AppSettings.ThemeVariations = _themeVariations;
-    }
-
     [Test]
     public void Get8bitColor_ShouldReturnBuiltinThemeColors()
     {
@@ -44,13 +17,12 @@ public class AnsiEscapeUtilitiesTest_Get8bitColor
                         // Only check the result for red, the other should just get a value
                         // (No need to maintain all ANSI theme colors in parallel)
                         Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(colorId, fore, bold, dim);
-                        if (colorId != _redId)
+                        if (colorId != RedId)
                         {
                             continue;
                         }
 
-                        int themeOffset = (dim ? 1 : 0) + (bold ? 2 : 0) + (fore ? 0 : 4);
-                        result.Should().Be(_redAnsiTheme[themeOffset], $"Failed for {themeOffset}");
+                        result.Should().Be(GetAnsiColor(RedId, fore, bold, dim), $"Failed for fore:{fore}, bold:{bold}, dim:{dim}");
                     }
                 }
             }

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesParseEscapeTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesParseEscapeTests.cs
@@ -1,36 +1,11 @@
 ﻿using System.Text;
-using GitCommands;
-using GitExtUtils.GitUI.Theming;
 using GitUI.Editor.Diff;
-using GitUI.Theming;
 using ICSharpCode.TextEditor.Document;
 
 namespace GitUITests.Editor.Diff;
-public class AnsiEscapeUtilitiesTest_ParseEscape
+public class AnsiEscapeUtilitiesParseEscapeTests : AnsiEscapeUtilitiesTestBase
 {
     private const string _escape_sequence = "\u001b[";
-    private readonly List<Color> _redAnsiTheme = [Color.FromArgb(211, 0, 11), Color.FromArgb(232, 127, 132), Color.FromArgb(255, 94, 94), Color.FromArgb(254, 174, 174),
-        Color.FromArgb(255, 200, 200), Color.FromArgb(254, 227, 227), Color.FromArgb(255, 165, 165), Color.FromArgb(254, 209, 209)];
-
-    private ThemeId _themeId;
-    private string[] _themeVariations = null!;
-
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        _themeId = AppSettings.ThemeId;
-        _themeVariations = AppSettings.ThemeVariations;
-        AppSettings.ThemeId = ThemeId.DefaultLight;
-        AppSettings.ThemeVariations = ThemeVariations.None;
-        ThemeModule.Load();
-    }
-
-    [OneTimeTearDown]
-    public void OneTimeTearDown()
-    {
-        AppSettings.ThemeId = _themeId;
-        AppSettings.ThemeVariations = _themeVariations;
-    }
 
     [Test]
     public void ParseEscape_ShouldAppendTextWithoutEscapeSequence_WhenNoEscapeSequenceIsPresent()
@@ -77,27 +52,27 @@ public class AnsiEscapeUtilitiesTest_ParseEscape
         textMarkers[0].Offset.Should().Be(10);
         textMarkers[0].Length.Should().Be(3);
         textMarkers[0].Color.Should().Be(SystemColors.Window);
-        textMarkers[0].ForeColor.Should().Be(_redAnsiTheme[0]);
+        textMarkers[0].ForeColor.Should().Be(GetAnsiColor());
 
         textMarkers[1].Offset.Should().Be(46);
         textMarkers[1].Length.Should().Be(8);
         textMarkers[1].Color.Should().Be(SystemColors.Window);
-        textMarkers[1].ForeColor.Should().Be(_redAnsiTheme[2]);
+        textMarkers[1].ForeColor.Should().Be(GetAnsiColor(bold: true));
 
         textMarkers[2].Offset.Should().Be(59);
         textMarkers[2].Length.Should().Be(16);
-        textMarkers[2].Color.Should().Be(_redAnsiTheme[6]);
+        textMarkers[2].Color.Should().Be(GetAnsiColor(fore: false, bold: true));
         textMarkers[2].ForeColor.Should().Be(Color.FromArgb(0, 0, 0));
 
         textMarkers[3].Offset.Should().Be(85);
         textMarkers[3].Length.Should().Be(7);
         textMarkers[3].Color.Should().Be(SystemColors.Window);
-        textMarkers[3].ForeColor.Should().Be(_redAnsiTheme[1]);
+        textMarkers[3].ForeColor.Should().Be(GetAnsiColor(dim: true));
 
         textMarkers[4].Offset.Should().Be(108);
         textMarkers[4].Length.Should().Be(15);
         textMarkers[4].Color.Should().Be(SystemColors.Window);
-        textMarkers[4].ForeColor.Should().Be(_redAnsiTheme[0]);
+        textMarkers[4].ForeColor.Should().Be(GetAnsiColor());
     }
 
     [Test]
@@ -198,26 +173,26 @@ public class AnsiEscapeUtilitiesTest_ParseEscape
         textMarkers[1].Offset.Should().Be(62);
         textMarkers[1].Length.Should().Be(1);
         textMarkers[1].Color.Should().Be(SystemColors.Window);
-        textMarkers[1].ForeColor.Should().Be(_redAnsiTheme[0]);
+        textMarkers[1].ForeColor.Should().Be(GetAnsiColor());
 
         textMarkers[2].Offset.Should().Be(63);
         textMarkers[2].Length.Should().Be(38);
         textMarkers[2].Color.Should().Be(SystemColors.Window);
-        textMarkers[2].ForeColor.Should().Be(_redAnsiTheme[2]);
+        textMarkers[2].ForeColor.Should().Be(GetAnsiColor(bold: true));
 
         textMarkers[3].Offset.Should().Be(102);
         textMarkers[3].Length.Should().Be(13);
         textMarkers[3].Color.Should().Be(SystemColors.Window);
-        textMarkers[3].ForeColor.Should().Be(_redAnsiTheme[1]);
+        textMarkers[3].ForeColor.Should().Be(GetAnsiColor(dim: true));
 
         textMarkers[4].Offset.Should().Be(116);
         textMarkers[4].Length.Should().Be(47);
         textMarkers[4].Color.Should().Be(SystemColors.Window);
-        textMarkers[4].ForeColor.Should().Be(_redAnsiTheme[2]);
+        textMarkers[4].ForeColor.Should().Be(GetAnsiColor(bold: true));
 
         textMarkers[5].Offset.Should().Be(164);
         textMarkers[5].Length.Should().Be(54);
         textMarkers[5].Color.Should().Be(SystemColors.Window);
-        textMarkers[5].ForeColor.Should().Be(_redAnsiTheme[0]);
+        textMarkers[5].ForeColor.Should().Be(GetAnsiColor());
     }
 }

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTestBase.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTestBase.cs
@@ -1,0 +1,79 @@
+﻿using GitCommands;
+using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+
+namespace GitUITests.Editor.Diff;
+
+public abstract class AnsiEscapeUtilitiesTestBase
+{
+    protected const int BlackId = 0;
+    protected const int RedId = 1;
+    protected const int YellowId = 3;
+
+    // The expected ANSI theme colors for the red palette (DefaultLight theme, no variations).
+    // Non bright and dim are theme colors.
+    // The expected dimmed and bright ("high-intensity") are the expected calculated values.
+    // Entries where the bright color matches the base are Color.Empty.
+    private static readonly Color[,,,] _redAnsiThemeColors =
+    {
+        // bright=false
+        {
+            // back=false (fore)
+            {
+                /* bold=false */ { Color.FromArgb(211, 0, 11), Color.FromArgb(234, 188, 188) }, // dim=false, dim=true
+                /* bold=true  */ { Color.FromArgb(255, 94, 94), Color.FromArgb(255, 197, 197) }, // dim=false, dim=true
+            },
+            // back=true
+            {
+                /* bold=false */ { Color.FromArgb(255, 200, 200), Color.FromArgb(255, 230, 230) }, // dim=false, dim=true
+                /* bold=true  */ { Color.FromArgb(255, 165, 165), Color.FromArgb(255, 216, 216) }, // dim=false, dim=true
+            },
+        },
+        // bright=true
+        {
+            // back=false (fore)
+            {
+                /* bold=false */ { Color.Empty, Color.Empty }, // dim=false, dim=true
+                /* bold=true  */ { Color.FromArgb(255, 145, 145), Color.FromArgb(255, 197, 197) }, // dim=false, dim=true
+            },
+            // back=true
+            {
+                /* bold=false */ { Color.Empty, Color.Empty }, // dim=false, dim=true
+                /* bold=true  */ { Color.FromArgb(255, 216, 216), Color.FromArgb(255, 237, 237) }, // dim=false, dim=true
+            },
+        },
+    };
+
+    /// <summary>
+    ///  Returns the expected ANSI theme color for <paramref name="colorId"/> and the given attribute flags.
+    /// </summary>
+    /// <remarks>
+    ///  Only <see cref="RedId"/> is currently supported; other values will cause the assertion to fail.
+    /// </remarks>
+    protected static Color GetAnsiColor(int colorId = RedId, bool fore = true, bool bold = false, bool dim = false, bool bright = false)
+    {
+        colorId.Should().Be(RedId, "only the red palette is defined in the test base");
+        return _redAnsiThemeColors[bright ? 1 : 0, fore ? 0 : 1, bold ? 1 : 0, dim ? 1 : 0];
+    }
+
+    private ThemeId _themeId;
+    private string[] _themeVariations = null!;
+
+    [OneTimeSetUp]
+    public void BaseOneTimeSetUp()
+    {
+        _themeId = AppSettings.ThemeId;
+        _themeVariations = AppSettings.ThemeVariations;
+        AppSettings.ThemeId = ThemeId.DefaultLight;
+        AppSettings.ThemeVariations = ThemeVariations.None;
+        ThemeModule.Load();
+    }
+
+    [OneTimeTearDown]
+    public void BaseOneTimeTearDown()
+    {
+        AppSettings.ThemeId = _themeId;
+        AppSettings.ThemeVariations = _themeVariations;
+        ThemeModule.Load();
+    }
+}

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTryGetColorsTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTryGetColorsTests.cs
@@ -1,58 +1,23 @@
-﻿using GitCommands;
-using GitExtUtils.GitUI.Theming;
-using GitUI.Editor.Diff;
-using GitUI.Theming;
+﻿using GitUI.Editor.Diff;
 
 namespace GitUITests.Editor.Diff;
-public class AnsiEscapeUtilitiesTest_TryGetColors
+public class AnsiEscapeUtilitiesTryGetColorsTests : AnsiEscapeUtilitiesTestBase
 {
-    private const int _blackId = 0;
     private readonly Color _textColor = Color.FromArgb(0, 0, 0);
-    private const int _redId = 1;
-    private const int _yellowId = 3;
-    private readonly List<Color> _redAnsiTheme = [
-        Color.FromArgb(211, 0, 11), Color.FromArgb(232, 127, 132), Color.FromArgb(255, 94, 94), Color.FromArgb(254, 174, 174),
-        Color.FromArgb(255, 200, 200), Color.FromArgb(254, 227, 227), Color.FromArgb(255, 165, 165), Color.FromArgb(254, 209, 209),
-        Color.Empty, Color.Empty, Color.FromArgb(255, 145, 145), Color.FromArgb(254, 174, 174),
-        Color.Empty, Color.Empty, Color.FromArgb(255, 216, 216), Color.FromArgb(254, 235, 235)];
-
-    private ThemeId _themeId;
-    private string[] _themeVariations = null!;
-
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        _redAnsiTheme[8] = _redAnsiTheme[2];
-        _redAnsiTheme[9] = _redAnsiTheme[3];
-        _redAnsiTheme[12] = _redAnsiTheme[6];
-        _redAnsiTheme[13] = _redAnsiTheme[7];
-        _themeId = AppSettings.ThemeId;
-        _themeVariations = AppSettings.ThemeVariations;
-        AppSettings.ThemeId = ThemeId.DefaultLight;
-        AppSettings.ThemeVariations = ThemeVariations.None;
-        ThemeModule.Load();
-    }
-
-    [OneTimeTearDown]
-    public void OneTimeTearDown()
-    {
-        AppSettings.ThemeId = _themeId;
-        AppSettings.ThemeVariations = _themeVariations;
-    }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldReset_WhenEscapeCodesIsEmpty()
     {
         // currentColorId should be preserved
         List<int> escapeCodes = [];
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeFalse();
         backColor.Should().BeNull();
         foreColor.Should().BeNull();
-        currentColorId.Should().Be(_blackId);
+        currentColorId.Should().Be(BlackId);
     }
 
     [Test]
@@ -60,14 +25,14 @@ public class AnsiEscapeUtilitiesTest_TryGetColors
     {
         // currentColorId should be reset
         List<int> escapeCodes = [0];
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeFalse();
         backColor.Should().BeNull();
         foreColor.Should().BeNull();
-        currentColorId.Should().Be(_blackId);
+        currentColorId.Should().Be(BlackId);
     }
 
     [Test]
@@ -75,14 +40,14 @@ public class AnsiEscapeUtilitiesTest_TryGetColors
     {
         // currentColorId should be unchanged, just bold
         List<int> escapeCodes = [1];
-        int currentColorId = _redId;
+        int currentColorId = RedId;
 
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
         backColor.Should().BeNull();
-        foreColor.Should().Be(_redAnsiTheme[2]);
-        currentColorId.Should().Be(_redId);
+        foreColor.Should().Be(GetAnsiColor(bold: true));
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
@@ -90,161 +55,161 @@ public class AnsiEscapeUtilitiesTest_TryGetColors
     {
         // currentColorId should be unchanged, just bold
         List<int> escapeCodes = [1];
-        int currentColorId = _redId;
+        int currentColorId = RedId;
 
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
         backColor.Should().BeNull();
-        foreColor.Should().Be(_redAnsiTheme[2]);
-        currentColorId.Should().Be(_redId);
+        foreColor.Should().Be(GetAnsiColor(bold: true));
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetBold()
     {
         // Some special cases, not fully specified
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [0, 91];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
         backColor.Should().BeNull();
-        foreColor.Should().Be(_redAnsiTheme[8]);
-        currentColorId.Should().Be(_redId);
+        foreColor.Should().Be(GetAnsiColor(bold: true));
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetBoldBold()
     {
         // Some special cases, not fully specified
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [1, 91];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
         backColor.Should().BeNull();
-        foreColor.Should().Be(_redAnsiTheme[10]);
-        currentColorId.Should().Be(_redId);
+        foreColor.Should().Be(GetAnsiColor(bold: true, bright: true));
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetBoldDim()
     {
         // Some special cases, not fully specified
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [1, 2, 31];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
         backColor.Should().BeNull();
-        foreColor.Should().Be(_redAnsiTheme[11]);
-        currentColorId.Should().Be(_redId);
+        foreColor.Should().Be(GetAnsiColor(bold: true, dim: true, bright: true));
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetBoldDim2()
     {
         // Some special cases, not fully specified
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [2, 91];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
         backColor.Should().BeNull();
-        foreColor.Should().Be(_redAnsiTheme[9]);
-        currentColorId.Should().Be(_redId);
+        foreColor.Should().Be(GetAnsiColor(bold: true, dim: true));
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetBackBoldBold()
     {
         // Some special cases, not fully specified
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [1, 101];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
-        backColor.Should().Be(_redAnsiTheme[14]);
-        currentColorId.Should().Be(_yellowId);
+        backColor.Should().Be(GetAnsiColor(fore: false, bold: true, bright: true));
+        currentColorId.Should().Be(YellowId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetBackDimBold()
     {
         // Some special cases, not fully specified
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [1, 2, 101];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
 
         result.Should().BeTrue();
-        backColor.Should().Be(_redAnsiTheme[15]);
-        currentColorId.Should().Be(_yellowId);
+        backColor.Should().Be(GetAnsiColor(fore: false, bold: true, dim: true, bright: true));
+        currentColorId.Should().Be(YellowId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldKeepThemeDim()
     {
         // Some special cases, not fully specified
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [1, 2, 31];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId, themeColors: true);
 
         result.Should().BeTrue();
         backColor.Should().BeNull();
-        foreColor.Should().Be(_redAnsiTheme[3]);
-        currentColorId.Should().Be(_redId);
+        foreColor.Should().Be(GetAnsiColor(bold: true, dim: true));
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetThemeBold()
     {
         // Adjusting difftastic colors
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [1, 31];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId, themeColors: true);
 
         result.Should().BeTrue();
-        backColor.Should().Be(_redAnsiTheme[4]);
+        backColor.Should().Be(GetAnsiColor(fore: false));
         foreColor.Should().Be(_textColor);
-        currentColorId.Should().Be(_redId);
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetThemeBold2()
     {
         // Adjusting difftastic colors
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [1, 91];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId, themeColors: true);
 
         result.Should().BeTrue();
-        backColor.Should().Be(_redAnsiTheme[12]);
+        backColor.Should().Be(GetAnsiColor(fore: false, bold: true));
         foreColor.Should().Be(_textColor);
-        currentColorId.Should().Be(_redId);
+        currentColorId.Should().Be(RedId);
     }
 
     [Test]
     public void TryGetColorsFromEscapeSequence_ShouldSetThemeNormal()
     {
         // Adjusting difftastic colors
-        int currentColorId = _yellowId;
+        int currentColorId = YellowId;
 
         List<int> escapeCodes = [0, 31];
         bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId, themeColors: true);
 
         result.Should().BeTrue();
-        backColor.Should().Be(_redAnsiTheme[5]);
+        backColor.Should().Be(GetAnsiColor(fore: false, dim: true));
         foreColor.Should().Be(_textColor);
-        currentColorId.Should().Be(_redId);
+        currentColorId.Should().Be(RedId);
     }
 }

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
@@ -135,7 +135,7 @@ public class DiffHighlightServiceTests
     {
         Color color = (isAdded ? AppColor.AnsiTerminalGreenBackNormal : AppColor.AnsiTerminalRedBackNormal).GetThemeColor();
         Color dimmedColor = color.DimColor().DimColor();
-        return new TextMarker(offset, length, TextMarkerType.SolidBlock, dimmedColor, ColorHelper.GetForeColorForBackColor(dimmedColor));
+        return new TextMarker(offset, length, TextMarkerType.SolidBlock, dimmedColor, dimmedColor.GetTextColor());
     }
 
     private sealed class MarkerComparer : IComparer<TextMarker>

--- a/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Editor/Diff/DiffHighlightServiceTests.cs
@@ -134,7 +134,7 @@ public class DiffHighlightServiceTests
     private static TextMarker CreateDimmedMarker(int offset, int length, bool isAdded)
     {
         Color color = (isAdded ? AppColor.AnsiTerminalGreenBackNormal : AppColor.AnsiTerminalRedBackNormal).GetThemeColor();
-        Color dimmedColor = ColorHelper.DimColor(ColorHelper.DimColor(color));
+        Color dimmedColor = color.DimColor().DimColor();
         return new TextMarker(offset, length, TextMarkerType.SolidBlock, dimmedColor, ColorHelper.GetForeColorForBackColor(dimmedColor));
     }
 


### PR DESCRIPTION
Will update description and add more screenshots, do not plan other changes right now to this PR.
The handling of gray colors in Light mode (hardcoded in dark mode) and background in dark mode may be improved later.

## Proposed changes

- fix: cache brushes
very minor performance improvement, but this is for consistency

- fix: AuthoredHighlight more yellow
#12943 updated the author highlighting to be darker (as the panel background is darker) but also more green. 
This adjusts it bach to more yellow

- fix: dim with perceptual midpoint

rgb is not perceptually linear, adjust the blending

remove adaption of a theme "Default"->EditorBackgound
in FindAndReplaceForm
(the marking is not really used anyway).
With this an alternative Dim implementation could be removed.

- fix: dim bright colors in dark mode

The background colors in Settings-Checklist and
ResetCurrentBranch are too bright in the dark mode.

- refactor: Rename MakeBackgroundDarkerBy()

- fix: Ensure adapted fore colors have enough contrast

The ForeColor are use for text, and must be readable to the background.
The previous implementation tried to adapt the fore color as the closest
app text-backround pair. The background was in most situations ignored,
or used to get a generic (black/white) fore color.

The updated algorithm use the actual background color to adopt the
current color to get sufficient contrast.

Cache color conversions, all text editor colors are converted.

adjust the AdaptColor api slightly, as the background and foreground
colors are adapted separetly.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

Changes to dimmed and foreground colors

<img width="501" height="344" alt="image" src="https://github.com/user-attachments/assets/dcf74fb9-746a-4987-80e4-d320bd62e804" />
<img width="505" height="341" alt="image" src="https://github.com/user-attachments/assets/d384c685-d168-4ee7-841b-1a66ab6481de" />

Subtle changes in dark too, only showing dark+

<img width="501" height="339" alt="image" src="https://github.com/user-attachments/assets/676bda80-8de1-47ed-9ffa-48843a6b39ec" />
<img width="497" height="339" alt="image" src="https://github.com/user-attachments/assets/45c7e33e-b5be-4e4f-9be2-7fba33a9b256" />

Syntax coloring adapted changed

<img width="474" height="386" alt="image" src="https://github.com/user-attachments/assets/0bffd2a9-ac55-4c8f-a545-84048a88c4c1" />
<img width="475" height="381" alt="image" src="https://github.com/user-attachments/assets/1f03afbb-e05e-4803-b213-4bd621639380" />

Similar in Checklist

<img width="464" height="527" alt="image" src="https://github.com/user-attachments/assets/d649cd1b-0022-4f66-a710-2c77a64fb7f2" />
<img width="460" height="524" alt="image" src="https://github.com/user-attachments/assets/623ef53b-3d15-4344-84a6-1d1ab0e106e3" />

<img width="387" height="234" alt="image" src="https://github.com/user-attachments/assets/c5efa334-15a9-4e77-80fb-154d68c9ea70" />
<img width="593" height="246" alt="image" src="https://github.com/user-attachments/assets/4314d87d-45d0-42e9-a9cf-289147fe2185" />

Adopted now, was hardcoded. I actually preferred the hardcoded, but this is slightly more consistent.
<img width="380" height="43" alt="image" src="https://github.com/user-attachments/assets/15180513-85e5-47d1-8298-66aeef73caae" />
<img width="369" height="47" alt="image" src="https://github.com/user-attachments/assets/7c445470-9043-4a98-bc90-dc23f0af1eb0" />

## Test methodology <!-- How did you ensure quality? -->

Mostly manual
Tests updated, the ansi color tests are using common definitions of colors now.

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).
May squash some

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
