### PR TITLE
Implement Mintty console emulator support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />
     <PackageVersion Include="RestSharp" Version="106.12.0" />

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1531,9 +1531,9 @@ public static partial class AppSettings
         set => SetFont("font", value);
     }
 
-    public static Font ConEmuConsoleFont
+    public static Font? ConEmuConsoleFont
     {
-        get => GetFont("conemuconsolefont", new Font("Consolas", 12));
+        get => GetFont("conemuconsolefont", null);
         set => SetFont("conemuconsolefont", value);
     }
 
@@ -2166,8 +2166,9 @@ public static partial class AppSettings
     public static void SetDate(string name, DateTime? value) => SettingsContainer.SetDate(name, value);
 
     // Font
-    public static Font GetFont(string name, Font defaultValue) => SettingsContainer.GetFont(name, defaultValue);
-    public static void SetFont(string name, Font value) => SettingsContainer.SetFont(name, value);
+    [return: NotNullIfNotNull("defaultValue")]
+    public static Font? GetFont(string name, Font? defaultValue) => SettingsContainer.GetFont(name, defaultValue);
+    public static void SetFont(string name, Font? value) => SettingsContainer.SetFont(name, value);
 
     [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is. Only used by ThemeMigration.")]
     public static Color GetColor(AppColor name)

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -490,23 +490,9 @@ public static partial class AppSettings
 
     public static ISetting<bool> ShowConEmuTab { get; } = Setting.Create(DetailedSettingsPath, nameof(ShowConEmuTab), true);
 
-    private const string ConEmuStyleDefault = "Default";
-    private const string ConEmuStyleDark = "<Tomorrow Night>";
-    private const string ConEmuStyleLight = "<Tomorrow>";
+    public static ISetting<string> ConsoleEmulatorName { get; } = Setting.Create(DetailedSettingsPath, nameof(ConsoleEmulatorName), "ConEmu");
 
-    public static ISetting<string> ConEmuStyle { get; } = Setting.Create(DetailedSettingsPath, nameof(ConEmuStyle), ConEmuStyleDefault);
-
-    /// <summary>
-    ///  Returns the ConEmu style to use. When the configured value is <see cref="ConEmuStyleDefault"/>,
-    ///  automatically selects a style that matches the current application theme.
-    /// </summary>
-    public static string GetEffectiveConEmuStyle()
-    {
-        string style = ConEmuStyle.Value;
-        return style == ConEmuStyleDefault
-            ? Application.IsDarkModeEnabled ? ConEmuStyleDark : ConEmuStyleLight
-            : style;
-    }
+    public static ISetting<string> ConEmuStyle { get; } = Setting.Create(DetailedSettingsPath, nameof(ConEmuStyle), "Default");
 
     public static ISetting<string> ConEmuTerminal { get; } = Setting.Create(DetailedSettingsPath, nameof(ConEmuTerminal), "bash");
     public static ISetting<int> OutputHistoryDepth { get; } = Setting.Create(DetailedSettingsPath, nameof(OutputHistoryDepth), 20);
@@ -1878,10 +1864,6 @@ public static partial class AppSettings
     }
 
     public static ISetting<bool> UseConsoleEmulatorForCommands { get; } = Setting.Create(RootSettingsPath, nameof(UseConsoleEmulatorForCommands), true);
