### PR TITLE
chore: Remove unused parts of ISetting<T>

### DIFF
--- a/src/app/GitCommands/Settings/ISetting.cs
+++ b/src/app/GitCommands/Settings/ISetting.cs
@@ -3,16 +3,6 @@
 public interface ISetting<T>
 {
     /// <summary>
-    ///  Event triggered after settings update.
-    /// </summary>
-    event EventHandler Updated;
-
-    /// <summary>
-    ///  Settings provider.
-    /// </summary>
-    SettingsPath SettingsSource { get; }
-
-    /// <summary>
     /// Name of the setting.
     /// </summary>
     string Name { get; }
@@ -32,14 +22,6 @@ public interface ISetting<T>
     ///  For non nullable is the value from storage or <see cref="Default"/>.
     /// </summary>
     T? Value { get; set; }
-
-    /// <summary>
-    ///  Value of the setting.
-    ///  For nullable except "string" always false (null is value too).
-    ///  For "string" is true when the stored value is null or is false when the stored value not null.
-    ///  For non nullable is true when the stored value is null or is false when the stored value not null.
-    /// </summary>
-    bool IsUnset { get; }
 
     /// <summary>
     ///  Full name of the setting.

--- a/src/app/GitCommands/Settings/RuntimeSetting.cs
+++ b/src/app/GitCommands/Settings/RuntimeSetting.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace GitCommands.Settings;
+﻿namespace GitCommands.Settings;
 
 /// <summary>
 ///  Represents a setting which has to be explicitly saved, if changed at runtime.
@@ -39,11 +37,7 @@ public class RuntimeSetting<T> : IRuntimeSetting<T>
 
     public string FullPath => _persistentSetting.FullPath;
 
-    public bool IsUnset => _persistentSetting.IsUnset;
-
     public string Name => _persistentSetting.Name;
-
-    public SettingsPath SettingsSource => _persistentSetting.SettingsSource;
 
     public T? Value
     {
@@ -56,14 +50,8 @@ public class RuntimeSetting<T> : IRuntimeSetting<T>
             }
 
             _value = value;
-            if (_loaded)
-            {
-                Updated?.Invoke(this, EventArgs.Empty);
-            }
         }
     }
-
-    public event EventHandler? Updated;
 
     public T GetValue(bool reload = false)
     {

--- a/src/app/GitCommands/Settings/Setting.cs
+++ b/src/app/GitCommands/Settings/Setting.cs
@@ -22,28 +22,12 @@ public static class Setting
         return new SettingOf<T?>(settingsSource, name);
     }
 
-    private sealed class SettingOf<T> : ISetting<T>
+    private sealed class SettingOf<T>(SettingsPath settingsSource, string name, T? defaultValue = default) : ISetting<T>
     {
-        /// <inheritdoc />
-        public event EventHandler? Updated;
+        public string Name { get; } = name;
 
-        public SettingOf(SettingsPath settingsSource, string name, T? defaultValue = default)
-        {
-            SettingsSource = settingsSource;
-            Name = name;
-            Default = defaultValue;
-        }
+        public T? Default { get; } = defaultValue;
 
-        /// <inheritdoc />
-        public SettingsPath SettingsSource { get; }
-
-        /// <inheritdoc />
-        public string Name { get; }
-
-        /// <inheritdoc />
-        public T? Default { get; }
-
-        /// <inheritdoc />
         public T? Value
         {
             get
@@ -93,36 +77,14 @@ public static class Setting
                 {
                     SetValue(Name, value);
                 }
-
-                Updated?.Invoke(this, EventArgs.Empty);
             }
         }
 
-        /// <inheritdoc />
-        public bool IsUnset
-        {
-            get
-            {
-                if (default(T) is null)
-                {
-                    if (Type.GetTypeCode(typeof(T)) != TypeCode.String)
-                    {
-                        return false;
-                    }
-                }
-
-                object? storedValue = GetValue(Name);
-
-                return storedValue is null;
-            }
-        }
-
-        /// <inheritdoc />
-        public string FullPath => SettingsSource.PathFor(Name);
+        public string FullPath => settingsSource.PathFor(Name);
 
         private object? GetValue(string name)
         {
-            string? stringValue = SettingsSource.GetValue(name);
+            string? stringValue = settingsSource.GetValue(name);
             if (stringValue is null)
             {
                 return null;
@@ -188,7 +150,7 @@ public static class Setting
                     break;
             }
 
-            SettingsSource.SetValue(name, stringValue);
+            settingsSource.SetValue(name, stringValue);
         }
     }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/RuntimeSettingTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/RuntimeSettingTests.cs
