### PR TITLE
feat(theme): refine dark visuals and add dark secreal

### DIFF
--- a/setup/installer/Product.wxs
+++ b/setup/installer/Product.wxs
@@ -314,6 +314,9 @@
       <Component Id="Themes.dark_plus.css" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Themes\dark+.css" />
       </Component>
+      <Component Id="Themes.dark_secreal.css" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Themes\dark secreal.css" />
+      </Component>
     </DirectoryRef>
     <DirectoryRef Id="PluginsDir">
       <Component Id="DeleteUnusedBranches.dll" Guid="*">
@@ -593,6 +596,7 @@
       <ComponentRef Id="Themes.light_plus.css" />
       <ComponentRef Id="Themes.dark.css" />
       <ComponentRef Id="Themes.dark_plus.css" />
+      <ComponentRef Id="Themes.dark_secreal.css" />
     </ComponentGroup>
     <ComponentGroup Id="Component.Translation">
       <ComponentRef Id="English.gif" />

--- a/src/app/GitExtUtils/GitUI/Theming/OtherColors.cs
+++ b/src/app/GitExtUtils/GitUI/Theming/OtherColors.cs
@@ -7,7 +7,7 @@ public static class OtherColors
     public static readonly Color MergeConflictsColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
     public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
     public static readonly Color PanelMessageWarningColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
-    public static readonly Color BrightGreen = Color.FromArgb(128, 255, 128);
-    public static readonly Color BrightYellow = Color.FromArgb(255, 255, 128);
-    public static readonly Color BrightRed = Color.FromArgb(255, 128, 128);
+    public static readonly Color BrightGreen = Color.FromArgb(15, 157, 88);
+    public static readonly Color BrightYellow = Color.FromArgb(253, 216, 53);
+    public static readonly Color BrightRed = Color.FromArgb(219, 68, 55);
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -585,7 +585,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     private static void RenderSettingSet(Button settingButton, Button settingFixButton, string text)
     {
         settingButton.BackColor = OtherColors.BrightGreen;
-        settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
+        settingButton.SetForeColorForBackColor();
         settingButton.Text = text;
         settingFixButton.Visible = false;
     }
@@ -596,7 +596,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     private static void RenderSettingUnset(Button settingButton, Button settingFixButton, string text)
     {
         settingButton.BackColor = OtherColors.BrightRed;
-        settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
+        settingButton.SetForeColorForBackColor();
         settingButton.Text = text;
         settingFixButton.Visible = true;
     }
@@ -604,7 +604,7 @@ public partial class ChecklistSettingsPage : SettingsPageWithHeader
     private static void RenderSettingNotRecommended(Button settingButton, Button settingFixButton, string text)
     {
         settingButton.BackColor = OtherColors.BrightYellow;
-        settingButton.ForeColor = ColorHelper.GetForeColorForBackColor(settingButton.BackColor);
+        settingButton.SetForeColorForBackColor();
         settingButton.Text = text;
         settingFixButton.Visible = true;
     }

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -15,6 +15,7 @@ using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.CommandsDialogs;
 using GitUI.Editor.RichTextBoxExtension;
+using GitUI.Theming;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -104,9 +105,15 @@ public partial class CommitInfo : GitModuleControl
         _gitRevisionExternalLinksParser = new GitRevisionExternalLinksParser(_effectiveLinkDefinitionsProvider, _externalLinkRevisionParser);
         _gitDescribeProvider = new GitDescribeProvider(() => Module);
 
-        Color messageBackground = SystemColors.Window.MakeBackgroundDarkerBy(0.04);
-        pnlCommitMessage.BackColor = messageBackground;
-        rtbxCommitMessage.BackColor = messageBackground;
+        Color panelBackground = AppColor.PanelBackground.GetThemeColor();
+        Color contentBackground = panelBackground;
+
+        BackColor = panelBackground;
+        tableLayout.BackColor = panelBackground;
+        commitInfoHeader.BackColor = contentBackground;
+        pnlCommitMessage.BackColor = contentBackground;
+        rtbxCommitMessage.BackColor = contentBackground;
+        RevisionInfo.BackColor = contentBackground;
 
         rtbxCommitMessage.Font = AppSettings.CommitFont;
         RevisionInfo.Font = AppSettings.Font;

--- a/src/app/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -2,7 +2,9 @@
 using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Editor.RichTextBoxExtension;