-
-    public static ISetting<string> ConsoleEmulatorName { get; } = Setting.Create(DetailedSettingsPath, nameof(ConsoleEmulatorName), "ConEmu");
-
-    public static ISetting<string> ConsoleEmulatorTheme { get; } = Setting.Create(DetailedSettingsPath, nameof(ConsoleEmulatorTheme), "");
 
     public static GitRefsSortBy RefsSortBy
     {

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1881,6 +1881,8 @@ public static partial class AppSettings
 
     public static ISetting<string> ConsoleEmulatorName { get; } = Setting.Create(DetailedSettingsPath, nameof(ConsoleEmulatorName), "ConEmu");
 
+    public static ISetting<string> ConsoleEmulatorTheme { get; } = Setting.Create(DetailedSettingsPath, nameof(ConsoleEmulatorTheme), "");
+
     public static GitRefsSortBy RefsSortBy
     {
         get => GetEnum("RefsSortBy", GitRefsSortBy.Default);

--- a/src/app/GitExtensions.Extensibility/Settings/SettingsSource.cs
+++ b/src/app/GitExtensions.Extensibility/Settings/SettingsSource.cs
@@ -111,9 +111,10 @@ public abstract class SettingsSource : IConfigValueStore
         SetValue(name, stringValue);
     }
 
-    public Font GetFont(string name, Font defaultValue) => FontParser.Parse(GetValue(name), defaultValue);
+    [return: NotNullIfNotNull("defaultValue")]
+    public Font? GetFont(string name, Font? defaultValue) => FontParser.Parse(GetValue(name), defaultValue!);
 
-    public void SetFont(string name, Font value) => SetValue(name, value.AsString());
+    public void SetFont(string name, Font? value) => SetValue(name, value?.AsString());
 
     public Color GetColor(string name, Color defaultValue)
     {

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
@@ -28,8 +28,11 @@ partial class ConsoleStyleSettingsPage
     /// </summary>
     private void InitializeComponent()
     {
+        components = new System.ComponentModel.Container();
         groupBoxConsoleSettings = new GroupBox();
         consoleFontChangeButton = new Button();
+        consoleFontResetButton = new Button();
+        consoleFontToolTip = new ToolTip(components);
         lblFontName = new Label();
         lblConsoleEmulator = new Label();
         cboConsoleEmulator = new ComboBox();
@@ -44,6 +47,7 @@ partial class ConsoleStyleSettingsPage
         groupBoxConsoleSettings.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
         groupBoxConsoleSettings.AutoSize = true;
         groupBoxConsoleSettings.Controls.Add(consoleFontChangeButton);
+        groupBoxConsoleSettings.Controls.Add(consoleFontResetButton);
         groupBoxConsoleSettings.Controls.Add(lblFontName);
         groupBoxConsoleSettings.Controls.Add(lblConsoleEmulator);
         groupBoxConsoleSettings.Controls.Add(cboConsoleEmulator);
@@ -117,6 +121,19 @@ partial class ConsoleStyleSettingsPage
         consoleFontChangeButton.UseVisualStyleBackColor = true;
         consoleFontChangeButton.Click += consoleFontChangeButton_Click;
         //
+        // consoleFontResetButton
+        //
+        consoleFontResetButton.Image = Properties.Images.ResetWorkingDirChanges;
+        consoleFontResetButton.Location = new Point(384, 82);
+        consoleFontResetButton.Margin = new Padding(0);
+        consoleFontResetButton.Name = "consoleFontResetButton";
+        consoleFontResetButton.Size = new Size(26, 26);
+        consoleFontResetButton.TabIndex = 6;
+        consoleFontResetButton.UseVisualStyleBackColor = true;
+        consoleFontResetButton.Visible = false;
+        consoleFontResetButton.Click += consoleFontResetButton_Click;
+        consoleFontToolTip.SetToolTip(consoleFontResetButton, "Reset to default");
+        //
         // consoleFontDialog
         //
         consoleFontDialog.AllowVerticalFonts = false;
@@ -147,5 +164,7 @@ partial class ConsoleStyleSettingsPage
     private Label label1;
     private ComboBox _NO_TRANSLATE_cboStyle;
     private Button consoleFontChangeButton;
+    private Button consoleFontResetButton;
+    private ToolTip consoleFontToolTip;
     private FontDialog consoleFontDialog;
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
@@ -1,13 +1,13 @@
-﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
 
 partial class ConsoleStyleSettingsPage
 {
-    /// <summary> 
+    /// <summary>
     /// Required designer variable.
     /// </summary>
     private System.ComponentModel.IContainer components = null;
 
-    /// <summary> 
+    /// <summary>
     /// Clean up any resources being used.
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -22,8 +22,8 @@ partial class ConsoleStyleSettingsPage
 
     #region Component Designer generated code
 
-    /// <summary> 
-    /// Required method for Designer support - do not modify 
+    /// <summary>
+    /// Required method for Designer support - do not modify
     /// the contents of this method with the code editor.
     /// </summary>
     private void InitializeComponent()
@@ -31,104 +31,99 @@ partial class ConsoleStyleSettingsPage
         groupBoxConsoleSettings = new GroupBox();
         consoleFontChangeButton = new Button();
         lblFontName = new Label();
+        lblConsoleEmulator = new Label();
+        cboConsoleEmulator = new ComboBox();
         label1 = new Label();
         _NO_TRANSLATE_cboStyle = new ComboBox();
         consoleFontDialog = new FontDialog();
         groupBoxConsoleSettings.SuspendLayout();
         SuspendLayout();
-        // 
+        //
         // groupBoxConsoleSettings
-        // 
+        //
         groupBoxConsoleSettings.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
         groupBoxConsoleSettings.AutoSize = true;
         groupBoxConsoleSettings.Controls.Add(consoleFontChangeButton);
         groupBoxConsoleSettings.Controls.Add(lblFontName);
+        groupBoxConsoleSettings.Controls.Add(lblConsoleEmulator);
+        groupBoxConsoleSettings.Controls.Add(cboConsoleEmulator);
         groupBoxConsoleSettings.Controls.Add(label1);
         groupBoxConsoleSettings.Controls.Add(_NO_TRANSLATE_cboStyle);
         groupBoxConsoleSettings.Location = new Point(8, 10);
         groupBoxConsoleSettings.Margin = new Padding(17, 2, 3, 2);
         groupBoxConsoleSettings.Name = "groupBoxConsoleSettings";
         groupBoxConsoleSettings.Padding = new Padding(3, 2, 3, 2);
-        groupBoxConsoleSettings.Size = new Size(1653, 95);
+        groupBoxConsoleSettings.Size = new Size(1653, 125);
         groupBoxConsoleSettings.TabIndex = 1;
         groupBoxConsoleSettings.TabStop = false;
         groupBoxConsoleSettings.Text = "Console settings (restart required)";
-        // 
-        // consoleFontChangeButton
-        // 
-        consoleFontChangeButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-        consoleFontChangeButton.Location = new Point(118, 54);
-        consoleFontChangeButton.Margin = new Padding(0);
-        consoleFontChangeButton.Name = "consoleFontChangeButton";
-        consoleFontChangeButton.Size = new Size(262, 23);
-        consoleFontChangeButton.TabIndex = 6;
-        consoleFontChangeButton.Text = "font name";
-        consoleFontChangeButton.UseVisualStyleBackColor = true;
-        consoleFontChangeButton.Click += consoleFontChangeButton_Click;
-        // 
-        // lblFontName
-        // 
-        lblFontName.AutoSize = true;
-        lblFontName.Location = new Point(5, 58);
-        lblFontName.Name = "lblFontName";
-        lblFontName.Size = new Size(31, 15);
-        lblFontName.TabIndex = 4;
-        lblFontName.Text = "Font";
-        // 
+        //
+        // lblConsoleEmulator
+        //
+        lblConsoleEmulator.AutoSize = true;
+        lblConsoleEmulator.Location = new Point(5, 28);
+        lblConsoleEmulator.Name = "lblConsoleEmulator";
+        lblConsoleEmulator.Size = new Size(101, 15);
+        lblConsoleEmulator.TabIndex = 0;
+        lblConsoleEmulator.Text = "Console emulator";
+        //
+        // cboConsoleEmulator
+        //
+        cboConsoleEmulator.DropDownStyle = ComboBoxStyle.DropDownList;
+        cboConsoleEmulator.FormattingEnabled = true;
+        cboConsoleEmulator.Location = new Point(118, 26);
+        cboConsoleEmulator.Margin = new Padding(3, 2, 3, 2);
+        cboConsoleEmulator.Name = "cboConsoleEmulator";
+        cboConsoleEmulator.Size = new Size(262, 23);
+        cboConsoleEmulator.TabIndex = 1;
+        //
         // label1
-        // 
+        //
         label1.AutoSize = true;
-        label1.Location = new Point(5, 28);
+        label1.Location = new Point(5, 58);
         label1.Name = "label1";
         label1.Size = new Size(77, 15);
         label1.TabIndex = 2;
         label1.Text = "Console style";
-        // 
+        //
         // _NO_TRANSLATE_cboStyle
-        // 
+        //
         _NO_TRANSLATE_cboStyle.DropDownStyle = ComboBoxStyle.DropDownList;
         _NO_TRANSLATE_cboStyle.FormattingEnabled = true;
-        _NO_TRANSLATE_cboStyle.Items.AddRange(new object[] {
-        "Default",
-        "<Default Windows scheme>",
-        "<Base16>",
-        "<Cobalt2>",
-        "<ConEmu>",
-        "<Gamma 1>",
-        "<Monokai>",
-        "<Murena scheme>",
-        "<PowerShell>",
-        "<Solarized>",
-        "<Solarized Git>",
-        "<Solarized (Luke Maciak)>",
-        "<Solarized (John Doe)>",
-        "<Solarized Light>",
-        "<SolarMe>",
-        "<Standard VGA>",
-        "<tc-maxx>",
-        "<Terminal.app>",
-        "<Tomorrow>",
-        "<Tomorrow Night>",
-        "<Tomorrow Night Blue>",
-        "<Tomorrow Night Bright>",
-        "<Tomorrow Night Eighties>",
-        "<Twilight>",
-        "<Ubuntu>",
-        "<xterm>",
-        "<Zenburn>"});
-        _NO_TRANSLATE_cboStyle.Location = new Point(118, 26);
+        _NO_TRANSLATE_cboStyle.Location = new Point(118, 56);
         _NO_TRANSLATE_cboStyle.Margin = new Padding(3, 2, 3, 2);
         _NO_TRANSLATE_cboStyle.Name = "_NO_TRANSLATE_cboStyle";
         _NO_TRANSLATE_cboStyle.Size = new Size(262, 23);
         _NO_TRANSLATE_cboStyle.TabIndex = 3;
-        // 
+        //
+        // lblFontName
+        //
+        lblFontName.AutoSize = true;
+        lblFontName.Location = new Point(5, 88);
+        lblFontName.Name = "lblFontName";
+        lblFontName.Size = new Size(31, 15);
+        lblFontName.TabIndex = 4;
+        lblFontName.Text = "Font";
+        //
+        // consoleFontChangeButton
+        //
+        consoleFontChangeButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        consoleFontChangeButton.Location = new Point(118, 84);
+        consoleFontChangeButton.Margin = new Padding(0);
+        consoleFontChangeButton.Name = "consoleFontChangeButton";
+        consoleFontChangeButton.Size = new Size(262, 23);
+        consoleFontChangeButton.TabIndex = 5;
+        consoleFontChangeButton.Text = "font name";
+        consoleFontChangeButton.UseVisualStyleBackColor = true;
+        consoleFontChangeButton.Click += consoleFontChangeButton_Click;
+        //
         // consoleFontDialog
-        // 
+        //
         consoleFontDialog.AllowVerticalFonts = false;
         consoleFontDialog.Color = SystemColors.ControlText;
-        // 
+        //
         // ConsoleStyleSettingsPage
-        // 
+        //
         AutoScaleDimensions = new SizeF(96F, 96F);
         AutoScaleMode = AutoScaleMode.Dpi;
         ClientSize = new Size(1679, 477);
@@ -147,6 +142,8 @@ partial class ConsoleStyleSettingsPage
 
     private GroupBox groupBoxConsoleSettings;
     private Label lblFontName;
+    private Label lblConsoleEmulator;
+    private ComboBox cboConsoleEmulator;
     private Label label1;
     private ComboBox _NO_TRANSLATE_cboStyle;
     private Button consoleFontChangeButton;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
@@ -1,24 +1,47 @@
-﻿using GitCommands;
+using GitCommands;
 using GitExtensions.Extensibility.Settings;
+using GitExtUtils;
+using GitUI.ConsoleEmulation;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
 
 public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
 {
+    private const string DefaultThemeDisplayName = "Default";
+
     private Font? _consoleFont;
 
     public ConsoleStyleSettingsPage(IServiceProvider serviceProvider)
         : base(serviceProvider)
     {
         InitializeComponent();
+
+        cboConsoleEmulator.DisplayMember = nameof(IConsoleEmulator.DisplayName);
+        cboConsoleEmulator.ValueMember = nameof(IConsoleEmulator.Name);
+
+        IReadOnlyCollection<IConsoleEmulator> emulators = serviceProvider.GetRequiredService<IConsoleEmulatorsRegistry>().AvailableConsoleEmulators;
+        foreach (IConsoleEmulator emulator in emulators)
+        {
+            cboConsoleEmulator.Items.Add(emulator);
+        }
+
+        cboConsoleEmulator.SelectedIndexChanged += (_, _) => RefreshThemeDropdown();
+
         InitializeComplete();
     }
 
     protected override void SettingsToPage()
     {
-        // Bind settings with controls
-        AddSettingBinding(AppSettings.ConEmuStyle, _NO_TRANSLATE_cboStyle);
+        cboConsoleEmulator.SelectedItem = cboConsoleEmulator.Items
+            .OfType<IConsoleEmulator>()
+            .FirstOrDefault(e => string.Equals(e.Name, AppSettings.ConsoleEmulatorName.Value, StringComparison.OrdinalIgnoreCase));
+        if (cboConsoleEmulator.SelectedIndex < 0 && cboConsoleEmulator.Items.Count > 0)
+        {
+            cboConsoleEmulator.SelectedIndex = 0;
+        }
+
+        RefreshThemeDropdown();
         SetCurrentConsoleFont(AppSettings.ConEmuConsoleFont);
 
         base.SettingsToPage();
@@ -27,6 +50,9 @@ public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
     protected override void PageToSettings()
     {
         Validates.NotNull(_consoleFont);
+
+        AppSettings.ConsoleEmulatorName.Value = (cboConsoleEmulator.SelectedItem as IConsoleEmulator)?.Name ?? "";
+        AppSettings.ConEmuStyle.Value = (string)_NO_TRANSLATE_cboStyle.SelectedItem!;
         AppSettings.ConEmuConsoleFont = _consoleFont;
 
         base.PageToSettings();
@@ -35,6 +61,48 @@ public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
     public static SettingsPageReference GetPageReference()
     {
         return new SettingsPageReferenceByType(typeof(ConsoleStyleSettingsPage));
+    }
+
+    private void RefreshThemeDropdown()
+    {
+        _NO_TRANSLATE_cboStyle.Items.Clear();
+
+        if (cboConsoleEmulator.SelectedItem is not IConsoleEmulator emulator)
+        {
+            _NO_TRANSLATE_cboStyle.Enabled = false;
+            return;
+        }
+
+        _NO_TRANSLATE_cboStyle.Items.Add(DefaultThemeDisplayName);
+        foreach (string theme in emulator.AvailableThemes)
+        {
+            _NO_TRANSLATE_cboStyle.Items.Add(theme);
+        }
+
+        _NO_TRANSLATE_cboStyle.Enabled = emulator.AvailableThemes.Count > 0;
+
+        string? saved = AppSettings.ConEmuStyle.Value;
+        int matchIndex = string.IsNullOrEmpty(saved)
+            ? 0
+            : FindThemeIndex(saved);
+        _NO_TRANSLATE_cboStyle.SelectedIndex = matchIndex >= 0 ? matchIndex : 0;
+        return;
+
+        int FindThemeIndex(string theme)
+        {
+            int index = 1; // skip "Default"
+            foreach (string available in emulator.AvailableThemes)
+            {
+                if (string.Equals(available, theme, StringComparison.OrdinalIgnoreCase))
+                {
+                    return index;
+                }
+
+                index++;
+            }
+
+            return -1;
+        }
     }
 
     private void consoleFontChangeButton_Click(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
@@ -49,8 +49,6 @@ public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
 
     protected override void PageToSettings()
     {
-        Validates.NotNull(_consoleFont);
-
         AppSettings.ConsoleEmulatorName.Value = (cboConsoleEmulator.SelectedItem as IConsoleEmulator)?.Name ?? "";
         AppSettings.ConEmuStyle.Value = (string)_NO_TRANSLATE_cboStyle.SelectedItem!;
         AppSettings.ConEmuConsoleFont = _consoleFont;
@@ -105,9 +103,14 @@ public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
         }
     }
 
+    private void consoleFontResetButton_Click(object sender, EventArgs e)
+    {
+        SetCurrentConsoleFont(null);
+    }
+
     private void consoleFontChangeButton_Click(object sender, EventArgs e)
     {
-        consoleFontDialog.Font = _consoleFont!;
+        consoleFontDialog.Font = _consoleFont ?? new Font("Consolas", 12);
         DialogResult result = consoleFontDialog.ShowDialog(this);
 
         if (result is (DialogResult.OK or DialogResult.Yes))
@@ -117,15 +120,19 @@ public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
         }
     }
 
-    private void SetCurrentConsoleFont(Font newFont)
+    private void SetCurrentConsoleFont(Font? font)
     {
-        _consoleFont = newFont;
-        SetFontButtonText(newFont, consoleFontChangeButton);
-    }
-
-    private static void SetFontButtonText(Font font, Button button)
-    {
-        button.Text = string.Format("{0}, {1}", font.FontFamily.Name, (int)(font.Size + 0.5f));
-        button.Font = font;
+        _consoleFont = font;
+        consoleFontResetButton.Visible = font is not null;
+        if (font is null)
+        {
+            consoleFontChangeButton.Text = "Console Default";
+            consoleFontChangeButton.ResetFont();
+        }
+        else
+        {
+            consoleFontChangeButton.Text = $"{font.FontFamily.Name}, {(int)(font.Size + 0.5f)}";
+            consoleFontChangeButton.Font = font;
+        }
     }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
@@ -3,12 +3,14 @@ using GitExtensions.Extensibility.Settings;
 using GitExtUtils;
 using GitUI.ConsoleEmulation;
 using Microsoft;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
 
 public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
 {
-    private const string DefaultThemeDisplayName = "Default";
+    private readonly TranslationString _defaultThemeDisplayName = new("Default");
+    private readonly TranslationString _consoleDefaultFontText = new("Console Default");
 
     private Font? _consoleFont;
 
@@ -71,7 +73,7 @@ public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
             return;
         }
 
-        _NO_TRANSLATE_cboStyle.Items.Add(DefaultThemeDisplayName);
+        _NO_TRANSLATE_cboStyle.Items.Add(_defaultThemeDisplayName.Text);
         foreach (string theme in emulator.AvailableThemes)
         {
             _NO_TRANSLATE_cboStyle.Items.Add(theme);
@@ -126,7 +128,7 @@ public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
         consoleFontResetButton.Visible = font is not null;
         if (font is null)
         {
-            consoleFontChangeButton.Text = "Console Default";
+            consoleFontChangeButton.Text = _consoleDefaultFontText.Text;
             consoleFontChangeButton.ResetFont();
         }
         else

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -37,6 +37,8 @@ partial class FormBrowseRepoSettingsPage
         lblDefaultShell = new Label();
         lblConsoleEmulatorChoice = new Label();
         cboConsoleEmulator = new ComboBox();
+        lblConsoleEmulatorTheme = new Label();
+        cboConsoleEmulatorTheme = new ComboBox();
         chkUseBrowseForFileHistory = new SettingsCheckBox();
         chkUseDiffViewerForBlame = new SettingsCheckBox();
         chkShowFindInCommitFilesGitGrep = new SettingsCheckBox();
@@ -130,9 +132,30 @@ partial class FormBrowseRepoSettingsPage
         cboConsoleEmulator.Name = "cboConsoleEmulator";
         cboConsoleEmulator.Size = new Size(262, 23);
         cboConsoleEmulator.TabIndex = 12;
-        // 
+        //
+        // lblConsoleEmulatorTheme
+        //
+        lblConsoleEmulatorTheme.AutoSize = true;
+        lblConsoleEmulatorTheme.Dock = DockStyle.Fill;
+        lblConsoleEmulatorTheme.Location = new Point(3, 54);
+        lblConsoleEmulatorTheme.Name = "lblConsoleEmulatorTheme";
+        lblConsoleEmulatorTheme.Size = new Size(251, 27);
+        lblConsoleEmulatorTheme.TabIndex = 13;
+        lblConsoleEmulatorTheme.Text = "Console emulator theme";
+        lblConsoleEmulatorTheme.TextAlign = ContentAlignment.MiddleLeft;
+        //
+        // cboConsoleEmulatorTheme
+        //
+        cboConsoleEmulatorTheme.DropDownStyle = ComboBoxStyle.DropDownList;
+        cboConsoleEmulatorTheme.FormattingEnabled = true;
+        cboConsoleEmulatorTheme.Location = new Point(260, 56);
+        cboConsoleEmulatorTheme.Margin = new Padding(3, 2, 3, 2);
+        cboConsoleEmulatorTheme.Name = "cboConsoleEmulatorTheme";
+        cboConsoleEmulatorTheme.Size = new Size(262, 23);
+        cboConsoleEmulatorTheme.TabIndex = 14;
+        //
         // chkUseBrowseForFileHistory
-        // 
+        //
         chkUseBrowseForFileHistory.AutoSize = true;
         chkUseBrowseForFileHistory.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         chkUseBrowseForFileHistory.Checked = false;
@@ -238,14 +261,17 @@ partial class FormBrowseRepoSettingsPage
         tlpnlGeneral.Controls.Add(lblDefaultShell, 0, 0);
         tlpnlGeneral.Controls.Add(lblConsoleEmulatorChoice, 0, 1);
         tlpnlGeneral.Controls.Add(cboConsoleEmulator, 1, 1);
-        tlpnlGeneral.Controls.Add(chkUseBrowseForFileHistory, 0, 2);
-        tlpnlGeneral.Controls.Add(chkUseDiffViewerForBlame, 0, 3);
-        tlpnlGeneral.Controls.Add(chkShowFindInCommitFilesGitGrep, 0, 4);
-        tlpnlGeneral.Controls.Add(chkShowRevisionGridTooltip, 0, 5);
+        tlpnlGeneral.Controls.Add(lblConsoleEmulatorTheme, 0, 2);
+        tlpnlGeneral.Controls.Add(cboConsoleEmulatorTheme, 1, 2);
+        tlpnlGeneral.Controls.Add(chkUseBrowseForFileHistory, 0, 3);
+        tlpnlGeneral.Controls.Add(chkUseDiffViewerForBlame, 0, 4);
+        tlpnlGeneral.Controls.Add(chkShowFindInCommitFilesGitGrep, 0, 5);
+        tlpnlGeneral.Controls.Add(chkShowRevisionGridTooltip, 0, 6);
         tlpnlGeneral.Dock = DockStyle.Fill;
         tlpnlGeneral.Location = new Point(8, 24);
         tlpnlGeneral.Name = "tlpnlGeneral";
-        tlpnlGeneral.RowCount = 6;
+        tlpnlGeneral.RowCount = 7;
+        tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
@@ -360,6 +386,8 @@ partial class FormBrowseRepoSettingsPage
     private Label lblDefaultShell;
     private Label lblConsoleEmulatorChoice;
     private ComboBox cboConsoleEmulator;
+    private Label lblConsoleEmulatorTheme;
+    private ComboBox cboConsoleEmulatorTheme;
     private SettingsCheckBox chkUseBrowseForFileHistory;
     private SettingsCheckBox chkUseDiffViewerForBlame;
     private SettingsCheckBox chkShowFindInCommitFilesGitGrep;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -35,10 +35,6 @@ partial class FormBrowseRepoSettingsPage
         chkShowConsoleTab = new SettingsCheckBox();
         cboTerminal = new ComboBox();
         lblDefaultShell = new Label();
-        lblConsoleEmulatorChoice = new Label();
-        cboConsoleEmulator = new ComboBox();
-        lblConsoleEmulatorTheme = new Label();
-        cboConsoleEmulatorTheme = new ComboBox();
         chkUseBrowseForFileHistory = new SettingsCheckBox();
         chkUseDiffViewerForBlame = new SettingsCheckBox();
         chkShowFindInCommitFilesGitGrep = new SettingsCheckBox();
@@ -111,48 +107,6 @@ partial class FormBrowseRepoSettingsPage
         lblDefaultShell.TabIndex = 0;
         lblDefaultShell.Text = "Default shell";
         lblDefaultShell.TextAlign = ContentAlignment.MiddleLeft;
-        //
-        // lblConsoleEmulatorChoice
-        //
-        lblConsoleEmulatorChoice.AutoSize = true;
-        lblConsoleEmulatorChoice.Dock = DockStyle.Fill;
-        lblConsoleEmulatorChoice.Location = new Point(3, 27);
-        lblConsoleEmulatorChoice.Name = "lblConsoleEmulatorChoice";
-        lblConsoleEmulatorChoice.Size = new Size(251, 27);
-        lblConsoleEmulatorChoice.TabIndex = 11;
-        lblConsoleEmulatorChoice.Text = "Console emulator";
-        lblConsoleEmulatorChoice.TextAlign = ContentAlignment.MiddleLeft;
-        //
-        // cboConsoleEmulator
-        //
-        cboConsoleEmulator.DropDownStyle = ComboBoxStyle.DropDownList;
-        cboConsoleEmulator.FormattingEnabled = true;
-        cboConsoleEmulator.Location = new Point(260, 29);
-        cboConsoleEmulator.Margin = new Padding(3, 2, 3, 2);
-        cboConsoleEmulator.Name = "cboConsoleEmulator";
-        cboConsoleEmulator.Size = new Size(262, 23);
-        cboConsoleEmulator.TabIndex = 12;
-        //
-        // lblConsoleEmulatorTheme
-        //
-        lblConsoleEmulatorTheme.AutoSize = true;
-        lblConsoleEmulatorTheme.Dock = DockStyle.Fill;
-        lblConsoleEmulatorTheme.Location = new Point(3, 54);
-        lblConsoleEmulatorTheme.Name = "lblConsoleEmulatorTheme";
-        lblConsoleEmulatorTheme.Size = new Size(251, 27);
-        lblConsoleEmulatorTheme.TabIndex = 13;
-        lblConsoleEmulatorTheme.Text = "Console emulator theme";
-        lblConsoleEmulatorTheme.TextAlign = ContentAlignment.MiddleLeft;
-        //
-        // cboConsoleEmulatorTheme
-        //
-        cboConsoleEmulatorTheme.DropDownStyle = ComboBoxStyle.DropDownList;
-        cboConsoleEmulatorTheme.FormattingEnabled = true;
-        cboConsoleEmulatorTheme.Location = new Point(260, 56);
-        cboConsoleEmulatorTheme.Margin = new Padding(3, 2, 3, 2);
-        cboConsoleEmulatorTheme.Name = "cboConsoleEmulatorTheme";
-        cboConsoleEmulatorTheme.Size = new Size(262, 23);
-        cboConsoleEmulatorTheme.TabIndex = 14;
         //
         // chkUseBrowseForFileHistory
         //
@@ -259,20 +213,14 @@ partial class FormBrowseRepoSettingsPage
         tlpnlGeneral.ColumnStyles.Add(new ColumnStyle());
         tlpnlGeneral.Controls.Add(cboTerminal, 1, 0);
         tlpnlGeneral.Controls.Add(lblDefaultShell, 0, 0);
-        tlpnlGeneral.Controls.Add(lblConsoleEmulatorChoice, 0, 1);
-        tlpnlGeneral.Controls.Add(cboConsoleEmulator, 1, 1);
-        tlpnlGeneral.Controls.Add(lblConsoleEmulatorTheme, 0, 2);
-        tlpnlGeneral.Controls.Add(cboConsoleEmulatorTheme, 1, 2);
-        tlpnlGeneral.Controls.Add(chkUseBrowseForFileHistory, 0, 3);
-        tlpnlGeneral.Controls.Add(chkUseDiffViewerForBlame, 0, 4);
-        tlpnlGeneral.Controls.Add(chkShowFindInCommitFilesGitGrep, 0, 5);
-        tlpnlGeneral.Controls.Add(chkShowRevisionGridTooltip, 0, 6);
+        tlpnlGeneral.Controls.Add(chkUseBrowseForFileHistory, 0, 1);
+        tlpnlGeneral.Controls.Add(chkUseDiffViewerForBlame, 0, 2);
+        tlpnlGeneral.Controls.Add(chkShowFindInCommitFilesGitGrep, 0, 3);
+        tlpnlGeneral.Controls.Add(chkShowRevisionGridTooltip, 0, 4);
         tlpnlGeneral.Dock = DockStyle.Fill;
         tlpnlGeneral.Location = new Point(8, 24);
         tlpnlGeneral.Name = "tlpnlGeneral";
-        tlpnlGeneral.RowCount = 7;
-        tlpnlGeneral.RowStyles.Add(new RowStyle());
-        tlpnlGeneral.RowStyles.Add(new RowStyle());
+        tlpnlGeneral.RowCount = 5;
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
         tlpnlGeneral.RowStyles.Add(new RowStyle());
@@ -384,10 +332,6 @@ partial class FormBrowseRepoSettingsPage
     private SettingsCheckBox chkShowConsoleTab;
     private ComboBox cboTerminal;
     private Label lblDefaultShell;
-    private Label lblConsoleEmulatorChoice;
-    private ComboBox cboConsoleEmulator;
-    private Label lblConsoleEmulatorTheme;
-    private ComboBox cboConsoleEmulatorTheme;
     private SettingsCheckBox chkUseBrowseForFileHistory;
     private SettingsCheckBox chkUseDiffViewerForBlame;
     private SettingsCheckBox chkShowFindInCommitFilesGitGrep;

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -37,6 +37,7 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
 
         cboConsoleEmulator.DisplayMember = nameof(IConsoleEmulator.DisplayName);
         cboConsoleEmulator.ValueMember = nameof(IConsoleEmulator.Name);
+        cboConsoleEmulator.SelectedIndexChanged += (_, _) => RefreshConsoleEmulatorThemeDropdown();
         InitializeComplete();
         string hotkey = serviceProvider.GetRequiredService<IHotkeySettingsManager>()
             .LoadHotkeys(FormBrowse.HotkeySettingsName)
@@ -52,8 +53,8 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
     protected override void OnRuntimeLoad()
     {
         // align 1st columns across all tables
-        tlpnlGeneral.AdjustWidthToSize(0, lblDefaultShell, lblConsoleEmulatorChoice, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
-        tlpnlTabs.AdjustWidthToSize(0, lblDefaultShell, lblConsoleEmulatorChoice, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
+        tlpnlGeneral.AdjustWidthToSize(0, lblDefaultShell, lblConsoleEmulatorChoice, lblConsoleEmulatorTheme, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
+        tlpnlTabs.AdjustWidthToSize(0, lblDefaultShell, lblConsoleEmulatorChoice, lblConsoleEmulatorTheme, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
 
         base.OnRuntimeLoad();
     }
@@ -78,6 +79,7 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
 
         AppSettings.ConEmuTerminal.Value = ((IShellDescriptor)cboTerminal.SelectedItem!).Name.ToLowerInvariant();
         AppSettings.ConsoleEmulatorName.Value = (cboConsoleEmulator.SelectedItem as IConsoleEmulator)?.Name ?? "";
+        AppSettings.ConsoleEmulatorTheme.Value = cboConsoleEmulatorTheme.SelectedItem as string ?? "";
 
         base.PageToSettings();
     }
@@ -111,7 +113,38 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
             cboConsoleEmulator.SelectedIndex = 0;
         }
 
+        RefreshConsoleEmulatorThemeDropdown();
+
         base.SettingsToPage();
+    }
+
+    private void RefreshConsoleEmulatorThemeDropdown()
+    {
+        cboConsoleEmulatorTheme.Items.Clear();
+
+        if (cboConsoleEmulator.SelectedItem is not IConsoleEmulator emulator
+            || emulator.AvailableThemes.Count == 0)
+        {
+            cboConsoleEmulatorTheme.SelectedItem = null;
+            cboConsoleEmulatorTheme.Enabled = false;
+            return;
+        }
+
+        cboConsoleEmulatorTheme.Enabled = true;
+        foreach (string theme in emulator.AvailableThemes)
+        {
+            cboConsoleEmulatorTheme.Items.Add(theme);
+        }
+
+        string? saved = AppSettings.ConsoleEmulatorTheme.Value;
+        if (!string.IsNullOrEmpty(saved) && cboConsoleEmulatorTheme.Items.Contains(saved))
+        {
+            cboConsoleEmulatorTheme.SelectedItem = saved;
+        }
+        else if (emulator.DefaultTheme is { } defaultTheme)
+        {
+            cboConsoleEmulatorTheme.SelectedItem = defaultTheme;
+        }
     }
 
     public static SettingsPageReference GetPageReference()

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -1,7 +1,6 @@
-﻿using GitCommands;
+using GitCommands;
 using GitExtensions.Extensibility.Settings;
 using GitExtUtils;
-using GitUI.ConsoleEmulation;
 using GitUI.Hotkey;
 using GitUI.Shells;
 using ResourceManager;
@@ -28,16 +27,6 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
     {
         InitializeComponent();
         cboTerminal.DisplayMember = "Name";
-
-        IReadOnlyCollection<IConsoleEmulator> emulators = serviceProvider.GetRequiredService<IConsoleEmulatorsRegistry>().AvailableConsoleEmulators;
-        foreach (IConsoleEmulator emulator in emulators)
-        {
-            cboConsoleEmulator.Items.Add(emulator);
-        }
-
-        cboConsoleEmulator.DisplayMember = nameof(IConsoleEmulator.DisplayName);
-        cboConsoleEmulator.ValueMember = nameof(IConsoleEmulator.Name);
-        cboConsoleEmulator.SelectedIndexChanged += (_, _) => RefreshConsoleEmulatorThemeDropdown();
         InitializeComplete();
         string hotkey = serviceProvider.GetRequiredService<IHotkeySettingsManager>()
             .LoadHotkeys(FormBrowse.HotkeySettingsName)
@@ -53,8 +42,8 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
     protected override void OnRuntimeLoad()
     {
         // align 1st columns across all tables
-        tlpnlGeneral.AdjustWidthToSize(0, lblDefaultShell, lblConsoleEmulatorChoice, lblConsoleEmulatorTheme, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
-        tlpnlTabs.AdjustWidthToSize(0, lblDefaultShell, lblConsoleEmulatorChoice, lblConsoleEmulatorTheme, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
+        tlpnlGeneral.AdjustWidthToSize(0, lblDefaultShell, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
+        tlpnlTabs.AdjustWidthToSize(0, lblDefaultShell, chkUseBrowseForFileHistory, chkUseDiffViewerForBlame, chkShowFindInCommitFilesGitGrep, chkShowRevisionGridTooltip, chkShowConsoleTab, chkShowGpgInformation);
 
         base.OnRuntimeLoad();
     }
@@ -78,8 +67,6 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
         }
 
         AppSettings.ConEmuTerminal.Value = ((IShellDescriptor)cboTerminal.SelectedItem!).Name.ToLowerInvariant();
-        AppSettings.ConsoleEmulatorName.Value = (cboConsoleEmulator.SelectedItem as IConsoleEmulator)?.Name ?? "";
-        AppSettings.ConsoleEmulatorTheme.Value = cboConsoleEmulatorTheme.SelectedItem as string ?? "";
 
         base.PageToSettings();
     }
@@ -105,46 +92,7 @@ public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
             }
         }
 
-        cboConsoleEmulator.SelectedItem = cboConsoleEmulator.Items
-            .OfType<IConsoleEmulator>()
-            .FirstOrDefault(x => string.Equals(x.Name, AppSettings.ConsoleEmulatorName.Value, StringComparison.OrdinalIgnoreCase));
-        if (cboConsoleEmulator.SelectedIndex < 0 && cboConsoleEmulator.Items.Count > 0)
-        {
-            cboConsoleEmulator.SelectedIndex = 0;
-        }
-
-        RefreshConsoleEmulatorThemeDropdown();
-
         base.SettingsToPage();
-    }
-
-    private void RefreshConsoleEmulatorThemeDropdown()
-    {
-        cboConsoleEmulatorTheme.Items.Clear();
-
-        if (cboConsoleEmulator.SelectedItem is not IConsoleEmulator emulator
-            || emulator.AvailableThemes.Count == 0)
-        {
-            cboConsoleEmulatorTheme.SelectedItem = null;
-            cboConsoleEmulatorTheme.Enabled = false;
-            return;
-        }
-
-        cboConsoleEmulatorTheme.Enabled = true;
-        foreach (string theme in emulator.AvailableThemes)
-        {
-            cboConsoleEmulatorTheme.Items.Add(theme);
-        }
-
-        string? saved = AppSettings.ConsoleEmulatorTheme.Value;
-        if (!string.IsNullOrEmpty(saved) && cboConsoleEmulatorTheme.Items.Contains(saved))
-        {
-            cboConsoleEmulatorTheme.SelectedItem = saved;
-        }
-        else if (emulator.DefaultTheme is { } defaultTheme)
-        {
-            cboConsoleEmulatorTheme.SelectedItem = defaultTheme;
-        }
     }
 
     public static SettingsPageReference GetPageReference()

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
@@ -13,15 +13,15 @@ namespace GitUI.ConsoleEmulation.ConEmu;
 /// </summary>
 internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRunner
 {
-    private readonly string _theme;
+    private readonly ConsoleEmulatorSettings _settings;
     private int _nLastExitCode;
 
     private Panel _panel;
     private ConEmuControl? _terminal;
 
-    public ConEmuConsoleCommandRunner(string theme)
+    public ConEmuConsoleCommandRunner(ConsoleEmulatorSettings settings)
     {
-        _theme = theme;
+        _settings = settings;
         InitializeComponent();
 
         Validates.NotNull(_panel);
@@ -135,7 +135,7 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
             };
 
             Validates.NotNull(_terminal);
-            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, _theme, AppSettings.ConEmuConsoleFont.Name, AppSettings.ConEmuConsoleFont.Size.ToString("F0", CultureInfo.InvariantCulture));
+            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, _settings.Theme, _settings.Font!.Name, _settings.Font.Size.ToString("F0", CultureInfo.InvariantCulture));
         }
         catch (Exception ex)
         {

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
@@ -135,7 +135,8 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
             };
 
             Validates.NotNull(_terminal);
-            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, _settings.Theme, _settings.Font!.Name, _settings.Font.Size.ToString("F0", CultureInfo.InvariantCulture));
+            Validates.NotNull(_settings.Font);
+            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, _settings.Theme, _settings.Font.Name, _settings.Font.Size.ToString("F0", CultureInfo.InvariantCulture));
         }
         catch (Exception ex)
         {

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleCommandRunner.cs
@@ -13,13 +13,15 @@ namespace GitUI.ConsoleEmulation.ConEmu;
 /// </summary>
 internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRunner
 {
+    private readonly string _theme;
     private int _nLastExitCode;
 
     private Panel _panel;
     private ConEmuControl? _terminal;
 
-    public ConEmuConsoleCommandRunner()
+    public ConEmuConsoleCommandRunner(string theme)
     {
+        _theme = theme;
         InitializeComponent();
 
         Validates.NotNull(_panel);
@@ -133,7 +135,7 @@ internal class ConEmuConsoleCommandRunner : ContainerControl, IConsoleCommandRun
             };
 
             Validates.NotNull(_terminal);
-            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.GetEffectiveConEmuStyle(), AppSettings.ConEmuConsoleFont.Name, AppSettings.ConEmuConsoleFont.Size.ToString("F0", CultureInfo.InvariantCulture));
+            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, _theme, AppSettings.ConEmuConsoleFont.Name, AppSettings.ConEmuConsoleFont.Size.ToString("F0", CultureInfo.InvariantCulture));
         }
         catch (Exception ex)
         {

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleEmulator.cs
@@ -1,4 +1,4 @@
-﻿namespace GitUI.ConsoleEmulation.ConEmu;
+namespace GitUI.ConsoleEmulation.ConEmu;
 
 internal class ConEmuConsoleEmulator : IConsoleEmulator
 {
@@ -8,12 +8,16 @@ internal class ConEmuConsoleEmulator : IConsoleEmulator
 
     public bool IsSupportedInCurrentEnvironment => OperatingSystem.IsWindows();
 
-    public IConsoleCommandRunner CreateCommandRunner()
+    public IReadOnlyCollection<string> AvailableThemes => [];
+
+    public string? DefaultTheme => null;
+
+    public IConsoleCommandRunner CreateCommandRunner(string? theme)
     {
         return new ConEmuConsoleCommandRunner();
     }
 
-    public IConsoleShellRunner CreateShellRunner()
+    public IConsoleShellRunner CreateShellRunner(string? theme)
     {
         return new ConEmuConsoleShellRunner();
     }

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleEmulator.cs
@@ -2,23 +2,61 @@ namespace GitUI.ConsoleEmulation.ConEmu;
 
 internal class ConEmuConsoleEmulator : IConsoleEmulator
 {
+    private const string DarkThemeFallback = "<Tomorrow Night>";
+    private const string LightThemeFallback = "<Tomorrow>";
+
     public string Name => "conemu";
 
     public string DisplayName => "ConEmu";
 
     public bool IsSupportedInCurrentEnvironment => OperatingSystem.IsWindows();
 
-    public IReadOnlyCollection<string> AvailableThemes => [];
+    public IReadOnlyCollection<string> AvailableThemes { get; } =
+    [
+        "<Default Windows scheme>",
+        "<Base16>",
+        "<Cobalt2>",
+        "<ConEmu>",
+        "<Gamma 1>",
+        "<Monokai>",
+        "<Murena scheme>",
+        "<PowerShell>",
+        "<Solarized>",
+        "<Solarized Git>",
+        "<Solarized (Luke Maciak)>",
+        "<Solarized (John Doe)>",
+        "<Solarized Light>",
+        "<SolarMe>",
+        "<Standard VGA>",
+        "<tc-maxx>",
+        "<Terminal.app>",
+        "<Tomorrow>",
+        "<Tomorrow Night>",
+        "<Tomorrow Night Blue>",
+        "<Tomorrow Night Bright>",
+        "<Tomorrow Night Eighties>",
+        "<Twilight>",
+        "<Ubuntu>",
+        "<xterm>",
+        "<Zenburn>",
+    ];
 
     public string? DefaultTheme => null;
 
     public IConsoleCommandRunner CreateCommandRunner(string? theme)
     {
-        return new ConEmuConsoleCommandRunner();
+        return new ConEmuConsoleCommandRunner(ResolveTheme(theme));
     }
 
     public IConsoleShellRunner CreateShellRunner(string? theme)
     {
-        return new ConEmuConsoleShellRunner();
+        return new ConEmuConsoleShellRunner(ResolveTheme(theme));
+    }
+
+    internal static string ResolveTheme(string? configuredTheme)
+    {
+        return string.IsNullOrEmpty(configuredTheme)
+            ? Application.IsDarkModeEnabled ? DarkThemeFallback : LightThemeFallback
+            : configuredTheme;
     }
 }

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleEmulator.cs
@@ -5,6 +5,8 @@ internal class ConEmuConsoleEmulator : IConsoleEmulator
     private const string DarkThemeFallback = "<Tomorrow Night>";
     private const string LightThemeFallback = "<Tomorrow>";
 
+    private static readonly Font DefaultFont = new("Consolas", 12);
+
     public string Name => "conemu";
 
     public string DisplayName => "ConEmu";
@@ -43,14 +45,22 @@ internal class ConEmuConsoleEmulator : IConsoleEmulator
 
     public string? DefaultTheme => null;
 
-    public IConsoleCommandRunner CreateCommandRunner(string? theme)
+    public IConsoleCommandRunner CreateCommandRunner(ConsoleEmulatorSettings settings)
     {
-        return new ConEmuConsoleCommandRunner(ResolveTheme(theme));
+        return new ConEmuConsoleCommandRunner(settings with
+        {
+            Theme = ResolveTheme(settings.Theme),
+            Font = settings.Font ?? DefaultFont,
+        });
     }
 
-    public IConsoleShellRunner CreateShellRunner(string? theme)
+    public IConsoleShellRunner CreateShellRunner(ConsoleEmulatorSettings settings)
     {
-        return new ConEmuConsoleShellRunner(ResolveTheme(theme));
+        return new ConEmuConsoleShellRunner(settings with
+        {
+            Theme = ResolveTheme(settings.Theme),
+            Font = settings.Font ?? DefaultFont,
+        });
     }
 
     internal static string ResolveTheme(string? configuredTheme)

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleShellRunner.cs
@@ -10,11 +10,13 @@ namespace GitUI.ConsoleEmulation.ConEmu;
 /// </summary>
 internal sealed class ConEmuConsoleShellRunner : IConsoleShellRunner
 {
+    private readonly string _theme;
     private readonly ConEmuControl _conEmu;
     private readonly ShellProvider _shellProvider = new();
 
-    internal ConEmuConsoleShellRunner()
+    internal ConEmuConsoleShellRunner(string theme)
     {
+        _theme = theme;
         _conEmu = new ConEmuControl
         {
             Dock = DockStyle.Fill,
@@ -69,7 +71,7 @@ internal sealed class ConEmuConsoleShellRunner : IConsoleShellRunner
             _conEmu.Start(
                 startInfo,
                 ThreadHelper.JoinableTaskFactory,
-                AppSettings.GetEffectiveConEmuStyle(),
+                _theme,
                 AppSettings.ConEmuConsoleFont.Name,
                 AppSettings.ConEmuConsoleFont.Size.ToString("F0", CultureInfo.InvariantCulture));
         }

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleShellRunner.cs
@@ -3,6 +3,7 @@ using ConEmu.WinForms;
 using GitCommands;
 using GitUI.ConsoleEmulation;
 using GitUI.Shells;
+using Microsoft;
 
 namespace GitUI.ConsoleEmulation.ConEmu;
 
@@ -69,11 +70,13 @@ internal sealed class ConEmuConsoleShellRunner : IConsoleShellRunner
 
         try
         {
+            Validates.NotNull(_settings.Font);
+
             _conEmu.Start(
                 startInfo,
                 ThreadHelper.JoinableTaskFactory,
                 _settings.Theme,
-                _settings.Font!.Name,
+                _settings.Font.Name,
                 _settings.Font.Size.ToString("F0", CultureInfo.InvariantCulture));
         }
         catch (InvalidOperationException)

--- a/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConEmu/ConEmuConsoleShellRunner.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using ConEmu.WinForms;
 using GitCommands;
+using GitUI.ConsoleEmulation;
 using GitUI.Shells;
 
 namespace GitUI.ConsoleEmulation.ConEmu;
@@ -10,13 +11,13 @@ namespace GitUI.ConsoleEmulation.ConEmu;
 /// </summary>
 internal sealed class ConEmuConsoleShellRunner : IConsoleShellRunner
 {
-    private readonly string _theme;
+    private readonly ConsoleEmulatorSettings _settings;
     private readonly ConEmuControl _conEmu;
     private readonly ShellProvider _shellProvider = new();
 
-    internal ConEmuConsoleShellRunner(string theme)
+    internal ConEmuConsoleShellRunner(ConsoleEmulatorSettings settings)
     {
-        _theme = theme;
+        _settings = settings;
         _conEmu = new ConEmuControl
         {
             Dock = DockStyle.Fill,
@@ -71,9 +72,9 @@ internal sealed class ConEmuConsoleShellRunner : IConsoleShellRunner
             _conEmu.Start(
                 startInfo,
                 ThreadHelper.JoinableTaskFactory,
-                _theme,
-                AppSettings.ConEmuConsoleFont.Name,
-                AppSettings.ConEmuConsoleFont.Size.ToString("F0", CultureInfo.InvariantCulture));
+                _settings.Theme,
+                _settings.Font!.Name,
+                _settings.Font.Size.ToString("F0", CultureInfo.InvariantCulture));
         }
         catch (InvalidOperationException)
         {

--- a/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorSettings.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorSettings.cs
@@ -1,0 +1,3 @@
+namespace GitUI.ConsoleEmulation;
+
+public record ConsoleEmulatorSettings(string? Theme, Font? Font);

--- a/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorSettings.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorSettings.cs
@@ -1,3 +1,8 @@
 namespace GitUI.ConsoleEmulation;
 
+/// <summary>
+///  Represents the visual settings used by the console emulator.
+/// </summary>
+/// <param name="Theme">The name of the theme to apply, or <see langword="null"/> to use the default theme.</param>
+/// <param name="Font">The font to use for console output, or <see langword="null"/> to use the default font.</param>
 public record ConsoleEmulatorSettings(string? Theme, Font? Font);

--- a/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorsRegistry.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorsRegistry.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands.Settings;
+using GitCommands.Settings;
 using GitUI.ConsoleEmulation.ConEmu;
 using GitUI.ConsoleEmulation.PlainText;
 
@@ -7,7 +7,8 @@ namespace GitUI.ConsoleEmulation;
 internal class ConsoleEmulatorsRegistry(
     IConsoleEmulator[] consoleEmulators,
     ISetting<bool> useConsoleEmulation,
-    ISetting<string> consoleEmulatorName)
+    ISetting<string> consoleEmulatorName,
+    ISetting<string> consoleEmulatorTheme)
     : IConsoleEmulatorsRegistry
 {
     public IReadOnlyCollection<IConsoleEmulator> AvailableConsoleEmulators { get; } =
@@ -25,12 +26,12 @@ internal class ConsoleEmulatorsRegistry(
 
         if (TryGetConfiguredConsoleEmulator() is { } configuredEmulator)
         {
-            return configuredEmulator.CreateCommandRunner();
+            return configuredEmulator.CreateCommandRunner(ResolveTheme(configuredEmulator));
         }
 
         if (TryGetFallbackConsoleEmulator() is { } fallbackConsoleEmulator)
         {
-            return fallbackConsoleEmulator.CreateCommandRunner();
+            return fallbackConsoleEmulator.CreateCommandRunner(ResolveTheme(fallbackConsoleEmulator));
         }
 
         // Fallback to no console emulation
@@ -44,15 +45,27 @@ internal class ConsoleEmulatorsRegistry(
     {
         if (TryGetConfiguredConsoleEmulator() is { } configuredEmulator)
         {
-            return configuredEmulator.CreateShellRunner();
+            return configuredEmulator.CreateShellRunner(ResolveTheme(configuredEmulator));
         }
 
         if (TryGetFallbackConsoleEmulator() is { } fallbackConsoleEmulator)
         {
-            return fallbackConsoleEmulator.CreateShellRunner();
+            return fallbackConsoleEmulator.CreateShellRunner(ResolveTheme(fallbackConsoleEmulator));
         }
 
         return null;
+    }
+
+    private string? ResolveTheme(IConsoleEmulator emulator)
+    {
+        string? configured = consoleEmulatorTheme.Value;
+        if (!string.IsNullOrEmpty(configured)
+            && emulator.AvailableThemes.Contains(configured, StringComparer.OrdinalIgnoreCase))
+        {
+            return configured;
+        }
+
+        return emulator.DefaultTheme;
     }
 
     private IConsoleEmulator? TryGetConfiguredConsoleEmulator()

--- a/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorsRegistry.cs
+++ b/src/app/GitUI/ConsoleEmulation/ConsoleEmulatorsRegistry.cs
@@ -8,7 +8,8 @@ internal class ConsoleEmulatorsRegistry(
     IConsoleEmulator[] consoleEmulators,
     ISetting<bool> useConsoleEmulation,
     ISetting<string> consoleEmulatorName,
-    ISetting<string> consoleEmulatorTheme)
+    ISetting<string> consoleEmulatorTheme,
+    Func<Font?> consoleFont)
     : IConsoleEmulatorsRegistry
 {
     public IReadOnlyCollection<IConsoleEmulator> AvailableConsoleEmulators { get; } =
@@ -26,12 +27,12 @@ internal class ConsoleEmulatorsRegistry(
 
         if (TryGetConfiguredConsoleEmulator() is { } configuredEmulator)
         {
-            return configuredEmulator.CreateCommandRunner(ResolveTheme(configuredEmulator));
+            return configuredEmulator.CreateCommandRunner(ResolveSettings(configuredEmulator));
         }
 
         if (TryGetFallbackConsoleEmulator() is { } fallbackConsoleEmulator)
         {
-            return fallbackConsoleEmulator.CreateCommandRunner(ResolveTheme(fallbackConsoleEmulator));
+            return fallbackConsoleEmulator.CreateCommandRunner(ResolveSettings(fallbackConsoleEmulator));
         }
 
         // Fallback to no console emulation
@@ -45,15 +46,20 @@ internal class ConsoleEmulatorsRegistry(
     {
         if (TryGetConfiguredConsoleEmulator() is { } configuredEmulator)
         {
-            return configuredEmulator.CreateShellRunner(ResolveTheme(configuredEmulator));
+            return configuredEmulator.CreateShellRunner(ResolveSettings(configuredEmulator));
         }
 
         if (TryGetFallbackConsoleEmulator() is { } fallbackConsoleEmulator)
         {
-            return fallbackConsoleEmulator.CreateShellRunner(ResolveTheme(fallbackConsoleEmulator));
+            return fallbackConsoleEmulator.CreateShellRunner(ResolveSettings(fallbackConsoleEmulator));
         }
 
         return null;
+    }
+
+    private ConsoleEmulatorSettings ResolveSettings(IConsoleEmulator emulator)
+    {
+        return new ConsoleEmulatorSettings(ResolveTheme(emulator), consoleFont());
     }
 
     private string? ResolveTheme(IConsoleEmulator emulator)

--- a/src/app/GitUI/ConsoleEmulation/IConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/IConsoleEmulator.cs
@@ -22,12 +22,25 @@ public interface IConsoleEmulator
     bool IsSupportedInCurrentEnvironment { get; }
 
     /// <summary>
+    ///  Gets the themes supported by this emulator. Empty when the emulator
+    ///  does not support theme selection or none are installed.
+    /// </summary>
+    IReadOnlyCollection<string> AvailableThemes { get; }
+
+    /// <summary>
+    ///  Gets the default theme to use when the configured theme is missing or
+    ///  unknown. Returns <see langword="null"/> when no usable default exists.
+    ///  When non-null, the value is guaranteed to be present in <see cref="AvailableThemes"/>.
+    /// </summary>
+    string? DefaultTheme { get; }
+
+    /// <summary>
     ///  Creates a console process runner for command dialogs.
     /// </summary>
-    IConsoleCommandRunner CreateCommandRunner();
+    IConsoleCommandRunner CreateCommandRunner(string? theme);
 
     /// <summary>
     ///  Creates a console shell runner for the repository browser's terminal tab.
     /// </summary>
-    IConsoleShellRunner CreateShellRunner();
+    IConsoleShellRunner CreateShellRunner(string? theme);
 }

--- a/src/app/GitUI/ConsoleEmulation/IConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/IConsoleEmulator.cs
@@ -37,10 +37,10 @@ public interface IConsoleEmulator
     /// <summary>
     ///  Creates a console process runner for command dialogs.
     /// </summary>
-    IConsoleCommandRunner CreateCommandRunner(string? theme);
+    IConsoleCommandRunner CreateCommandRunner(ConsoleEmulatorSettings settings);
 
     /// <summary>
     ///  Creates a console shell runner for the repository browser's terminal tab.
     /// </summary>
-    IConsoleShellRunner CreateShellRunner(string? theme);
+    IConsoleShellRunner CreateShellRunner(ConsoleEmulatorSettings settings);
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
@@ -91,7 +91,7 @@ internal sealed partial class MinttyCommandRunner : IConsoleCommandRunner
                 startInfo.SetEnv(name, value);
             }
 
-            _terminal.StartCommand(startInfo, _minttyPath, _bashPath, _settings.Theme, _settings.Font);
+            _terminal.StartCommand(startInfo, _minttyPath, _bashPath, _settings);
         }
         catch (Exception ex)
         {

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
@@ -1,0 +1,129 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using GitCommands;
+using GitCommands.Logging;
+using GitExtensions.Extensibility;
+
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal sealed partial class MinttyCommandRunner : IConsoleCommandRunner
+{
+    private readonly string _minttyPath;
+    private readonly string _bashPath;
+    private readonly string? _theme;
+
+    private MinttyControl? _terminal;
+    private readonly Panel _panel;
+
+    internal MinttyCommandRunner(string minttyPath, string bashPath, string? theme)
+    {
+        _minttyPath = minttyPath;
+        _bashPath = bashPath;
+        _theme = theme;
+
+        _panel = new Panel { Dock = DockStyle.Fill, BorderStyle = BorderStyle.None };
+    }
+
+    public Control Control => _panel;
+
+    public event EventHandler<ConsoleOutputEventArgs>? CommandOutputReceived;
+    public event EventHandler<ConsoleProcessExitEventArgs>? CommandProcessExited;
+    public event EventHandler? ConsoleHostTerminated;
+
+    public void WriteCommandProcessInput(string text)
+    {
+        _terminal?.SendConsoleInput(text);
+    }
+
+    public void KillCommandProcess()
+    {
+        _terminal?.RunningSession?.Kill();
+    }
+
+    [MemberNotNull(nameof(_terminal))]
+    public void ResetConsole()
+    {
+        MinttyControl? oldTerminal = _terminal;
+
+        _terminal = new MinttyControl { Dock = DockStyle.Fill };
+
+        if (oldTerminal is not null)
+        {
+            _panel.Controls.Remove(oldTerminal);
+            oldTerminal.Dispose();
+        }
+
+        _panel.Controls.Add(_terminal);
+    }
+
+    public void StartCommand(string command, string arguments, string workDir, Dictionary<string, string> envVariables)
+    {
+        if (_terminal is null)
+        {
+            ResetConsole();
+        }
+
+        ProcessOperation operation = CommandLog.LogProcessStart(command, arguments, workDir);
+
+        try
+        {
+            string commandLine = new ArgumentBuilder { command.Quote(), arguments }.ToString();
+
+            MinttyStartInfo startInfo = new()
+            {
+                ConsoleProcessCommandLine = commandLine,
+                StartupDirectory = workDir,
+                ProcessExitedCallback = exitCode =>
+                {
+                    operation.LogProcessEnd(exitCode);
+                    SafeBeginInvoke(() => CommandProcessExited?.Invoke(this, new ConsoleProcessExitEventArgs(exitCode)));
+                },
+                ConsoleClosedCallback = () => SafeBeginInvoke(() => ConsoleHostTerminated?.Invoke(this, EventArgs.Empty)),
+                AnsiOutputLineCallback = line =>
+                {
+                    line = StripAnsiCodesRegex().Replace(line, string.Empty);
+                    CommandOutputReceived?.Invoke(this, new ConsoleOutputEventArgs(line));
+                },
+            };
+
+            foreach ((string name, string value) in envVariables)
+            {
+                startInfo.SetEnv(name, value);
+            }
+
+            _terminal.StartCommand(startInfo, _minttyPath, _bashPath, _theme);
+        }
+        catch (Exception ex)
+        {
+            operation.LogProcessEnd(ex);
+            throw;
+        }
+    }
+
+    private void SafeBeginInvoke(Action action)
+    {
+        if (_panel.IsHandleCreated)
+        {
+            try
+            {
+                _panel.BeginInvoke(action);
+                return;
+            }
+            catch (InvalidOperationException)
+            {
+                // Handle was destroyed between IsHandleCreated and BeginInvoke.
+            }
+        }
+
+        // Process.Exited fires on a thread-pool thread; running the action inline
+        // would push UI updates off the UI thread. Hop via JTF instead.
+        ThreadHelper.FileAndForget(async () =>
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            action();
+        });
+    }
+
+    [GeneratedRegex(@"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")]
+    private static partial Regex StripAnsiCodesRegex();
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
@@ -71,6 +71,7 @@ internal sealed partial class MinttyCommandRunner : IConsoleCommandRunner
 
             MinttyStartInfo startInfo = new()
             {
+                ProcessOperation = operation,
                 ConsoleProcessCommandLine = commandLine,
                 StartupDirectory = workDir,
                 ProcessExitedCallback = exitCode =>

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
@@ -10,16 +10,16 @@ internal sealed partial class MinttyCommandRunner : IConsoleCommandRunner
 {
     private readonly string _minttyPath;
     private readonly string _bashPath;
-    private readonly string? _theme;
+    private readonly ConsoleEmulatorSettings _settings;
 
     private MinttyControl? _terminal;
     private readonly Panel _panel;
 
-    internal MinttyCommandRunner(string minttyPath, string bashPath, string? theme)
+    internal MinttyCommandRunner(string minttyPath, string bashPath, ConsoleEmulatorSettings settings)
     {
         _minttyPath = minttyPath;
         _bashPath = bashPath;
-        _theme = theme;
+        _settings = settings;
 
         _panel = new Panel { Dock = DockStyle.Fill, BorderStyle = BorderStyle.None };
     }
@@ -91,7 +91,7 @@ internal sealed partial class MinttyCommandRunner : IConsoleCommandRunner
                 startInfo.SetEnv(name, value);
             }
 
-            _terminal.StartCommand(startInfo, _minttyPath, _bashPath, _theme);
+            _terminal.StartCommand(startInfo, _minttyPath, _bashPath, _settings.Theme, _settings.Font);
         }
         catch (Exception ex)
         {

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyCommandRunner.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
-using GitCommands;
 using GitCommands.Logging;
 using GitExtensions.Extensibility;
 
@@ -77,19 +76,22 @@ internal sealed partial class MinttyCommandRunner : IConsoleCommandRunner
                 ProcessExitedCallback = exitCode =>
                 {
                     operation.LogProcessEnd(exitCode);
-                    SafeBeginInvoke(() => CommandProcessExited?.Invoke(this, new ConsoleProcessExitEventArgs(exitCode)));
+                    Control.InvokeAndForget(() => CommandProcessExited?.Invoke(this, new ConsoleProcessExitEventArgs(exitCode)));
                 },
-                ConsoleClosedCallback = () => SafeBeginInvoke(() => ConsoleHostTerminated?.Invoke(this, EventArgs.Empty)),
+                ConsoleClosedCallback = () =>
+                {
+                    Control.InvokeAndForget(() => ConsoleHostTerminated?.Invoke(this, EventArgs.Empty));
+                },
                 AnsiOutputLineCallback = line =>
                 {
                     line = StripAnsiCodesRegex().Replace(line, string.Empty);
-                    CommandOutputReceived?.Invoke(this, new ConsoleOutputEventArgs(line));
-                },
+                    Control.InvokeAndForget(() => CommandOutputReceived?.Invoke(this, new ConsoleOutputEventArgs(line)));
+                }
             };
 
             foreach ((string name, string value) in envVariables)
             {
-                startInfo.SetEnv(name, value);
+                startInfo.EnvironmentVariables[name] = value;
             }
 
             _terminal.StartCommand(startInfo, _minttyPath, _bashPath, _settings);
@@ -99,30 +101,6 @@ internal sealed partial class MinttyCommandRunner : IConsoleCommandRunner
             operation.LogProcessEnd(ex);
             throw;
         }
-    }
-
-    private void SafeBeginInvoke(Action action)
-    {
-        if (_panel.IsHandleCreated)
-        {
-            try
-            {
-                _panel.BeginInvoke(action);
-                return;
-            }
-            catch (InvalidOperationException)
-            {
-                // Handle was destroyed between IsHandleCreated and BeginInvoke.
-            }
-        }
-
-        // Process.Exited fires on a thread-pool thread; running the action inline
-        // would push UI updates off the UI thread. Hop via JTF instead.
-        ThreadHelper.FileAndForget(async () =>
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            action();
-        });
     }
 
     [GeneratedRegex(@"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")]

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleEmulator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using GitCommands;
 
@@ -73,8 +74,9 @@ internal sealed class MinttyConsoleEmulator : IConsoleEmulator
                 .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
         }
-        catch
+        catch (Exception ex)
         {
+            Trace.WriteLine(ex);
             return [];
         }
     }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleEmulator.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics.CodeAnalysis;
+using GitCommands;
+
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal sealed class MinttyConsoleEmulator : IConsoleEmulator
+{
+    private const string PreferredDefaultTheme = "monokai-dimmed";
+
+    private IReadOnlyCollection<string>? _availableThemes;
+
+    public string Name => "mintty";
+
+    public string DisplayName => "Mintty";
+
+    public bool IsSupportedInCurrentEnvironment => OperatingSystem.IsWindows() && TryResolvePaths(out _, out _);
+
+    public IReadOnlyCollection<string> AvailableThemes => _availableThemes ??= LoadAvailableThemes();
+
+    public string? DefaultTheme =>
+        AvailableThemes.Contains(PreferredDefaultTheme, StringComparer.OrdinalIgnoreCase)
+            ? PreferredDefaultTheme
+            : null;
+
+    public IConsoleCommandRunner CreateCommandRunner(string? theme)
+    {
+        (string minttyPath, string bashPath) = ResolvePaths();
+        return new MinttyCommandRunner(minttyPath, bashPath, theme);
+    }
+
+    public IConsoleShellRunner CreateShellRunner(string? theme)
+    {
+        (string minttyPath, string bashPath) = ResolvePaths();
+        return new MinttyShellRunner(minttyPath, bashPath, theme);
+    }
+
+    private static (string MinttyPath, string BashPath) ResolvePaths()
+    {
+        if (!TryResolvePaths(out string? minttyPath, out string? bashPath))
+        {
+            throw new InvalidOperationException($"mintty or bash not found. Check {nameof(IsSupportedInCurrentEnvironment)} before calling.");
+        }
+
+        return (minttyPath, bashPath);
+    }
+
+    private static bool TryResolvePaths([NotNullWhen(true)] out string? minttyPath, [NotNullWhen(true)] out string? bashPath)
+    {
+        bool foundMintty = PathUtil.TryFindShellPath(@"usr\bin\mintty.exe", out minttyPath);
+        bool foundBash = PathUtil.TryFindShellPath("bash.exe", out bashPath);
+        return foundMintty && foundBash;
+    }
+
+    private static IReadOnlyCollection<string> LoadAvailableThemes()
+    {
+        if (!TryResolvePaths(out string? minttyPath, out _))
+        {
+            return [];
+        }
+
+        try
+        {
+            string themesDir = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(minttyPath)!, "..", "share", "mintty", "themes"));
+            if (!Directory.Exists(themesDir))
+            {
+                return [];
+            }
+
+            return Directory.EnumerateFiles(themesDir)
+                .Select(Path.GetFileName)
+                .Where(name => !string.IsNullOrEmpty(name))
+                .Select(name => name!)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleEmulator.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleEmulator.cs
@@ -22,16 +22,16 @@ internal sealed class MinttyConsoleEmulator : IConsoleEmulator
             ? PreferredDefaultTheme
             : null;
 
-    public IConsoleCommandRunner CreateCommandRunner(string? theme)
+    public IConsoleCommandRunner CreateCommandRunner(ConsoleEmulatorSettings settings)
     {
         (string minttyPath, string bashPath) = ResolvePaths();
-        return new MinttyCommandRunner(minttyPath, bashPath, theme);
+        return new MinttyCommandRunner(minttyPath, bashPath, settings);
     }
 
-    public IConsoleShellRunner CreateShellRunner(string? theme)
+    public IConsoleShellRunner CreateShellRunner(ConsoleEmulatorSettings settings)
     {
         (string minttyPath, string bashPath) = ResolvePaths();
-        return new MinttyShellRunner(minttyPath, bashPath, theme);
+        return new MinttyShellRunner(minttyPath, bashPath, settings);
     }
 
     private static (string MinttyPath, string BashPath) ResolvePaths()

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -101,7 +101,7 @@ internal static partial class MinttyConsoleRuntime
         }
     }
 
-    [GeneratedRegex(@"\x1b\[8mGITEX_EXIT:(\d+)\x1b\[0?m")]
+    [GeneratedRegex(@"\x1b\[8mGITEX_EXIT:(\d+)\x1b\[0m")]
     private static partial Regex ExitSentinelRegex();
 
     private static string BuildWrapperScript(string commandLine)
@@ -114,13 +114,13 @@ internal static partial class MinttyConsoleRuntime
               printf '\x1b[0;38;5;5;49m%s\x1b[0m\n' "$GITEX_CMD_DISPLAY"
               {{bashCommandLine}}
               GITEX_RC=$?
-              printf '\033[8mGITEX_EXIT:%d\033[0m' "$GITEX_RC"
+              printf '\x1b[8mGITEX_EXIT:%d\x1b[0m' "$GITEX_RC"
               echo
               if [ "$GITEX_RC" -ne 0 ]; then
-                  printf '\x1b[0;38;5;160;49mProcess exited with code %d\033[0m\n' "$GITEX_RC"
+                  printf '\x1b[0;38;5;160;49mProcess exited with code %d\x1b[0m\n' "$GITEX_RC"
               fi
-              printf '\x1b[0;38;5;243;49mDone\033[0m\n'
-              printf '\x1b[0;38;5;243;49mPress Enter or Esc to exit...\033[0m\n'
+              printf '\x1b[0;38;5;243;49mDone\x1b[0m\n'
+              printf '\x1b[0;38;5;243;49mPress Enter or Esc to exit...\x1b[0m\n'
               echo
               read -n 1
               exit 0

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -81,8 +81,9 @@ internal static partial class MinttyConsoleRuntime
         catch (OperationCanceledException)
         {
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Trace.WriteLine($"Failed to read mintty output: {ex}");
         }
 
         return;

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -49,13 +49,14 @@ internal static partial class MinttyConsoleRuntime
         Action<string>? lineCallback,
         Action<int>? exitCallback)
     {
+        char[] charBuf = new char[4096];
+        StringBuilder pendingLine = new();
+        Decoder decoder = Encoding.UTF8.GetDecoder();
+
         try
         {
             Stream stdout = minttyProcess.StandardOutput.BaseStream;
             byte[] buffer = new byte[4096];
-            char[] charBuf = new char[4096];
-            Decoder decoder = Encoding.UTF8.GetDecoder();
-            StringBuilder line = new();
 
             while (true)
             {
@@ -65,24 +66,14 @@ internal static partial class MinttyConsoleRuntime
                     break;
                 }
 
-                Span<byte> bytes = buffer.AsSpan(0, read);
-
-                int chars = decoder.GetChars(bytes, charBuf, true);
-                for (int i = 0; i < chars; i++)
-                {
-                    char c = charBuf[i];
-                    line.Append(c);
-                    if (c == '\n')
-                    {
-                        EmitLine(line.ToString());
-                        line.Clear();
-                    }
-                }
+                DecodeAndEmitLines(buffer.AsSpan(0, read), flush: false);
             }
 
-            if (line.Length > 0)
+            DecodeAndEmitLines(ReadOnlySpan<byte>.Empty, flush: true);
+
+            if (pendingLine.Length > 0)
             {
-                EmitLine(line.ToString());
+                EmitLine(pendingLine.ToString());
             }
         }
         catch (Exception ex)
@@ -91,6 +82,23 @@ internal static partial class MinttyConsoleRuntime
         }
 
         return;