@@ -33,31 +33,25 @@ internal sealed class RuntimeSettingTests
         RuntimeSetting<Enum> runtimeSetting = new(persistentSetting);
 
         runtimeSetting.Value.Should().Be(Enum.HardCodedDefault);
-        runtimeSetting.IsUnset.Should().BeTrue();
 
         runtimeSetting.Value = Enum.PersistentValue;
         runtimeSetting.Value.Should().Be(Enum.PersistentValue);
         persistentSetting.Value.Should().Be(Enum.HardCodedDefault);
-        runtimeSetting.IsUnset.Should().BeTrue();
 
         runtimeSetting.Save();
         runtimeSetting.Value.Should().Be(Enum.PersistentValue);
         persistentSetting.Value.Should().Be(Enum.PersistentValue);
-        runtimeSetting.IsUnset.Should().BeFalse();
 
         runtimeSetting.Value = Enum.RuntimeValue;
         runtimeSetting.Value.Should().Be(Enum.RuntimeValue);
         persistentSetting.Value.Should().Be(Enum.PersistentValue);
-        runtimeSetting.IsUnset.Should().BeFalse();
 
         runtimeSetting.Reload();
         runtimeSetting.Value.Should().Be(Enum.PersistentValue);
         persistentSetting.Value.Should().Be(Enum.PersistentValue);
-        runtimeSetting.IsUnset.Should().BeFalse();
 
         runtimeSetting.ResetToDefault();
         runtimeSetting.Value.Should().Be(Enum.HardCodedDefault);
         persistentSetting.Value.Should().Be(Enum.PersistentValue);
-        runtimeSetting.IsUnset.Should().BeFalse();
     }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -90,26 +90,6 @@ internal sealed class SettingTests
     }
 
     [Test]
-    [TestCaseSource(nameof(SaveCases))]
-    public void Should_trigger_updated_event_for_setting<T>(T settingDefault, T value)
-        where T : struct
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<T> setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().Be(settingDefault);
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
     [TestCaseSource(nameof(CreateCases))]
     public void Should_return_default_value_for_setting_if_value_not_exist<T>(T settingDefault)
         where T : struct
@@ -223,25 +203,6 @@ internal sealed class SettingTests
         storedValue.Should().Be(value ?? string.Empty);
     }
 
-    [Test]
-    [TestCaseSource(nameof(SaveStringCases))]
-    public void Should_trigger_updated_event_for_string_setting(string settingDefault, string value)
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<string> setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().Be(settingDefault ?? string.Empty);
-        setting.Value.Should().Be(value ?? string.Empty);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
     #endregion String Setting
 
     #region Bool Setting
