### PR TITLE
fix(set_version_to.cs): Add shebang

### DIFF
--- a/eng/set_version_to.cs
+++ b/eng/set_version_to.cs
@@ -1,3 +1,4 @@
+﻿#!/usr/bin/env dotnet-run
 #:property TargetFramework=net10.0
 #:property UseWindowsForms=false
 #:property EnableStyleCopAnalyzers=false


### PR DESCRIPTION
Fixes GHA build failure since yesterday

## Proposed changes

- `set_version_to.cs`: Add shebang "#!...", which is mandatory since Visual Studio 2026 and the .NET 10 SDK

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- CI

## Test environment(s) <!-- Remove any that don't apply -->

GHA redirecting to windows-2025-vs2026 which includes Visual Studio 2026 and the .NET 10 SDK

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).