+
+        void DecodeAndEmitLines(ReadOnlySpan<byte> bytes, bool flush)
+        {
+            // flush: false mid-stream so a multi-byte UTF-8 sequence split across reads
+            // is carried into the next call instead of being emitted as U+FFFD.
+            int count = decoder.GetChars(bytes, charBuf, flush);
+            for (int i = 0; i < count; i++)
+            {
+                char c = charBuf[i];
+                pendingLine.Append(c);
+                if (c == '\n')
+                {
+                    EmitLine(pendingLine.ToString());
+                    pendingLine.Clear();
+                }
+            }
+        }
 
         void EmitLine(string text)
         {
@@ -170,12 +178,43 @@ internal static partial class MinttyConsoleRuntime
         {
             char c = commandLine[i];
 
-            if (c == '\\' && i + 1 < commandLine.Length && commandLine[i + 1] == '"')
+            if (c == '\\')
             {
-                // Escaped quote produced by StringExtensions.Quote(): keep the literal '"'.
-                current.Append('"');
+                // Apply the Windows CommandLineToArgvW backslash rules so a run of
+                // backslashes before a quote is interpreted correctly:
+                //   2n   backslashes + '"' => n literal backslashes, the quote toggles
+                //   2n+1 backslashes + '"' => n literal backslashes + a literal '"'
+                //   backslashes not before a '"' are all literal.
+                // Without this, a quoted path ending in '\' (escaped as `\\"`) loses its
+                // closing quote and swallows every following token.
+                int backslashes = 0;
+                while (i < commandLine.Length && commandLine[i] == '\\')
+                {
+                    backslashes++;
+                    i++;
+                }
+
+                if (i < commandLine.Length && commandLine[i] == '"')
+                {
+                    current.Append('\\', backslashes / 2);
+                    if (backslashes % 2 == 0)
+                    {
+                        inQuotes = !inQuotes;
+                    }
+                    else
+                    {
+                        current.Append('"');
+                    }
+                }
+                else
+                {
+                    current.Append('\\', backslashes);
+
+                    // Reprocess the non-backslash character (or stop at end of string).
+                    i--;
+                }
+
                 hasContent = true;
-                i++;
             }
             else if (c == '"')
             {

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -172,72 +172,64 @@ internal static partial class MinttyConsoleRuntime
         List<string> tokens = [];
         StringBuilder current = new();
         bool inQuotes = false;
-        bool hasContent = false;
+        bool hasToken = false;
+        int pendingBackslashes = 0;
 
-        for (int i = 0; i < commandLine.Length; i++)
+        foreach (char c in commandLine)
         {
-            char c = commandLine[i];
-
             if (c == '\\')
             {
-                // Apply the Windows CommandLineToArgvW backslash rules so a run of
-                // backslashes before a quote is interpreted correctly:
+                // Defer: per the Windows CommandLineToArgvW rules, the meaning of a
+                // backslash run depends on whether a '"' follows it.
+                pendingBackslashes++;
+                hasToken = true;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                // Resolve the deferred backslash run:
                 //   2n   backslashes + '"' => n literal backslashes, the quote toggles
                 //   2n+1 backslashes + '"' => n literal backslashes + a literal '"'
-                //   backslashes not before a '"' are all literal.
                 // Without this, a quoted path ending in '\' (escaped as `\\"`) loses its
                 // closing quote and swallows every following token.
-                int backslashes = 0;
-                while (i < commandLine.Length && commandLine[i] == '\\')
+                current.Append('\\', pendingBackslashes / 2);
+                if (pendingBackslashes % 2 == 0)
                 {
-                    backslashes++;
-                    i++;
-                }
-
-                if (i < commandLine.Length && commandLine[i] == '"')
-                {
-                    current.Append('\\', backslashes / 2);
-                    if (backslashes % 2 == 0)
-                    {
-                        inQuotes = !inQuotes;
-                    }
-                    else
-                    {
-                        current.Append('"');
-                    }
+                    inQuotes = !inQuotes;
                 }
                 else
                 {
-                    current.Append('\\', backslashes);
-
-                    // Reprocess the non-backslash character (or stop at end of string).
-                    i--;
+                    current.Append('"');
                 }
 
-                hasContent = true;
+                pendingBackslashes = 0;
+                hasToken = true;
+                continue;
             }
-            else if (c == '"')
+
+            // Backslashes not followed by a '"' are all literal.
+            current.Append('\\', pendingBackslashes);
+            pendingBackslashes = 0;
+
+            if (char.IsWhiteSpace(c) && !inQuotes)
             {
-                inQuotes = !inQuotes;
-                hasContent = true;
-            }
-            else if (char.IsWhiteSpace(c) && !inQuotes)
-            {
-                if (hasContent)
+                if (hasToken)
                 {
                     tokens.Add(current.ToString());
                     current.Clear();
-                    hasContent = false;
+                    hasToken = false;
                 }
             }
             else
             {
                 current.Append(c);
-                hasContent = true;
+                hasToken = true;
             }
         }
 
-        if (hasContent)
+        current.Append('\\', pendingBackslashes);
+        if (hasToken)
         {
             tokens.Add(current.ToString());
         }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -85,9 +85,6 @@ internal static partial class MinttyConsoleRuntime
                 EmitLine(line.ToString());
             }
         }
-        catch (OperationCanceledException)
-        {
-        }
         catch (Exception ex)
         {
             Trace.WriteLine($"Failed to read mintty output: {ex}");

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -49,14 +49,19 @@ internal static partial class MinttyConsoleRuntime
         Action<string>? lineCallback,
         Action<int>? exitCallback)
     {
-        char[] charBuf = new char[4096];
+        const int byteBufferSize = 4096;
+
+        // GetMaxCharCount accounts for a partial multi-byte sequence the decoder
+        // buffered from the previous read; sizing by the byte count alone can fall
+        // one char short and make GetChars throw, killing the reader.
+        char[] charBuf = new char[Encoding.UTF8.GetMaxCharCount(byteBufferSize)];
         StringBuilder pendingLine = new();
         Decoder decoder = Encoding.UTF8.GetDecoder();
 
         try
         {
             Stream stdout = minttyProcess.StandardOutput.BaseStream;
-            byte[] buffer = new byte[4096];
+            byte[] buffer = new byte[byteBufferSize];
 
             while (true)
             {

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal static partial class MinttyConsoleRuntime
+{
+    internal readonly record struct CommandLaunchParams(
+        string BashBootstrapCommand,
+        Dictionary<string, string> EnvironmentVariables);
+
+    internal static CommandLaunchParams CreateLaunchParams(MinttyStartInfo startInfo)
+    {
+        string script = BuildWrapperScript(startInfo.ConsoleProcessCommandLine);
+        string scriptBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(script));
+
+        const string bashBootstrap = @"GITEX_D=$(printf '%s' \""$GITEX_SCRIPT\"" | base64 -d) && eval \""$GITEX_D\""";
+
+        Dictionary<string, string> envVars = [];
+        foreach ((string key, string value) in startInfo.EnvironmentVariables)
+        {
+            envVars[key] = value;
+        }
+
+        envVars["GITEX_SCRIPT"] = scriptBase64;
+        envVars["GITEX_CMD_DISPLAY"] = startInfo.ConsoleProcessCommandLine;
+
+        return new CommandLaunchParams(bashBootstrap, envVars);
+    }
+
+    internal static void StartOutputReader(
+        Process minttyProcess,
+        Action<string>? lineCallback,
+        Action<int>? exitCallback,
+        CancellationToken ct)
+    {
+        _ = ReadLogStreamAsync(minttyProcess, lineCallback, exitCallback, ct);
+    }
+
+    private static async Task ReadLogStreamAsync(
+        Process minttyProcess,
+        Action<string>? lineCallback,
+        Action<int>? exitCallback,
+        CancellationToken ct)
+    {
+        try
+        {
+            Stream stdout = minttyProcess.StandardOutput.BaseStream;
+            byte[] buffer = new byte[4096];
+            char[] charBuf = new char[4096];
+            Decoder decoder = Encoding.UTF8.GetDecoder();
+            StringBuilder line = new();
+
+            while (!ct.IsCancellationRequested)
+            {
+                int read = await stdout.ReadAsync(buffer.AsMemory(), ct);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                int chars = decoder.GetChars(buffer, 0, read, charBuf, 0);
+                for (int i = 0; i < chars; i++)
+                {
+                    char c = charBuf[i];
+                    line.Append(c);
+                    if (c == '\n')
+                    {
+                        EmitLine(line.ToString());
+                        line.Clear();
+                    }
+                }
+            }
+
+            if (line.Length > 0)
+            {
+                EmitLine(line.ToString());
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception)
+        {
+        }
+
+        return;
+
+        void EmitLine(string text)
+        {
+            Match match = ExitSentinelRegex().Match(text);
+            if (match.Success && int.TryParse(match.Groups[1].ValueSpan, out int exitCode))
+            {
+                exitCallback?.Invoke(exitCode);
+            }
+            else
+            {
+                lineCallback?.Invoke(text);
+            }
+        }
+    }
+
+    [GeneratedRegex(@"\x1b\[8mGITEX_EXIT:(\d+)\x1b\[0?m")]
+    private static partial Regex ExitSentinelRegex();
+
+    private static string BuildWrapperScript(string commandLine)
+    {
+        string bashCommandLine = ConvertCommandLineToBash(commandLine);
+
+        return
+            $$"""
+              #!/bin/bash
+              printf '\x1b[0;38;5;5;49m%s\x1b[0m\n' "$GITEX_CMD_DISPLAY"
+              {{bashCommandLine}}
+              GITEX_RC=$?
+              printf '\033[8mGITEX_EXIT:%d\033[0m' "$GITEX_RC"
+              echo
+              if [ "$GITEX_RC" -ne 0 ]; then
+                  printf '\x1b[0;38;5;160;49mProcess exited with code %d\033[0m\n' "$GITEX_RC"
+              fi
+              printf '\x1b[0;38;5;243;49mDone\033[0m\n'
+              printf '\x1b[0;38;5;243;49mPress Enter or Esc to exit...\033[0m\n'
+              echo
+              read -n 1
+              exit 0
+              """;
+    }
+
+    private static string ConvertCommandLineToBash(string commandLine)
+    {
+        if (commandLine.StartsWith('"'))
+        {
+            int closingQuote = commandLine.IndexOf('"', 1);
+            if (closingQuote > 0)
+            {
+                string path = commandLine[1..closingQuote].Replace('\\', '/');
+                string rest = commandLine[(closingQuote + 1)..];
+                return $"'{path}'{rest}";
+            }
+        }
+
+        int firstSpace = commandLine.IndexOf(' ');
+        if (firstSpace > 0)
+        {
+            return commandLine[..firstSpace].Replace('\\', '/') + commandLine[firstSpace..];
+        }
+
+        return commandLine.Replace('\\', '/');
+    }
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -91,6 +91,18 @@ internal static partial class MinttyConsoleRuntime
             for (int i = 0; i < count; i++)
             {
                 char c = charBuf[i];
+
+                // A '\r' not followed by '\n' terminates a transient progress line
+                // (e.g. git's "Receiving objects: 42%\r"). Emit it with the trailing
+                // '\r' so consumers can tell it apart from a completed line; waiting
+                // for the eventual '\n' would merge the whole progress stream into
+                // one huge line. "\r\n" breaks (pty ONLCR) remain a single line.
+                if (c != '\n' && pendingLine.Length > 0 && pendingLine[^1] == '\r')
+                {
+                    EmitLine(pendingLine.ToString());
+                    pendingLine.Clear();
+                }
+
                 pendingLine.Append(c);
                 if (c == '\n')
                 {

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -41,7 +41,7 @@ internal static partial class MinttyConsoleRuntime
         Action<string>? lineCallback,
         Action<int>? exitCallback)
     {
-        _ = ReadLogStreamAsync(minttyProcess, lineCallback, exitCallback);
+        ThreadHelper.FileAndForget(() => ReadLogStreamAsync(minttyProcess, lineCallback, exitCallback));
     }
 
     private static async Task ReadLogStreamAsync(

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -127,25 +127,77 @@ internal static partial class MinttyConsoleRuntime
               """;
     }
 
-    private static string ConvertCommandLineToBash(string commandLine)
+    /// <summary>
+    /// Tokenizes the Windows-style command line and re-emits each token wrapped in bash
+    /// single quotes. Single quotes preserve everything literally, so backslashes and
+    /// dollar signs (e.g. WSL UNC paths like <c>\\wsl$\distro\...</c>) survive bash
+    /// parsing unmodified — splicing the raw command line into the script would let
+    /// bash collapse <c>\\</c> to <c>\</c> and break the path.
+    /// </summary>
+    internal static string ConvertCommandLineToBash(string commandLine)
     {
-        if (commandLine.StartsWith('"'))
+        List<string> tokens = TokenizeWindowsCommandLine(commandLine);
+        if (tokens.Count == 0)
         {
-            int closingQuote = commandLine.IndexOf('"', 1);
-            if (closingQuote > 0)
+            return string.Empty;
+        }
+
+        // Backslash → forward slash for the executable path so MSYS resolves
+        // Windows paths consistently (e.g. C:/Program Files/Git/bin/git.exe).
+        tokens[0] = tokens[0].Replace('\\', '/');
+
+        return string.Join(' ', tokens.Select(BashSingleQuote));
+    }
+
+    private static string BashSingleQuote(string token)
+    {
+        return $"'{token.Replace("'", "'\\''")}'";
+    }
+
+    private static List<string> TokenizeWindowsCommandLine(string commandLine)
+    {
+        List<string> tokens = [];
+        StringBuilder current = new();
+        bool inQuotes = false;
+        bool hasContent = false;
+
+        for (int i = 0; i < commandLine.Length; i++)
+        {
+            char c = commandLine[i];
+
+            if (c == '\\' && i + 1 < commandLine.Length && commandLine[i + 1] == '"')
             {
-                string path = commandLine[1..closingQuote].Replace('\\', '/');
-                string rest = commandLine[(closingQuote + 1)..];
-                return $"'{path}'{rest}";
+                // Escaped quote produced by StringExtensions.Quote(): keep the literal '"'.
+                current.Append('"');
+                hasContent = true;
+                i++;
+            }
+            else if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                hasContent = true;
+            }
+            else if (char.IsWhiteSpace(c) && !inQuotes)
+            {
+                if (hasContent)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                    hasContent = false;
+                }
+            }
+            else
+            {
+                current.Append(c);
+                hasContent = true;
             }
         }
 
-        int firstSpace = commandLine.IndexOf(' ');
-        if (firstSpace > 0)
+        if (hasContent)
         {
-            return commandLine[..firstSpace].Replace('\\', '/') + commandLine[firstSpace..];
+            tokens.Add(current.ToString());
         }
 
-        return commandLine.Replace('\\', '/');
+        return tokens;
     }
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -26,6 +26,13 @@ internal static partial class MinttyConsoleRuntime
         envVars["GITEX_SCRIPT"] = scriptBase64;
         envVars["GITEX_CMD_DISPLAY"] = startInfo.ConsoleProcessCommandLine;
 
+        // MSYS would otherwise rewrite POSIX-looking arguments (e.g. /home/user/...)
+        // into Windows paths prefixed with the MSYS root before passing them to native
+        // Windows binaries like wsl.exe. The C# side already produces arguments in their
+        // target form — both vars are needed to cover MSYS and MSYS2 builds of bash.
+        envVars["MSYS_NO_PATHCONV"] = "1";
+        envVars["MSYS2_ARG_CONV_EXCL"] = "*";
+
         return new CommandLaunchParams(bashBootstrap, envVars);
     }
 

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -39,17 +39,15 @@ internal static partial class MinttyConsoleRuntime
     internal static void StartOutputReader(
         Process minttyProcess,
         Action<string>? lineCallback,
-        Action<int>? exitCallback,
-        CancellationToken ct)
+        Action<int>? exitCallback)
     {
-        _ = ReadLogStreamAsync(minttyProcess, lineCallback, exitCallback, ct);
+        _ = ReadLogStreamAsync(minttyProcess, lineCallback, exitCallback);
     }
 
     private static async Task ReadLogStreamAsync(
         Process minttyProcess,
         Action<string>? lineCallback,
-        Action<int>? exitCallback,
-        CancellationToken ct)
+        Action<int>? exitCallback)
     {
         try
         {
@@ -59,15 +57,17 @@ internal static partial class MinttyConsoleRuntime
             Decoder decoder = Encoding.UTF8.GetDecoder();
             StringBuilder line = new();
 
-            while (!ct.IsCancellationRequested)
+            while (true)
             {
-                int read = await stdout.ReadAsync(buffer.AsMemory(), ct);
+                int read = await stdout.ReadAsync(buffer.AsMemory());
                 if (read == 0)
                 {
                     break;
                 }
 
-                int chars = decoder.GetChars(buffer, 0, read, charBuf, 0);
+                Span<byte> bytes = buffer.AsSpan(0, read);
+
+                int chars = decoder.GetChars(bytes, charBuf, true);
                 for (int i = 0; i < chars; i++)
                 {
                     char c = charBuf[i];

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyConsoleRuntime.cs
@@ -119,7 +119,7 @@ internal static partial class MinttyConsoleRuntime
             {
                 exitCallback?.Invoke(exitCode);
             }
-            else
+            else if (!text.StartsWith(ScriptChromeMarker, StringComparison.Ordinal))
             {
                 lineCallback?.Invoke(text);
             }
@@ -129,6 +129,17 @@ internal static partial class MinttyConsoleRuntime
     [GeneratedRegex(@"\x1b\[8mGITEX_EXIT:(\d+)\x1b\[0m")]
     private static partial Regex ExitSentinelRegex();
 
+    /// <summary>
+    /// Zero-width SGR pair (conceal on/off) prefixed to every line the wrapper script
+    /// generates itself (command echo, exit sentinel, "Done", exit prompts). Mintty
+    /// renders the marker as nothing, while the log reader uses it to keep such chrome
+    /// out of the command output — mirroring ConEmu, which filters the echoed command
+    /// line. The exit sentinel is matched before the chrome filter (the regex scans the
+    /// line, so the prefix does not interfere); its marker only ensures a malformed
+    /// sentinel is dropped instead of leaking into the output.
+    /// </summary>
+    private const string ScriptChromeMarker = "\x1b[8m\x1b[28m";
+
     private static string BuildWrapperScript(string commandLine)
     {
         string bashCommandLine = ConvertCommandLineToBash(commandLine);
@@ -136,18 +147,17 @@ internal static partial class MinttyConsoleRuntime
         return
             $$"""
               #!/bin/bash
-              printf '\x1b[0;38;5;5;49m%s\x1b[0m\n' "$GITEX_CMD_DISPLAY"
+              printf '{{ScriptChromeMarker}}\x1b[0;38;5;5;49m%s\x1b[0m\n' "$GITEX_CMD_DISPLAY"
               {{bashCommandLine}}
               GITEX_RC=$?
-              printf '\x1b[8mGITEX_EXIT:%d\x1b[0m' "$GITEX_RC"
-              echo
+              printf '{{ScriptChromeMarker}}\x1b[8mGITEX_EXIT:%d\x1b[0m\n' "$GITEX_RC"
               if [ "$GITEX_RC" -ne 0 ]; then
-                  printf '\x1b[0;38;5;160;49mProcess exited with code %d\x1b[0m\n' "$GITEX_RC"
+                  printf '{{ScriptChromeMarker}}\x1b[0;38;5;160;49mProcess exited with code %d\x1b[0m\n' "$GITEX_RC"
               fi
-              printf '\x1b[0;38;5;243;49mDone\x1b[0m\n'
-              printf '\x1b[0;38;5;243;49mPress Enter or Esc to exit...\x1b[0m\n'
-              echo
-              read -n 1
+              printf '{{ScriptChromeMarker}}\x1b[0;38;5;243;49mDone\x1b[0m\n'
+              printf '{{ScriptChromeMarker}}\x1b[0;38;5;243;49mPress Enter or Esc to exit...\x1b[0m\n'
+              printf '{{ScriptChromeMarker}}\n'
+              read -s -n 1
               exit 0
               """;
     }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -146,7 +146,10 @@ internal sealed class MinttyControl : Panel
         Process minttyProcess = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start mintty.exe");
 
-        PInvoke.AssignProcessToJobObject(_jobHandle, new HANDLE(minttyProcess.Handle));
+        if (!_jobHandle.IsNull)
+        {
+            PInvoke.AssignProcessToJobObject(_jobHandle, new HANDLE(minttyProcess.Handle));
+        }
 
         minttyProcess.EnableRaisingEvents = true;
 
@@ -193,7 +196,7 @@ internal sealed class MinttyControl : Panel
         }
         catch (Exception)
         {
-            // Do nothing
+           session.Kill();
         }
     }
 

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -168,13 +168,13 @@ internal sealed class MinttyControl : Panel
 
         session.AttachProcess(minttyProcess);
 
-        FindAndEmbedWindow(minttyProcess, session, ct);
+        ThreadHelper.FileAndForget(() => FindAndEmbedWindowAsync(minttyProcess, session, ct));
     }
 
-#pragma warning disable VSTHRD100
-    private async void FindAndEmbedWindow(Process minttyProcess, MinttySession session, CancellationToken sessionCt)
-#pragma warning restore VSTHRD100
+    private async Task FindAndEmbedWindowAsync(Process minttyProcess, MinttySession session, CancellationToken sessionCt)
     {
+        ThreadHelper.ThrowIfOnUIThread();
+
         using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(15));
         using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(sessionCt, timeoutCts.Token);
         CancellationToken ct = linkedCts.Token;
@@ -186,7 +186,7 @@ internal sealed class MinttyControl : Panel
             // and causes the host dialog's focus to flicker as it races with our embed.
             // If the wait times out under load, proceed anyway: the embed may still
             // succeed, and killing mintty here would also kill the spawned git process.
-            bool idle = await Task.Run(() => minttyProcess.WaitForInputIdle(TimeSpan.FromSeconds(10)), ct).ConfigureAwait(true);
+            bool idle = await Task.Run(() => minttyProcess.WaitForInputIdle(TimeSpan.FromSeconds(10)), ct);
             if (!idle)
             {
                 throw new InvalidOperationException($"Waiting for mintty to get idle timed out after 10 seconds for PID {minttyProcess.Id}.");
@@ -203,7 +203,7 @@ internal sealed class MinttyControl : Panel
                 }
 
                 // It is essential to capture original synchronization context
-                await Task.Delay(TimeSpan.FromMilliseconds(50), ct).ConfigureAwait(true);
+                await Task.Delay(TimeSpan.FromMilliseconds(50), ct);
             }
 
             if (hwnd.IsNull)
