### PR TITLE
fix: Fixup substition of startIndex by means of slicing

### DIFF
--- a/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 
@@ -101,8 +101,7 @@ public sealed class RepositoryDescriptionProvider : IRepositoryDescriptionProvid
     {
         const int maxDescriptiveLength = 25;
         string descriptive = Get(repositoryDir, isValidGitWorkingDir: default);
-        int endOfLineIndex = descriptive.IndexOfAny(Delimiters.LineFeedAndCarriageReturnAndNull);
-        int descriptiveEnd = endOfLineIndex >= 0 ? endOfLineIndex : descriptive.Length;
+        int descriptiveEnd = descriptive.GetLineEnd(lineEndings: Delimiters.LineFeedAndCarriageReturnAndNull);
         descriptiveEnd = Math.Min(descriptiveEnd, maxDescriptiveLength);
         ReadOnlySpan<char> shortName = descriptive.AsSpan(0, descriptiveEnd).Trim();
 

--- a/src/app/GitExtensions.Extensibility/Extensions/StringExtensions.cs
+++ b/src/app/GitExtensions.Extensibility/Extensions/StringExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Buffers;
+using GitExtensions.Extensibility;
+
+// ReSharper disable once CheckNamespace
+namespace System;
+
+public static class StringExtensions
+{
+    /// <summary>
+    ///  Returns the index of the first line-ending character at or after <paramref name="startIndex"/>,
+    ///  or <see cref="string.Length"/> if the remainder of the string contains no line ending.
+    /// </summary>
+    /// <param name="startIndex">The zero-based index at which the search starts.</param>
+    /// <param name="lineEndings">The set of characters that count as line endings.</param>
+    /// <returns>The zero-based index of the first line-ending character, or <see cref="string.Length"/> if none was found.</returns>
+    public static int GetLineEnd(this string s, int startIndex = 0, SearchValues<char>? lineEndings = null)
+    {
+        int relativeIndex = s.AsSpan(startIndex).IndexOfAny(lineEndings ?? Delimiters.LineFeedAndCarriageReturnSearchValues);
+        return relativeIndex < 0 ? s.Length : startIndex + relativeIndex;
+    }
+
+    /// <summary>
+    ///  Reports the zero-based index of the first occurrence of any character in <paramref name="values"/>
+    ///  found in this string, starting at <paramref name="startIndex"/>.
+    /// </summary>
+    /// <param name="values">The set of characters to search for.</param>
+    /// <param name="startIndex">The zero-based index at which the search starts.</param>
+    /// <returns>The zero-based index of the first occurrence of any character in <paramref name="values"/>, or -1 if no character was found.</returns>
+    public static int IndexOfAny(this string s, SearchValues<char> values, int startIndex)
+    {
+        int relativeIndex = s.AsSpan(startIndex).IndexOfAny(values);
+        return relativeIndex < 0 ? -1 : startIndex + relativeIndex;
+    }
+}

--- a/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Text;
 using GitCommands;
 using GitCommands.Git.Extensions;
@@ -247,8 +247,8 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IPlainText
 
             for (int startIndex = 0; startIndex < output.Length;)
             {
-                int nextLineEnd = output.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) + 1;
-                if (nextLineEnd == 0)
+                int nextLineEnd = startIndex + output.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) + 1;
+                if (nextLineEnd == startIndex)
                 {
                     nextLineEnd = output.Length;
                 }

--- a/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
+++ b/src/app/GitUI/ConsoleEmulation/PlainText/PlainTextConsoleCommandRunner.cs
@@ -247,16 +247,16 @@ public sealed class PlainTextConsoleCommandRunner : ContainerControl, IPlainText
 
             for (int startIndex = 0; startIndex < output.Length;)
             {
-                int nextLineEnd = startIndex + output.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) + 1;
-                if (nextLineEnd == startIndex)
+                int nextLineStart = output.IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues, startIndex) + 1;
+                if (nextLineStart == 0)
                 {
-                    nextLineEnd = output.Length;
+                    nextLineStart = output.Length;
                 }
 
-                string outputLine = output[startIndex..nextLineEnd];
+                string outputLine = output[startIndex..nextLineStart];
                 CommandOutputReceived?.Invoke(this, new ConsoleOutputEventArgs(outputLine));
 
-                startIndex = nextLineEnd;
+                startIndex = nextLineStart;
             }
         }
     }

--- a/src/app/GitUI/UserControls/TextBoxSilencer.cs
+++ b/src/app/GitUI/UserControls/TextBoxSilencer.cs
@@ -48,7 +48,7 @@ internal sealed class TextBoxSilencer
 
     private static int GetLineEnd(string text, int startIndex)
     {
-        int eol = text.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues);
+        int eol = startIndex + text.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues);
         return eol >= startIndex ? eol : text.Length;
     }
 }

