### PR TITLE
fix(FileStatusList): Avoid filename truncation to empty

### DIFF
--- a/src/app/GitUI/UserControls/PathFormatter.cs
+++ b/src/app/GitUI/UserControls/PathFormatter.cs
@@ -26,7 +26,7 @@ internal sealed class PathFormatter
     public (string? prefix, string? text, string? suffix) FormatTextForDrawing(int maxWidth, string name, string? oldName)
     {
         string? prefix = null;
-        string? text = string.Empty;
+        string? text = string.IsNullOrEmpty(name) ? "" : "...";
         string? suffix = null;
 
         switch (AppSettings.TruncatePathMethod)
@@ -37,17 +37,14 @@ internal sealed class PathFormatter
 
             case TruncatePathMethod.None:
             case TruncatePathMethod.Compact when !OperatingSystem.IsWindows():
-                (prefix, text, suffix) = FormatString(name, oldName, step: 0, isNameTruncated: false);
+                (prefix, text, suffix) = FormatString(name, oldName, step: 0);
                 return (prefix, text, suffix);
 
             default:
-                int maxStep = oldName is null
-                    ? name.Length
-                    : Math.Max(name.Length, oldName.Length) * 2;
-
+                int maxStep = name.Length + (oldName?.Length ?? 0);
                 BinarySearch.Find(min: 0, count: maxStep + 1, step =>
                 {
-                    (string? tmpPrefix, string? tmpText, string? tmpSuffix) = FormatString(name, oldName, step, isNameTruncated: step % 2 == 0);
+                    (string? tmpPrefix, string? tmpText, string? tmpSuffix) = FormatString(name, oldName, step);
                     int measuredWidth = MeasureString(tmpPrefix, tmpText, tmpSuffix).Width;
                     bool isShortEnough = measuredWidth <= maxWidth;
 
@@ -99,15 +96,15 @@ internal sealed class PathFormatter
     public void DrawString(string str, Rectangle rect, Color color) =>
         TextRenderer.DrawText(_graphics, str, _font, rect, color, FilePathStringFormat);
 
-    private static (string? prefix, string? text, string? suffix) FormatString(string name, string? oldName, int step, bool isNameTruncated)
+    private static (string? prefix, string? text, string? suffix) FormatString(string name, string? oldName, int step)
     {
         if (oldName is not null)
         {
-            int numberOfTruncatedChars = step / 2;
-            int nameTruncatedChars = isNameTruncated ? step - numberOfTruncatedChars : numberOfTruncatedChars;
-            int oldNameTruncatedChars = step - nameTruncatedChars;
+            // Suffix (oldName) is truncated first so that 'name' text always takes precedence.
+            int oldNameTruncatedChars = Math.Min(step, oldName.Length);
+            int nameTruncatedChars = step - oldNameTruncatedChars;
 
-            (string? path, string? filename) = SplitPathName(TruncatePath(name, name.Length - oldNameTruncatedChars));
+            (string? path, string? filename) = SplitPathName(TruncatePath(name, name.Length - nameTruncatedChars));
             string? suffix = FormatOldName(TruncatePath(oldName, oldName.Length - oldNameTruncatedChars));
             return (path, filename, suffix);
         }
@@ -124,7 +121,9 @@ internal sealed class PathFormatter
 
             if (length <= 0)
             {
-                return string.Empty;
+                // A non-empty truncated path must still be represented by "..." so that
+                // the caller can always show at least a minimal indication of a path.
+                return "...";
             }
 
             // The win32 method PathCompactPathEx is only supported on Windows
@@ -179,5 +178,6 @@ internal sealed class PathFormatter
     {
         internal static string? FormatOldName(string oldName) => PathFormatter.FormatOldName(oldName);
         internal static (string? path, string? fileName) SplitPathName(string name) => PathFormatter.SplitPathName(name);
+        internal static (string? prefix, string? text, string? suffix) FormatString(string name, string? oldName, int step) => PathFormatter.FormatString(name, oldName, step);
     }
 }

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/PathFormatterTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/PathFormatterTests.cs
@@ -32,8 +32,8 @@ public class PathFormatterTests
     [TestCase("name.ext", "old.ext", TruncatePathMethod.None, int.MaxValue, null, "name.ext", " (old.ext)")]
     [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.None, int.MaxValue, "path/", "name.ext", " (old/old.ext)")]
     [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, int.MaxValue, "path/", "name.ext", " (old/old.ext)")]
-    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, 1, null, "", null)]
-    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, 18, null, "", null)]
+    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, 1, null, "...", null)]
+    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, 18, null, "...", null)]
     [TestCase("name.ext", null, TruncatePathMethod.FileNameOnly, int.MaxValue, null, "name.ext", null)]
     [TestCase("path/name.ext", null, TruncatePathMethod.FileNameOnly, int.MaxValue, null, "name.ext", null)]
     [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.FileNameOnly, int.MaxValue, null, "name.ext", " (old.ext)")]