@@ -211,7 +211,7 @@ internal sealed class MinttyControl : Panel
                 throw new InvalidOperationException($"Could not locate mintty window for PID {minttyProcess.Id} within 5 seconds.");
             }
 
-            await EmbedWindowAsync(hwnd).ConfigureAwait(true);
+            await EmbedWindowAsync(hwnd);
 
             // Set WindowHandle only after the embed completes so OnResize doesn't
             // post a SetWindowPos to mintty mid-reparent.
@@ -233,51 +233,48 @@ internal sealed class MinttyControl : Panel
 
     private async Task EmbedWindowAsync(HWND hwnd)
     {
-        // Capture WinForms state on the UI thread before going to the threadpool.
-        // After the awaited Task.Run resumes via ConfigureAwait(true), we are back
-        // on the UI thread for the focus call.
-        HWND panelHwnd = (HWND)Handle;
+        // Capture WinForms state on the UI thread - as it's required by the control.
+        TaskCompletionSource<HWND> panelHwndTcs = new();
+        BeginInvoke(() => panelHwndTcs.SetResult((HWND)Handle));
+
+        HWND panelHwnd = await panelHwndTcs.Task;
         int width = Width;
         int height = Height;
 
         // The synchronous cross-process Win32 calls below all send messages to
         // mintty's thread. Running them on the UI thread freezes the entire app
-        // when mintty's pump stalls. Move them to a threadpool thread so a stalled
-        // pump can only block the worker, not the UI.
-        await Task.Run(() =>
+        // when mintty's pump stalls.
+        ThreadHelper.ThrowIfOnUIThread();
+
+        // Probe mintty's pump before any blocking cross-process call.
+        // SendMessageTimeout(SMTO_ABORTIFHUNG) is bounded and cannot itself
+        // hang. If this fails, none of the cross-process calls below are safe.
+        if (!NativeMethods.IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
         {
-            // Probe mintty's pump before any blocking cross-process call.
-            // SendMessageTimeout(SMTO_ABORTIFHUNG) is bounded and cannot itself
-            // hang. If this fails, none of the cross-process calls below are safe.
-            if (!NativeMethods.IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
-            {
-                throw new InvalidOperationException("Mintty window did not respond within 5 seconds.");
-            }
+            throw new InvalidOperationException("Mintty window did not respond within 5 seconds.");
+        }
 
-            WINDOW_STYLE style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
-            style &= ~(WINDOW_STYLE.WS_CAPTION | WINDOW_STYLE.WS_THICKFRAME | WINDOW_STYLE.WS_BORDER);
-            style |= WINDOW_STYLE.WS_CHILD;
-            PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (int)style);
+        WINDOW_STYLE style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
+        style &= ~(WINDOW_STYLE.WS_CAPTION | WINDOW_STYLE.WS_THICKFRAME | WINDOW_STYLE.WS_BORDER);
+        style |= WINDOW_STYLE.WS_CHILD;
+        PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (int)style);
 
-            WINDOW_EX_STYLE extendedStyle = (WINDOW_EX_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
-            extendedStyle &= ~(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_WINDOWEDGE | WINDOW_EX_STYLE.WS_EX_APPWINDOW);
-            extendedStyle |= WINDOW_EX_STYLE.WS_EX_TOOLWINDOW;
-            PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, (int)extendedStyle);
+        WINDOW_EX_STYLE extendedStyle = (WINDOW_EX_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
+        extendedStyle &= ~(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_WINDOWEDGE | WINDOW_EX_STYLE.WS_EX_APPWINDOW);
+        extendedStyle |= WINDOW_EX_STYLE.WS_EX_TOOLWINDOW;
+        PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, (int)extendedStyle);
 
-            PInvoke.SetParent(hwnd, panelHwnd);
+        PInvoke.SetParent(hwnd, panelHwnd);
 
-            // SWP_ASYNCWINDOWPOS posts the size/show change to mintty's thread instead
-            // of a synchronous cross-process SendMessage. SWP_SHOWWINDOW combined with
-            // SWP_NOACTIVATE is equivalent to SW_SHOWNA. See OnResize for the same pattern.
-            PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, width, height,
-                SET_WINDOW_POS_FLAGS.SWP_NOZORDER
-                | SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
-                | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
-                | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
-                | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
-
-            return true;
-        }).ConfigureAwait(true);
+        // SWP_ASYNCWINDOWPOS posts the size/show change to mintty's thread instead
+        // of a synchronous cross-process SendMessage. SWP_SHOWWINDOW combined with
+        // SWP_NOACTIVATE is equivalent to SW_SHOWNA. See OnResize for the same pattern.
+        PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, width, height,
+            SET_WINDOW_POS_FLAGS.SWP_NOZORDER
+            | SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
+            | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
+            | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
+            | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
 
         // Defer Focus via BeginInvoke so our pump gets one cycle to drain. Mintty
         // is now parented to our panel — that means cross-process messages