--- a/src/app/GitUI/UserControls/TextBoxSilencer.cs
+++ b/src/app/GitUI/UserControls/TextBoxSilencer.cs
@@ -28,9 +28,9 @@ internal sealed class TextBoxSilencer
         int position = _textBox.SelectionStart;
 
         bool isAtFirstColumn = position == _textBox.GetFirstCharIndexOfCurrentLine();
-        bool isAtEndColumn = position == GetLineEnd(text, startIndex: position);
-        bool isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
-        bool isAtLastLine = text.AsSpan(position).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues) < 0;
+        bool isAtEndColumn = position == text.GetLineEnd(startIndex: position);
+        bool isAtFirstLine = position <= text.GetLineEnd(startIndex: 0);
+        bool isAtLastLine = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues, position) < 0;
         bool ctrl = e.Control;
 
         switch (e.KeyCode)
@@ -44,11 +44,5 @@ internal sealed class TextBoxSilencer
                 e.Handled = true;
                 break;
         }
-    }
-
-    private static int GetLineEnd(string text, int startIndex)
-    {
-        int eol = startIndex + text.AsSpan(startIndex).IndexOfAny(Delimiters.LineFeedAndCarriageReturnSearchValues);
-        return eol >= startIndex ? eol : text.Length;
     }
 }

--- a/tests/app/UnitTests/GitExtensions.Extensibility.Tests/StringExtensionsTests.cs
+++ b/tests/app/UnitTests/GitExtensions.Extensibility.Tests/StringExtensionsTests.cs
@@ -5,7 +5,7 @@ namespace GitExtensions.ExtensibilityTests;
 [TestFixture]
 public sealed class StringExtensionsTests
 {
-    private static readonly SearchValues<char> _separators = SearchValues.Create([',', ';']);
+    private static readonly SearchValues<char> _separators = SearchValues.Create(',', ';');
 
     [TestCase("a,b;c", 0, ExpectedResult = 1)]
     [TestCase("a,b;c", 1, ExpectedResult = 1)]

--- a/tests/app/UnitTests/GitExtensions.Extensibility.Tests/StringExtensionsTests.cs
+++ b/tests/app/UnitTests/GitExtensions.Extensibility.Tests/StringExtensionsTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Buffers;
+
+namespace GitExtensions.ExtensibilityTests;
+
+[TestFixture]
+public sealed class StringExtensionsTests
+{
+    private static readonly SearchValues<char> _separators = SearchValues.Create([',', ';']);
+
+    [TestCase("a,b;c", 0, ExpectedResult = 1)]
+    [TestCase("a,b;c", 1, ExpectedResult = 1)]
+    [TestCase("a,b;c", 2, ExpectedResult = 3)]
+    [TestCase("a,b;c", 3, ExpectedResult = 3)]
+    [TestCase("a,b;c", 4, ExpectedResult = -1)]
+    [TestCase("a,b;c", 5, ExpectedResult = -1)]
+    [TestCase("abc", 0, ExpectedResult = -1)]
+    [TestCase(",", 0, ExpectedResult = 0)]
+    [TestCase(",", 1, ExpectedResult = -1)]
+    [TestCase("", 0, ExpectedResult = -1)]
+    public int IndexOfAny_returns_expected(string input, int startIndex)
+        => input.IndexOfAny(_separators, startIndex);
+
+    [TestCase("abc", 0, ExpectedResult = 3)] // no line ending → string length
+    [TestCase("abc", 2, ExpectedResult = 3)] // startIndex at last char
+    [TestCase("abc", 3, ExpectedResult = 3)] // startIndex past end
+    [TestCase("", 0, ExpectedResult = 0)] // empty string → length (0)
+    [TestCase("a\nb", 0, ExpectedResult = 1)] // LF found from start
+    [TestCase("a\nb", 1, ExpectedResult = 1)] // startIndex at LF
+    [TestCase("a\nb", 2, ExpectedResult = 3)] // startIndex past LF → no further ending
+    [TestCase("a\r\nb", 0, ExpectedResult = 1)] // CR found before LF
+    [TestCase("a\r\nb", 2, ExpectedResult = 2)] // startIndex at LF
+    [TestCase("a\r\nb", 3, ExpectedResult = 4)] // startIndex past CRLF → no ending
+    [TestCase("a\nb\nc", 2, ExpectedResult = 3)] // second LF
+    public int GetLineEnd_returns_expected(string input, int startIndex)
+        => input.GetLineEnd(startIndex);
+}


### PR DESCRIPTION
Fixes regression from #13041
reported in https://github.com/gitextensions/gitextensions/pull/13035#issuecomment-4409980046

## Proposed changes

- `startIndex` must be added to search result if the searched string was sliced by means of `.AsSpan(startIndex)`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).