@@ -267,26 +228,6 @@ internal sealed class SettingTests
     [TestCase(false)]
     [TestCase(true)]
     public void Should_save_nullable_bool_setting(bool? value)
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
-    [TestCase(false)]
-    [TestCase(true)]
-    public void Should_trigger_updated_event_for_nullable_bool_setting(bool? value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
@@ -382,26 +323,6 @@ internal sealed class SettingTests
     [TestCase(char.MinValue)]
     [TestCase(' ')]
     public void Should_save_nullable_char_setting(char? value)
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
-    [TestCase(char.MinValue)]
-    [TestCase(' ')]
-    public void Should_trigger_updated_event_for_nullable_char_setting(char? value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
@@ -515,27 +436,6 @@ internal sealed class SettingTests
     }
 
     [Test]
-    [TestCase(byte.MinValue)]
-    [TestCase(byte.MaxValue)]
-    [TestCase(0)]
-    public void Should_trigger_updated_event_for_nullable_byte_setting(byte? value)
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
     public void Should_return_default_value_for_nullable_byte_setting_if_value_not_exist()
     {
         string pathName = Guid.NewGuid().ToString();
@@ -632,27 +532,6 @@ internal sealed class SettingTests
     }
 
     [Test]
-    [TestCase(int.MinValue)]
-    [TestCase(int.MaxValue)]
-    [TestCase(0)]
-    public void Should_trigger_updated_event_for_nullable_int_setting(int? value)
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
     public void Should_return_default_value_for_nullable_int_setting_if_value_not_exist()
     {
         string pathName = Guid.NewGuid().ToString();
@@ -732,27 +611,6 @@ internal sealed class SettingTests
     [TestCase(float.MaxValue)]
     [TestCase(0f)]
     public void Should_save_nullable_float_setting(float? value)
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
-    [TestCase(float.MinValue)]
-    [TestCase(float.MaxValue)]
-    [TestCase(0f)]
-    public void Should_trigger_updated_event_for_nullable_float_setting(float? value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
@@ -905,26 +763,6 @@ internal sealed class SettingTests
     }
 
     [Test]
-    [TestCase(TestEnum.First)]
-    [TestCase(TestEnum.Second)]
-    public void Should_trigger_updated_event_for_nullable_enum_setting(TestEnum? value)
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-
-        ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
     public void Should_return_default_value_for_nullable_enum_setting_if_value_not_exist()
     {
         string pathName = Guid.NewGuid().ToString();
@@ -1006,32 +844,6 @@ internal sealed class SettingTests
 
     [Test]
     public void Should_save_nullable_struct_setting()
-    {
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        TestStruct? value = new TestStruct
-        {
-            Bool = false,
-            Char = ' ',
-            Byte = 0,
-            Int = 0,
-            Float = 0f
-        };
-
-        ISetting<TestStruct?> setting = Setting.Create<TestStruct>(settingsPath, settingName);
-
-        setting.Value = value;
-
-        setting.Should().NotBeNull();
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-    }
-
-    [Test]
-    public void Should_trigger_updated_event_for_nullable_struct_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -39,21 +39,16 @@ internal sealed class SettingTests
     public void Should_create_setting<T>(T settingDefault)
         where T : struct
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<T> setting = Setting.Create(settingsPath, settingName, settingDefault);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().Be(settingDefault);
         setting.Value.Should().Be(settingDefault);
-        setting.IsUnset.Should().BeTrue();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -62,14 +57,12 @@ internal sealed class SettingTests
     public void Should_save_setting<T>(T settingDefault, T value)
         where T : struct
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         T storedValue = default;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<T> setting = Setting.Create(settingsPath, settingName, settingDefault);
@@ -93,7 +86,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().Be(value);
     }
 
@@ -102,65 +94,19 @@ internal sealed class SettingTests
     public void Should_trigger_updated_event_for_setting<T>(T settingDefault, T value)
         where T : struct
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<T> setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().Be(settingDefault);
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCaseSource(nameof(SaveCases))]
-    public void Should_not_trigger_updated_event_for_setting<T>(T settingDefault, T value)
-        where T : struct
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<T> setting = Setting.Create(settingsPath, settingName, settingDefault);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().Be(settingDefault);
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     [Test]
@@ -168,14 +114,12 @@ internal sealed class SettingTests
     public void Should_return_default_value_for_setting_if_value_not_exist<T>(T settingDefault)
         where T : struct
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         T storedValue = default;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<T> setting = Setting.Create(settingsPath, settingName, settingDefault);
@@ -183,7 +127,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().Be(settingDefault);
     }
 
@@ -192,14 +135,12 @@ internal sealed class SettingTests
     public void Should_return_default_value_for_setting_if_value_is_incorrect<T>(T settingDefault)
         where T : struct
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         T storedValue = default;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
@@ -223,7 +164,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().Be(settingDefault);
     }
 
@@ -235,21 +175,16 @@ internal sealed class SettingTests
     [TestCaseSource(nameof(CreateStringCases))]
     public void Should_create_string_setting(string settingDefault)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<string> setting = Setting.Create(settingsPath, settingName, settingDefault);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().Be(settingDefault ?? string.Empty);
         setting.Value.Should().Be(settingDefault ?? string.Empty);
-        setting.IsUnset.Should().BeTrue();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -257,13 +192,11 @@ internal sealed class SettingTests
     [TestCaseSource(nameof(SaveStringCases))]
     public void Should_save_string_setting(string settingDefault, string value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
         string? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, settingDefault);
@@ -287,7 +220,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().Be(value ?? string.Empty);
     }
 
@@ -295,64 +227,19 @@ internal sealed class SettingTests
     [TestCaseSource(nameof(SaveStringCases))]
     public void Should_trigger_updated_event_for_string_setting(string settingDefault, string value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<string> setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().Be(settingDefault ?? string.Empty);
-        setting.Value.Should().Be(value ?? string.Empty);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCaseSource(nameof(SaveStringCases))]
-    public void Should_not_trigger_updated_event_for_string_setting(string settingDefault, string value)
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<string> setting = Setting.Create(settingsPath, settingName, settingDefault);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().Be(settingDefault ?? string.Empty);
         setting.Value.Should().Be(value ?? string.Empty);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     #endregion String Setting