@@ -332,8 +329,9 @@ internal sealed class MinttyControl : Panel
                 {
                     PInvoke.TerminateJobObject(_jobHandle, 0);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Trace.WriteLine(ex);
                 }
 
                 PInvoke.CloseHandle(_jobHandle);
@@ -438,6 +436,7 @@ internal sealed class MinttyControl : Panel
                 // GWLP_HWNDPARENT sets the owner relationship (despite the name):
                 // mintty stays above the host form — closest cross-process approximation
                 // of a modal child without disabling the host's input queue.
+
                 NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWLP_HWNDPARENT, ownerHwnd);
             }
 

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -16,7 +16,7 @@ internal sealed class MinttyControl : Panel
 
     internal bool IsShellRunning => _runningSession is not null && !_runningSession.IsExited;
 
-    public MinttySession StartCommand(MinttyStartInfo startInfo, string minttyPath, string bashPath, string? theme)
+    public MinttySession StartCommand(MinttyStartInfo startInfo, string minttyPath, string bashPath, string? theme, Font? font)
     {
         ResetSession();
 
@@ -26,7 +26,7 @@ internal sealed class MinttyControl : Panel
         (MinttySession session, MinttyConsoleRuntime.CommandLaunchParams launchParams) = MinttySession.StartCommandSession(startInfo);
         _runningSession = session;
 
-        string minttyArgs = $"{BuildThemeArg(theme)}--nodaemon --window hide --log - \"{bashPath}\" -c \"{launchParams.BashBootstrapCommand}\"";
+        string minttyArgs = $"{BuildThemeArg(theme)}{BuildFontArgs(font)}--nodaemon --window hide --log - \"{bashPath}\" -c \"{launchParams.BashBootstrapCommand}\"";
 
         LaunchAndEmbed(session, minttyPath, minttyArgs, startInfo.StartupDirectory, launchParams.EnvironmentVariables, ct, redirectStdout: true);
 
@@ -44,13 +44,13 @@ internal sealed class MinttyControl : Panel
         return session;
     }
 
-    public MinttySession StartInteractiveShell(string minttyPath, string bashPath, string? theme, string workDir, Action? shellExitedCallback = null)
+    public MinttySession StartInteractiveShell(string minttyPath, string bashPath, string? theme, string workDir, Font? font, Action? shellExitedCallback = null)
     {
         ResetSession();
         CancellationTokenSource sessionCts = _sessionCts!;
         CancellationToken ct = sessionCts.Token;
 
-        string minttyArgs = $"{BuildThemeArg(theme)}--nodaemon --window hide \"{bashPath}\" --login -i";
+        string minttyArgs = $"{BuildThemeArg(theme)}{BuildFontArgs(font)}--nodaemon --window hide \"{bashPath}\" --login -i";
 
         MinttySession session = MinttySession.StartInteractiveShellSession();
         _runningSession = session;
@@ -108,6 +108,16 @@ internal sealed class MinttyControl : Panel
     private static string BuildThemeArg(string? theme)
     {
         return string.IsNullOrEmpty(theme) ? "" : $"-o \"ThemeFile={theme}\" ";
+    }
+
+    private static string BuildFontArgs(Font? font)
+    {
+        if (font is null)
+        {
+            return "";
+        }
+
+        return $"-o \"Font={font.Name}\" -o \"FontHeight={(int)(font.Size + 0.5f)}\" ";
     }
 
     private void ResetSession()

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -174,7 +174,7 @@ internal sealed class MinttyControl : Panel
     private async void FindAndEmbedWindow(Process minttyProcess, MinttySession session, CancellationToken sessionCt)
 #pragma warning restore VSTHRD100
     {
-        using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(5));
+        using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(15));
         using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(sessionCt, timeoutCts.Token);
         CancellationToken ct = linkedCts.Token;
 
@@ -185,7 +185,7 @@ internal sealed class MinttyControl : Panel
             // and causes the host dialog's focus to flicker as it races with our embed.
             // If the wait times out under load, proceed anyway: the embed may still
             // succeed, and killing mintty here would also kill the spawned git process.
-            bool idle = await Task.Run(() => minttyProcess.WaitForInputIdle(10000), ct).ConfigureAwait(true);
+            bool idle = await Task.Run(() => minttyProcess.WaitForInputIdle(TimeSpan.FromSeconds(10)), ct).ConfigureAwait(true);
             if (!idle)
             {
                 throw new InvalidOperationException($"Waiting for mintty to get idle timed out after 10 seconds for PID {minttyProcess.Id}.");
@@ -356,6 +356,7 @@ internal sealed class MinttyControl : Panel
 
             Label errorLabel = new()
             {
+                // ReSharper disable once LocalizableElement - rare error, no need to localize
                 Text = $"Failed to display the embedded console:{Environment.NewLine}{ex.Message}",
                 Dock = DockStyle.Fill,
                 TextAlign = ContentAlignment.MiddleCenter,
@@ -365,6 +366,7 @@ internal sealed class MinttyControl : Panel
 
             Button showButton = new()
             {
+                // ReSharper disable once LocalizableElement - rare error, no need to localize
                 Text = "Show mintty window externally",
                 AutoSize = true,
                 Anchor = AnchorStyles.None,

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -175,7 +175,8 @@ internal sealed class MinttyControl : Panel
     {
         ThreadHelper.ThrowIfOnUIThread();
 
-        using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(15));
+        TimeSpan findWindowTimeout = TimeSpan.FromSeconds(15);
+        using CancellationTokenSource timeoutCts = new(findWindowTimeout);
         using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(sessionCt, timeoutCts.Token);
         CancellationToken ct = linkedCts.Token;
 
@@ -186,10 +187,11 @@ internal sealed class MinttyControl : Panel
             // and causes the host dialog's focus to flicker as it races with our embed.
             // If the wait times out under load, proceed anyway: the embed may still
             // succeed, and killing mintty here would also kill the spawned git process.
-            bool idle = await Task.Run(() => minttyProcess.WaitForInputIdle(TimeSpan.FromSeconds(10)), ct);
+            TimeSpan idleTimeout = TimeSpan.FromSeconds(10);
+            bool idle = await Task.Run(() => minttyProcess.WaitForInputIdle(idleTimeout), ct);
             if (!idle)
             {
-                throw new InvalidOperationException($"Waiting for mintty to get idle timed out after 10 seconds for PID {minttyProcess.Id}.");
+                throw new InvalidOperationException($"Waiting for mintty to get idle timed out after {idleTimeout.TotalSeconds} seconds for PID {minttyProcess.Id}.");
             }
 
             HWND hwnd = HWND.Null;
@@ -208,7 +210,7 @@ internal sealed class MinttyControl : Panel
 
             if (hwnd.IsNull)
             {
-                throw new InvalidOperationException($"Could not locate mintty window for PID {minttyProcess.Id} within 5 seconds.");
+                throw new InvalidOperationException($"Could not locate mintty window for PID {minttyProcess.Id} within {findWindowTimeout.TotalSeconds} seconds.");
             }
 
             await EmbedWindowAsync(hwnd);
@@ -227,7 +229,7 @@ internal sealed class MinttyControl : Panel
             // terminated mid-write, leaving traces like index.lock behind. Let the command finish in
             // the hidden mintty window — its output still reaches the host via stdout.
             Trace.WriteLine($"MinttyControl: Failed to embed mintty window for PID {minttyProcess.Id}. The command will continue running invisibly until completion. Error: {ex}");
-            ShowEmbedFailure(ex, minttyProcess);
+            this.InvokeAndForget(() => ShowEmbedFailure(ex, minttyProcess));
         }
     }
 
@@ -249,9 +251,10 @@ internal sealed class MinttyControl : Panel
         // Probe mintty's pump before any blocking cross-process call.
         // SendMessageTimeout(SMTO_ABORTIFHUNG) is bounded and cannot itself
         // hang. If this fails, none of the cross-process calls below are safe.
-        if (!NativeMethods.IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
+        TimeSpan responsivenessTimeout = TimeSpan.FromSeconds(5);
+        if (!NativeMethods.IsWindowResponsive(hwnd, responsivenessTimeout))
         {
-            throw new InvalidOperationException("Mintty window did not respond within 5 seconds.");
+            throw new InvalidOperationException($"Mintty window did not respond within {responsivenessTimeout.TotalSeconds} seconds.");
         }
 
         WINDOW_STYLE style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
@@ -344,113 +347,72 @@ internal sealed class MinttyControl : Panel
 
     private void ShowEmbedFailure(Exception ex, Process minttyProcess)
     {
-        if (!IsHandleCreated || IsDisposed)
+        if (IsDisposed)
         {
             return;
         }
 
-        BeginInvoke(() =>
+        TableLayoutPanel layout = new()
         {
-            if (IsDisposed)
-            {
-                return;
-            }
+            Dock = DockStyle.Fill,
+            BackColor = SystemColors.Control,
+            ColumnCount = 1,
+            RowCount = 2,
+            Padding = new Padding(20),
+        };
+        layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
 
-            TableLayoutPanel layout = new()
-            {
-                Dock = DockStyle.Fill,
-                BackColor = SystemColors.Control,
-                ColumnCount = 1,
-                RowCount = 2,
-                Padding = new Padding(20),
-            };
-            layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
-            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        Label errorLabel = new()
+        {
+            // ReSharper disable once LocalizableElement - rare error, no need to localize
+            Text = $"Failed to display the embedded console:{Environment.NewLine}{ex.Message}",
+            Dock = DockStyle.Fill,
+            TextAlign = ContentAlignment.MiddleCenter,
+            AutoSize = false,
+            ForeColor = SystemColors.GrayText,
+        };
 
-            Label errorLabel = new()
+        Button showButton = new()
+        {
+            // ReSharper disable once LocalizableElement - rare error, no need to localize
+            Text = "Show mintty window externally",
+            AutoSize = true,
+            Anchor = AnchorStyles.None,
+            Margin = new Padding(0, 8, 0, 0),
+        };
+        showButton.Click += (_, _) =>
+        {
+            try
             {
-                // ReSharper disable once LocalizableElement - rare error, no need to localize
-                Text = $"Failed to display the embedded console:{Environment.NewLine}{ex.Message}",
-                Dock = DockStyle.Fill,
-                TextAlign = ContentAlignment.MiddleCenter,
-                AutoSize = false,
-                ForeColor = SystemColors.GrayText,
-            };
-
-            Button showButton = new()
-            {
-                // ReSharper disable once LocalizableElement - rare error, no need to localize
-                Text = "Show mintty window externally",
-                AutoSize = true,
-                Anchor = AnchorStyles.None,
-                Margin = new Padding(0, 8, 0, 0),
-            };
-            showButton.Click += (_, _) =>
-            {
-                // showButton.Enabled = false;
-
-                try
+                if (minttyProcess.HasExited)
                 {
-                    ShowMinttyExternally(minttyProcess);
+                    return;
                 }
-                catch (Exception clickEx)
+
+                // Try the targeted lookup first; only fall back to enumerating every top-level window of the process
+                // if it fails (e.g. mintty's pump was so slow we never saw its window appear).
+                HWND mainHwnd = NativeMethods.FindMinttyWindowForProcess(minttyProcess.Id);
+                List<HWND> windows = mainHwnd.IsNull
+                    ? NativeMethods.EnumerateProcessWindows(minttyProcess.Id)
+                    : [mainHwnd];
+
+                foreach (HWND hwnd in windows)
                 {
-                    Trace.WriteLine($"MinttyControl: Failed to surface mintty window externally: {clickEx}");
+                    // mintty was started with --window hide; if embedding failed, it threw
+                    // before we touched any styles, so the window keeps its original chrome
+                    // and just needs to be unhidden.
+                    PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWNORMAL);
                 }
-            };
-
-            layout.Controls.Add(errorLabel, 0, 0);
-            layout.Controls.Add(showButton, 0, 1);
-            Controls.Add(layout);
-        });
-    }
-
-    private void ShowMinttyExternally(Process minttyProcess)
-    {
-        if (minttyProcess.HasExited)
-        {
-            return;
-        }
-
-        // mintty was started with --window hide; if embedding failed, it threw
-        // before we touched any styles, so the window keeps its original chrome
-        // and just needs to be unhidden.
-        HWND ownerHwnd = HWND.Null;
-        Form? hostForm = FindForm();
-        if (hostForm is { IsHandleCreated: true, IsDisposed: false })
-        {
-            ownerHwnd = (HWND)hostForm.Handle;
-        }
-
-        // Try the targeted lookup first; only fall back to enumerating every top-level window of the process
-        // if it fails (e.g. mintty's pump was so slow we never saw its window appear).
-        HWND mainHwnd = NativeMethods.FindMinttyWindowForProcess(minttyProcess.Id);
-        List<HWND> windows = mainHwnd.IsNull
-            ? NativeMethods.EnumerateProcessWindows(minttyProcess.Id)
-            : [mainHwnd];
-
-        foreach (HWND hwnd in windows)
-        {
-            if (!ownerHwnd.IsNull)
-            {
-                // GWLP_HWNDPARENT sets the owner relationship (despite the name):
-                // mintty stays above the host form — closest cross-process approximation
-                // of a modal child without disabling the host's input queue.
-
-                NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWLP_HWNDPARENT, ownerHwnd);
             }
+            catch (Exception clickEx)
+            {
+                Trace.WriteLine($"MinttyControl: Failed to surface mintty window externally: {clickEx}");
+            }
+        };
 
-            // SWP_ASYNCWINDOWPOS posts the show to mintty's thread instead of a
-            // synchronous SendMessage — we must not block on a slow mintty pump
-            // (the same reason the embed failed in the first place).
-            PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, 0, 0,
-                SET_WINDOW_POS_FLAGS.SWP_NOMOVE
-                | SET_WINDOW_POS_FLAGS.SWP_NOSIZE
-                | SET_WINDOW_POS_FLAGS.SWP_NOZORDER
-                | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
-                | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
-
-            PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWNORMAL);
-        }
+        layout.Controls.Add(errorLabel, 0, 0);
+        layout.Controls.Add(showButton, 0, 1);
+        Controls.Add(layout);
     }
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -79,7 +79,7 @@ internal sealed class MinttyControl : Panel
             return;
         }
 
-        FocusWithAttachedInput(hwnd);
+        NativeMethods.FocusWindowWithAttachedInput(hwnd);
 
         foreach (char c in text)
         {
@@ -101,7 +101,7 @@ internal sealed class MinttyControl : Panel
         HWND hwnd = _runningSession?.WindowHandle ?? HWND.Null;
         if (!hwnd.IsNull)
         {
-            FocusWithAttachedInput(hwnd);
+            NativeMethods.FocusWindowWithAttachedInput(hwnd);
         }
     }
 
@@ -169,19 +169,25 @@ internal sealed class MinttyControl : Panel
     }
 
 #pragma warning disable VSTHRD100
-    private async void FindAndEmbedWindow(Process minttyProcess, MinttySession session, CancellationToken ct)
+    private async void FindAndEmbedWindow(Process minttyProcess, MinttySession session, CancellationToken sessionCt)
 #pragma warning restore VSTHRD100
     {
-        using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(30));
-        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
-        ct = linkedCts.Token;
+        using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(5));
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(sessionCt, timeoutCts.Token);
+        CancellationToken ct = linkedCts.Token;
 
         try
         {
             // Wait until mintty's message pump is idle before embedding — otherwise
             // mintty may still be running startup code that calls ShowWindow/SetFocus
             // and causes the host dialog's focus to flicker as it races with our embed.
-            await Task.Run(() => minttyProcess.WaitForInputIdle(5000), ct).ConfigureAwait(true);
+            // If the wait times out under load, proceed anyway: the embed may still
+            // succeed, and killing mintty here would also kill the spawned git process.
+            bool idle = await Task.Run(() => minttyProcess.WaitForInputIdle(10000), ct).ConfigureAwait(true);
+            if (!idle)
+            {
+                throw new InvalidOperationException($"Waiting for mintty to get idle timed out after 10 seconds for PID {minttyProcess.Id}.");
+            }
 
             HWND hwnd = HWND.Null;
 
@@ -197,16 +203,26 @@ internal sealed class MinttyControl : Panel
                 await Task.Delay(TimeSpan.FromMilliseconds(50), ct).ConfigureAwait(true);
             }
 
+            if (hwnd.IsNull)
+            {
+                throw new InvalidOperationException($"Could not locate mintty window for PID {minttyProcess.Id} within 5 seconds.");
+            }
+
             session.WindowHandle = hwnd;
 
-            if (!hwnd.IsNull)
-            {
-                EmbedWindow(hwnd);
-            }
+            EmbedWindow(hwnd);
         }
-        catch (Exception)
+        catch (OperationCanceledException) when (sessionCt.IsCancellationRequested)
         {
-           session.Kill();
+            // Session was reset/disposed while we were waiting — no error to surface.
+        }
+        catch (Exception ex)
+        {
+            // Don't kill mintty: the spawned git process is in the same job and would be
+            // terminated mid-write, leaving traces like index.lock behind. Let the command finish in
+            // the hidden mintty window — its output still reaches the host via stdout.
+            Trace.WriteLine($"MinttyControl: Failed to embed mintty window for PID {minttyProcess.Id}. The command will continue running invisibly until completion. Error: {ex}");
+            ShowEmbedFailure(ex, minttyProcess);
         }
     }
 
@@ -221,12 +237,11 @@ internal sealed class MinttyControl : Panel
         // on GWL_STYLE/GWL_EXSTYLE synchronously sends WM_STYLECHANGING/CHANGED to
         // mintty's thread; SetParent and AttachThreadInput are similarly synchronous.
         // Under system load mintty's pump can stall — without this probe the host
