### PR TITLE
fix(repo menu): Actually update on revisions loaded

### DIFF
--- a/src/app/GitUI/RepositoryCurrentBranchNameCache.cs
+++ b/src/app/GitUI/RepositoryCurrentBranchNameCache.cs
@@ -9,16 +9,30 @@ namespace GitUI;
 /// </summary>
 public interface IRepositoryCurrentBranchNameCache : IRepositoryCurrentBranchNameProvider
 {
-    /// <summary>Returns the cached branch name for <paramref name="repositoryPath"/>, or <see langword="null"/> if not yet cached.</summary>
+    /// <summary>
+    ///  Returns the cached branch name for <paramref name="repositoryPath"/>, or <see langword="null"/> if not yet cached.
+    /// </summary>
     string? GetCachedBranchName(string repositoryPath);
 
-    /// <summary>Writes the resolved branch name into the cache, or removes the entry when the name is blank or error occurred.</summary>
+    /// <summary>
+    ///  Resolves the branch name and forwards it to <see cref="UpdateCache"/>.
+    /// </summary>
+    /// <returns>The branch name for <paramref name="repositoryPath"/>.</returns>
+    string GetUpdatedBranchName(string repositoryPath);
+
+    /// <summary>
+    ///  Writes the resolved branch name into the cache, or removes the entry when the name is blank or error occurred.
+    /// </summary>
     void UpdateCache(string repositoryPath, string branchName);
 
-    /// <summary>Clears all cached branch names, forcing fresh reads on the next access.</summary>
+    /// <summary>
+    ///  Clears all cached branch names, forcing fresh reads on the next access.
+    /// </summary>
     void InvalidateAll();
 
-    /// <summary><see langword="true"/> when no branch names have been cached yet.</summary>
+    /// <summary>
+    ///  Returns <see langword="true"/> when no branch names have been cached yet.
+    /// </summary>
     bool IsEmpty { get; }
 }
 
@@ -29,14 +43,16 @@ internal sealed class RepositoryCurrentBranchNameCache(IRepositoryCurrentBranchN
     public string? GetCachedBranchName(string repositoryPath)
         => _cache.TryGetValue(repositoryPath, out string? cached) ? cached : null;
 
-    /// <summary>Gets the current branch name, reading from the cache when available.</summary>
+    /// <summary>
+    ///  Gets the current branch name, reading from the cache when available.
+    /// </summary>
     public string GetCurrentBranchName(string repositoryPath)
-    {
-        if (_cache.TryGetValue(repositoryPath, out string? cached))
-        {
-            return cached;
-        }
+        => _cache.TryGetValue(repositoryPath, out string? cached)
+            ? cached
+            : GetUpdatedBranchName(repositoryPath);
 
+    public string GetUpdatedBranchName(string repositoryPath)
+    {
         string branchName = inner.GetCurrentBranchName(repositoryPath);
         UpdateCache(repositoryPath, branchName);
         return branchName;

--- a/src/app/GitUI/RepositoryHistoryUIService.cs
+++ b/src/app/GitUI/RepositoryHistoryUIService.cs
@@ -284,7 +284,7 @@ internal class RepositoryHistoryUIService : IRepositoryHistoryUIService
                     .AsParallel()
                     .WithCancellation(cancellationToken)
                     .WithDegreeOfParallelism(Math.Min(MaxBranchNameFetchParallelism, Math.Max(1, Environment.ProcessorCount / 2)))
-                    .ForAll(path => _ = _branchNameCache.GetCurrentBranchName(path));
+                    .ForAll(path => _ = _branchNameCache.GetUpdatedBranchName(path));
             }
         }
     }


### PR DESCRIPTION
Fixes #13036

## Proposed changes

- Add `IRepositoryCurrentBranchNameCache.GetUpdatedBranchName`
- `RepositoryHistoryUIService.UpdateBranchNamesCache`: force update

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).