+using GitUI.Theming;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -24,6 +26,10 @@ public partial class CommitInfoHeader : GitModuleControl
     {
         InitializeComponent();
         InitializeComplete();
+
+        Color contentBackground = AppColor.PanelBackground.GetThemeColor();
+        BackColor = contentBackground;
+        rtbRevisionHeader.BackColor = contentBackground;
 
         TabbedHeaderLabelFormatter labelFormatter = new();
         TabbedHeaderRenderStyleProvider headerRenderer = new();

--- a/src/app/GitUI/Themes/dark secreal.css
+++ b/src/app/GitUI/Themes/dark secreal.css
@@ -1,0 +1,17 @@
+/* See (App install)\Themes\README.md for instructions on how to create or modify a theme */
+
+@import url("dark.css");
+
+/* Application colors */
+.PanelBackground { color: #252526; }
+.EditorBackground { color: #252526; }
+.LineNumberBackground { color: #252526; }
+.AuthoredHighlight { color: #1f1f1f; }
+.Selection { color: #37373d; }
+.HighlightAllOccurences { color: #515c6a; }
+.InactiveSelectionHighlight { color: #2d2d30; }
+
+.Branch { color: #8ab878; }
+.RemoteBranch { color: #c96767; }
+.Tag { color: #8ab878; }
+.OtherTag { color: #7b7b7b; }

--- a/src/app/GitUI/Themes/dark+.css
+++ b/src/app/GitUI/Themes/dark+.css
@@ -3,12 +3,15 @@
 @import url("dark.css");
 
 /* Application colors */
-.PanelBackground { color: #191a1b; }
-.EditorBackground { color: #121314; }
+.PanelBackground { color: #252526; }
+.EditorBackground { color: #252526; }
 .LineNumberBackground { color: #252526; }
-.AuthoredHighlight { color: #232c00; }
-.Selection { color: #2d6981; }
-.HighlightAllOccurences { color: #1a475a; }
-.InactiveSelectionHighlight { color: #1e3d4b; }
+.AuthoredHighlight { color: #1f1f1f; }
+.Selection { color: #37373d; }
+.HighlightAllOccurences { color: #515c6a; }
+.InactiveSelectionHighlight { color: #2d2d30; }
 
-.Branch { color: #00d76b; }
+.Branch { color: #8ab878; }
+.RemoteBranch { color: #c96767; }
+.Tag { color: #8ab878; }
+.OtherTag { color: #7b7b7b; }

--- a/src/app/GitUI/Themes/dark.css
+++ b/src/app/GitUI/Themes/dark.css
@@ -3,67 +3,67 @@
 /* SystemColorMode.Dark listed for reference
 System colors cannot be changed, used when adapting colors (many occurrences are not themeable)
 
-ActiveBorder: ff464646
-ActiveCaption: ff3c5f78
+ActiveBorder: ff3f3f46
+ActiveCaption: ff3c3c3c
 ActiveCaptionText: ffffffff
-AppWorkspace: ff3c3c3c
-ButtonFace: ff202020
-ButtonHighlight: ff101010
-ButtonShadow: ff464646
-Control: ff202020
-ControlDark: ff4a4a4a
-ControlDarkDark: ff5a5a5a
-ControlLight: ff2e2e2e
-ControlLightLight: ff1f1f1f
-ControlText: ffffffff
-Desktop: ff101010
-GradientActiveCaption: ff416482
-GradientInactiveCaption: ff557396
-GrayText: ff969696
-Highlight: ff2864b4
+AppWorkspace: ff252526
+ButtonFace: ff252526
+ButtonHighlight: ff3e3e42
+ButtonShadow: ff3e3e42
+Control: ff252526
+ControlDark: ff2f2f34
+ControlDarkDark: ff1e1e1e
+ControlLight: ff333337
+ControlLightLight: ff45494e
+ControlText: ffcccccc
+Desktop: ff1e1e1e
+GradientActiveCaption: ff3c3c3c
+GradientInactiveCaption: ff2d2d30
+GrayText: ff858585
+Highlight: ff264f78
 HighlightText: ff000000
-HotTrack: ff2d5faf
-InactiveBorder: ff3c3f41
-InactiveCaption: ff374b5a
-InactiveCaptionText: ffbebebe
-Info: ff50503c
-InfoText: ffbebebe
-Menu: ff373737
-MenuBar: ff373737
-MenuHighlight: ff2a80d2
-MenuText: fff0f0f0
-ScrollBar: ff505050
-Window: ff323232
-WindowFrame: ff282828
-WindowText: fff0f0f0
+HotTrack: ff3794ff
+InactiveBorder: ff2d2d30
+InactiveCaption: ff2d2d30
+InactiveCaptionText: ffcccccc
+Info: ff252526
+InfoText: ffcccccc
+Menu: ff252526
+MenuBar: ff252526
+MenuHighlight: ff094771
+MenuText: ffc8c8c8
+ScrollBar: ff3c3c3c
+Window: ff252526
+WindowFrame: ff1e1e1e
+WindowText: ffcccccc
 */
 
 /* Application colors */
 /* PanelBackground sets Windows Dark mode */
-.PanelBackground { color: #323232; }
-.EditorBackground { color: #323232; }
-.LineNumberBackground { color: #323232; }
-.AuthoredHighlight { color: #393920; }
-.Selection { color: #00009b; }
-.HighlightAllOccurences { color: #1d4897; }
-.InactiveSelectionHighlight { color: #436689; }
+.PanelBackground { color: #252526; }
+.EditorBackground { color: #252526; }
+.LineNumberBackground { color: #252526; }
+.AuthoredHighlight { color: #252526; }
+.Selection { color: #37373d; }
+.HighlightAllOccurences { color: #515c6a; }
+.InactiveSelectionHighlight { color: #2d2d30; }
 
-.GraphBranch1 { color: #db5b93; }
-.GraphBranch2 { color: #6fa7d4; }
-.GraphBranch3 { color: #1da31b; }
-.GraphBranch4 { color: #8a67cf; }
-.GraphBranch5 { color: #c02a22; }
-.GraphBranch6 { color: #17aa8f; }
-.GraphBranch7 { color: #ca9b0d; }
+.GraphBranch1 { color: #d16d9e; }
+.GraphBranch2 { color: #569cd6; }
+.GraphBranch3 { color: #4ec9b0; }
+.GraphBranch4 { color: #c586c0; }
+.GraphBranch5 { color: #f44747; }
+.GraphBranch6 { color: #4fc1ff; }
+.GraphBranch7 { color: #dcdcaa; }
 .GraphBranch8 { } /* color not specified, color slot will not be used */
-.GraphNonRelativeBranch { color: #707070; }
+.GraphNonRelativeBranch { color: #5c6370; }
 
-.Branch { color: #7FE28A; }
-.RemoteBranch { color: #fd9797; } /* hsl(0, 100%, 70%) */
-.RemoteBranch.colorblind { color: #0080ff; } /* hsl(210, 100%, 50%) */
-.Tag { color: #40BAF7; }
-.OtherTag { color: #cfb3b3; }
-.DiffSection { color: #5f5e5e; }
+.Branch { color: #8fbf7a; }
+.RemoteBranch { color: #cf6a6a; }
+.RemoteBranch.colorblind { color: #4a8fc8; }
+.Tag { color: #8fbf7a; }
+.OtherTag { color: #757575; }
+.DiffSection { color: #252526; }
 
 /* translation of terminal (cli) ansi color output sequences */
 /* Colors match VS Code Dark terminal ANSI palette */

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
@@ -36,7 +36,7 @@ internal sealed class AuthorNameColumnProvider : ColumnProvider
     {
         if (!revision.IsArtificial)
         {
-            Font font = _authorHighlighting.IsHighlighted(revision) ? style.BoldFont : style.NormalFont;
+            Font font = style.NormalFont;
 
             _grid.DrawColumnText(e, (string)e.FormattedValue!, font, style.ForeColor, e.CellBounds.ReduceLeft(ColumnLeftMargin));
         }

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -26,6 +26,7 @@ public sealed partial class RevisionDataGridView : DataGridView
     private readonly SolidBrush _rowBackgroundBrush;
     private readonly SolidBrush _alternatingRowBackgroundBrush;
     private readonly SolidBrush _authoredHighlightBrush;
+    private readonly SolidBrush _selectionBrush;
     private readonly SolidBrush _inactiveSelectionHighlightBrush;
 
     private readonly BackgroundUpdater _rowCountUpdater;
@@ -103,8 +104,9 @@ public sealed partial class RevisionDataGridView : DataGridView
         DoubleBuffered = true;
 
         _rowBackgroundBrush = new SolidBrush(AppColor.PanelBackground.GetThemeColor());
-        _alternatingRowBackgroundBrush = new SolidBrush(_rowBackgroundBrush.Color.MakeBackgroundDarkerBy(Application.IsDarkModeEnabled ? -0.018 : 0.025));
+        _alternatingRowBackgroundBrush = new SolidBrush(_rowBackgroundBrush.Color);
         _authoredHighlightBrush = new SolidBrush(AppColor.AuthoredHighlight.GetThemeColor());
+        _selectionBrush = new SolidBrush(AppColor.Selection.GetThemeColor());
         _inactiveSelectionHighlightBrush = new SolidBrush(AppColor.InactiveSelectionHighlight.GetThemeColor());
 
         UpdateRowHeight();
@@ -242,16 +244,16 @@ public sealed partial class RevisionDataGridView : DataGridView
     }
 
     private Color GetForeground(bool isSelected, bool isFocused, bool isNonRelativeGray)
-        => (isNonRelativeGray, isSelectedAndFocused: isSelected && isFocused) switch
+        => (isNonRelativeGray, isSelected) switch
         {
             // Unselected revisions of the currently checked out branch and all revisions reachable from HEAD
-            (isNonRelativeGray: false, isSelectedAndFocused: false) => SystemColors.ControlText,
+            (isNonRelativeGray: false, isSelected: false) => SystemColors.ControlText,
 
             // Selected revisions of the currently checked out branch and all revisions reachable from HEAD
-            (isNonRelativeGray: false, isSelectedAndFocused: true) => _relativeNonSelectedSubjectColor,
+            (isNonRelativeGray: false, isSelected: true) => _relativeNonSelectedSubjectColor,
 
             // All revisions not reachable from HEAD, revisions aren't selected
-            (isNonRelativeGray: true, isSelectedAndFocused: false) => _nonRelativeNonSelectedSubjectColor,
+            (isNonRelativeGray: true, isSelected: false) => _nonRelativeNonSelectedSubjectColor,
 
             // (isNonRelativeGray: true, isSelected: true)
             _ => _nonRelativeSelectedSubjectColor
@@ -277,7 +279,7 @@ public sealed partial class RevisionDataGridView : DataGridView
     {
         if (isSelected)
         {
-            return isFocused ? SystemBrushes.Highlight : _inactiveSelectionHighlightBrush;
+            return isFocused ? _selectionBrush : _inactiveSelectionHighlightBrush;
         }
 
         if (_highlightAuthoredRevisions && revision?.IsArtificial is false && AuthorHighlighting?.IsHighlighted(revision) is true)
@@ -422,15 +424,13 @@ public sealed partial class RevisionDataGridView : DataGridView
         // Reload settings that will be used during drawing
         _revisionGraphDrawNonRelativesTextGray = AppSettings.RevisionGraphDrawNonRelativesTextGray;
 
-        // relativeNonSelectedSubject: SystemColors.ControlText
         _relativeNonSelectedSubjectColor = Application.IsDarkModeEnabled ? SystemColors.ControlText : SystemColors.HighlightText;
-        _nonRelativeNonSelectedSubjectColor = Application.IsDarkModeEnabled ? Color.FromArgb(192, 192, 192) : SystemColors.GrayText;
-        _nonRelativeSelectedSubjectColor = Application.IsDarkModeEnabled ? Color.FromArgb(235, 235, 215) : GetHighlightedGrayTextColor(degreeOfGrayness: 1f);
+        _nonRelativeNonSelectedSubjectColor = Application.IsDarkModeEnabled ? Color.FromArgb(0x98, 0x98, 0x98) : GetGrayControlTextColor(degreeOfGrayness: 1f);
+        _nonRelativeSelectedSubjectColor = Application.IsDarkModeEnabled ? SystemColors.ControlText : GetHighlightedGrayTextColor(degreeOfGrayness: 1f);
 
-        // relativeNonSelectedBody: SystemColors.GrayText
-        _relativeSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(170, 170, 150) : _nonRelativeSelectedSubjectColor;
-        _nonRelativeNonSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(130, 130, 130) : GetGrayControlTextColor(degreeOfGrayness: 1.4f);
-        _nonRelativeSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(170, 170, 150) : GetHighlightedGrayTextColor(degreeOfGrayness: 1.4f);
+        _relativeSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(0xb0, 0xb0, 0xb0) : GetHighlightedGrayTextColor(degreeOfGrayness: 0.7f);
+        _nonRelativeNonSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(0x7a, 0x7a, 0x7a) : GetGrayControlTextColor(degreeOfGrayness: 1.4f);
+        _nonRelativeSelectedBodyColor = Application.IsDarkModeEnabled ? Color.FromArgb(0xb0, 0xb0, 0xb0) : GetHighlightedGrayTextColor(degreeOfGrayness: 1.4f);
 
         _highlightAuthoredRevisions = AppSettings.HighlightAuthoredRevisions;
         _revisionGraphDrawAlternateBackColor = AppSettings.RevisionGraphDrawAlternateBackColor;


### PR DESCRIPTION
## Summary
- refine the built-in dark theme visuals for a calmer, more consistent UI
- tune checklist/reset status colors to better match the updated dark styling
- add a new `dark secreal` theme entry so the customized palette can be selected directly

## Testing
- dotnet build .\\src\\app\\GitExtensions\\GitExtensions.csproj -c Debug --no-restore -p:RestoreSources=https://api.nuget.org/v3/index.json -p:NuGetAudit=false
- manual visual check in the locally built GitExtensions app