-        // UI thread blocks indefinitely inside one of those calls. If the probe
-        // fails, kill mintty so the session resets cleanly via Process.Exited.
-        if (!IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
+        // UI thread blocks indefinitely inside one of those calls. Throw so the
+        // caller can surface the failure without killing the in-flight git process.
+        if (!NativeMethods.IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
         {
-            _runningSession?.Kill();
-            return;
+            throw new InvalidOperationException("Mintty window did not respond within 5 seconds.");
         }
 
         // Capture the hosting form before embedding: mintty's process startup can
@@ -264,63 +279,7 @@ internal sealed class MinttyControl : Panel
             hostForm.Activate();
         }
 
-        FocusWithAttachedInput(hwnd);
-    }
-
-    /// <summary>
-    /// Pings the target window with WM_NULL via SendMessageTimeout to verify its
-    /// message pump is alive. SMTO_ABORTIFHUNG returns immediately if the OS has
-    /// already marked the window as hung; otherwise the call returns once the pump
-    /// dispatches the no-op message or the timeout expires. Returns false on
-    /// failure — caller must not proceed with synchronous cross-process calls.
-    /// </summary>
-    private static bool IsWindowResponsive(HWND hwnd, TimeSpan timeout)
-    {
-        nint result = PInvoke.SendMessageTimeout(
-            hwnd,
-            Msg: 0, // WM_NULL
-            wParam: default,
-            lParam: default,
-            SEND_MESSAGE_TIMEOUT_FLAGS.SMTO_ABORTIFHUNG,
-            (uint)timeout.TotalMilliseconds,
-            out _);
-        return result != 0;
-    }
-
-    /// <summary>
-    /// SetFocus only works when the target hwnd belongs to the calling thread, or when
-    /// the calling thread's input queue is attached to the target window's thread.
-    /// Mintty runs in another process, so we must attach input queues for the call to
-    /// take effect — otherwise SetFocus is silently dropped.
-    /// </summary>
-    private static void FocusWithAttachedInput(HWND hwnd)
-    {
-        uint targetThreadId = PInvoke.GetWindowThreadProcessId(hwnd, out _);
-        if (targetThreadId == 0)
-        {
-            return;
-        }
-
-        uint currentThreadId = PInvoke.GetCurrentThreadId();
-        if (targetThreadId == currentThreadId)
-        {
-            PInvoke.SetFocus(hwnd);
-            return;
-        }
-
-        if (!PInvoke.AttachThreadInput(currentThreadId, targetThreadId, true))
-        {
-            return;
-        }
-
-        try
-        {
-            PInvoke.SetFocus(hwnd);
-        }
-        finally
-        {
-            PInvoke.AttachThreadInput(currentThreadId, targetThreadId, false);
-        }
+        NativeMethods.FocusWindowWithAttachedInput(hwnd);
     }
 
     protected override void OnResize(EventArgs e)
@@ -366,5 +325,114 @@ internal sealed class MinttyControl : Panel
         }
 
         base.Dispose(disposing);
+    }
+
+    private void ShowEmbedFailure(Exception ex, Process minttyProcess)
+    {
+        if (!IsHandleCreated || IsDisposed)
+        {
+            return;
+        }
+
+        BeginInvoke(() =>
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            TableLayoutPanel layout = new()
+            {
+                Dock = DockStyle.Fill,
+                BackColor = SystemColors.Control,
+                ColumnCount = 1,
+                RowCount = 2,
+                Padding = new Padding(20),
+            };
+            layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+            Label errorLabel = new()
+            {
+                Text = $"Failed to display the embedded console:{Environment.NewLine}{ex.Message}",
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter,
+                AutoSize = false,
+                ForeColor = SystemColors.GrayText,
+            };
+
+            Button showButton = new()
+            {
+                Text = "Show mintty window externally",
+                AutoSize = true,
+                Anchor = AnchorStyles.None,
+                Margin = new Padding(0, 8, 0, 0),
+            };
+            showButton.Click += (_, _) =>
+            {
+                // showButton.Enabled = false;
+
+                try
+                {
+                    ShowMinttyExternally(minttyProcess);
+                }
+                catch (Exception clickEx)
+                {
+                    Trace.WriteLine($"MinttyControl: Failed to surface mintty window externally: {clickEx}");
+                }
+            };
+
+            layout.Controls.Add(errorLabel, 0, 0);
+            layout.Controls.Add(showButton, 0, 1);
+            Controls.Add(layout);
+        });
+    }
+
+    private void ShowMinttyExternally(Process minttyProcess)
+    {
+        if (minttyProcess.HasExited)
+        {
+            return;
+        }
+
+        // mintty was started with --window hide; if embedding failed, it threw
+        // before we touched any styles, so the window keeps its original chrome
+        // and just needs to be unhidden.
+        HWND ownerHwnd = HWND.Null;
+        Form? hostForm = FindForm();
+        if (hostForm is { IsHandleCreated: true, IsDisposed: false })
+        {
+            ownerHwnd = (HWND)hostForm.Handle;
+        }
+
+        // Try the targeted lookup first; only fall back to enumerating every top-level window of the process
+        // if it fails (e.g. mintty's pump was so slow we never saw its window appear).
+        HWND mainHwnd = NativeMethods.FindMinttyWindowForProcess(minttyProcess.Id);
+        List<HWND> windows = mainHwnd.IsNull
+            ? NativeMethods.EnumerateProcessWindows(minttyProcess.Id)
+            : [mainHwnd];
+
+        foreach (HWND hwnd in windows)
+        {
+            if (!ownerHwnd.IsNull)
+            {
+                // GWLP_HWNDPARENT sets the owner relationship (despite the name):
+                // mintty stays above the host form — closest cross-process approximation
+                // of a modal child without disabling the host's input queue.
+                NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWLP_HWNDPARENT, ownerHwnd);
+            }
+
+            // SWP_ASYNCWINDOWPOS posts the show to mintty's thread instead of a
+            // synchronous SendMessage — we must not block on a slow mintty pump
+            // (the same reason the embed failed in the first place).
+            PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, 0, 0,
+                SET_WINDOW_POS_FLAGS.SWP_NOMOVE
+                | SET_WINDOW_POS_FLAGS.SWP_NOSIZE
+                | SET_WINDOW_POS_FLAGS.SWP_NOZORDER
+                | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
+                | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
+
+            PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWNORMAL);
+        }
     }
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Text;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
@@ -16,7 +17,7 @@ internal sealed class MinttyControl : Panel
 
     internal bool IsShellRunning => _runningSession is not null && !_runningSession.IsExited;
 
-    public MinttySession StartCommand(MinttyStartInfo startInfo, string minttyPath, string bashPath, string? theme, Font? font)
+    public MinttySession StartCommand(MinttyStartInfo startInfo, string minttyPath, string bashPath, ConsoleEmulatorSettings consoleSettings)
     {
         ResetSession();
 
@@ -26,7 +27,7 @@ internal sealed class MinttyControl : Panel
         (MinttySession session, MinttyConsoleRuntime.CommandLaunchParams launchParams) = MinttySession.StartCommandSession(startInfo);
         _runningSession = session;
 
-        string minttyArgs = $"{BuildThemeArg(theme)}{BuildFontArgs(font)}--nodaemon --window hide --log - \"{bashPath}\" -c \"{launchParams.BashBootstrapCommand}\"";
+        string minttyArgs = $"{BuildMinttyThemingArgs(consoleSettings)}--nodaemon --window hide --log - \"{bashPath}\" -c \"{launchParams.BashBootstrapCommand}\"";
 
         LaunchAndEmbed(session, minttyPath, minttyArgs, startInfo.StartupDirectory, launchParams.EnvironmentVariables, ct, redirectStdout: true);
 
@@ -44,13 +45,13 @@ internal sealed class MinttyControl : Panel
         return session;
     }
 
-    public MinttySession StartInteractiveShell(string minttyPath, string bashPath, string? theme, string workDir, Font? font, Action? shellExitedCallback = null)
+    public MinttySession StartInteractiveShell(string minttyPath, string bashPath, string workDir, ConsoleEmulatorSettings consoleSettings, Action? shellExitedCallback = null)
     {
         ResetSession();
         CancellationTokenSource sessionCts = _sessionCts!;
         CancellationToken ct = sessionCts.Token;
 
-        string minttyArgs = $"{BuildThemeArg(theme)}{BuildFontArgs(font)}--nodaemon --window hide \"{bashPath}\" --login -i";
+        string minttyArgs = $"{BuildMinttyThemingArgs(consoleSettings)}--nodaemon --window hide \"{bashPath}\" --login -i";
 
         MinttySession session = MinttySession.StartInteractiveShellSession();
         _runningSession = session;
@@ -105,19 +106,20 @@ internal sealed class MinttyControl : Panel
         }
     }
 
-    private static string BuildThemeArg(string? theme)
+    private static string BuildMinttyThemingArgs(ConsoleEmulatorSettings consoleSettings)
     {
-        return string.IsNullOrEmpty(theme) ? "" : $"-o \"ThemeFile={theme}\" ";
-    }
-
-    private static string BuildFontArgs(Font? font)
-    {
-        if (font is null)
+        StringBuilder args = new();
+        if (!string.IsNullOrEmpty(consoleSettings.Theme))
         {
-            return "";
+            args.Append($"-o \"ThemeFile={consoleSettings.Theme}\" ");
         }
 
-        return $"-o \"Font={font.Name}\" -o \"FontHeight={(int)(font.Size + 0.5f)}\" ";
+        if (consoleSettings.Font is { } font)
+        {
+            args.Append($"-o \"Font={font.Name}\" -o \"FontHeight={(int)(font.Size + 0.5f)}\" ");
+        }
+
+        return args.ToString();
     }
 
     private void ResetSession()

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -13,6 +13,16 @@ internal sealed class MinttyControl : Panel
     private CancellationTokenSource? _sessionCts;
     private HANDLE _jobHandle = NativeMethods.CreateKillOnCloseJob();
 
+    public MinttyControl()
+    {
+        // Make the panel focusable so Focus() works programmatically and
+        // OnGotFocus runs whenever WinForms restores focus here (e.g. after
+        // alt-tabbing back to the host form). OnGotFocus then forwards focus
+        // to the embedded mintty hwnd — centralising what used to be scattered
+        // FocusWindowWithAttachedInput calls at every entry point.
+        SetStyle(ControlStyles.Selectable, true);
+    }
+
     internal MinttySession? RunningSession => _runningSession;
 
     internal bool IsShellRunning => _runningSession is not null && !_runningSession.IsExited;
@@ -94,15 +104,6 @@ internal sealed class MinttyControl : Panel
             {
                 PInvoke.PostMessage(hwnd, NativeMethods.WM_CHAR, (nuint)c, (nint)0);
             }
-        }
-    }
-
-    public void FocusConsole()
-    {
-        HWND hwnd = _runningSession?.WindowHandle ?? HWND.Null;
-        if (!hwnd.IsNull)
-        {
-            NativeMethods.FocusWindowWithAttachedInput(hwnd);
         }
     }
 
@@ -210,9 +211,11 @@ internal sealed class MinttyControl : Panel
                 throw new InvalidOperationException($"Could not locate mintty window for PID {minttyProcess.Id} within 5 seconds.");
             }
 
-            session.WindowHandle = hwnd;
+            await EmbedWindowAsync(hwnd).ConfigureAwait(true);
 
-            EmbedWindow(hwnd);
+            // Set WindowHandle only after the embed completes so OnResize doesn't
+            // post a SetWindowPos to mintty mid-reparent.
+            session.WindowHandle = hwnd;
         }
         catch (OperationCanceledException) when (sessionCt.IsCancellationRequested)
         {
@@ -228,60 +231,72 @@ internal sealed class MinttyControl : Panel
         }
     }
 
-    private void EmbedWindow(HWND hwnd)
+    private async Task EmbedWindowAsync(HWND hwnd)
     {
-        if (!IsHandleCreated || hwnd.IsNull)
+        // Capture WinForms state on the UI thread before going to the threadpool.
+        // After the awaited Task.Run resumes via ConfigureAwait(true), we are back
+        // on the UI thread for the focus call.
+        HWND panelHwnd = (HWND)Handle;
+        int width = Width;
+        int height = Height;
+
+        // The synchronous cross-process Win32 calls below all send messages to
+        // mintty's thread. Running them on the UI thread freezes the entire app
+        // when mintty's pump stalls. Move them to a threadpool thread so a stalled
+        // pump can only block the worker, not the UI.
+        await Task.Run(() =>
         {
-            return;
-        }
+            // Probe mintty's pump before any blocking cross-process call.
+            // SendMessageTimeout(SMTO_ABORTIFHUNG) is bounded and cannot itself
+            // hang. If this fails, none of the cross-process calls below are safe.
+            if (!NativeMethods.IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
+            {
+                throw new InvalidOperationException("Mintty window did not respond within 5 seconds.");
+            }
 
-        // Probe mintty's pump before any blocking cross-process call. SetWindowLong
-        // on GWL_STYLE/GWL_EXSTYLE synchronously sends WM_STYLECHANGING/CHANGED to
-        // mintty's thread; SetParent and AttachThreadInput are similarly synchronous.
-        // Under system load mintty's pump can stall — without this probe the host
-        // UI thread blocks indefinitely inside one of those calls. Throw so the
-        // caller can surface the failure without killing the in-flight git process.
-        if (!NativeMethods.IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
+            WINDOW_STYLE style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
+            style &= ~(WINDOW_STYLE.WS_CAPTION | WINDOW_STYLE.WS_THICKFRAME | WINDOW_STYLE.WS_BORDER);
+            style |= WINDOW_STYLE.WS_CHILD;
+            PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (int)style);
+
+            WINDOW_EX_STYLE extendedStyle = (WINDOW_EX_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
+            extendedStyle &= ~(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_WINDOWEDGE | WINDOW_EX_STYLE.WS_EX_APPWINDOW);
+            extendedStyle |= WINDOW_EX_STYLE.WS_EX_TOOLWINDOW;
+            PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, (int)extendedStyle);
+
+            PInvoke.SetParent(hwnd, panelHwnd);
+
+            // SWP_ASYNCWINDOWPOS posts the size/show change to mintty's thread instead
+            // of a synchronous cross-process SendMessage. SWP_SHOWWINDOW combined with
+            // SWP_NOACTIVATE is equivalent to SW_SHOWNA. See OnResize for the same pattern.
+            PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, width, height,
+                SET_WINDOW_POS_FLAGS.SWP_NOZORDER
+                | SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
+                | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
+                | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
+                | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
+
+            return true;
+        }).ConfigureAwait(true);
+
+        // Defer Focus via BeginInvoke so our pump gets one cycle to drain. Mintty
+        // is now parented to our panel — that means cross-process messages
+        // (WM_PARENTNOTIFY, WM_MOUSEACTIVATE, focus-traversal traffic, etc.) can
+        // flow synchronously from mintty into our pump. Anything mintty posts
+        // while our continuation is dispatched gets handled before our queued
+        // Focus runs, instead of being processed reentrantly underneath SetFocus.
+        BeginInvoke(Focus);
+    }
+
+    protected override void OnGotFocus(EventArgs e)
+    {
+        base.OnGotFocus(e);
+
+        HWND hwnd = _runningSession?.WindowHandle ?? HWND.Null;
+        if (!hwnd.IsNull)
         {
-            throw new InvalidOperationException("Mintty window did not respond within 5 seconds.");
+            NativeMethods.FocusWindowWithAttachedInput(hwnd);
         }
-
-        // Capture the hosting form before embedding: mintty's process startup can
-        // shift foreground/activation away from the dialog that triggered the command,
-        // so we need a handle to restore activation after the embed completes.
-        Form? hostForm = FindForm();
-
-        WINDOW_STYLE style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
-        style &= ~(WINDOW_STYLE.WS_CAPTION | WINDOW_STYLE.WS_THICKFRAME | WINDOW_STYLE.WS_BORDER);
-        style |= WINDOW_STYLE.WS_CHILD;
-        PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (int)style);
-
-        WINDOW_EX_STYLE extendedStyle = (WINDOW_EX_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
-        extendedStyle &= ~(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_WINDOWEDGE | WINDOW_EX_STYLE.WS_EX_APPWINDOW);
-        extendedStyle |= WINDOW_EX_STYLE.WS_EX_TOOLWINDOW;
-        PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, (int)extendedStyle);
-
-        PInvoke.SetParent(hwnd, new HWND(Handle));
-
-        // SWP_ASYNCWINDOWPOS posts the size/show change to mintty's thread instead of
-        // a synchronous cross-process SendMessage, so a slow mintty pump under system
-        // load cannot freeze our UI thread during embed. SWP_SHOWWINDOW replaces the
-        // separate ShowWindow call (which has no async variant) — combined with
-        // SWP_NOACTIVATE this is equivalent to SW_SHOWNA. See OnResize for the same
-        // pattern.
-        PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, Width, Height,
-            SET_WINDOW_POS_FLAGS.SWP_NOZORDER
-            | SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
-            | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
-            | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
-            | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
-
-        if (hostForm is { IsHandleCreated: true, IsDisposed: false })
-        {
-            hostForm.Activate();
-        }
-
-        NativeMethods.FocusWindowWithAttachedInput(hwnd);
     }
 
     protected override void OnResize(EventArgs e)

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -39,9 +39,11 @@ internal sealed class MinttyControl : Panel
 
         string minttyArgs = $"{BuildMinttyThemingArgs(consoleSettings)}--nodaemon --window hide --log - \"{bashPath}\" -c \"{launchParams.BashBootstrapCommand}\"";
 
-        LaunchAndEmbed(session, minttyPath, minttyArgs, startInfo.StartupDirectory, launchParams.EnvironmentVariables, ct, redirectStdout: true);
+        LaunchAndEmbed(session, minttyPath, minttyArgs, startInfo.StartupDirectory, launchParams.EnvironmentVariables, OnExited, ct, redirectStdout: true);
 
-        session.MinttyProcess!.Exited += (_, _) =>
+        return session;
+
+        void OnExited()
         {
             // If ResetSession already cancelled this CTS, skip the callback —
             // the old session was intentionally killed, not a host termination.
@@ -50,9 +52,7 @@ internal sealed class MinttyControl : Panel
                 sessionCts.Cancel();
                 startInfo.ConsoleClosedCallback?.Invoke();
             }
-        };
-
-        return session;
+        }
     }
 
     public MinttySession StartInteractiveShell(string minttyPath, string bashPath, string workDir, ConsoleEmulatorSettings consoleSettings, Action? shellExitedCallback = null)
@@ -66,9 +66,11 @@ internal sealed class MinttyControl : Panel
         MinttySession session = MinttySession.StartInteractiveShellSession();
         _runningSession = session;
 
-        LaunchAndEmbed(session, minttyPath, minttyArgs, workDir, new Dictionary<string, string>(), ct);
+        LaunchAndEmbed(session, minttyPath, minttyArgs, workDir, new Dictionary<string, string>(), OnExited, ct);
 
-        session.MinttyProcess!.Exited += (_, _) =>
+        return session;
+
+        void OnExited()
         {
             // If ResetSession already cancelled this CTS, skip the callback —
             // the old session was intentionally killed, not a host termination.
@@ -77,9 +79,7 @@ internal sealed class MinttyControl : Panel
                 sessionCts.Cancel();
                 shellExitedCallback?.Invoke();
             }
-        };
-
-        return session;
+        }
     }
 
     public void SendConsoleInput(string text)
@@ -128,16 +128,16 @@ internal sealed class MinttyControl : Panel
         _sessionCts?.Cancel();
         _sessionCts?.Dispose();
         _sessionCts = new CancellationTokenSource();
-        _runningSession?.Kill();
+        _runningSession?.Dispose();
         _runningSession = null;
     }
 