@@ -63,6 +63,65 @@ public class PathFormatterTests
         int maxWidth = formatter.MeasureString(null, string.Empty, $" ({oldName})").Width;
 
         formatter.FormatTextForDrawing(maxWidth, string.Empty, oldName).Should().Be((null, string.Empty, $" ({oldName})"));
+    }
+
+    [Test]
+    public void FormatTextForDrawing_TrimStart_non_empty_name_never_yields_empty_text()
+    {
+        // Even with maxWidth so small that nothing fits, a non-empty name must still
+        // produce at least "..." so the caller always has something to display.
+        AppSettings.TruncatePathMethod = TruncatePathMethod.TrimStart;
+        PathFormatter formatter = new(_graphics, _font);
+
+        (string? prefix, string? text, string? suffix) = formatter.FormatTextForDrawing(maxWidth: 0, name: "path/file.ext", oldName: null);
+
+        prefix.Should().BeNull();
+        text.Should().Be("...");
+        suffix.Should().BeNull();
+    }
+
+    [Test]
+    public void FormatTextForDrawing_TrimStart_truncates_suffix_before_text()
+    {
+        // FormatString must consume all oldName chars before touching name chars.
+        // Check that at every step up to oldName.Length the text is unchanged,
+        // and only beyond that does text start to shrink.
+        const string name = "file.ext";
+        const string oldName = "very_long_old_name.ext";
+        AppSettings.TruncatePathMethod = TruncatePathMethod.TrimStart;
+
+        for (int step = 0; step <= oldName.Length; step++)
+        {
+            (string? prefix, string? text, string? suffix) = PathFormatter.TestAccessor.FormatString(name, oldName, step);
+
+            // Name must stay fully intact while only the suffix is being consumed.
+            prefix.Should().BeNull($"step={step}");
+            text.Should().Be(name, $"step={step}");
+        }
+
+        // One step beyond the full oldName length: name must start shrinking.
+        (string? prefixAfter, string? textAfter, string? suffixAfter) = PathFormatter.TestAccessor.FormatString(name, oldName, oldName.Length + 1);
+
+        textAfter.Should().NotBe(name, "name must start shrinking once oldName is fully consumed");
+        suffixAfter.Should().Be(" (...)", "with TrimStart the maximally-truncated oldName is still shown as '...'");
+    }
+
+    [Test]
+    public void FormatTextForDrawing_TrimStart_truncates_name_independently_of_oldName()
+    {
+        // Verify name and oldName are truncated by their respective counters (not swapped).
+        // At step 0 both strings appear unmodified.
+        const string name = "path/file.ext";
+        const string oldName = "oldpath/oldfile.ext";
+        AppSettings.TruncatePathMethod = TruncatePathMethod.TrimStart;
+        PathFormatter formatter = new(_graphics, _font);
+        int maxWidth = formatter.MeasureString("path/", "file.ext", $" ({oldName})").Width;
+
+        (string? prefix, string? text, string? suffix) = formatter.FormatTextForDrawing(maxWidth, name, oldName);
+
+        prefix.Should().Be("path/");
+        text.Should().Be("file.ext");
+        suffix.Should().Be($" ({oldName})");
     }
 
     [TestCase("new.ext", null, "new.ext", null)]

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/PathFormatterTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/PathFormatterTests.cs
@@ -1,9 +1,70 @@
-﻿using GitUI;
+﻿using GitCommands;
+using GitUI;
 
 namespace GitUITests.CommandsDialogs;
 
 public class PathFormatterTests
 {
+    private Bitmap _bitmap = null!;
+    private Graphics _graphics = null!;
+    private Font _font = null!;
+    private TruncatePathMethod _originalTruncatePathMethod;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bitmap = new Bitmap(1, 1);
+        _graphics = Graphics.FromImage(_bitmap);
+        _font = SystemFonts.DefaultFont;
+        _originalTruncatePathMethod = AppSettings.TruncatePathMethod;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        AppSettings.TruncatePathMethod = _originalTruncatePathMethod;
+        _graphics.Dispose();
+        _bitmap.Dispose();
+    }
+
+    [TestCase("name.ext", null, TruncatePathMethod.None, int.MaxValue, null, "name.ext", null)]
+    [TestCase("path/name.ext", null, TruncatePathMethod.None, int.MaxValue, "path/", "name.ext", null)]
+    [TestCase("name.ext", "old.ext", TruncatePathMethod.None, int.MaxValue, null, "name.ext", " (old.ext)")]
+    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.None, int.MaxValue, "path/", "name.ext", " (old/old.ext)")]
+    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, int.MaxValue, "path/", "name.ext", " (old/old.ext)")]
+    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, 1, null, "", null)]
+    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.TrimStart, 18, null, "", null)]
+    [TestCase("name.ext", null, TruncatePathMethod.FileNameOnly, int.MaxValue, null, "name.ext", null)]
+    [TestCase("path/name.ext", null, TruncatePathMethod.FileNameOnly, int.MaxValue, null, "name.ext", null)]
+    [TestCase("path/name.ext", "old/old.ext", TruncatePathMethod.FileNameOnly, int.MaxValue, null, "name.ext", " (old.ext)")]
+    public void FormatTextForDrawing_returns_expected_for_method(
+        string name,
+        string? oldName,
+        TruncatePathMethod truncatePathMethod,
+        int maxWidth,
+        string? expectedPrefix,
+        string? expectedText,
+        string? expectedSuffix)
+    {
+        AppSettings.TruncatePathMethod = truncatePathMethod;
+        PathFormatter formatter = new(_graphics, _font);
+
+        formatter.FormatTextForDrawing(maxWidth, name, oldName).Should().Be((expectedPrefix, expectedText, expectedSuffix));
+    }
+
+    [Test]
+    public void FormatTextForDrawing_TrimStart_with_empty_name_returns_null_prefix_empty_text_and_oldName_suffix()
+    {
+        // When name is empty and oldName differs, even a low maxWidth accommodates
+        // the suffix-only result produced at step 0 of the binary search.
+        const string oldName = "b";
+        AppSettings.TruncatePathMethod = TruncatePathMethod.TrimStart;
+        PathFormatter formatter = new(_graphics, _font);
+        int maxWidth = formatter.MeasureString(null, string.Empty, $" ({oldName})").Width;
+
+        formatter.FormatTextForDrawing(maxWidth, string.Empty, oldName).Should().Be((null, string.Empty, $" ({oldName})"));
+    }
+
     [TestCase("new.ext", null, "new.ext", null)]
     [TestCase("new.ext", "", "new.ext", null)]
     [TestCase("path/new.ext", null, "new.ext", null)]


### PR DESCRIPTION
Fixes #13028

## Proposed changes

`PathFormatter.FormatTextForDrawing(int maxWidth, string name, string? oldName)`:
- Truncate `oldName` first, then `name`, i.e. not interchanging as before
- Never return empty string on non-empty input, return "..." at least

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="400" height="348" alt="image" src="https://github.com/user-attachments/assets/87e4a2ab-1d34-41ff-b920-93a4d7057f95" />

<img width="400" height="348" alt="image" src="https://github.com/user-attachments/assets/67e46ac0-8d33-4425-bf7c-410da338b571" />

### After

<img width="400" height="348" alt="image" src="https://github.com/user-attachments/assets/05c122c9-a490-4985-9053-4e614c3a8b2d" />

<img width="400" height="348" alt="image" src="https://github.com/user-attachments/assets/5c631da4-9e35-45b9-b5cf-932c0e5cf58a" />

## Test methodology <!-- How did you ensure quality? -->

- add tests reproducing the issue
- add further tests for the change

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).