### PR TITLE
fix(git config): Do not throw on multiple values when not changed

### DIFF
--- a/src/app/GitCommands/Settings/GitConfigSettings.cs
+++ b/src/app/GitCommands/Settings/GitConfigSettings.cs
@@ -106,15 +106,6 @@ public sealed class GitConfigSettings : GitConfigSettingsBase, IGitConfigSetting
 
     public void SetValue(string name, string? value)
     {
-        if (_multiValueSettings.ContainsKey(name))
-        {
-            throw new UserExternalOperationException(new InvalidOperationException($"""
-                Changing multi-value git settings is not supported. Tried to set "{name}" = "{value}".
-                But you have set multiple values for "{name}" in the {GitSettingLevel.ToString().ToLower()} git config file. This is unusual for this configuration entry.
-                Please make the entry unique manually.
-                """));
-        }
-
         name = NormalizeSettingName(name);
 
         if (value?.Length is 0)
@@ -125,6 +116,15 @@ public sealed class GitConfigSettings : GitConfigSettingsBase, IGitConfigSetting
         if (value == GetValue(name))
         {
             return;
+        }
+
+        if (_multiValueSettings.ContainsKey(name))
+        {
+            throw new UserExternalOperationException(new InvalidOperationException($"""
+                Changing multi-value git settings is not supported. Tried to set "{name}" = "{value}".
+                But you have set multiple values for "{name}" in the {GitSettingLevel.ToString().ToLower()} git config file. This is unusual for this configuration entry.
+                Please make the entry unique manually.
+                """));
         }
 
         if (UniqueValueSettings.TryGetValue(name, out string? storedValue) && value == storedValue)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

I have a special git configuration when user name and email is conditional - depending on the current folder. It works correctly with git, but GitExtensions are a bit confused about it.

The main annoyance is when I try to use Git -> Config settings page to update git settings - it doesn't let me and fails with an error, even when I don't touch user name or email.

## Proposed changes

Move the check down, so we throw an error if we indeed try to modify the value. As if we are skipping it anyway - then we should not fail.


## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="442" height="436" alt="image" src="https://github.com/user-attachments/assets/a42459ac-2885-48ac-96b2-ec8cc1741f0c" />

### After

No longer happens if I don't touch user name or email.

## Test methodology <!-- How did you ensure quality? -->

- Saved without modifying user and email - saves
- Tried saving when modifying user or email - fails

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