-    private void LaunchAndEmbed(
-        MinttySession session,
+    private void LaunchAndEmbed(MinttySession session,
         string minttyPath,
         string minttyArgs,
         string? workDir,
         IReadOnlyDictionary<string, string> envVariables,
+        Action onExited,
         CancellationToken ct,
         bool redirectStdout = false)
     {
@@ -164,6 +164,9 @@ internal sealed class MinttyControl : Panel
             PInvoke.AssignProcessToJobObject(_jobHandle, new HANDLE(minttyProcess.Handle));
         }
 
+        // Subscribe before enabling events so a near-instant exit (e.g. mintty fails to start)
+        // can't fire and be lost before the handler is attached.
+        minttyProcess.Exited += (_, _) => onExited();
         minttyProcess.EnableRaisingEvents = true;
 
         session.AttachProcess(minttyProcess);
@@ -236,12 +239,10 @@ internal sealed class MinttyControl : Panel
     private async Task EmbedWindowAsync(HWND hwnd)
     {
         // Capture WinForms state on the UI thread - as it's required by the control.
-        TaskCompletionSource<HWND> panelHwndTcs = new();
-        BeginInvoke(() => panelHwndTcs.SetResult((HWND)Handle));
+        TaskCompletionSource<(HWND Handle, int Width, int Height)> panelStateTcs = new();
+        BeginInvoke(() => panelStateTcs.SetResult(((HWND)Handle, Width, Height)));
 
-        HWND panelHwnd = await panelHwndTcs.Task;
-        int width = Width;
-        int height = Height;
+        (HWND panelHwnd, int width, int height) = await panelStateTcs.Task;
 
         // The synchronous cross-process Win32 calls below all send messages to
         // mintty's thread. Running them on the UI thread freezes the entire app
@@ -323,7 +324,7 @@ internal sealed class MinttyControl : Panel
             _sessionCts?.Cancel();
             _sessionCts?.Dispose();
             _sessionCts = null;
-            _runningSession?.Kill();
+            _runningSession?.Dispose();
             _runningSession = null;
 
             if (!_jobHandle.IsNull)

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -1,0 +1,357 @@
+﻿using System.Diagnostics;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal sealed class MinttyControl : Panel
+{
+    private MinttySession? _runningSession;
+    private CancellationTokenSource? _sessionCts;
+    private HANDLE _jobHandle = NativeMethods.CreateKillOnCloseJob();
+
+    internal MinttySession? RunningSession => _runningSession;
+
+    internal bool IsShellRunning => _runningSession is not null && !_runningSession.IsExited;
+
+    public MinttySession StartCommand(MinttyStartInfo startInfo, string minttyPath, string bashPath, string? theme)
+    {
+        ResetSession();
+
+        CancellationTokenSource sessionCts = _sessionCts!;
+        CancellationToken ct = sessionCts.Token;
+
+        (MinttySession session, MinttyConsoleRuntime.CommandLaunchParams launchParams) = MinttySession.StartCommandSession(startInfo);
+        _runningSession = session;
+
+        string minttyArgs = $"{BuildThemeArg(theme)}--nodaemon --window hide --log - \"{bashPath}\" -c \"{launchParams.BashBootstrapCommand}\"";
+
+        LaunchAndEmbed(session, minttyPath, minttyArgs, startInfo.StartupDirectory, launchParams.EnvironmentVariables, ct, redirectStdout: true);
+
+        session.MinttyProcess!.Exited += (_, _) =>
+        {
+            // If ResetSession already cancelled this CTS, skip the callback —
+            // the old session was intentionally killed, not a host termination.
+            if (!sessionCts.IsCancellationRequested)
+            {
+                sessionCts.Cancel();
+                startInfo.ConsoleClosedCallback?.Invoke();
+            }
+        };
+
+        return session;
+    }
+
+    public MinttySession StartInteractiveShell(string minttyPath, string bashPath, string? theme, string workDir, Action? shellExitedCallback = null)
+    {
+        ResetSession();
+        CancellationTokenSource sessionCts = _sessionCts!;
+        CancellationToken ct = sessionCts.Token;
+
+        string minttyArgs = $"{BuildThemeArg(theme)}--nodaemon --window hide \"{bashPath}\" --login -i";
+
+        MinttySession session = MinttySession.StartInteractiveShellSession();
+        _runningSession = session;
+
+        LaunchAndEmbed(session, minttyPath, minttyArgs, workDir, new Dictionary<string, string>(), ct);
+
+        session.MinttyProcess!.Exited += (_, _) =>
+        {
+            // If ResetSession already cancelled this CTS, skip the callback —
+            // the old session was intentionally killed, not a host termination.
+            if (!sessionCts.IsCancellationRequested)
+            {
+                sessionCts.Cancel();
+                shellExitedCallback?.Invoke();
+            }
+        };
+
+        return session;
+    }
+
+    public void SendConsoleInput(string text)
+    {
+        HWND hwnd = _runningSession?.WindowHandle ?? HWND.Null;
+        if (hwnd.IsNull)
+        {
+            return;
+        }
+
+        FocusWithAttachedInput(hwnd);
+
+        foreach (char c in text)
+        {
+            if (c is '\r' or '\n')
+            {
+                PInvoke.PostMessage(hwnd, NativeMethods.WM_KEYDOWN, (nuint)VIRTUAL_KEY.VK_RETURN, (nint)0);
+                PInvoke.PostMessage(hwnd, NativeMethods.WM_CHAR, (nuint)'\r', (nint)0);
+                PInvoke.PostMessage(hwnd, NativeMethods.WM_KEYUP, (nuint)VIRTUAL_KEY.VK_RETURN, (nint)0);
+            }
+            else
+            {
+                PInvoke.PostMessage(hwnd, NativeMethods.WM_CHAR, (nuint)c, (nint)0);
+            }
+        }
+    }
+
+    public void FocusConsole()
+    {
+        HWND hwnd = _runningSession?.WindowHandle ?? HWND.Null;
+        if (!hwnd.IsNull)
+        {
+            FocusWithAttachedInput(hwnd);
+        }
+    }
+
+    private static string BuildThemeArg(string? theme)
+    {
+        return string.IsNullOrEmpty(theme) ? "" : $"-o \"ThemeFile={theme}\" ";
+    }
+
+    private void ResetSession()
+    {
+        _sessionCts?.Cancel();
+        _sessionCts?.Dispose();
+        _sessionCts = new CancellationTokenSource();
+        _runningSession?.Kill();
+        _runningSession = null;
+    }
+
+    private void LaunchAndEmbed(
+        MinttySession session,
+        string minttyPath,
+        string minttyArgs,
+        string? workDir,
+        IReadOnlyDictionary<string, string> envVariables,
+        CancellationToken ct,
+        bool redirectStdout = false)
+    {
+        ProcessStartInfo psi = new()
+        {
+            FileName = minttyPath,
+            Arguments = minttyArgs,
+            WorkingDirectory = workDir ?? Environment.CurrentDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = redirectStdout,
+            CreateNoWindow = true,
+        };
+
+        foreach ((string key, string value) in envVariables)
+        {
+            psi.EnvironmentVariables[key] = value;
+        }
+
+        Process minttyProcess = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start mintty.exe");
+
+        PInvoke.AssignProcessToJobObject(_jobHandle, new HANDLE(minttyProcess.Handle));
+
+        minttyProcess.EnableRaisingEvents = true;
+
+        session.AttachProcess(minttyProcess, ct);
+
+        FindAndEmbedWindow(minttyProcess, session, ct);
+    }
+
+#pragma warning disable VSTHRD100
+    private async void FindAndEmbedWindow(Process minttyProcess, MinttySession session, CancellationToken ct)
+#pragma warning restore VSTHRD100
+    {
+        using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(30));
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        ct = linkedCts.Token;
+
+        try
+        {
+            // Wait until mintty's message pump is idle before embedding — otherwise
+            // mintty may still be running startup code that calls ShowWindow/SetFocus
+            // and causes the host dialog's focus to flicker as it races with our embed.
+            await Task.Run(() => minttyProcess.WaitForInputIdle(5000), ct).ConfigureAwait(true);
+
+            HWND hwnd = HWND.Null;
+
+            while (!ct.IsCancellationRequested)
+            {
+                hwnd = NativeMethods.FindMinttyWindowForProcess(minttyProcess.Id);
+                if (!hwnd.IsNull)
+                {
+                    break;
+                }
+
+                // It is essential to capture original synchronization context
+                await Task.Delay(TimeSpan.FromMilliseconds(50), ct).ConfigureAwait(true);
+            }
+
+            session.WindowHandle = hwnd;
+
+            if (!hwnd.IsNull)
+            {
+                EmbedWindow(hwnd);
+            }
+        }
+        catch (Exception)
+        {
+            // Do nothing
+        }
+    }
+
+    private void EmbedWindow(HWND hwnd)
+    {
+        if (!IsHandleCreated || hwnd.IsNull)
+        {
+            return;
+        }
+
+        // Probe mintty's pump before any blocking cross-process call. SetWindowLong
+        // on GWL_STYLE/GWL_EXSTYLE synchronously sends WM_STYLECHANGING/CHANGED to
+        // mintty's thread; SetParent and AttachThreadInput are similarly synchronous.
+        // Under system load mintty's pump can stall — without this probe the host
+        // UI thread blocks indefinitely inside one of those calls. If the probe
+        // fails, kill mintty so the session resets cleanly via Process.Exited.
+        if (!IsWindowResponsive(hwnd, TimeSpan.FromSeconds(5)))
+        {
+            _runningSession?.Kill();
+            return;
+        }
+
+        // Capture the hosting form before embedding: mintty's process startup can
+        // shift foreground/activation away from the dialog that triggered the command,
+        // so we need a handle to restore activation after the embed completes.
+        Form? hostForm = FindForm();
+
+        WINDOW_STYLE style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
+        style &= ~(WINDOW_STYLE.WS_CAPTION | WINDOW_STYLE.WS_THICKFRAME | WINDOW_STYLE.WS_BORDER);
+        style |= WINDOW_STYLE.WS_CHILD;
+        PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (int)style);
+
+        WINDOW_EX_STYLE extendedStyle = (WINDOW_EX_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
+        extendedStyle &= ~(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_WINDOWEDGE | WINDOW_EX_STYLE.WS_EX_APPWINDOW);
+        extendedStyle |= WINDOW_EX_STYLE.WS_EX_TOOLWINDOW;
+        PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, (int)extendedStyle);
+
+        PInvoke.SetParent(hwnd, new HWND(Handle));
+
+        // SWP_ASYNCWINDOWPOS posts the size/show change to mintty's thread instead of
+        // a synchronous cross-process SendMessage, so a slow mintty pump under system
+        // load cannot freeze our UI thread during embed. SWP_SHOWWINDOW replaces the
+        // separate ShowWindow call (which has no async variant) — combined with
+        // SWP_NOACTIVATE this is equivalent to SW_SHOWNA. See OnResize for the same
+        // pattern.
+        PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, Width, Height,
+            SET_WINDOW_POS_FLAGS.SWP_NOZORDER
+            | SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
+            | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
+            | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
+            | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
+
+        if (hostForm is { IsHandleCreated: true, IsDisposed: false })
+        {
+            hostForm.Activate();
+        }
+
+        FocusWithAttachedInput(hwnd);
+    }
+
+    /// <summary>
+    /// Pings the target window with WM_NULL via SendMessageTimeout to verify its
+    /// message pump is alive. SMTO_ABORTIFHUNG returns immediately if the OS has
+    /// already marked the window as hung; otherwise the call returns once the pump
+    /// dispatches the no-op message or the timeout expires. Returns false on
+    /// failure — caller must not proceed with synchronous cross-process calls.
+    /// </summary>
+    private static bool IsWindowResponsive(HWND hwnd, TimeSpan timeout)
+    {
+        nint result = PInvoke.SendMessageTimeout(
+            hwnd,
+            Msg: 0, // WM_NULL
+            wParam: default,
+            lParam: default,
+            SEND_MESSAGE_TIMEOUT_FLAGS.SMTO_ABORTIFHUNG,
+            (uint)timeout.TotalMilliseconds,
+            out _);
+        return result != 0;
+    }
+
+    /// <summary>
+    /// SetFocus only works when the target hwnd belongs to the calling thread, or when
+    /// the calling thread's input queue is attached to the target window's thread.
+    /// Mintty runs in another process, so we must attach input queues for the call to
+    /// take effect — otherwise SetFocus is silently dropped.
+    /// </summary>
+    private static void FocusWithAttachedInput(HWND hwnd)
+    {
+        uint targetThreadId = PInvoke.GetWindowThreadProcessId(hwnd, out _);
+        if (targetThreadId == 0)
+        {
+            return;
+        }
+
+        uint currentThreadId = PInvoke.GetCurrentThreadId();
+        if (targetThreadId == currentThreadId)
+        {
+            PInvoke.SetFocus(hwnd);
+            return;
+        }
+
+        if (!PInvoke.AttachThreadInput(currentThreadId, targetThreadId, true))
+        {
+            return;
+        }
+
+        try
+        {
+            PInvoke.SetFocus(hwnd);
+        }
+        finally
+        {
+            PInvoke.AttachThreadInput(currentThreadId, targetThreadId, false);
+        }
+    }
+
+    protected override void OnResize(EventArgs e)
+    {
+        base.OnResize(e);
+        HWND hwnd = _runningSession?.WindowHandle ?? HWND.Null;
+        if (!hwnd.IsNull && Width > 0 && Height > 0)
+        {
+            // SWP_ASYNCWINDOWPOS posts the size change to mintty's thread instead of a
+            // synchronous cross-process SendMessage. MoveWindow (and plain SetWindowPos)
+            // blocks on mintty's message pump, which can deadlock with the modal resize
+            // loop if mintty has a SendMessage pending into our window.
+            PInvoke.SetWindowPos(hwnd, HWND.Null, 0, 0, Width, Height,
+                SET_WINDOW_POS_FLAGS.SWP_NOZORDER
+                | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
+                | SET_WINDOW_POS_FLAGS.SWP_ASYNCWINDOWPOS);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _sessionCts?.Cancel();
+            _sessionCts?.Dispose();
+            _sessionCts = null;
+            _runningSession?.Kill();
+            _runningSession = null;
+
+            if (!_jobHandle.IsNull)
+            {
+                try
+                {
+                    PInvoke.TerminateJobObject(_jobHandle, 0);
+                }
+                catch
+                {
+                }
+
+                PInvoke.CloseHandle(_jobHandle);
+                _jobHandle = HANDLE.Null;
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyControl.cs
@@ -166,7 +166,7 @@ internal sealed class MinttyControl : Panel
 
         minttyProcess.EnableRaisingEvents = true;
 
-        session.AttachProcess(minttyProcess, ct);
+        session.AttachProcess(minttyProcess);
 
         FindAndEmbedWindow(minttyProcess, session, ct);
     }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using GitCommands.Logging;
 using Windows.Win32.Foundation;
 
 namespace GitUI.ConsoleEmulation.Mintty;
@@ -6,6 +7,7 @@ namespace GitUI.ConsoleEmulation.Mintty;
 internal sealed class MinttySession
 {
     private Process? _minttyProcess;
+    private ProcessOperation? _processOperation;
     private Action<string>? _lineCallback;
     private Action<int>? _exitCallback;
 
@@ -19,6 +21,7 @@ internal sealed class MinttySession
 
         MinttySession session = new()
         {
+            _processOperation = startInfo.ProcessOperation,
             _lineCallback = startInfo.AnsiOutputLineCallback,
             _exitCallback = startInfo.ProcessExitedCallback,
         };
@@ -53,6 +56,7 @@ internal sealed class MinttySession
     internal void AttachProcess(Process minttyProcess, CancellationToken ct)
     {
         _minttyProcess = minttyProcess;
+        _processOperation?.SetProcessId(minttyProcess.Id);
 
         // The interactive shell launches with stdout not redirected; reading
         // Process.StandardOutput in that case throws InvalidOperationException.

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
@@ -48,8 +48,9 @@ internal sealed class MinttySession
             {
                 return MinttyProcess is null || MinttyProcess.HasExited;
             }
-            catch
+            catch (Exception ex)
             {
+                Trace.WriteLine(ex);
                 return true;
             }
         }
@@ -84,8 +85,9 @@ internal sealed class MinttySession
                 MinttyProcess.Kill();
             }
         }
-        catch
+        catch (Exception ex)
         {
+            Trace.WriteLine(ex);
         }
     }
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
@@ -6,22 +6,28 @@ namespace GitUI.ConsoleEmulation.Mintty;
 
 internal sealed class MinttySession
 {
-    private Process? _minttyProcess;
-    private ProcessOperation? _processOperation;
     private Action<string>? _lineCallback;
     private Action<int>? _exitCallback;
+
+    public ProcessOperation? ProcessOperation { get; private set; }
+
+    public HWND WindowHandle { get; set; }
+
+    public Process? MinttyProcess { get; private set; }
+
+    public int? ExitCode { get; private set; }
 
     private MinttySession()
     {
     }
 
-    internal static (MinttySession Session, MinttyConsoleRuntime.CommandLaunchParams LaunchParams) StartCommandSession(MinttyStartInfo startInfo)
+    public static (MinttySession Session, MinttyConsoleRuntime.CommandLaunchParams LaunchParams) StartCommandSession(MinttyStartInfo startInfo)
     {
         MinttyConsoleRuntime.CommandLaunchParams launchParams = MinttyConsoleRuntime.CreateLaunchParams(startInfo);
 
         MinttySession session = new()
         {
-            _processOperation = startInfo.ProcessOperation,
+            ProcessOperation = startInfo.ProcessOperation,
             _lineCallback = startInfo.AnsiOutputLineCallback,
             _exitCallback = startInfo.ProcessExitedCallback,
         };
@@ -29,22 +35,18 @@ internal sealed class MinttySession
         return (session, launchParams);
     }
 
-    internal static MinttySession StartInteractiveShellSession()
+    public static MinttySession StartInteractiveShellSession()
     {
         return new MinttySession();
     }
 
-    internal Process? MinttyProcess => _minttyProcess;
-
-    internal HWND WindowHandle { get; set; }
-
-    internal bool IsExited
+    public bool IsExited
     {
         get
         {
             try
             {
-                return _minttyProcess is null || _minttyProcess.HasExited;
+                return MinttyProcess is null || MinttyProcess.HasExited;
             }
             catch
             {
@@ -53,26 +55,33 @@ internal sealed class MinttySession
         }
     }
 
-    internal void AttachProcess(Process minttyProcess)
+    public void AttachProcess(Process minttyProcess)
     {
-        _minttyProcess = minttyProcess;
-        _processOperation?.SetProcessId(minttyProcess.Id);
+        MinttyProcess = minttyProcess;
+        ProcessOperation?.SetProcessId(minttyProcess.Id);
 
         // The interactive shell launches with stdout not redirected; reading
         // Process.StandardOutput in that case throws InvalidOperationException.
         if (minttyProcess.StartInfo.RedirectStandardOutput)
         {
-            MinttyConsoleRuntime.StartOutputReader(minttyProcess, _lineCallback, _exitCallback);
+            MinttyConsoleRuntime.StartOutputReader(
+                minttyProcess,
+                _lineCallback,
+                exitCallback: exitCode =>
+                {
+                    ExitCode = exitCode;
+                    _exitCallback?.Invoke(exitCode);
+                });
         }
     }
 
-    internal void Kill()
+    public void Kill()
     {
         try
         {
-            if (_minttyProcess is not null && !_minttyProcess.HasExited)
+            if (MinttyProcess is not null && !MinttyProcess.HasExited)
             {
-                _minttyProcess.Kill();
+                MinttyProcess.Kill();
             }
         }
         catch

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
@@ -4,7 +4,7 @@ using Windows.Win32.Foundation;
 
 namespace GitUI.ConsoleEmulation.Mintty;
 
-internal sealed class MinttySession
+internal sealed class MinttySession : IDisposable
 {
     private Action<string>? _lineCallback;
     private Action<int>? _exitCallback;
@@ -89,5 +89,15 @@ internal sealed class MinttySession
         {
             Trace.WriteLine(ex);
         }
+    }
+
+    // Kills the process and releases its handle. The output reader (if any) holds the
+    // stdout stream; killing closes the pipe so it drains and exits, and any read still
+    // in flight when the Process is disposed fails into the reader's own try/catch.
+    public void Dispose()
+    {
+        Kill();
+        MinttyProcess?.Dispose();
+        MinttyProcess = null;
     }
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
@@ -53,7 +53,7 @@ internal sealed class MinttySession
         }
     }
 
-    internal void AttachProcess(Process minttyProcess, CancellationToken ct)
+    internal void AttachProcess(Process minttyProcess)
     {
         _minttyProcess = minttyProcess;
         _processOperation?.SetProcessId(minttyProcess.Id);
@@ -62,7 +62,7 @@ internal sealed class MinttySession
         // Process.StandardOutput in that case throws InvalidOperationException.
         if (minttyProcess.StartInfo.RedirectStandardOutput)
         {
-            MinttyConsoleRuntime.StartOutputReader(minttyProcess, _lineCallback, _exitCallback, ct);
+            MinttyConsoleRuntime.StartOutputReader(minttyProcess, _lineCallback, _exitCallback);
         }
     }
 

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
@@ -76,7 +76,31 @@ internal sealed class MinttySession : IDisposable
         }
     }
 
+    /// <summary>
+    ///  Deliberately aborts the session and reports the command as failed.
+    ///  Use <see cref="Dispose"/> for a silent teardown without exit notification.
+    /// </summary>
     public void Kill()
