### PR TITLE
fix(FormPush): Invalidate git config

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -467,6 +467,9 @@ public partial class FormPush : GitModuleForm
         form.ShowDialog(owner);
         ErrorOccurred = form.ErrorOccurred();
 
+        // Invalidate the cached git config so that tracking info written by git (e.g. via --set-upstream) is picked up on the next refresh.
+        Module.InvalidateGitSettings();
+
         if (!Module.InTheMiddleOfAction() && !form.ErrorOccurred())
         {
             ScriptsRunner.RunEventScripts(ScriptEvent.AfterPush, this);


### PR DESCRIPTION
Fixes #13039

## Proposed changes

`FormPush: Invalidate git config in order to get possibly updated tracking info

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).