### PR TITLE
feat: tooltip for submodules in the left panel

### DIFF
--- a/src/app/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/src/app/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -307,16 +307,16 @@ internal sealed class SubmoduleStatusProvider(IGitExecutorProvider executorProvi
             // (changed commit can be missed, but top module can only be dirty)
             SetModuleAsDirtyUpwards(module);
         }
-        else if (_submoduleInfos[module.WorkingDir].Detailed is not null)
+        else if (info.Detailed is { } detailed)
         {
             // No Git changes for this module, clear dirty status (but unknown for super projects)
-            if (_submoduleInfos[module.WorkingDir].Detailed!.Status == SubmoduleStatus.Unknown)
+            if (detailed.Status == SubmoduleStatus.Unknown)
             {
-                _submoduleInfos[module.WorkingDir].Detailed = null;
+                info.Detailed = null;
             }
             else
             {
-                _submoduleInfos[module.WorkingDir].Detailed!.IsDirty = false;
+                detailed.IsDirty = false;
             }
         }
 
@@ -424,8 +424,9 @@ internal sealed class SubmoduleStatusProvider(IGitExecutorProvider executorProvi
         GitSubmoduleStatus? submoduleStatus = await SubmoduleHelpers.GetSubmoduleCurrentChangesAsync(superModule, fileName: submoduleName, oldFileName: submoduleName, staged: false, noLocks: true)
             .ConfigureAwait(false);
 
-        // If no changes, set info.Detailed to null
-        info.Detailed = submoduleStatus is null ?
+        // If no changes, set submoduleInfo.Detailed to null
+        // if commit sha is not set the parsing was empty or there were no changes (ignore errors)
+        info.Detailed = submoduleStatus is null || submoduleStatus.Commit is null ?
             null :
             new DetailedSubmoduleInfo
             {
@@ -468,7 +469,7 @@ internal sealed class SubmoduleStatusProvider(IGitExecutorProvider executorProvi
 
         if (info.Detailed is null)
         {
-            // If no info, submodules are already the default
+            // If no submoduleInfo, submodules are already the default
             return;
         }
 

--- a/src/app/GitUI/LeftPanel/DummyNode.cs
+++ b/src/app/GitUI/LeftPanel/DummyNode.cs
@@ -1,9 +1,0 @@
-﻿namespace GitUI.LeftPanel;
-
-// Used temporarily to facilitate building a tree
-internal sealed class DummyNode : Node
-{
-    public DummyNode() : base(null)
-    {
-    }
-}

--- a/src/app/GitUI/LeftPanel/SubmoduleNode.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleNode.cs
@@ -162,11 +162,11 @@ internal sealed class SubmoduleNode : Node
 
     internal async Task SetStatusToolTipAsync(CancellationToken token)
     {
+        await TaskScheduler.Default;
         string toolTip;
         if (Info.Detailed?.RawStatus is not null)
         {
             // Prefer submodule status, shows ahead/behind
-            await TaskScheduler.Default;
             toolTip = SubmoduleResources.GetSubmoduleStatusText(
                 new GitModule(UICommands.GetRequiredService<IGitExecutorProvider>(), Info.Path),
                 Info.Detailed.RawStatus,
@@ -175,15 +175,16 @@ internal sealed class SubmoduleNode : Node
         }
         else if (GitStatus is not null)
         {
-            await TaskScheduler.Default;
             ArtificialCommitChangeCount changeCount = new();
             changeCount.Update(GitStatus);
             toolTip = changeCount.GetSummary();
         }
         else
         {
-            // No data need to be set
-            return;
+            toolTip = SubmoduleResources.GetSubmoduleText(
+                new GitModule(UICommands.GetRequiredService<IGitExecutorProvider>(), "."),
+                Info.Path,
+                hash: "");
         }
 
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(token);

--- a/src/app/GitUI/LeftPanel/SubmoduleTree.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleTree.cs
@@ -94,6 +94,7 @@ internal sealed class SubmoduleTree : Tree
 
             if (_currentNodes is null)
             {
+                // Load the nodes in the tree
                 // Module.GetRefs() is not used for submodules
                 JoinableTask joinableTask = ReloadNodesDetached((_, token) =>
                     {
@@ -201,9 +202,7 @@ internal sealed class SubmoduleTree : Tree
         // We always want to display submodules rooted from the top project.
         CreateSubmoduleNodes(result, threadModule, ref submoduleNodes);
 
-        Nodes nodes = new(this);
-        AddTopAndNodesToTree(ref nodes, submoduleNodes, threadModule, result);
-        return nodes;
+        return AddTopAndNodesToTree(submoduleNodes, threadModule, result);
     }
 
     private void CreateSubmoduleNodes(SubmoduleInfoResult result, IGitModule threadModule, ref List<SubmoduleNode> nodes)
@@ -257,8 +256,7 @@ internal sealed class SubmoduleTree : Tree
         return node.SuperPath.SubstringAfter(topModule.WorkingDir).ToPosixPath() + node.LocalPath;
     }
 
-    private void AddTopAndNodesToTree(
-        ref Nodes nodes,
+    private Nodes AddTopAndNodesToTree(
         List<SubmoduleNode> submoduleNodes,
         IGitModule threadModule,
         SubmoduleInfoResult result)
@@ -317,12 +315,21 @@ internal sealed class SubmoduleTree : Tree
             }
         }
 
+        // Add top-module node
+        Validates.NotNull(result.TopProject);
+        SubmoduleNode topModuleNode = new(
+            this,
+            result.TopProject,
+            result.TopProject.Bold,
+            result.TopProject.Bold ? result.CurrentSubmoduleStatus : null,
+            "",
+            result.TopProject.Path);
+
         // Now build the tree
-        DummyNode rootNode = new();
         HashSet<Node> nodesInTree = [];
         foreach (SubmoduleNode node in submoduleNodes)
         {
-            Node parentNode = rootNode;
+            Node parentNode = topModuleNode;
             string[] parts = GetNodeRelativePath(topModule, node).Split(Delimiters.ForwardSlash);
 
             for (int i = 0; i < parts.Length; ++i)
@@ -342,22 +349,12 @@ internal sealed class SubmoduleTree : Tree
         }
 
         // Compact chains of single-child folder nodes for a cleaner display
-        CompactSingleChildFolderChains(rootNode.Nodes);
+        CompactSingleChildFolderChains(topModuleNode.Nodes);
 
-        Validates.NotNull(result.TopProject);
-
-        // Add top-module node, and move children of root to it
-        SubmoduleNode topModuleNode = new(
-            this,
-            result.TopProject,
-            result.TopProject.Bold,
-            result.TopProject.Bold ? result.CurrentSubmoduleStatus : null,
-            "",
-            result.TopProject.Path);
-        topModuleNode.Nodes.AddNodes(rootNode.Nodes);
+        Nodes nodes = new(this);
         nodes.AddNode(topModuleNode);
 
-        return;
+        return nodes;
 
         static void CompactSingleChildFolderChains(Nodes nodes)
         {

--- a/src/app/GitUI/LeftPanel/Tree.cs
+++ b/src/app/GitUI/LeftPanel/Tree.cs
@@ -168,16 +168,12 @@ internal abstract class Tree : NodeBase, IDisposable
 
         TreeNode? selectedNode = TreeViewNode.TreeView!.SelectedNode;
 
-        if (originalSelectedNodeFullNamePath != selectedNode?.GetFullNamePath())
+        if (originalSelectedNodeFullNamePath != selectedNode?.GetFullNamePath()
+            && TreeViewNode.GetNodeFromPath(originalSelectedNodeFullNamePath) is { } node)
         {
-            TreeNode? node = TreeViewNode.GetNodeFromPath(originalSelectedNodeFullNamePath);
-
-            if (node is not null)
-            {
-                TreeViewNode.TreeView.SelectedNode = node.Tag is not BaseRevisionNode branchNode || branchNode.Visible
-                    ? node
-                    : null;
-            }
+            TreeViewNode.TreeView.SelectedNode = node.Tag is not BaseRevisionNode branchNode || branchNode.Visible
+                ? node
+                : null;
         }
 
         PostFillTreeViewNode(firstTime);

--- a/tests/app/UnitTests/GitUI.Tests/LeftPanel/DummyNode.cs
+++ b/tests/app/UnitTests/GitUI.Tests/LeftPanel/DummyNode.cs
@@ -1,0 +1,11 @@
+﻿using GitUI.LeftPanel;
+
+namespace GitUITests.LeftPanel;
+
+// A non-folder leaf node used in tests to verify compaction stops at non-SubmoduleFolderNode children.
+internal sealed class DummyNode : Node
+{
+    public DummyNode() : base(null)
+    {
+    }
+}


### PR DESCRIPTION
## Proposed changes

Add tooltip for submodules in the left pane with the commit infol, also when there are no changes. Currently just the name is shown.

Some minor code refactoring.

This is a followup to #12505, it was not possible before.
I considered adding more info like branches as well, this is good enough for now.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="298" height="125" alt="image" src="https://github.com/user-attachments/assets/beff6df1-f0a0-4d52-82fc-3025c0b24700" />

### After

<img width="627" height="211" alt="image" src="https://github.com/user-attachments/assets/fd5c325e-c37f-4d30-93a2-33f2e13edb54" />

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