+    {
+        if (IsExited)
+        {
+            return;
+        }
+
+        KillProcess();
+
+        if (ExitCode is null)
+        {
+            // Killing the host means the exit sentinel never arrives, so no exit
+            // notification would fire and the aborted command would be mistaken
+            // for a successful one. Report a non-zero exit code, like ConEmu does
+            // when the command is interrupted.
+            ExitCode = -1;
+            _exitCallback?.Invoke(-1);
+        }
+    }
+
+    private void KillProcess()
     {
         try
         {
@@ -96,7 +120,7 @@ internal sealed class MinttySession : IDisposable
     // in flight when the Process is disposed fails into the reader's own try/catch.
     public void Dispose()
     {
-        Kill();
+        KillProcess();
         MinttyProcess?.Dispose();
         MinttyProcess = null;
     }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttySession.cs
@@ -1,0 +1,78 @@
+﻿using System.Diagnostics;
+using Windows.Win32.Foundation;
+
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal sealed class MinttySession
+{
+    private Process? _minttyProcess;
+    private Action<string>? _lineCallback;
+    private Action<int>? _exitCallback;
+
+    private MinttySession()
+    {
+    }
+
+    internal static (MinttySession Session, MinttyConsoleRuntime.CommandLaunchParams LaunchParams) StartCommandSession(MinttyStartInfo startInfo)
+    {
+        MinttyConsoleRuntime.CommandLaunchParams launchParams = MinttyConsoleRuntime.CreateLaunchParams(startInfo);
+
+        MinttySession session = new()
+        {
+            _lineCallback = startInfo.AnsiOutputLineCallback,
+            _exitCallback = startInfo.ProcessExitedCallback,
+        };
+
+        return (session, launchParams);
+    }
+
+    internal static MinttySession StartInteractiveShellSession()
+    {
+        return new MinttySession();
+    }
+
+    internal Process? MinttyProcess => _minttyProcess;
+
+    internal HWND WindowHandle { get; set; }
+
+    internal bool IsExited
+    {
+        get
+        {
+            try
+            {
+                return _minttyProcess is null || _minttyProcess.HasExited;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+    }
+
+    internal void AttachProcess(Process minttyProcess, CancellationToken ct)
+    {
+        _minttyProcess = minttyProcess;
+
+        // The interactive shell launches with stdout not redirected; reading
+        // Process.StandardOutput in that case throws InvalidOperationException.
+        if (minttyProcess.StartInfo.RedirectStandardOutput)
+        {
+            MinttyConsoleRuntime.StartOutputReader(minttyProcess, _lineCallback, _exitCallback, ct);
+        }
+    }
+
+    internal void Kill()
+    {
+        try
+        {
+            if (_minttyProcess is not null && !_minttyProcess.HasExited)
+            {
+                _minttyProcess.Kill();
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
@@ -6,14 +6,14 @@ internal sealed class MinttyShellRunner : IConsoleShellRunner
 {
     private readonly string _minttyPath;
     private readonly string _bashPath;
-    private readonly string? _theme;
+    private readonly ConsoleEmulatorSettings _settings;
     private readonly MinttyControl _control;
 
-    internal MinttyShellRunner(string minttyPath, string bashPath, string? theme)
+    internal MinttyShellRunner(string minttyPath, string bashPath, ConsoleEmulatorSettings settings)
     {
         _minttyPath = minttyPath;
         _bashPath = bashPath;
-        _theme = theme;
+        _settings = settings;
         _control = new MinttyControl { Dock = DockStyle.Fill };
     }
 
@@ -23,7 +23,7 @@ internal sealed class MinttyShellRunner : IConsoleShellRunner
 
     public void StartShell(string workDir)
     {
-        _control.StartInteractiveShell(_minttyPath, _bashPath, _theme, workDir);
+        _control.StartInteractiveShell(_minttyPath, _bashPath, _settings.Theme, workDir, _settings.Font);
     }
 
     public void ChangeWorkingDirectory(string path)

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
@@ -23,7 +23,7 @@ internal sealed class MinttyShellRunner : IConsoleShellRunner
 
     public void StartShell(string workDir)
     {
-        _control.StartInteractiveShell(_minttyPath, _bashPath, _settings.Theme, workDir, _settings.Font);
+        _control.StartInteractiveShell(_minttyPath, _bashPath, workDir, _settings);
     }
 
     public void ChangeWorkingDirectory(string path)

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
@@ -28,8 +28,8 @@ internal sealed class MinttyShellRunner : IConsoleShellRunner
 
     public void ChangeWorkingDirectory(string path)
     {
-        string changeDirCommand = $"cd {path.ToMountPath("/")}";
-        _control.SendConsoleInput("\x01\x0B" + changeDirCommand + "\n");
+        string changeDirCommand = $"cd \"{path.ToMountPath("/")}\"";
+        _control.SendConsoleInput($"\x1\xb{changeDirCommand}\n");
     }
 
     public void FocusTerminal()

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
@@ -1,0 +1,39 @@
+﻿using GitCommands;
+
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal sealed class MinttyShellRunner : IConsoleShellRunner
+{
+    private readonly string _minttyPath;
+    private readonly string _bashPath;
+    private readonly string? _theme;
+    private readonly MinttyControl _control;
+
+    internal MinttyShellRunner(string minttyPath, string bashPath, string? theme)
+    {
+        _minttyPath = minttyPath;
+        _bashPath = bashPath;
+        _theme = theme;
+        _control = new MinttyControl { Dock = DockStyle.Fill };
+    }
+
+    public bool IsShellRunning => _control.IsShellRunning;
+
+    public Control Control => _control;
+
+    public void StartShell(string workDir)
+    {
+        _control.StartInteractiveShell(_minttyPath, _bashPath, _theme, workDir);
+    }
+
+    public void ChangeWorkingDirectory(string path)
+    {
+        string changeDirCommand = $"cd {path.ToMountPath("/")}";
+        _control.SendConsoleInput("\x01\x0B" + changeDirCommand + "\n");
+    }
+
+    public void FocusTerminal()
+    {
+        _control.FocusConsole();
+    }
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyShellRunner.cs
@@ -34,6 +34,6 @@ internal sealed class MinttyShellRunner : IConsoleShellRunner
 
     public void FocusTerminal()
     {
-        _control.FocusConsole();
+        _control.Focus();
     }
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyStartInfo.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyStartInfo.cs
@@ -4,21 +4,17 @@ namespace GitUI.ConsoleEmulation.Mintty;
 
 internal sealed class MinttyStartInfo
 {
-    private readonly Dictionary<string, string> _environmentVariables = new();
+    public string ConsoleProcessCommandLine { get; init; } = "";
 
-    internal string ConsoleProcessCommandLine { get; init; } = "";
+    public required string StartupDirectory { get; init; }
 
-    internal required string StartupDirectory { get; init; }
+    public Dictionary<string, string> EnvironmentVariables { get; } = [];
 
-    internal IReadOnlyDictionary<string, string> EnvironmentVariables => _environmentVariables;
+    public Action<int>? ProcessExitedCallback { get; init; }
 
-    internal Action<int>? ProcessExitedCallback { get; init; }
+    public Action? ConsoleClosedCallback { get; init; }
 
-    internal Action? ConsoleClosedCallback { get; init; }
+    public required ProcessOperation ProcessOperation { get; init; }
 
-    internal required ProcessOperation ProcessOperation { get; init; }
-
-    internal Action<string>? AnsiOutputLineCallback { get; init; }
-
-    internal void SetEnv(string name, string value) => _environmentVariables[name] = value;
+    public Action<string>? AnsiOutputLineCallback { get; init; }
 }

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyStartInfo.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyStartInfo.cs
@@ -1,0 +1,20 @@
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal sealed class MinttyStartInfo
+{
+    private readonly Dictionary<string, string> _environmentVariables = new();
+
+    internal string ConsoleProcessCommandLine { get; init; } = "";
+
+    internal string? StartupDirectory { get; init; }
+
+    internal IReadOnlyDictionary<string, string> EnvironmentVariables => _environmentVariables;
+
+    internal Action<int>? ProcessExitedCallback { get; init; }
+
+    internal Action? ConsoleClosedCallback { get; init; }
+
+    internal Action<string>? AnsiOutputLineCallback { get; init; }
+
+    internal void SetEnv(string name, string value) => _environmentVariables[name] = value;
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/MinttyStartInfo.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/MinttyStartInfo.cs
@@ -1,3 +1,5 @@
+using GitCommands.Logging;
+
 namespace GitUI.ConsoleEmulation.Mintty;
 
 internal sealed class MinttyStartInfo
@@ -6,13 +8,15 @@ internal sealed class MinttyStartInfo
 
     internal string ConsoleProcessCommandLine { get; init; } = "";
 
-    internal string? StartupDirectory { get; init; }
+    internal required string StartupDirectory { get; init; }
 
     internal IReadOnlyDictionary<string, string> EnvironmentVariables => _environmentVariables;
 
     internal Action<int>? ProcessExitedCallback { get; init; }
 
     internal Action? ConsoleClosedCallback { get; init; }
+
+    internal required ProcessOperation ProcessOperation { get; init; }
 
     internal Action<string>? AnsiOutputLineCallback { get; init; }
 

--- a/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.JobObjects;
@@ -11,28 +10,6 @@ internal static class NativeMethods
     internal const uint WM_CHAR = 0x0102;
     internal const uint WM_KEYDOWN = 0x0100;
     internal const uint WM_KEYUP = 0x0101;
-
-    internal const int GWLP_HWNDPARENT = -8;
-
-    /// <summary>
-    /// Cross-bitness wrapper for SetWindowLongPtr. CsWin32 does not expose the Ptr
-    /// variant, and on x86 the Win32 header defines it as a macro for SetWindowLong.
-    /// </summary>
-    internal static nint SetWindowLongPtr(HWND hwnd, int nIndex, nint newValue)
-    {
-        if (IntPtr.Size == 8)
-        {
-            return SetWindowLongPtr64(hwnd, nIndex, newValue);
-        }
-
-        return SetWindowLong32(hwnd, nIndex, (int)newValue);
-    }
-
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", CharSet = CharSet.Unicode, ExactSpelling = true)]
-    private static extern nint SetWindowLongPtr64(HWND hwnd, int nIndex, nint newLong);
-
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", CharSet = CharSet.Unicode, ExactSpelling = true)]
-    private static extern int SetWindowLong32(HWND hwnd, int nIndex, int newLong);
 
     internal static HWND FindMinttyWindowForProcess(int processId)
     {

--- a/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
@@ -1,6 +1,8 @@
+using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.JobObjects;
+using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace GitUI.ConsoleEmulation.Mintty;
 
@@ -9,6 +11,28 @@ internal static class NativeMethods
     internal const uint WM_CHAR = 0x0102;
     internal const uint WM_KEYDOWN = 0x0100;
     internal const uint WM_KEYUP = 0x0101;
+
+    internal const int GWLP_HWNDPARENT = -8;
+
+    /// <summary>
+    /// Cross-bitness wrapper for SetWindowLongPtr. CsWin32 does not expose the Ptr
+    /// variant, and on x86 the Win32 header defines it as a macro for SetWindowLong.
+    /// </summary>
+    internal static nint SetWindowLongPtr(HWND hwnd, int nIndex, nint newValue)
+    {
+        if (IntPtr.Size == 8)
+        {
+            return SetWindowLongPtr64(hwnd, nIndex, newValue);
+        }
+
+        return SetWindowLong32(hwnd, nIndex, (int)newValue);
+    }
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern nint SetWindowLongPtr64(HWND hwnd, int nIndex, nint newLong);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern int SetWindowLong32(HWND hwnd, int nIndex, int newLong);
 
     internal static HWND FindMinttyWindowForProcess(int processId)
     {
@@ -33,6 +57,78 @@ internal static class NativeMethods
                         return false;
                     }
                 }
+            }
+
+            return true;
+        }, 0);
+        return found;
+    }
+
+    /// <summary>
+    /// Pings the target window with WM_NULL via SendMessageTimeout to verify its
+    /// message pump is alive. SMTO_ABORTIFHUNG returns immediately if the OS has
+    /// already marked the window as hung; otherwise the call returns once the pump
+    /// dispatches the no-op message or the timeout expires. Returns false on
+    /// failure — caller must not proceed with synchronous cross-process calls.
+    /// </summary>
+    internal static bool IsWindowResponsive(HWND hwnd, TimeSpan timeout)
+    {
+        nint result = PInvoke.SendMessageTimeout(
+            hwnd,
+            Msg: 0, // WM_NULL
+            wParam: default,
+            lParam: default,
+            SEND_MESSAGE_TIMEOUT_FLAGS.SMTO_ABORTIFHUNG,
+            (uint)timeout.TotalMilliseconds,
+            out _);
+        return result != 0;
+    }
+
+    /// <summary>
+    /// SetFocus only works when the target hwnd belongs to the calling thread, or when
+    /// the calling thread's input queue is attached to the target window's thread.
+    /// Mintty runs in another process, so we must attach input queues for the call to
+    /// take effect — otherwise SetFocus is silently dropped.
+    /// </summary>
+    internal static void FocusWindowWithAttachedInput(HWND hwnd)
+    {
+        uint targetThreadId = PInvoke.GetWindowThreadProcessId(hwnd, out _);
+        if (targetThreadId == 0)
+        {
+            return;
+        }
+
+        uint currentThreadId = PInvoke.GetCurrentThreadId();
+        if (targetThreadId == currentThreadId)
+        {
+            PInvoke.SetFocus(hwnd);
+            return;
+        }
+
+        if (!PInvoke.AttachThreadInput(currentThreadId, targetThreadId, true))
+        {
+            return;
+        }
+
+        try
+        {
+            PInvoke.SetFocus(hwnd);
+        }
+        finally
+        {
+            PInvoke.AttachThreadInput(currentThreadId, targetThreadId, false);
+        }
+    }
+
+    internal static List<HWND> EnumerateProcessWindows(int processId)
+    {
+        List<HWND> found = [];
+        PInvoke.EnumWindows((hwnd, _) =>
+        {
+            PInvoke.GetWindowThreadProcessId(hwnd, out uint pid);
+            if (pid == (uint)processId)
+            {
+                found.Add(hwnd);
             }
 
             return true;

--- a/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
@@ -1,0 +1,58 @@
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.JobObjects;
+
+namespace GitUI.ConsoleEmulation.Mintty;
+
+internal static class NativeMethods
+{
+    internal const uint WM_CHAR = 0x0102;
+    internal const uint WM_KEYDOWN = 0x0100;
+    internal const uint WM_KEYUP = 0x0101;
+
+    internal static HWND FindMinttyWindowForProcess(int processId)
+    {
+        HWND found = HWND.Null;
+        PInvoke.EnumWindows((hwnd, _) =>
+        {
+            PInvoke.GetWindowThreadProcessId(hwnd, out uint pid);
+            if (pid != (uint)processId)
+            {
+                return true;
+            }
+
+            Span<char> classNameBuf = stackalloc char[20];
+            unsafe
+            {
+                fixed (char* pBuf = classNameBuf)
+                {
+                    int len = PInvoke.GetClassName(hwnd, pBuf, classNameBuf.Length);
+                    if (len > 0 && classNameBuf[..len] is "mintty")
+                    {
+                        found = hwnd;
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }, 0);
+        return found;
+    }
+
+    internal static unsafe HANDLE CreateKillOnCloseJob()
+    {
+        HANDLE job = PInvoke.CreateJobObject(default(Windows.Win32.Security.SECURITY_ATTRIBUTES*), null);
+        if (job.IsNull)
+        {
+            return HANDLE.Null;
+        }
+
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION info = default;
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        PInvoke.SetInformationJobObject(job, JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation,
+            &info, (uint)sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+
+        return job;
+    }
+}

--- a/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
+++ b/src/app/GitUI/ConsoleEmulation/Mintty/NativeMethods.cs
@@ -50,8 +50,15 @@ internal static class NativeMethods
 
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION info = default;
         info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-        PInvoke.SetInformationJobObject(job, JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation,
-            &info, (uint)sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+        if (!PInvoke.SetInformationJobObject(
+                job,
+                JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation,
+                &info,
+                (uint)sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION)))
+        {
+            PInvoke.CloseHandle(job);
+            return HANDLE.Null;
+        }
 
         return job;
     }

--- a/src/app/GitUI/GitUI.csproj
+++ b/src/app/GitUI/GitUI.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="ExCSS" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Core" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" />
+    <PackageReference Include="Microsoft.Windows.CsWin32">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="JetBrains.Annotations" />
   </ItemGroup>
 
@@ -44,6 +48,8 @@
 
   <ItemGroup>
     <!-- Resources -->
+    <AdditionalFiles Include="Interops\NativeMethods.json" />
+    <AdditionalFiles Include="Interops\NativeMethods.txt" />
     <EmbeddedResource Update="Properties\Images.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Images.Designer.cs</LastGenOutput>

--- a/src/app/GitUI/Interops/NativeMethods.json
+++ b/src/app/GitUI/Interops/NativeMethods.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "allowMarshaling": true,
+  "wideCharOnly": true,
+  "useSafeHandles": false
+}

--- a/src/app/GitUI/Interops/NativeMethods.txt
+++ b/src/app/GitUI/Interops/NativeMethods.txt
@@ -1,0 +1,28 @@
+// kernel32 - Job Object
+CreateJobObject
+SetInformationJobObject
+AssignProcessToJobObject
+TerminateJobObject
+CloseHandle
+JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+
+// kernel32 - Threading
+GetCurrentThreadId
+
+// user32 - Window management
+SetParent
+GetWindowLong
+SetWindowLong
+MoveWindow
+ShowWindow
+SetWindowPos
+SetFocus
+AttachThreadInput
+GetWindowThreadProcessId
+PostMessage
+SendMessageTimeout
+EnumWindows
+GetClassName
+VIRTUAL_KEY
+WINDOW_STYLE
+WINDOW_EX_STYLE

--- a/src/app/GitUI/ServiceContainerRegistry.cs
+++ b/src/app/GitUI/ServiceContainerRegistry.cs
@@ -56,6 +56,6 @@ public static class ServiceContainerRegistry
                 consoleEmulators: [new ConEmuConsoleEmulator(), new MinttyConsoleEmulator()],
                 useConsoleEmulation: AppSettings.UseConsoleEmulatorForCommands,
                 consoleEmulatorName: AppSettings.ConsoleEmulatorName,
-                consoleEmulatorTheme: AppSettings.ConsoleEmulatorTheme));
+                consoleEmulatorTheme: AppSettings.ConEmuStyle));
     }
 }

--- a/src/app/GitUI/ServiceContainerRegistry.cs
+++ b/src/app/GitUI/ServiceContainerRegistry.cs
@@ -56,6 +56,7 @@ public static class ServiceContainerRegistry
                 consoleEmulators: [new ConEmuConsoleEmulator(), new MinttyConsoleEmulator()],
                 useConsoleEmulation: AppSettings.UseConsoleEmulatorForCommands,
                 consoleEmulatorName: AppSettings.ConsoleEmulatorName,
-                consoleEmulatorTheme: AppSettings.ConEmuStyle));
+                consoleEmulatorTheme: AppSettings.ConEmuStyle,
+                consoleFont: () => AppSettings.ConEmuConsoleFont));
     }
 }

--- a/src/app/GitUI/ServiceContainerRegistry.cs
+++ b/src/app/GitUI/ServiceContainerRegistry.cs
@@ -6,6 +6,7 @@ using GitExtUtils;
 using GitUI.CommandsDialogs;
 using GitUI.ConsoleEmulation;
 using GitUI.ConsoleEmulation.ConEmu;
+using GitUI.ConsoleEmulation.Mintty;
 using GitUI.Hotkey;
 using GitUI.Models;
 using GitUI.ScriptsEngine;
@@ -52,8 +53,9 @@ public static class ServiceContainerRegistry
 
         serviceContainer.AddService<IConsoleEmulatorsRegistry>(
             new ConsoleEmulatorsRegistry(
-                consoleEmulators: [new ConEmuConsoleEmulator()],
+                consoleEmulators: [new ConEmuConsoleEmulator(), new MinttyConsoleEmulator()],
                 useConsoleEmulation: AppSettings.UseConsoleEmulatorForCommands,
-                consoleEmulatorName: AppSettings.ConsoleEmulatorName));
+                consoleEmulatorName: AppSettings.ConsoleEmulatorName,
+                consoleEmulatorTheme: AppSettings.ConsoleEmulatorTheme));
     }
 }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1133,6 +1133,14 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>Console style</source>
         <target />
       </trans-unit>
+      <trans-unit id="_consoleDefaultFontText.Text">
+        <source>Console Default</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_defaultThemeDisplayName.Text">
+        <source>Default</source>
+        <target />
+      </trans-unit>
       <trans-unit id="consoleFontChangeButton.Text">
         <source>font name</source>
         <target />

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1137,6 +1137,10 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>font name</source>
         <target />
       </trans-unit>
+      <trans-unit id="consoleFontResetButton.consoleFontToolTip">
+        <source>Reset to default</source>
+        <target />
+      </trans-unit>
       <trans-unit id="groupBoxConsoleSettings.Text">
         <source>Console settings (restart required)</source>
         <target />

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -3519,6 +3519,10 @@ Focus the output history and (when displayed as panel) toggle its visibility usi
         <source>Console emulator</source>
         <target />
       </trans-unit>
+      <trans-unit id="lblConsoleEmulatorTheme.Text">
+        <source>Console emulator theme</source>
+        <target />
+      </trans-unit>
       <trans-unit id="lblDefaultShell.Text">
         <source>Default shell</source>
         <target />

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -1145,6 +1145,10 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>Console style</source>
         <target />
       </trans-unit>
+      <trans-unit id="lblConsoleEmulator.Text">
+        <source>Console emulator</source>
+        <target />
+      </trans-unit>
       <trans-unit id="lblFontName.Text">
         <source>Font</source>
         <target />
@@ -3513,14 +3517,6 @@ Focus the output history and (when displayed as panel) toggle its visibility usi
       </trans-unit>
       <trans-unit id="groupBox1.Text">
         <source>General</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="lblConsoleEmulatorChoice.Text">
-        <source>Console emulator</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="lblConsoleEmulatorTheme.Text">
-        <source>Console emulator theme</source>
         <target />
       </trans-unit>
       <trans-unit id="lblDefaultShell.Text">

--- a/tests/app/UnitTests/GitUI.Tests/ConsoleEmulation/Mintty/MinttyConsoleRuntimeTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ConsoleEmulation/Mintty/MinttyConsoleRuntimeTests.cs
@@ -46,15 +46,15 @@ public sealed class MinttyConsoleRuntimeTests
         // Regression test for WSL repos. Previously the raw command line was spliced into
         // a bash script verbatim; bash collapsed the `\\` in the double-quoted UNC path
         // to a single `\` and wsl.exe rejected the malformed argument with E_INVALIDARG.
-        const string commandLine =
+        string commandLine =
             """
             "wsl" -d Ubuntu-22.04 --cd "\\wsl$\Ubuntu-22.04\home\user\src\WLED" git -c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress "--all" --prune --force
-            """;
+            """.Trim();
 
-        const string expected =
+        string expected =
             """
             'wsl' '-d' 'Ubuntu-22.04' '--cd' '\\wsl$\Ubuntu-22.04\home\user\src\WLED' 'git' '-c' 'fetch.parallel=0' '-c' 'submodule.fetchjobs=0' 'fetch' '--progress' '--all' '--prune' '--force'
-            """;
+            """.Trim();
 
         MinttyConsoleRuntime.ConvertCommandLineToBash(commandLine).Should().Be(expected);
     }

--- a/tests/app/UnitTests/GitUI.Tests/ConsoleEmulation/Mintty/MinttyConsoleRuntimeTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ConsoleEmulation/Mintty/MinttyConsoleRuntimeTests.cs
@@ -1,0 +1,116 @@
+using GitUI.ConsoleEmulation.Mintty;
+
+namespace GitUITests.ConsoleEmulation.Mintty;
+
+[TestFixture]
+public sealed class MinttyConsoleRuntimeTests
+{
+    [Test]
+    public void ConvertCommandLineToBash_returns_empty_for_empty_input()
+    {
+        MinttyConsoleRuntime.ConvertCommandLineToBash("").Should().Be("");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_wraps_single_executable_token()
+    {
+        MinttyConsoleRuntime.ConvertCommandLineToBash("git").Should().Be("'git'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_strips_quotes_from_executable_and_keeps_args()
+    {
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" status")
+            .Should().Be("'git' 'status'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_converts_backslashes_in_executable_path_only()
+    {
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""C:\Program Files\Git\bin\git.exe"" status")
+            .Should().Be("'C:/Program Files/Git/bin/git.exe' 'status'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_preserves_backslashes_in_arguments()
+    {
+        // Argument backslashes must NOT be converted — they may belong to Windows-native
+        // paths the target binary needs verbatim (e.g. wsl.exe receiving \\wsl$\... below).
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" log ""C:\repo\file.txt""")
+            .Should().Be(@"'git' 'log' 'C:\repo\file.txt'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_preserves_wsl_unc_path_for_wsl_repo()
+    {
+        // Regression test for WSL repos. Previously the raw command line was spliced into
+        // a bash script verbatim; bash collapsed the `\\` in the double-quoted UNC path
+        // to a single `\` and wsl.exe rejected the malformed argument with E_INVALIDARG.
+        const string commandLine =
+            """
+            "wsl" -d Ubuntu-22.04 --cd "\\wsl$\Ubuntu-22.04\home\user\src\WLED" git -c fetch.parallel=0 -c submodule.fetchjobs=0 fetch --progress "--all" --prune --force
+            """;
+
+        const string expected =
+            """
+            'wsl' '-d' 'Ubuntu-22.04' '--cd' '\\wsl$\Ubuntu-22.04\home\user\src\WLED' 'git' '-c' 'fetch.parallel=0' '-c' 'submodule.fetchjobs=0' 'fetch' '--progress' '--all' '--prune' '--force'
+            """;
+
+        MinttyConsoleRuntime.ConvertCommandLineToBash(commandLine).Should().Be(expected);
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_preserves_dollar_sign_in_arguments()
+    {
+        // `$` must reach the target binary literally; bash would otherwise expand
+        // `$VAR` style references inside double quotes.
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""echo"" ""$HOME and $PATH""")
+            .Should().Be("'echo' '$HOME and $PATH'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_escapes_embedded_single_quote_in_argument()
+    {
+        // Single quote inside a single-quoted bash string: close, escape, reopen.
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" commit -m ""it's working""")
+            .Should().Be(@"'git' 'commit' '-m' 'it'\''s working'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_unescapes_backslash_quote_sequence()
+    {
+        // StringExtensions.Quote() escapes inner `"` as `\"`; the tokenizer must
+        // round-trip the literal quote character into the resulting bash token.
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" commit -m ""say \""hi\""""")
+            .Should().Be(@"'git' 'commit' '-m' 'say ""hi""'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_collapses_runs_of_whitespace_between_tokens()
+    {
+        MinttyConsoleRuntime.ConvertCommandLineToBash("git    status   --short")
+            .Should().Be("'git' 'status' '--short'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_treats_tab_as_token_separator()
+    {
+        MinttyConsoleRuntime.ConvertCommandLineToBash("git\tstatus")
+            .Should().Be("'git' 'status'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_keeps_unquoted_executable_intact()
+    {
+        // Some callers pass an unquoted command (no surrounding `"..."`).
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"C:\tools\bin\app.exe --flag")
+            .Should().Be("'C:/tools/bin/app.exe' '--flag'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_handles_argument_with_spaces_in_quotes()
+    {
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" log --author=""John Doe""")
+            .Should().Be("'git' 'log' '--author=John Doe'");
+    }
+}

--- a/tests/app/UnitTests/GitUI.Tests/ConsoleEmulation/Mintty/MinttyConsoleRuntimeTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/ConsoleEmulation/Mintty/MinttyConsoleRuntimeTests.cs
@@ -113,4 +113,40 @@ public sealed class MinttyConsoleRuntimeTests
         MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" log --author=""John Doe""")
             .Should().Be("'git' 'log' '--author=John Doe'");
     }
+
+    [Test]
+    public void ConvertCommandLineToBash_treats_doubled_backslash_before_closing_quote_as_literal_backslash()
+    {
+        // A properly escaped trailing backslash in a quoted path is written as `\\"`
+        // (two backslashes = one literal backslash, then the closing quote). Without
+        // backslash-run counting the closing quote is swallowed and every following
+        // token is merged into the path.
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" status ""C:\dir\\""")
+            .Should().Be(@"'git' 'status' 'C:\dir\'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_does_not_merge_tokens_after_quoted_trailing_backslash()
+    {
+        // Regression: a quoted argument ending in a backslash must not absorb the
+        // arguments that follow it.
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" -C ""C:\repo\\"" status --short")
+            .Should().Be(@"'git' '-C' 'C:\repo\' 'status' '--short'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_treats_even_backslash_run_before_quote_as_pairs()
+    {
+        // Four backslashes before a quote = two literal backslashes + a real quote toggle.
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" ""a\\\\""b")
+            .Should().Be(@"'git' 'a\\b'");
+    }
+
+    [Test]
+    public void ConvertCommandLineToBash_keeps_odd_backslash_run_before_quote_as_escaped_quote()
+    {
+        // Three backslashes before a quote = one literal backslash + an escaped (literal) quote.
+        MinttyConsoleRuntime.ConvertCommandLineToBash(@"""git"" ""a\\\""b""")
+            .Should().Be(@"'git' 'a\""b'");
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Implement mintty console support - re-using the shell which is installed with Git for Windows. Current ConEmu emulator is not being actively developed and it is totally broken with vim editor. Mintty on other hand is perfectly maintained and works awesome! It's also way faster than ConEmu - feels almost as fast as plain text editor.

The main features supported:
- Use Mintty as both command runner and shell
- Support resizing support
- Support theming support. Add configuration option to select the theme. Offer `monokai-dimmed` by default
- Correctly propagate command exit code all the way up
- Support changing directory in Shell
- Added a bit of timeous in case something does wrong during control creation. It works fine thought during my local testing

Structure of the code was partially inspired by ConEmu, so I also added a concept of a session.

Mintty is not natively supporting embedding, so I use a few tricks to do that:
- Run process with hidden window. Wait until we could discover main window.
- Reposition, re-parent, hide borders, show and focus the main window in the form, so it looks like it's a control
- Run everything in a window job, so when mintty processes exists, all the child processes are killed too.

I am not sure if that embedding is breaking something, it worked okay for me.

Another trick is around bash command. I had to pack quite a long command to run in bash (to print entry point, capture exit code and nicely render "closing"/error message) and passing that inline would be annoying. So instead command is encoded as base64 and is passed as an environment variable. Quite an elegant solution. Later we proceed console output and we could extract exit code.

I also needed to update regex to detect failed push to handle spaces better - there is a difference in what console returns. I don't think it's a bit deal.

I used `Microsoft.Windows.CsWin32` generator to generate native method stubs instead of doing it manually. It's a way nicer way of doing it and it doesn't have runtime dependencies. I didn't touch the existing code, just added it side-by-side.

**Notice**, I was heavily AI coding here with Claude Opus/Sonnet. I read through all the code many times and it looks totally okay to me, but yet most of it is AI-written. 

P.S. As you remember, I initially wanted to support this as an external plugin and you convinced me to contribute it here. I tried my best to make a reasonable solution, but it might be not perfect. So please be kind and reasonable in the requested changes. I do not mind to polish the code a bit. But if you feel like some bigger changes are required/you don't like architecture/etc - I would appreciate your help as well. This project already took many evenings for me 😌

## Known issue

There is a small flickering/lost focus when the console is started. I've already merged PR to mintty to fix it (https://github.com/mintty/mintty/pull/1362), so it will be solved somewhere in the future with a new versions of Git for Windows.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

<img width="1642" height="473" alt="image" src="https://github.com/user-attachments/assets/e54d4498-3590-4540-b14b-72c2e8373dad" />

<img width="934" height="574" alt="image" src="https://github.com/user-attachments/assets/0f942596-80e2-4501-902e-559e34f60b9b" />

<img width="934" height="574" alt="image" src="https://github.com/user-attachments/assets/08a167af-ae43-4c02-8750-85c9fc311a78" />


## Test methodology <!-- How did you ensure quality? -->
Tested it heavily on my Windows machine and work laptop. It looks and works fine so far. I fixed all the issues I caught along the way.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.52.0
- Windows 11
- Tested with both 100% and 150% scaling - looks fine.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
