### PR TITLE
 Use SearchValues to find indexes of chars

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -226,3 +226,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/01/07, xan2622, Xan Seiehun, xan2622(at)online(dot).fr
 2026/01/09, jmg2k, Jonas Guss, 44924601+jmg2k@users.noreply.github.com
 2026/02/19, apoorvdarshan, Apoorv Darshan, ad13dtu(at)gmail.com
+2026/05/04, Henr1k80, Henrik Gedionsen, Henrik.Gedionsen[.@)gmail.com

--- a/src/app/GitCommands/Config/ConfigFile.cs
+++ b/src/app/GitCommands/Config/ConfigFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+using System.Buffers;
+using System.Text;
 using System.Text.RegularExpressions;
 using GitExtensions.Extensibility.Configurations;
 
@@ -7,7 +8,7 @@ namespace GitCommands.Config;
 public class ConfigFile : IConfigFile
 {
     private static Encoding GetEncoding() => GitModule.SystemEncoding;
-    public static readonly char[] CommentChars = [';', '#'];
+    private static readonly SearchValues<char> _commentChars = SearchValues.Create(';', '#');
 
     private readonly List<IConfigSection> _configSections = [];
 
@@ -49,7 +50,7 @@ public class ConfigFile : IConfigFile
         value = value.Replace("\n", "\\n");
         value = value.Replace("\t", "\\t");
 
-        if (value.IndexOfAny(CommentChars) != -1 || value.Trim() != value)
+        if (value.IndexOfAny(_commentChars) != -1 || value.Trim() != value)
         {
             value = value.Quote();
         }

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Frozen;
+using System.Buffers;
+using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -29,6 +30,7 @@ public sealed partial class GitModule : IGitModule
     private const string GitError = "Git Error";
 
     private static readonly Encoding _defaultEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+    private static readonly SearchValues<char> _spaceAndTabSearchValues = SearchValues.Create(' ', '\t');
 
     // the amount of lines we must skip in order to get to an annotated tag's message when doing git cat-file -p <tag_name>
     private static readonly int StandardCatFileTagHeaderLength = 5;
@@ -739,10 +741,10 @@ public sealed partial class GitModule : IGitModule
 
         foreach (string line in unmerged)
         {
-            int findSecondWhitespace = line.IndexOfAny([' ', '\t']);
+            int findSecondWhitespace = line.IndexOfAny(_spaceAndTabSearchValues);
             string fileStage = findSecondWhitespace >= 0 ? line[findSecondWhitespace..].Trim() : "";
 
-            findSecondWhitespace = fileStage.IndexOfAny([' ', '\t']);
+            findSecondWhitespace = fileStage.IndexOfAny(_spaceAndTabSearchValues);
 
             string hash = findSecondWhitespace >= 0 ? fileStage[..findSecondWhitespace].Trim() : "";
             fileStage = findSecondWhitespace >= 0 ? fileStage[findSecondWhitespace..].Trim() : "";

--- a/src/app/GitCommands/PathUtil.cs
+++ b/src/app/GitCommands/PathUtil.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace GitCommands;
@@ -19,6 +20,7 @@ public static partial class PathUtil
     // TODO verify whether the user profile contains forwards/backwards slashes on other platforms
     public static readonly string UserProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
     private static StringComparison _pathComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    private static readonly SearchValues<char> _questionMarkAndHashSearchValues = SearchValues.Create('?', '#');
 
     [GeneratedRegex(@"^(\w+):\/\/([\S]+)", RegexOptions.ExplicitCapture)]
     private static partial Regex DriveLetterRegex { get; }
@@ -129,7 +131,7 @@ public static partial class PathUtil
             return false;
         }
 
-        return (Uri.IsWellFormedUriString(url, UriKind.Absolute) && url.IndexOfAny(['?', '#']) == -1)
+        return (Uri.IsWellFormedUriString(url, UriKind.Absolute) && url.IndexOfAny(_questionMarkAndHashSearchValues) == -1)
                || url.EndsWith(".git", StringComparison.CurrentCultureIgnoreCase)
                || url.EndsWith(".git/", StringComparison.CurrentCultureIgnoreCase)
                || GitModule.IsValidGitWorkingDir(url);

--- a/src/app/GitExtUtils/StringBuilderExtensions.cs
+++ b/src/app/GitExtUtils/StringBuilderExtensions.cs
@@ -1,10 +1,11 @@
-﻿using System.Text;
+using System.Buffers;
+using System.Text;
 
 namespace GitExtUtils;
 
 public static class StringBuilderExtensions
 {
-    private static readonly char[] _whiteSpaceChars = [' ', '\r', '\n', '\t'];
+    private static readonly SearchValues<char> _whiteSpaceChars = SearchValues.Create(' ', '\r', '\n', '\t');
 
     public static StringBuilder AppendQuoted(this StringBuilder builder, string s)
     {

--- a/src/app/GitExtUtils/StringBuilderExtensions.cs
+++ b/src/app/GitExtUtils/StringBuilderExtensions.cs
@@ -1,12 +1,10 @@
-using System.Buffers;
 using System.Text;
+using GitExtensions.Extensibility;
 
 namespace GitExtUtils;
 
 public static class StringBuilderExtensions
 {
-    private static readonly SearchValues<char> _whiteSpaceChars = SearchValues.Create(' ', '\r', '\n', '\t');
-
     public static StringBuilder AppendQuoted(this StringBuilder builder, string s)
     {
         if (NeedsEscaping())
@@ -28,7 +26,7 @@ public static class StringBuilderExtensions
                 return true;
             }
 
-            if (s.IndexOfAny(_whiteSpaceChars) == -1)
+            if (s.IndexOfAny(Delimiters.WhiteSpaceChars) == -1)
             {
                 // Doesn't contain any white space
                 return false;

--- a/src/app/GitExtensions.Extensibility/Delimiters.cs
+++ b/src/app/GitExtensions.Extensibility/Delimiters.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+
 namespace GitExtensions.Extensibility;
 
 /// <summary>
@@ -24,7 +26,8 @@ public static class Delimiters
     public static readonly char[] GitOutput = ['*', Space, LineFeed, CarriageReturn];
     public static readonly char[] LineAndVerticalFeed = [LineFeed, VerticalFeed];
     public static readonly char[] LineFeedAndCarriageReturn = [LineFeed, CarriageReturn];
-    public static readonly char[] LineFeedAndCarriageReturnAndNull = [LineFeed, CarriageReturn, Null];
+    public static readonly SearchValues<char> LineFeedAndCarriageReturnSearchValues = SearchValues.Create(LineFeedAndCarriageReturn);
+    public static readonly SearchValues<char> LineFeedAndCarriageReturnAndNull = SearchValues.Create(LineFeed, CarriageReturn, Null);
     public static readonly string[] NewLines = [$"{CarriageReturn}{LineFeed}", $"{LineFeed}"];
     public static readonly char[] NullAndLineFeed = [Null, LineFeed];
     public static readonly char[] PathSeparators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];

--- a/src/app/GitExtensions.Extensibility/Delimiters.cs
+++ b/src/app/GitExtensions.Extensibility/Delimiters.cs
@@ -34,4 +34,7 @@ public static class Delimiters
     public static readonly SearchValues<char> PathSeparatorsSearchValues = SearchValues.Create(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     public static readonly char[] TabAndLineFeedAndCarriageReturn = [Tab, LineFeed, CarriageReturn];
     public static readonly char[] TabAndSpace = [Tab, Space];
+    public static readonly SearchValues<char> WildcardBranchSearchValues = SearchValues.Create('?', '*', '[');
+    public static readonly SearchValues<char> InvalidPathCharsSearchValues = SearchValues.Create(Path.GetInvalidPathChars());
+    public static readonly SearchValues<char> WhiteSpaceChars = SearchValues.Create(Space, CarriageReturn, LineFeed, Tab);
 }

--- a/src/app/GitExtensions.Extensibility/Delimiters.cs
+++ b/src/app/GitExtensions.Extensibility/Delimiters.cs
@@ -24,13 +24,14 @@ public static class Delimiters
     public const char VerticalFeed = '\v';
 
     public static readonly char[] GitOutput = ['*', Space, LineFeed, CarriageReturn];
-    public static readonly char[] LineAndVerticalFeed = [LineFeed, VerticalFeed];
+    public static readonly SearchValues<char> LineAndVerticalFeed = SearchValues.Create(LineFeed, VerticalFeed);
     public static readonly char[] LineFeedAndCarriageReturn = [LineFeed, CarriageReturn];
     public static readonly SearchValues<char> LineFeedAndCarriageReturnSearchValues = SearchValues.Create(LineFeedAndCarriageReturn);
     public static readonly SearchValues<char> LineFeedAndCarriageReturnAndNull = SearchValues.Create(LineFeed, CarriageReturn, Null);
     public static readonly string[] NewLines = [$"{CarriageReturn}{LineFeed}", $"{LineFeed}"];
     public static readonly char[] NullAndLineFeed = [Null, LineFeed];
     public static readonly char[] PathSeparators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
+    public static readonly SearchValues<char> PathSeparatorsSearchValues = SearchValues.Create(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     public static readonly char[] TabAndLineFeedAndCarriageReturn = [Tab, LineFeed, CarriageReturn];
     public static readonly char[] TabAndSpace = [Tab, Space];
 }

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -332,8 +332,8 @@ public partial class FormClone : GitExtensionsDialog
 
     private void ToTextUpdate(object sender, EventArgs e)
     {
-        bool destinationUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_To.Text) || _NO_TRANSLATE_To.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) >= 0;
-        bool subDirectoryUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_NewDirectory.Text) || _NO_TRANSLATE_NewDirectory.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) >= 0;
+        bool destinationUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_To.Text) || _NO_TRANSLATE_To.Text.IndexOfAny(Delimiters.InvalidPathCharsSearchValues) >= 0;
+        bool subDirectoryUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_NewDirectory.Text) || _NO_TRANSLATE_NewDirectory.Text.IndexOfAny(Delimiters.InvalidPathCharsSearchValues) >= 0;
 
         string destinationDirectory = destinationUnfilled ? $@"[{destinationLabel.Text}]" : _NO_TRANSLATE_To.Text;
         string destinationSubDirectory = subDirectoryUnfilled ? $@"[{subdirectoryLabel.Text}]" : _NO_TRANSLATE_NewDirectory.Text;

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -332,8 +332,8 @@ public partial class FormClone : GitExtensionsDialog
 
     private void ToTextUpdate(object sender, EventArgs e)
     {
-        bool destinationUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_To.Text) || _NO_TRANSLATE_To.Text.IndexOfAny(System.IO.Path.GetInvalidPathChars()) >= 0;
-        bool subDirectoryUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_NewDirectory.Text) || _NO_TRANSLATE_NewDirectory.Text.IndexOfAny(System.IO.Path.GetInvalidPathChars()) >= 0;
+        bool destinationUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_To.Text) || _NO_TRANSLATE_To.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) >= 0;
+        bool subDirectoryUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_NewDirectory.Text) || _NO_TRANSLATE_NewDirectory.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) >= 0;
 
         string destinationDirectory = destinationUnfilled ? $@"[{destinationLabel.Text}]" : _NO_TRANSLATE_To.Text;
         string destinationSubDirectory = subDirectoryUnfilled ? $@"[{subdirectoryLabel.Text}]" : _NO_TRANSLATE_NewDirectory.Text;

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -524,7 +524,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
 
     private void _destinationTB_Validating(object sender, System.ComponentModel.CancelEventArgs e)
     {
-        if (destinationTB.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) != -1)
+        if (destinationTB.Text.IndexOfAny(Delimiters.InvalidPathCharsSearchValues) != -1)
         {
             e.Cancel = true;
         }