@@ -362,21 +249,16 @@ internal sealed class SettingTests
     [Test]
     public void Should_create_nullable_bool_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().BeNull();
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -386,23 +268,18 @@ internal sealed class SettingTests
     [TestCase(true)]
     public void Should_save_nullable_bool_setting(bool? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
 
         setting.Value = value;
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -411,79 +288,30 @@ internal sealed class SettingTests
     [TestCase(true)]
     public void Should_trigger_updated_event_for_nullable_bool_setting(bool? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCase(null)]
-    [TestCase(false)]
-    [TestCase(true)]
-    public void Should_not_trigger_updated_event_for_nullable_bool_setting(bool? value)
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_bool_setting_if_value_not_exist()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         bool? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
@@ -491,21 +319,18 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_bool_setting_if_value_is_incorrect()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         bool? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
@@ -529,7 +354,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
@@ -540,21 +364,16 @@ internal sealed class SettingTests
     [Test]
     public void Should_create_nullable_char_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().BeNull();
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -564,23 +383,18 @@ internal sealed class SettingTests
     [TestCase(' ')]
     public void Should_save_nullable_char_setting(char? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
 
         setting.Value = value;
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -589,79 +403,30 @@ internal sealed class SettingTests
     [TestCase(' ')]
     public void Should_trigger_updated_event_for_nullable_char_setting(char? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCase(null)]
-    [TestCase(char.MinValue)]
-    [TestCase(' ')]
-    public void Should_not_trigger_updated_event_for_nullable_char_setting(char? value)
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_char_setting_if_value_not_exist()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         char? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
@@ -669,21 +434,18 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_char_setting_if_value_is_incorrect()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         char? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
@@ -707,7 +469,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
@@ -718,21 +479,16 @@ internal sealed class SettingTests
     [Test]
     public void Should_create_nullable_byte_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().BeNull();
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -743,23 +499,18 @@ internal sealed class SettingTests
     [TestCase(0)]
     public void Should_save_nullable_byte_setting(byte? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
 
         setting.Value = value;
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -769,80 +520,30 @@ internal sealed class SettingTests
     [TestCase(0)]
     public void Should_trigger_updated_event_for_nullable_byte_setting(byte? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCase(null)]
-    [TestCase(byte.MinValue)]
-    [TestCase(byte.MaxValue)]
-    [TestCase(0)]
-    public void Should_not_trigger_updated_event_for_nullable_byte_setting(byte? value)
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_byte_setting_if_value_not_exist()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         byte? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
@@ -850,21 +551,18 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_byte_setting_if_value_is_incorrect()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         byte? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
@@ -888,7 +586,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
@@ -899,21 +596,16 @@ internal sealed class SettingTests
     [Test]
     public void Should_create_nullable_int_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().BeNull();
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -924,23 +616,18 @@ internal sealed class SettingTests
     [TestCase(0)]
     public void Should_save_nullable_int_setting(int? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
 
         setting.Value = value;
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -950,80 +637,30 @@ internal sealed class SettingTests
     [TestCase(0)]
     public void Should_trigger_updated_event_for_nullable_int_setting(int? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCase(null)]
-    [TestCase(int.MinValue)]
-    [TestCase(int.MaxValue)]
-    [TestCase(0)]
-    public void Should_not_trigger_updated_event_for_nullable_int_setting(int? value)
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_int_setting_if_value_not_exist()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         int? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
@@ -1031,21 +668,18 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_int_setting_if_value_is_incorrect()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         int? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
@@ -1069,7 +703,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
@@ -1080,21 +713,16 @@ internal sealed class SettingTests
     [Test]
     public void Should_create_nullable_float_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().BeNull();
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -1105,23 +733,18 @@ internal sealed class SettingTests
     [TestCase(0f)]
     public void Should_save_nullable_float_setting(float? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
 
         setting.Value = value;
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -1131,80 +754,30 @@ internal sealed class SettingTests
     [TestCase(0f)]
     public void Should_trigger_updated_event_for_nullable_float_setting(float? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCase(null)]
-    [TestCase(float.MinValue)]
-    [TestCase(float.MaxValue)]
-    [TestCase(0f)]
-    public void Should_not_trigger_updated_event_for_nullable_float_setting(float? value)
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_float_setting_if_value_not_exist()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         float? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
@@ -1212,21 +785,18 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_float_setting_if_value_is_incorrect()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         float? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
@@ -1250,7 +820,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
@@ -1261,21 +830,16 @@ internal sealed class SettingTests
     [Test]
     public void Should_create_nullable_enum_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().BeNull();
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -1285,23 +849,18 @@ internal sealed class SettingTests
     [TestCase(TestEnum.Second)]
     public void Should_save_nullable_enum_setting(TestEnum? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
 
         setting.Value = value;
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
@@ -1311,14 +870,12 @@ internal sealed class SettingTests
     [TestCase(TestEnum.Second)]
     public void Should_save_nullable_enum_setting_as_string(TestEnum? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         string? storedValue = string.Empty;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
@@ -1344,7 +901,6 @@ internal sealed class SettingTests
 
         bool isNumber = int.TryParse(storedValue, out _);
 
-        // Assert
         isNumber.Should().BeFalse();
     }
 
@@ -1353,79 +909,30 @@ internal sealed class SettingTests
     [TestCase(TestEnum.Second)]
     public void Should_trigger_updated_event_for_nullable_enum_setting(TestEnum? value)
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
 
-        // Act
-        ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    [TestCase(null)]
-    [TestCase(TestEnum.First)]
-    [TestCase(TestEnum.Second)]
-    public void Should_not_trigger_updated_event_for_nullable_enum_setting(TestEnum? value)
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        bool updated = false;
-
-        // Act
         ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_enum_setting_if_value_not_exist()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         TestEnum? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
@@ -1433,21 +940,18 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
     [Test]
     public void Should_return_default_value_for_nullable_enum_setting_if_value_is_incorrect()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
         TestEnum? storedValue = null;
 
-        // Act
         AppSettings.UsingContainer(_settingContainer, () =>
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
@@ -1471,7 +975,6 @@ internal sealed class SettingTests
             storedValue = setting.Value;
         });
 
-        // Assert
         storedValue.Should().BeNull();
     }
 
@@ -1488,28 +991,22 @@ internal sealed class SettingTests
     [Test]
     public void Should_create_nullable_struct_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        // Act
         ISetting<TestStruct?> setting = Setting.Create<TestStruct>(settingsPath, settingName);
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().BeNull();
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
     public void Should_save_nullable_struct_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
@@ -1522,25 +1019,20 @@ internal sealed class SettingTests
             Float = 0f
         };
 
-        // Act
         ISetting<TestStruct?> setting = Setting.Create<TestStruct>(settingsPath, settingName);
 
         setting.Value = value;
 
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
     public void Should_trigger_updated_event_for_nullable_struct_setting()
     {
-        // Arrange
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
@@ -1553,68 +1045,15 @@ internal sealed class SettingTests
             Float = 0f
         };
 
-        bool updated = false;
-
-        // Act
-        ISetting<TestStruct?> setting = Setting.Create<TestStruct>(settingsPath, settingName);
-
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
-        setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
-        setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
-        setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeTrue();
-    }
-
-    [Test]
-    public void Should_not_trigger_updated_event_for_nullable_struct_setting()
-    {
-        // Arrange
-        string pathName = Guid.NewGuid().ToString();
-        string settingName = Guid.NewGuid().ToString();
-        AppSettingsPath settingsPath = new(pathName);
-        TestStruct? value = new TestStruct
-        {
-            Bool = false,
-            Char = ' ',
-            Byte = 0,
-            Int = 0,
-            Float = 0f
-        };
-
-        bool updated = false;
-
-        // Act
         ISetting<TestStruct?> setting = Setting.Create<TestStruct>(settingsPath, settingName);
 
         setting.Value = value;
 
-        setting.Updated += (source, eventArgs) =>
-        {
-            updated = true;
-        };
-
-        setting.Value = value;
-
-        // Assert
         setting.Should().NotBeNull();
-        setting.SettingsSource.Should().Be(settingsPath);
         setting.Name.Should().Be(settingName);
         setting.Default.Should().BeNull();
         setting.Value.Should().Be(value);
-        setting.IsUnset.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
-        updated.Should().BeFalse();
     }
 
     public struct TestStruct


### PR DESCRIPTION
first part from #12959, extended

## Proposed changes

- `ISetting<T>`: Remove unused event `Updated` as well as properties `SettingsSource` and `IsUnset`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapt existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).