@@ -532,7 +532,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
 
     private void _createDirTB_Validating(object sender, System.ComponentModel.CancelEventArgs e)
     {
-        if (createDirTB.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) != -1)
+        if (createDirTB.Text.IndexOfAny(Delimiters.InvalidPathCharsSearchValues) != -1)
         {
             e.Cancel = true;
         }

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -524,7 +524,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
 
     private void _destinationTB_Validating(object sender, System.ComponentModel.CancelEventArgs e)
     {
-        if (destinationTB.Text.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+        if (destinationTB.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) != -1)
         {
             e.Cancel = true;
         }
@@ -532,7 +532,7 @@ public partial class ForkAndCloneForm : GitExtensionsForm
 
     private void _createDirTB_Validating(object sender, System.ComponentModel.CancelEventArgs e)
     {
-        if (createDirTB.Text.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+        if (createDirTB.Text.IndexOfAny(GitUIExtensions.InvalidPathCharsSearchValues) != -1)
         {
             e.Cancel = true;
         }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -164,7 +164,7 @@ Diff selection:
             return;
         }
 
-        bool containsAnyImageWithoutPath = EmbeddedIcons.Images.Keys.Cast<string>().Any(name => !name.ContainsAny(Delimiters.PathSeparators));
+        bool containsAnyImageWithoutPath = EmbeddedIcons.Images.Keys.Cast<string>().Any(name => !name.ContainsAny(Delimiters.PathSeparatorsSearchValues));
         if (!containsAnyImageWithoutPath)
         {
             System.Resources.ResourceManager rm = new("GitUI.Properties.Images", Assembly.GetExecutingAssembly());

--- a/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
@@ -247,7 +247,7 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IPlainText
 
             for (int startIndex = 0; startIndex < output.Length;)
             {
-                int nextLineEnd = output.AsSpan()[startIndex..].IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) + 1;
+                int nextLineEnd = output.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) + 1;
                 if (nextLineEnd == 0)
                 {
                     nextLineEnd = output.Length;

--- a/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
@@ -247,7 +247,7 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IPlainText
 
             for (int startIndex = 0; startIndex < output.Length;)
             {
-                int nextLineEnd = output.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex) + 1;
+                int nextLineEnd = output.AsSpan()[startIndex..].IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) + 1;
                 if (nextLineEnd == 0)
                 {
                     nextLineEnd = output.Length;

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using System.Text;
 using System.Text.RegularExpressions;
 using GitCommands;
@@ -15,8 +14,6 @@ namespace GitUI;
 
 public static partial class GitUIExtensions
 {
-    internal static readonly SearchValues<char> WildcardBranchSearchValues = SearchValues.Create('?', '*', '[');
-    internal static readonly SearchValues<char> InvalidPathCharsSearchValues = SearchValues.Create(Path.GetInvalidPathChars());
     [GeneratedRegex(@"\n\s*(@@|##)\s+(?<file>[^#:\n]+)", RegexOptions.ExplicitCapture)]
     private static partial Regex FileNameRegex { get; }
 

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+using System.Buffers;
+using System.Text;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Git;
@@ -14,6 +15,8 @@ namespace GitUI;
 
 public static partial class GitUIExtensions
 {
+    internal static readonly SearchValues<char> WildcardBranchSearchValues = SearchValues.Create('?', '*', '[');
+    internal static readonly SearchValues<char> InvalidPathCharsSearchValues = SearchValues.Create(Path.GetInvalidPathChars());
     [GeneratedRegex(@"\n\s*(@@|##)\s+(?<file>[^#:\n]+)", RegexOptions.ExplicitCapture)]
     private static partial Regex FileNameRegex { get; }
 

--- a/src/app/GitUI/UserControls/FilterToolBar.cs
+++ b/src/app/GitUI/UserControls/FilterToolBar.cs
@@ -81,7 +81,7 @@ internal partial class FilterToolBar : ToolStripEx
             // Ignore quoting, Git revisions do not allow spaces.
             foreach (string branch in filter.Split((char[]?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
             {
-                bool wildcardBranchFilter = branch.IndexOfAny(['?', '*', '[']) >= 0;
+                bool wildcardBranchFilter = branch.IndexOfAny(GitUIExtensions.WildcardBranchSearchValues) >= 0;
                 if (branch.StartsWith("--") || refs.Any(r => r.LocalName == branch) || branch.Contains(".."))
                 {
                     // Added as git-log option or revision filter

--- a/src/app/GitUI/UserControls/FilterToolBar.cs
+++ b/src/app/GitUI/UserControls/FilterToolBar.cs
@@ -81,7 +81,7 @@ internal partial class FilterToolBar : ToolStripEx
             // Ignore quoting, Git revisions do not allow spaces.
             foreach (string branch in filter.Split((char[]?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
             {
-                bool wildcardBranchFilter = branch.IndexOfAny(GitUIExtensions.WildcardBranchSearchValues) >= 0;
+                bool wildcardBranchFilter = branch.IndexOfAny(Delimiters.WildcardBranchSearchValues) >= 0;
                 if (branch.StartsWith("--") || refs.Any(r => r.LocalName == branch) || branch.Contains(".."))
                 {
                     // Added as git-log option or revision filter

--- a/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -456,7 +456,7 @@ public record FilterInfo
             // Ignore quouting, Git revisions do not allow spaces.
             foreach (string branch in BranchFilter.Split((char[]?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
             {
-                bool wildcardBranchFilter = branch.IndexOfAny(['?', '*', '[']) >= 0;
+                bool wildcardBranchFilter = branch.IndexOfAny(GitUIExtensions.WildcardBranchSearchValues) >= 0;
                 filter.Add(wildcardBranchFilter && !branch.StartsWith("--") && !branch.Contains("..")
                     ? $"--branches={branch}"
                     : branch);

--- a/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -456,7 +456,7 @@ public record FilterInfo
             // Ignore quouting, Git revisions do not allow spaces.
             foreach (string branch in BranchFilter.Split((char[]?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
             {
-                bool wildcardBranchFilter = branch.IndexOfAny(GitUIExtensions.WildcardBranchSearchValues) >= 0;
+                bool wildcardBranchFilter = branch.IndexOfAny(Delimiters.WildcardBranchSearchValues) >= 0;
                 filter.Add(wildcardBranchFilter && !branch.StartsWith("--") && !branch.Contains("..")
                     ? $"--branches={branch}"
                     : branch);

--- a/src/app/GitUI/UserControls/TextBoxSilencer.cs
+++ b/src/app/GitUI/UserControls/TextBoxSilencer.cs
@@ -30,7 +30,7 @@ internal sealed class TextBoxSilencer
         bool isAtFirstColumn = position == _textBox.GetFirstCharIndexOfCurrentLine();
         bool isAtEndColumn = position == GetLineEnd(text, startIndex: position);
         bool isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
-        bool isAtLastLine = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex: position) < 0;
+        bool isAtLastLine = text.AsSpan()[position..].IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) < 0;
         bool ctrl = e.Control;
 
         switch (e.KeyCode)
@@ -48,7 +48,7 @@ internal sealed class TextBoxSilencer
 
     private static int GetLineEnd(string text, int startIndex)
     {
-        int eol = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex);
+        int eol = text.AsSpan()[startIndex..].IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues);
         return eol >= startIndex ? eol : text.Length;
     }
 }

--- a/src/app/GitUI/UserControls/TextBoxSilencer.cs
+++ b/src/app/GitUI/UserControls/TextBoxSilencer.cs
@@ -9,7 +9,7 @@ namespace GitUI.UserControls;
 /// because they are implemented using SendMessage calls.
 internal sealed class TextBoxSilencer
 {
-    private RichTextBox _textBox;
+    private readonly RichTextBox _textBox;
 
     public TextBoxSilencer(RichTextBox textBox)
     {

--- a/src/app/GitUI/UserControls/TextBoxSilencer.cs
+++ b/src/app/GitUI/UserControls/TextBoxSilencer.cs
@@ -30,7 +30,7 @@ internal sealed class TextBoxSilencer
         bool isAtFirstColumn = position == _textBox.GetFirstCharIndexOfCurrentLine();
         bool isAtEndColumn = position == GetLineEnd(text, startIndex: position);
         bool isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
-        bool isAtLastLine = text.AsSpan()[position..].IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) < 0;
+        bool isAtLastLine = text.AsSpan(position).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) < 0;
         bool ctrl = e.Control;
 
         switch (e.KeyCode)
@@ -48,7 +48,7 @@ internal sealed class TextBoxSilencer
 
     private static int GetLineEnd(string text, int startIndex)
     {
-        int eol = text.AsSpan()[startIndex..].IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues);
+        int eol = text.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues);
         return eol >= startIndex ? eol : text.Length;
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes performance

## Proposed changes
- Use .NET 8 `SearchValues` to quickly find indexes of chars
#
~~I have placed the shared ones in the existing `GitUIExtensions` class and made them `internal`, to avoid having new public ones in other projects.  
They can be made public in other projects if they fit better there, or be moved to a new internal class, if that is better.~~

## Test methodology <!-- How did you ensure quality? -->
- Ran the unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.53
- Windows 11


## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
