### PR TITLE
perf(ObjectId): convert from sealed class to readonly struct

### DIFF
--- a/src/app/GitCommands/AppTitleGenerator.cs
+++ b/src/app/GitCommands/AppTitleGenerator.cs
@@ -81,7 +81,7 @@ public sealed class AppTitleGenerator : IAppTitleGenerator
     public static void Initialise(string sha, string buildBranch)
     {
 #if DEBUG
-        if (ObjectId.TryParse(sha, out ObjectId? objectId))
+        if (ObjectId.TryParse(sha, out ObjectId objectId))
         {
             _extraInfo = $" {objectId.ToShortString()}";
             if (!string.IsNullOrWhiteSpace(buildBranch))

--- a/src/app/GitCommands/ArgumentBuilderExtensions.cs
+++ b/src/app/GitCommands/ArgumentBuilderExtensions.cs
@@ -231,16 +231,15 @@ public static class ArgumentBuilderExtensions
     /// <summary>
     /// Adds <paramref name="objectId"/> as a SHA-1 argument without allocating a string.
     /// </summary>
-    /// <remarks>
-    /// If <paramref name="objectId"/> is <c>null</c> then no change is made to the arguments.
-    /// </remarks>
     /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-    /// <param name="objectId">The SHA-1 object ID to add to the builder, or <c>null</c>.</param>
-    /// <exception cref="ArgumentException"><paramref name="objectId"/> represents an artificial commit.</exception>
-    [SkipLocalsInit]
-    public static void Add(this ArgumentBuilder builder, ObjectId? objectId)
+    /// <param name="objectId">The SHA-1 object ID to add to the builder.</param>
+    /// <exception cref="ArgumentException"><paramref name="objectId"/> does not represent a real git object.</exception>
+    /// <remarks>
+    ///  If <paramref name="objectId"/> is zero then no change is made to the arguments.
+    /// </remarks>
+    public static void Add(this ArgumentBuilder builder, ObjectId objectId)
     {
-        if (objectId is null)
+        if (objectId.IsZero)
         {
             return;
         }
@@ -258,20 +257,17 @@ public static class ArgumentBuilderExtensions
     /// <summary>
     /// Adds a sequence of <paramref name="objectIds"/> to the builder.
     /// </summary>
-    /// <remarks>
-    /// If <paramref name="objectIds"/> is <c>null</c> then no change is made to the arguments.
-    /// </remarks>
     /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-    /// <param name="objectIds">A sequence of SHA-1 object IDs to add to the builder, or <c>null</c>.</param>
+    /// <param name="objectIds">A sequence of SHA-1 object IDs to add to the builder, or <see langword="null"/>.</param>
     /// <exception cref="ArgumentException"><paramref name="objectIds"/> contains an artificial commit.</exception>
-    public static void Add(this ArgumentBuilder builder, IEnumerable<ObjectId?>? objectIds)
+    public static void Add(this ArgumentBuilder builder, IEnumerable<ObjectId>? objectIds)
     {
         if (objectIds is null)
         {
             return;
         }
 
-        foreach (ObjectId? objectId in objectIds)
+        foreach (ObjectId objectId in objectIds)
         {
             builder.Add(objectId);
         }

--- a/src/app/GitCommands/CommitDataManager.cs
+++ b/src/app/GitCommands/CommitDataManager.cs
@@ -117,9 +117,9 @@ public sealed class CommitDataManager : ICommitDataManager
     {
         ArgumentNullException.ThrowIfNull(revision);
 
-        if (revision.ObjectId is null)
+        if (revision.ObjectId.IsZero)
         {
-            throw new ArgumentException($"Cannot have a null {nameof(GitRevision.ObjectId)}.", nameof(revision));
+            throw new ArgumentException($"Cannot have a zero {nameof(GitRevision.ObjectId)}.", nameof(revision));
         }
 
         return new CommitData(revision.ObjectId, revision.ParentIds,

--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -72,13 +72,13 @@ public static partial class Commands
         };
     }
 
-    public static ArgumentString Branch(string branchName, string revision, bool checkout)
+    public static ArgumentString Branch(string branchName, ObjectId objectId, bool checkout)
     {
         return new GitArgumentBuilder(checkout ? "checkout" : "branch")
         {
             { checkout, "-b" },
             branchName.Trim().Quote(),
-            revision?.Trim().QuoteNE()
+            objectId
         };
     }
 
@@ -211,12 +211,12 @@ public static partial class Commands
         };
     }
 
-    public static ArgumentString ContinueBisect(GitBisectOption bisectOption, params ObjectId[] revisions)
+    public static ArgumentString ContinueBisect(GitBisectOption bisectOption, params ObjectId[] objectIds)
     {
         return new GitArgumentBuilder("bisect")
         {
             bisectOption,
-            revisions
+            objectIds
         };
     }
 
@@ -231,7 +231,7 @@ public static partial class Commands
     }
 
     /// <summary>Create a new orphan branch from <paramref name="startPoint"/> and switch to it.</summary>
-    public static ArgumentString CreateOrphan(string newBranchName, ObjectId? startPoint = null)
+    public static ArgumentString CreateOrphan(string newBranchName, ObjectId startPoint = default)
     {
         return new GitArgumentBuilder("checkout")
         {

--- a/src/app/GitCommands/Git/Commands.cs
+++ b/src/app/GitCommands/Git/Commands.cs
@@ -58,9 +58,9 @@ public static partial class Commands
 
         static void Validate(GitCreateTagArgs gitCreateTagArgs, string? tagMessageFileName)
         {
-            if (gitCreateTagArgs.ObjectId is null)
+            if (gitCreateTagArgs.ObjectId.IsArtificial)
             {
-                throw new ArgumentException("Revision is required.");
+                throw new ArgumentException("A valid, non-artificial revision is required for tagging.", nameof(gitCreateTagArgs.ObjectId));
             }
 
             if (string.IsNullOrWhiteSpace(gitCreateTagArgs.TagName))

--- a/src/app/GitCommands/Git/GetAllChangedFilesOutputParser.cs
+++ b/src/app/GitCommands/Git/GetAllChangedFilesOutputParser.cs
@@ -104,7 +104,7 @@ public class GetAllChangedFilesOutputParser
                 gitItemStatusX.IsSubmodule = true;
             }
 
-            // ignore the sha in status (could be used to set TreeGuid)
+            // ignore the sha in status (could be used to set TreeId)
 
             diffFiles.Add(gitItemStatusX);
         }

--- a/src/app/GitCommands/Git/GitCreateTagArgs.cs
+++ b/src/app/GitCommands/Git/GitCreateTagArgs.cs
@@ -1,4 +1,4 @@
-using GitCommands.Git.Tag;
+﻿using GitCommands.Git.Tag;
 using GitExtensions.Extensibility.Git;
 
 namespace GitCommands.Git;
@@ -16,6 +16,11 @@ public class GitCreateTagArgs
     /// <param name="force">Force parameter</param>
     public GitCreateTagArgs(string tagName, ObjectId objectId, TagOperation operation = TagOperation.Lightweight, string tagMessage = "", string signKeyId = "", bool force = false)
     {
+        if (objectId.IsArtificial)
+        {
+            throw new ArgumentException("A valid, non-artificial revision is required for tagging.", nameof(objectId));
+        }
+
         TagName = tagName;
         ObjectId = objectId;
         Operation = operation;

--- a/src/app/GitCommands/Git/GitDescribeProvider.cs
+++ b/src/app/GitCommands/Git/GitDescribeProvider.cs
@@ -9,10 +9,10 @@ public interface IGitDescribeProvider
     /// If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number
     /// of additional commits on top of the tagged object and the abbreviated object name of the most recent commit.
     /// </summary>
-    /// <param name="revision">A revision to describe.</param>
+    /// <param name="objectId">An objectId to describe.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>Describe information.</returns>
-    (string precedingTag, string commitCount) Get(ObjectId revision, CancellationToken cancellationToken = default);
+    (string precedingTag, string commitCount) Get(ObjectId objectId, CancellationToken cancellationToken = default);
 }
 
 public sealed class GitDescribeProvider : IGitDescribeProvider
@@ -25,9 +25,9 @@ public sealed class GitDescribeProvider : IGitDescribeProvider
     }
 
     /// <inheritdoc />
-    public (string precedingTag, string commitCount) Get(ObjectId revision, CancellationToken cancellationToken = default)
+    public (string precedingTag, string commitCount) Get(ObjectId objectId, CancellationToken cancellationToken = default)
     {
-        string? description = GetModule().GetDescribe(revision, cancellationToken);
+        string? description = GetModule().GetDescribe(objectId, cancellationToken);
         if (string.IsNullOrEmpty(description))
         {
             return (string.Empty, string.Empty);
@@ -40,7 +40,7 @@ public sealed class GitDescribeProvider : IGitDescribeProvider
         }
 
         string commitHash = description[(commitHashPos + 2)..];
-        if (commitHash.Length == 0 || revision.ToString() != commitHash)
+        if (commitHash.Length == 0 || objectId.ToString() != commitHash)
         {
             return (description, string.Empty);
         }

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -868,7 +868,7 @@ public sealed partial class GitModule : IGitModule
 
     public string GetCommitCountString(ObjectId fromId, string to)
     {
-        bool cache = !fromId.IsArtificial && ObjectId.TryParse(to, out ObjectId? toId) && !toId.IsArtificial;
+        bool cache = !fromId.IsArtificial && ObjectId.TryParse(to, out ObjectId toId) && !toId.IsArtificial;
         (int? added, int? removed) = GetRevListLeftRightCount(fromId, to, cache);
 
         if (removed is null || added is null)
@@ -961,9 +961,9 @@ public sealed partial class GitModule : IGitModule
         return GetParents(objectId).Count > 1;
     }
 
-    public GitRevision GetRevision(ObjectId? objectId = null, bool shortFormat = false, bool loadRefs = false)
+    public GitRevision GetRevision(ObjectId objectId = default, bool shortFormat = false, bool loadRefs = false)
     {
-        GitRevision revision = new RevisionReader(this, allBodies: true).GetRevision(objectId?.ToString()!, hasNotes: !shortFormat, throwOnError: true, cancellationToken: default)!;
+        GitRevision revision = new RevisionReader(this, allBodies: true).GetRevision(objectId.IsZero ? null! : objectId.ToString(), hasNotes: !shortFormat, throwOnError: true, cancellationToken: default)!;
 
         if (loadRefs)
         {
@@ -1041,19 +1041,19 @@ public sealed partial class GitModule : IGitModule
 
     /// <summary>
     /// Gets the commit ID of the currently checked out commit.
-    /// If the repo is bare, has no commits, detached head or is corrupt, <c>null</c> is returned.
+    /// If the repo is bare, has no commits, detached head or is corrupt, a zero <see cref="ObjectId"/> is returned.
     /// </summary>
-    public ObjectId? GetCurrentCheckout()
+    public ObjectId GetCurrentCheckout()
     {
         GitArgumentBuilder args = new("rev-parse") { "HEAD" };
         ExecutionResult result = GitExecutable.Execute(args, throwOnErrorExit: false);
 
-        return result.ExitedSuccessfully && ObjectId.TryParse(result.StandardOutput, offset: 0, out ObjectId? objectId)
+        return result.ExitedSuccessfully && ObjectId.TryParse(result.StandardOutput, offset: 0, out ObjectId objectId)
             ? objectId
-            : null;
+            : default;
     }
 
-    public bool TryResolvePartialCommitId(string objectIdPrefix, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public bool TryResolvePartialCommitId(string objectIdPrefix, out ObjectId objectId)
     {
         // If the prefix is already a full SHA1 then return immediately without invoking a git process.
         if (ObjectId.TryParse(objectIdPrefix, out objectId))
@@ -1079,11 +1079,11 @@ public sealed partial class GitModule : IGitModule
         return false;
     }
 
-    public async Task<(char Code, ObjectId? CommitId)> GetSuperprojectCurrentCheckoutAsync()
+    public async Task<(char Code, ObjectId CommitId)> GetSuperprojectCurrentCheckoutAsync()
     {
         if (string.IsNullOrEmpty(SuperprojectModule?.WorkingDir))
         {
-            return (' ', null);
+            return (' ', default);
         }
 
         GitArgumentBuilder args = new("submodule")
@@ -1097,15 +1097,15 @@ public sealed partial class GitModule : IGitModule
 
         if (lines.Length == 0)
         {
-            return (' ', null);
+            return (' ', default);
         }
 
         string submodule = lines[0];
 
         if (submodule.Length < ObjectId.Sha1CharCount + 3
-            || !ObjectId.TryParse(submodule, 1, out ObjectId? commitId))
+            || !ObjectId.TryParse(submodule, 1, out ObjectId commitId))
         {
-            return (' ', null);
+            return (' ', default);
         }
 
         return (submodule[0], commitId);
@@ -1241,7 +1241,7 @@ public sealed partial class GitModule : IGitModule
             string localPath = match.Groups["path"].Value;
             string branch = match.Groups["branch"].Value;
 
-            if (!ObjectId.TryParse(match.Groups["sha"].Value, out ObjectId? currentCommitId))
+            if (!ObjectId.TryParse(match.Groups["sha"].Value, out ObjectId currentCommitId))
             {
                 info = default;
                 return false;
@@ -1342,9 +1342,9 @@ public sealed partial class GitModule : IGitModule
     /// <param name="output">Error messages from the reset.</param>
     /// <param name="progressAction">Action when unstaging files (to update a progress bar).</param>
     /// <returns><see langword="true"/> if successfully executed</returns>
-    public bool ResetChanges(ObjectId? resetId, IReadOnlyList<GitItemStatus> selectedItems, bool resetAndDelete, IFullPathResolver fullPathResolver, out StringBuilder output, Action<BatchProgressEventArgs>? progressAction = null)
+    public bool ResetChanges(ObjectId resetId, IReadOnlyList<GitItemStatus> selectedItems, bool resetAndDelete, IFullPathResolver fullPathResolver, out StringBuilder output, Action<BatchProgressEventArgs>? progressAction = null)
     {
-        if (resetId?.IsArtificial is true && resetId != ObjectId.IndexId)
+        if (resetId.IsArtificial && resetId != ObjectId.IndexId)
         {
             throw new InvalidOperationException(nameof(resetId));
         }
@@ -1423,7 +1423,7 @@ public sealed partial class GitModule : IGitModule
             }
             else if (!item.IsNew && !postUnstageStatus.Value.Any(i => i.IsNew && i.Name == item.Name))
             {
-                if (resetId is not null || UnmergedNotIndex(item, postUnstageStatus))
+                if (!resetId.IsZero || UnmergedNotIndex(item, postUnstageStatus))
                 {
                     filesToCheckout.Add(item.IsRenamed ? item.OldName! : item.Name);
                 }
@@ -1491,15 +1491,33 @@ public sealed partial class GitModule : IGitModule
             });
     }
 
-    public string CheckoutFiles(IReadOnlyList<string> files, ObjectId? revision, bool force)
+    public string CheckoutFiles(IReadOnlyList<string> files, ObjectId objectId, bool force)
     {
-        if (files.Count == 0 || (revision?.IsArtificial is true && revision != ObjectId.IndexId))
+        if (files.Count == 0 || (objectId.IsArtificial && objectId != ObjectId.IndexId))
         {
             return "";
         }
 
-        // Reset to index has no revision string
-        string revStr = revision == ObjectId.IndexId ? "" : revision?.ToString() ?? RevParse("HEAD")!.ToString();
+        // Reset to index has no objectId string
+        string revStr;
+        if (objectId == ObjectId.IndexId)
+        {
+            revStr = "";
+        }
+        else if (objectId.IsZero)
+        {
+            ObjectId headObjectId = RevParse("HEAD");
+            if (headObjectId.IsZero)
+            {
+                throw new InvalidOperationException("Cannot checkout files because HEAD could not be resolved.");
+            }
+
+            revStr = headObjectId.ToString();
+        }
+        else
+        {
+            revStr = objectId.ToString();
+        }
 
         // Run batch arguments to work around max command line length on Windows. Fix #6593
         // 3: double quotes + ' '
@@ -2242,8 +2260,8 @@ public sealed partial class GitModule : IGitModule
     }
 
     public async Task<ExecutionResult> GetSingleDifftoolAsync(
-        ObjectId? firstId,
-        ObjectId? secondId,
+        ObjectId firstId,
+        ObjectId secondId,
         string? fileName,
         string? oldFileName,
         ArgumentString extraDiffArguments,
@@ -2256,8 +2274,8 @@ public sealed partial class GitModule : IGitModule
         // fix refs slashes
         fileName = fileName.ToPosixPath();
         oldFileName = oldFileName.ToPosixPath();
-        string? firstRevision = firstId?.ToString();
-        string? secondRevision = secondId?.ToString();
+        string? firstRevision = firstId.IsZero ? null : firstId.ToString();
+        string? secondRevision = secondId.IsZero ? null : secondId.ToString();
 
         string? diffOptions = _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked);
 
@@ -2292,8 +2310,8 @@ public sealed partial class GitModule : IGitModule
     }
 
     public async Task<(Patch? Patch, string? ErrorMessage)> GetSingleDiffAsync(
-        ObjectId? firstId,
-        ObjectId? secondId,
+        ObjectId firstId,
+        ObjectId secondId,
         string? fileName,
         string? oldFileName,
         string extraDiffArguments,
@@ -2307,8 +2325,8 @@ public sealed partial class GitModule : IGitModule
         // fix refs slashes
         fileName = fileName.ToPosixPath();
         oldFileName = oldFileName.ToPosixPath();
-        string? firstRevision = firstId?.ToString();
-        string? secondRevision = secondId?.ToString();
+        string? firstRevision = firstId.IsZero ? null : firstId.ToString();
+        string? secondRevision = secondId.IsZero ? null : secondId.ToString();
 
         string? diffOptions = _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked);
 
@@ -2352,8 +2370,8 @@ public sealed partial class GitModule : IGitModule
     public async Task<ExecutionResult> GetRangeDiffAsync(
         ObjectId firstId,
         ObjectId secondId,
-        ObjectId? firstBase,
-        ObjectId? secondBase,
+        ObjectId firstBase,
+        ObjectId secondBase,
         string extraDiffArguments,
         string? pathFilter,
         bool useGitColoring,
@@ -2364,7 +2382,7 @@ public sealed partial class GitModule : IGitModule
         string first = firstId.IsArtificial ? "HEAD" : firstId.ToString();
         string second = secondId.IsArtificial ? "HEAD" : secondId.ToString();
 
-        if ((firstBase?.IsArtificial is true) || (secondBase?.IsArtificial is true))
+        if (firstBase.IsArtificial || secondBase.IsArtificial)
         {
             throw new ArgumentException($"Cannot get range diff for artificial commit base of A: {firstBase} or base of B: {secondBase}.");
         }
@@ -2377,7 +2395,7 @@ public sealed partial class GitModule : IGitModule
             { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
             { useGitColoring, "--color=always" },
             extraDiffArguments,
-            { firstBase is null || secondBase is null,  $"{first}...{second}", $"{firstBase}..{first} {secondBase}..{second}" },
+            { firstBase.IsZero || secondBase.IsZero,  $"{first}...{second}", $"{firstBase}..{first} {secondBase}..{second}" },
             { GitVersion.SupportRangeDiffPath && !string.IsNullOrWhiteSpace(pathFilter), "--" },
             { GitVersion.SupportRangeDiffPath && !string.IsNullOrWhiteSpace(pathFilter), pathFilter }
         };
@@ -2527,15 +2545,15 @@ public sealed partial class GitModule : IGitModule
             cancellationToken: cancellationToken);
     }
 
-    public IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(ObjectId? firstId,
-        ObjectId? secondId,
-        ObjectId? parentToSecond,
+    public IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(ObjectId firstId,
+        ObjectId secondId,
+        ObjectId parentToSecond,
         bool excludeSkipWorktreeFiles,
         UntrackedFilesMode untrackedFilesMode,
         CancellationToken cancellationToken)
     {
         StagedStatus stagedStatus = GetStagedStatus(firstId, secondId, parentToSecond);
-        IReadOnlyList<GitItemStatus> status = GetDiffFilesWithUntracked(firstId?.ToString(), secondId?.ToString(), stagedStatus, excludeSkipWorktreeFiles, untrackedFilesMode, cancellationToken: cancellationToken);
+        IReadOnlyList<GitItemStatus> status = GetDiffFilesWithUntracked(firstId.IsZero ? null : firstId.ToString(), secondId.IsZero ? null : secondId.ToString(), stagedStatus, excludeSkipWorktreeFiles, untrackedFilesMode, cancellationToken: cancellationToken);
         GetSubmoduleDiffStatus(status, firstId, secondId, cancellationToken);
         return status;
     }
@@ -2543,11 +2561,11 @@ public sealed partial class GitModule : IGitModule
     /// <summary>
     /// If possible, find if files in a diff are index or worktree.
     /// </summary>
-    /// <param name="firstId">from revision string.</param>
-    /// <param name="secondId">to revision.</param>
-    /// <param name="parentToSecond">The parent for the second revision.</param>
+    /// <param name="firstId">from objectId string.</param>
+    /// <param name="secondId">to objectId.</param>
+    /// <param name="parentToSecond">The parent for the second objectId.</param>
     /// <remarks>Git revisions are required to determine if <see cref="StagedStatus"/> allows stage/unstage.</remarks>
-    public static StagedStatus GetStagedStatus(ObjectId? firstId, ObjectId? secondId, ObjectId? parentToSecond)
+    public static StagedStatus GetStagedStatus(ObjectId firstId, ObjectId secondId, ObjectId parentToSecond)
     {
         StagedStatus staged;
         if (firstId == ObjectId.IndexId && secondId == ObjectId.WorkTreeId)
@@ -2558,8 +2576,7 @@ public sealed partial class GitModule : IGitModule
         {
             staged = StagedStatus.Index;
         }
-        else if (firstId is not null && !firstId.IsArtificial &&
-                 secondId is not null && !secondId.IsArtificial)
+        else if (!firstId.IsZeroOrArtificial && !secondId.IsZeroOrArtificial)
         {
             // This cannot be a worktree/index file
             staged = StagedStatus.None;
@@ -2601,7 +2618,7 @@ public sealed partial class GitModule : IGitModule
                 ((x.Staged == StagedStatus.WorkTree && x.IsNew) || x.IsStatusOnly))];
             if (firstRevision == GitRevision.WorkTreeGuid)
             {
-                // The file is seen as "deleted" in 'to' revision
+                // The file is seen as "deleted" in 'to' objectId
                 foreach (GitItemStatus item in files)
                 {
                     item.IsNew = false;
@@ -2630,7 +2647,7 @@ public sealed partial class GitModule : IGitModule
             "--max-count=1"
         };
         ExecutionResult executionResult = GitExecutable.Execute(args, throwOnErrorExit: false);
-        if (executionResult.ExitedSuccessfully && ObjectId.TryParse(executionResult.StandardOutput, out ObjectId? treeId))
+        if (executionResult.ExitedSuccessfully && ObjectId.TryParse(executionResult.StandardOutput, out ObjectId treeId))
         {
             IEnumerable<GitItemStatus> files = GetTreeFiles(treeId, full: true)
                 .Select(i =>
@@ -2651,14 +2668,14 @@ public sealed partial class GitModule : IGitModule
             {
                 // IsTracked is always true, only tracked are reported
                 // (all with TreeId are tracked)
-                // TreeGuid for worktree reflects Index, just for reference
+                // TreeId for worktree reflects Index, just for reference
                 // New/Changed/Deleted are are just set
                 IsTracked = true,
                 IsNew = false,
                 IsChanged = false,
                 IsDeleted = false,
                 Staged = StagedStatus.Unset,
-                TreeGuid = file.ObjectId,
+                TreeId = file.ObjectId,
                 IsSubmodule = file.ObjectType == GitObjectType.Commit
             })
             .ToList();
@@ -2770,7 +2787,7 @@ public sealed partial class GitModule : IGitModule
         }
     }
 
-    private void GetSubmoduleDiffStatus(IReadOnlyList<GitItemStatus> status, ObjectId? firstId, ObjectId? secondId, CancellationToken cancellationToken)
+    private void GetSubmoduleDiffStatus(IReadOnlyList<GitItemStatus> status, ObjectId firstId, ObjectId secondId, CancellationToken cancellationToken)
     {
         foreach (GitItemStatus item in status.Where(i => i.IsSubmodule))
         {
@@ -3202,9 +3219,9 @@ public sealed partial class GitModule : IGitModule
             .Split(Delimiters.NullAndLineFeed);
     }
 
-    public IEnumerable<IObjectGitItem> GetTree(ObjectId? commitId, bool full, string fileName = "", CancellationToken cancellationToken = default)
+    public IEnumerable<IObjectGitItem> GetTree(ObjectId commitId, bool full, string fileName = "", CancellationToken cancellationToken = default)
     {
-        bool isArtificial = commitId?.IsArtificial is true;
+        bool isArtificial = commitId.IsArtificial;
         if (isArtificial && !full)
         {
             throw new ArgumentOutOfRangeException(nameof(full), "Artificial commit requires 'full'.");
@@ -3230,7 +3247,7 @@ public sealed partial class GitModule : IGitModule
                 // optimized codepath, default is "--format={_gitTreeParser.GitTreeFormat}"
                 "-z",
                 { full, "-r" },
-                { commitId?.ToString() ?? "HEAD" },
+                { commitId.IsZero ? "HEAD" : commitId.ToString() },
                 "--",
                 fileName.QuoteNE()
             };
@@ -3350,7 +3367,7 @@ public sealed partial class GitModule : IGitModule
         List<GitBlameLine> lines = new(capacity: Math.Min(Math.Max(256, output.Length / GitBlameLengthPerLineHeuristicValue), 5000));
 
         bool hasCommitHeader;
-        ObjectId? objectId;
+        ObjectId objectId;
         int finalLineNumber;
         int originLineNumber;
         string? author;
@@ -3381,15 +3398,18 @@ public sealed partial class GitModule : IGitModule
                 // The contents of the actual line is output after the above header, prefixed by a TAB. This is to allow adding more header elements later.
                 string text = ReEncodeStringFromLossless(line[1..], encoding);
 
+                // objectId is guaranteed to be set by the preceding git blame header line
+                ObjectId oid = objectId.IsZero ? throw new InvalidOperationException("Invalid git blame output: missing object ID header before content line.") : objectId;
+
                 GitBlameCommit commit;
                 if (hasCommitHeader)
                 {
                     // TODO quite a few nullable suppressions here (via ! character) which should be addressed as they hint at a design flaw
 
-                    if (!commitByObjectId.TryGetValue(objectId!, out GitBlameCommit? commitData))
+                    if (!commitByObjectId.TryGetValue(oid, out GitBlameCommit? commitData))
                     {
                         commit = new GitBlameCommit(
-                            objectId!,
+                            oid,
                             author!,
                             authorMail!,
                             authorTime,
@@ -3400,7 +3420,7 @@ public sealed partial class GitModule : IGitModule
                             committerTimeZone!,
                             summary!,
                             filename!);
-                        commitByObjectId[objectId!] = commit;
+                        commitByObjectId[oid] = commit;
                     }
                     else
                     {
@@ -3427,7 +3447,7 @@ public sealed partial class GitModule : IGitModule
                 }
                 else
                 {
-                    commit = commitByObjectId[objectId!];
+                    commit = commitByObjectId[oid];
                 }
 
                 lines.Add(new GitBlameLine(commit, finalLineNumber, originLineNumber, text));
@@ -3492,7 +3512,7 @@ public sealed partial class GitModule : IGitModule
         void Reset()
         {
             hasCommitHeader = false;
-            objectId = null;
+            objectId = default;
             finalLineNumber = -1;
             originLineNumber = -1;
             author = null;
@@ -3526,12 +3546,12 @@ public sealed partial class GitModule : IGitModule
         return exec.StandardOutput;
     }
 
-    public ObjectId? GetFileBlobHash(string fileName, ObjectId objectId)
+    public ObjectId GetFileBlobHash(string fileName, ObjectId objectId)
     {
         IObjectGitItem[] items = [.. GetTree(objectId, full: true, fileName)];
         return items.Length == 1 && items[0].ObjectType is GitObjectType.Blob
             ? items[0].ObjectId
-            : null;
+            : default;
     }
 
     public Task<MemoryStream?> GetFileStreamAsync(string blob, CancellationToken cancellationToken)
@@ -3615,14 +3635,14 @@ public sealed partial class GitModule : IGitModule
         });
     }
 
-    public ObjectId? RevParse(string? revisionExpression)
+    public ObjectId RevParse(string? revisionExpression)
     {
         if (string.IsNullOrWhiteSpace(revisionExpression) || revisionExpression.Length > 260)
         {
-            return null;
+            return default;
         }
 
-        if (ObjectId.TryParse(revisionExpression, out ObjectId? objectId))
+        if (ObjectId.TryParse(revisionExpression, out ObjectId objectId))
         {
             return objectId;
         }
@@ -3637,10 +3657,10 @@ public sealed partial class GitModule : IGitModule
 
         return result.ExitedSuccessfully && ObjectId.TryParse(result.StandardOutput, offset: 0, out objectId)
             ? objectId
-            : null;
+            : default;
     }
 
-    public ObjectId? GetMergeBase(ObjectId a, ObjectId b)
+    public ObjectId GetMergeBase(ObjectId a, ObjectId b)
     {
         if (a == b)
         {
@@ -3655,9 +3675,9 @@ public sealed partial class GitModule : IGitModule
         ExecutionResult result = GitExecutable.Execute(args, cache: GitCommandCache, throwOnErrorExit: false);
         string output = result.StandardOutput;
 
-        return ObjectId.TryParse(output, offset: 0, out ObjectId? objectId)
+        return ObjectId.TryParse(output, offset: 0, out ObjectId objectId)
             ? objectId
-            : null;
+            : default;
     }
 
     public bool CheckBranchFormat(string branchName)
@@ -3683,7 +3703,7 @@ public sealed partial class GitModule : IGitModule
 
         string fullBranchName = GitRefName.GetFullBranchName(branchName);
 
-        if (RevParse(fullBranchName) is null)
+        if (RevParse(fullBranchName).IsZero)
         {
             return branchName;
         }
@@ -3920,7 +3940,7 @@ public sealed partial class GitModule : IGitModule
     }
 
     public bool GetCombinedDiffContent(
-        ObjectId revisionOfMergeCommit,
+        ObjectId objectIdOfMergeCommit,
         string filePath,
         string extraArgs,
         Encoding encoding,
@@ -3936,7 +3956,7 @@ public sealed partial class GitModule : IGitModule
             { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
             { useGitColoring, "--color=always" },
             extraArgs,
-            revisionOfMergeCommit,
+            objectIdOfMergeCommit,
             "--",
             filePath.ToPosixPath().Quote()
         };
@@ -4096,7 +4116,7 @@ public sealed partial class GitModule : IGitModule
         public List<GitItemStatus> GetDiffChangedFilesFromString(string statusString, StagedStatus staged)
             => _gitModule.GetDiffChangedFilesFromString(statusString, staged);
 
-        public StagedStatus GetStagedStatus(ObjectId? firstId, ObjectId? secondId, ObjectId? parentToSecond)
+        public StagedStatus GetStagedStatus(ObjectId firstId, ObjectId secondId, ObjectId parentToSecond)
             => GitModule.GetStagedStatus(firstId, secondId, parentToSecond);
     }
 }

--- a/src/app/GitCommands/Git/GitRef.cs
+++ b/src/app/GitCommands/Git/GitRef.cs
@@ -23,11 +23,11 @@ public sealed class GitRef : IGitRef
 
     public IGitModule Module { get; }
 
-    public GitRef(IGitModule module, ObjectId? objectId, string completeName, string remote = "")
+    public GitRef(IGitModule module, ObjectId objectId, string completeName, string remote = "")
     {
         Module = module;
         ObjectId = objectId;
-        Guid = objectId?.ToString();
+        Guid = objectId.IsZero ? null : objectId.ToString();
         CompleteName = completeName;
         Remote = remote;
 
@@ -169,12 +169,12 @@ public sealed class GitRef : IGitRef
 
     public static GitRef NoHead(IGitModule module)
     {
-        return new GitRef(module, null, "");
+        return new GitRef(module, default, "");
     }
 
     #region IGitItem Members
 
-    public ObjectId? ObjectId { get; }
+    public ObjectId ObjectId { get; }
     public string? Guid { get; }
     public string Name { get; }
 

--- a/src/app/GitCommands/Git/GitSubmoduleInfo.cs
+++ b/src/app/GitCommands/Git/GitSubmoduleInfo.cs
@@ -12,12 +12,17 @@ public sealed class GitSubmoduleInfo : IGitSubmoduleInfo
     public bool IsInitialized { get; }
     public bool IsUpToDate { get; }
 
-    public GitSubmoduleInfo(string name, string localPath, string remotePath, ObjectId currentCommitGuid, string branch, bool isInitialized, bool isUpToDate)
+    public GitSubmoduleInfo(string name, string localPath, string remotePath, ObjectId currentCommitId, string branch, bool isInitialized, bool isUpToDate)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         LocalPath = localPath ?? throw new ArgumentNullException(nameof(localPath));
         RemotePath = remotePath ?? throw new ArgumentNullException(nameof(remotePath));
-        CurrentCommitId = currentCommitGuid ?? throw new ArgumentNullException(nameof(currentCommitGuid));
+        if (currentCommitId.IsZero)
+        {
+            throw new ArgumentNullException(nameof(currentCommitId));
+        }
+
+        CurrentCommitId = currentCommitId;
         Branch = branch ?? throw new ArgumentNullException(nameof(branch));
         IsInitialized = isInitialized;
         IsUpToDate = isUpToDate;

--- a/src/app/GitCommands/Git/SubmoduleHelpers.cs
+++ b/src/app/GitCommands/Git/SubmoduleHelpers.cs
@@ -12,7 +12,7 @@ public static partial class SubmoduleHelpers
     [GeneratedRegex(@"diff --cc (?<filenamea>.+)", RegexOptions.ExplicitCapture)]
     private static partial Regex CombinedDiffCommandRegex { get; }
 
-    public static async Task<GitSubmoduleStatus?> GetSubmoduleDiffChangesAsync(IGitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId, CancellationToken cancellationToken)
+    public static async Task<GitSubmoduleStatus?> GetSubmoduleDiffChangesAsync(IGitModule module, string? fileName, string? oldFileName, ObjectId firstId, ObjectId secondId, CancellationToken cancellationToken)
     {
         (Patch? patch, string? errorMessage) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true, isTracked: true, useGitColoring: false, commandConfiguration: null!, cancellationToken: cancellationToken).ConfigureAwait(false);
         return GetSubmoduleChanges(patch, errorMessage, module, fileName);
@@ -29,7 +29,7 @@ public static partial class SubmoduleHelpers
         if (!string.IsNullOrEmpty(errorMessage))
         {
             // (some) Git errors, propagate
-            return new GitSubmoduleStatus(errorMessage, null, false, null, null, null, null, null, GetSubmoduleStatus);
+            return new GitSubmoduleStatus(errorMessage, null, false, default, default, null, null, null, GetSubmoduleStatus);
         }
 
         if (string.IsNullOrEmpty(patch?.Text))
@@ -48,8 +48,8 @@ public static partial class SubmoduleHelpers
         string? name = null;
         string? oldName = null;
         bool isDirty = false;
-        ObjectId? commitId = null;
-        ObjectId? oldCommitId = null;
+        ObjectId commitId = default;
+        ObjectId oldCommitId = default;
         int? addedCommits = null;
         int? removedCommits = null;
 
@@ -122,7 +122,7 @@ public static partial class SubmoduleHelpers
         }
 
         // Force calculation of caches, could be separate
-        if (oldCommitId is not null && commitId is not null)
+        if (!oldCommitId.IsZero && !commitId.IsZero)
         {
             if (oldCommitId == commitId)
             {
@@ -147,12 +147,12 @@ public static partial class SubmoduleHelpers
 
     private static SubmoduleStatus GetSubmoduleStatus(GitSubmoduleStatus submoduleStatus)
     {
-        if (submoduleStatus.OldCommit is null)
+        if (submoduleStatus.OldCommit.IsZero)
         {
             return SubmoduleStatus.NewSubmodule;
         }
 
-        if (submoduleStatus.Commit is null)
+        if (submoduleStatus.Commit.IsZero)
         {
             return SubmoduleStatus.RemovedSubmodule;
         }

--- a/src/app/GitCommands/GitRevisionInfoProvider.cs
+++ b/src/app/GitCommands/GitRevisionInfoProvider.cs
@@ -31,7 +31,7 @@ public sealed class GitRevisionInfoProvider : IGitRevisionInfoProvider
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        if (item.ObjectId is null)
+        if (item.ObjectId.IsZero)
         {
             throw new ArgumentException("Item must have a valid identifier", nameof(item));
         }

--- a/src/app/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/src/app/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -142,7 +142,7 @@ public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
                                .Select(s => s.Split(Delimiters.Colon))
                                .Where(t => t.Length == 2)
                                .Where(t => IsSettingForBranch(t[0], branch))
-                               .Select(t => new GitRef(module, objectId: null, t[1]))
+                               .Select(t => new GitRef(module, objectId: default, t[1]))
                                .FirstOrDefault(h => h.IsHead);
 
         if (remoteHead is not null)
@@ -154,20 +154,20 @@ public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
                                .Select(s => s.Split(Delimiters.Colon))
                                .Where(t => t.Length == 2)
                                .Where(t => IsSettingForWildcardBranch(t[0]))
-                               .Select(t => new GitRef(module, objectId: null, t[1].Replace("*", branch)))
+                               .Select(t => new GitRef(module, objectId: default, t[1].Replace("*", branch)))
                                .FirstOrDefault(h => h.IsHead);
 
         return remoteWildcardHead?.Name;
 
         bool IsSettingForBranch(string setting, string branchName)
         {
-            GitRef head = new(module, objectId: null, setting);
+            GitRef head = new(module, objectId: default, setting);
             return head.IsHead && head.Name.Equals(branchName, StringComparison.OrdinalIgnoreCase);
         }
 
         bool IsSettingForWildcardBranch(string setting)
         {
-            GitRef head = new(module, objectId: null, setting);
+            GitRef head = new(module, objectId: default, setting);
             return head.IsHead && head.Name == "*";
         }
     }

--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -178,11 +178,13 @@ public sealed class RevisionReader
     public async Task<GitRevision?> GetRevisionAsync(string commitHash, bool hasNotes, bool throwOnError, CancellationToken cancellationToken)
     {
         // output can be cached if git-notes is not included and hash is a sha.
-        bool doCacheGitOutput = ObjectId.TryParse(commitHash, out ObjectId? objectId) && !hasNotes;
-        if (objectId?.IsArtificial is true)
+        bool isValidSha = ObjectId.TryParse(commitHash, out ObjectId objectId);
+        if (isValidSha && objectId.IsArtificial)
         {
             throw new InvalidOperationException(nameof(commitHash));
         }
+
+        bool doCacheGitOutput = isValidSha && !hasNotes;
 
         GitArgumentBuilder arguments = new("log")
         {
@@ -355,7 +357,7 @@ public sealed class RevisionReader
     {
         string autoStashFileName = Path.Join(workingDirGitDir, "rebase-merge/autostash");
         if (!File.Exists(autoStashFileName)
-            || !ObjectId.TryParse(File.ReadLines(autoStashFileName).FirstOrDefault(), out ObjectId? autoStashCommitId))
+            || !ObjectId.TryParse(File.ReadLines(autoStashFileName).FirstOrDefault(), out ObjectId autoStashCommitId))
         {
             return;
         }
@@ -371,7 +373,7 @@ public sealed class RevisionReader
 
         string origHeadFileName = Path.Join(workingDirGitDir, "rebase-merge/orig-head");
         if (File.Exists(origHeadFileName)
-            && ObjectId.TryParse(File.ReadLines(origHeadFileName).FirstOrDefault(), out ObjectId? origHeadCommitId))
+            && ObjectId.TryParse(File.ReadLines(origHeadFileName).FirstOrDefault(), out ObjectId origHeadCommitId))
         {
             autoStashRevision.ParentIds = [origHeadCommitId];
         }
@@ -420,7 +422,7 @@ public sealed class RevisionReader
         // The first 40 bytes are the revision ID and the tree ID back to back
         ReadOnlyMemory<byte> commitHash = buffer.Slice(0, ObjectId.Sha1CharCount);
         ReadOnlySpan<byte> commitHashSpan = commitHash.Span;
-        ObjectId? objectId;
+        ObjectId objectId;
         if (_cache is not null && commitHashSpan.SequenceEqual(_cache.Value.buffer.Span))
         {
             objectId = _cache.Value.objectId;
@@ -436,7 +438,7 @@ public sealed class RevisionReader
         }
 
         ReadOnlyMemory<byte> parentCommitHash = buffer.Slice(ObjectId.Sha1CharCount, ObjectId.Sha1CharCount);
-        if (!ObjectId.TryParse(parentCommitHash.Span, out ObjectId? treeId))
+        if (!ObjectId.TryParse(parentCommitHash.Span, out ObjectId treeId))
         {
             ParseAssert($"Log parse error, object id: {buffer.Length}({parentCommitHash}");
             revision = default;
@@ -488,7 +490,7 @@ public sealed class RevisionReader
             for (int parentIndex = 0; parentIndex < noParents; parentIndex++)
             {
                 ReadOnlyMemory<byte> hashParent = buffer.Slice(offset, ObjectId.Sha1CharCount);
-                if (!ObjectId.TryParse(hashParent.Span, out ObjectId? parentId))
+                if (!ObjectId.TryParse(hashParent.Span, out ObjectId parentId))
                 {
                     ParseAssert($"Log parse error, parent {parentIndex} for {objectId}");
                     revision = default;
@@ -536,7 +538,7 @@ public sealed class RevisionReader
         revision = new GitRevision(objectId)
         {
             ParentIds = parentIds,
-            TreeGuid = treeId,
+            TreeId = treeId,
 
             Author = GetNextLine(bufferSpan),
             AuthorEmail = GetNextLine(bufferSpan),

--- a/src/app/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/src/app/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -426,7 +426,7 @@ internal sealed class SubmoduleStatusProvider(IGitExecutorProvider executorProvi
 
         // If no changes, set submoduleInfo.Detailed to null
         // if commit sha is not set the parsing was empty or there were no changes (ignore errors)
-        info.Detailed = submoduleStatus is null || submoduleStatus.Commit is null ?
+        info.Detailed = submoduleStatus is null || submoduleStatus.Commit.IsZero ?
             null :
             new DetailedSubmoduleInfo
             {

--- a/src/app/GitExtensions.Extensibility/BrowseArguments.cs
+++ b/src/app/GitExtensions.Extensibility/BrowseArguments.cs
@@ -17,12 +17,12 @@ public record BrowseArguments
     /// <summary>
     ///  Gets the currently (last) selected commit id.
     /// </summary>
-    public ObjectId? SelectedId { get; init; }
+    public ObjectId SelectedId { get; init; }
 
     /// <summary>
     ///  Gets the first selected commit id (as in a diff).
     /// </summary>
-    public ObjectId? FirstId { get; init; }
+    public ObjectId FirstId { get; init; }
 
     /// <summary>
     /// If to start in "FileHistory mode", hiding left panel.

--- a/src/app/GitExtensions.Extensibility/Git/GitItemStatus.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitItemStatus.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 
@@ -95,7 +95,7 @@ public sealed class GitItemStatus
     public string? OldName { get; set; }
     public RelativePath Path { get; private set; }
     public string? ErrorMessage { get; set; }
-    public ObjectId? TreeGuid { get; set; }
+    public ObjectId TreeId { get; set; }
     public string? RenameCopyPercentage { get; set; }
 
     public StagedStatus Staged { get; set; }
@@ -289,7 +289,7 @@ public sealed class GitItemStatus
             Name = IsRenamed ? (OldName ?? string.Empty) : Name,
             OldName = IsRenamed ? Name : OldName,
             ErrorMessage = ErrorMessage,
-            TreeGuid = TreeGuid,
+            TreeId = TreeId,
             RenameCopyPercentage = RenameCopyPercentage,
             Staged = Staged,
             DiffStatus = DiffStatus,

--- a/src/app/GitExtensions.Extensibility/Git/GitRevision.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitRevision.cs
@@ -28,7 +28,12 @@ public sealed partial class GitRevision : IGitItem, INotifyPropertyChanged
 
     public GitRevision(ObjectId objectId)
     {
-        ObjectId = objectId ?? throw new ArgumentNullException(nameof(objectId));
+        if (objectId.IsZero)
+        {
+            throw new ArgumentException("ObjectId must not be the default (zero) value.", nameof(objectId));
+        }
+
+        ObjectId = objectId;
     }
 
     /// <summary>
@@ -56,7 +61,7 @@ public sealed partial class GitRevision : IGitItem, INotifyPropertyChanged
     /// </remarks>
     public IReadOnlyList<ObjectId>? ParentIds { get; set; }
 
-    public ObjectId? TreeGuid { get; set; }
+    public ObjectId TreeId { get; set; }
 
     public string? Author { get; set; }
     public string? AuthorEmail { get; set; }
@@ -134,7 +139,7 @@ public sealed partial class GitRevision : IGitItem, INotifyPropertyChanged
 
     public bool HasParent => ParentIds?.Count > 0;
 
-    public ObjectId? FirstParentId => HasParent ? ParentIds?[0] : null;
+    public ObjectId FirstParentId => HasParent ? ParentIds![0] : default;
 
     #region INotifyPropertyChanged
 

--- a/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
@@ -11,8 +11,8 @@ public sealed class GitSubmoduleStatus
     public string Name { get; }
     public string? OldName { get; }
     public bool IsDirty { get; }
-    public ObjectId? Commit { get; }
-    public ObjectId? OldCommit { get; }
+    public ObjectId Commit { get; }
+    public ObjectId OldCommit { get; }
     public int? AddedCommits { get; }
     public int? RemovedCommits { get; }
 
@@ -34,11 +34,11 @@ public sealed class GitSubmoduleStatus
 
     // Get CommitData without Notes (will cache contents)
     public CommitData? CommitData
-        => GetCommitData is not null && Commit is not null ? GetCommitData(Commit.ToString()) : null;
+        => GetCommitData is not null && !Commit.IsZero ? GetCommitData(Commit.ToString()) : null;
     public CommitData? OldCommitData
-        => GetCommitData is not null && OldCommit is not null ? GetCommitData(OldCommit.ToString()) : null;
+        => GetCommitData is not null && !OldCommit.IsZero ? GetCommitData(OldCommit.ToString()) : null;
 
-    public GitSubmoduleStatus(string name, string? oldName, bool isDirty, ObjectId? commit, ObjectId? oldCommit, int? addedCommits, int? removedCommits, Func<string, CommitData?>? getCommitData, Func<GitSubmoduleStatus, SubmoduleStatus> getSubmoduleStatus)
+    public GitSubmoduleStatus(string name, string? oldName, bool isDirty, ObjectId commit, ObjectId oldCommit, int? addedCommits, int? removedCommits, Func<string, CommitData?>? getCommitData, Func<GitSubmoduleStatus, SubmoduleStatus> getSubmoduleStatus)
     {
         ArgumentNullException.ThrowIfNull(name);
         Name = name;

--- a/src/app/GitExtensions.Extensibility/Git/IGitItem.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitItem.cs
@@ -2,7 +2,10 @@
 
 public interface IGitItem
 {
-    ObjectId? ObjectId { get; }
+    /// <summary>
+    /// Gets the object ID, or the zero <see cref="ObjectId"/> if not known.
+    /// </summary>
+    ObjectId ObjectId { get; }
 
     string? Guid { get; }
 }

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -21,7 +21,7 @@ public interface IGitModule
 
     IReadOnlyList<IGitRef> GetRefs(RefsFilter getRef);
     IEnumerable<string> GetSettings(string setting);
-    IEnumerable<IObjectGitItem> GetTree(ObjectId? commitId, bool full, string fileName = "", CancellationToken cancellationToken = default);
+    IEnumerable<IObjectGitItem> GetTree(ObjectId commitId, bool full, string fileName = "", CancellationToken cancellationToken = default);
 
     /// <summary>
     ///  Loads the user-defined colors for the remote branches specific for the current repository.
@@ -61,7 +61,7 @@ public interface IGitModule
     /// </summary>
     /// <param name="revisionExpression">An expression like HEAD or commit hash that can be parsed as a git reference.</param>
     /// <returns>An ObjectID representing that git reference</returns>
-    ObjectId? RevParse(string revisionExpression);
+    ObjectId RevParse(string revisionExpression);
 
     void SetSetting(string setting, string value, bool append = false);
     void UnsetSetting(string setting);
@@ -149,7 +149,7 @@ public interface IGitModule
     /// <returns>The path in Windows format with native file separators.</returns>
     public string GetWindowsPath(string path);
 
-    bool TryResolvePartialCommitId(string objectIdPrefix, [NotNullWhen(returnValue: true)] out ObjectId? objectId);
+    public bool TryResolvePartialCommitId(string objectIdPrefix, out ObjectId objectId);
 
     string GetSubmoduleFullPath(string localPath);
 
@@ -176,14 +176,14 @@ public interface IGitModule
 
     /// <summary>
     /// Gets the commit ID of the currently checked out commit.
-    /// If the repo is bare or has no commits, <c>null</c> is returned.
+    /// If the repo is bare or has no commits, a zero <see cref="ObjectId"/> is returned.
     /// </summary>
-    ObjectId? GetCurrentCheckout();
+    ObjectId GetCurrentCheckout();
 
     /// <summary>Gets the remote of the current branch; or "" if no remote is configured.</summary>
     string GetCurrentRemote();
 
-    GitRevision GetRevision(ObjectId? objectId = null, bool shortFormat = false, bool loadRefs = false);
+    GitRevision GetRevision(ObjectId objectId = default, bool shortFormat = false, bool loadRefs = false);
 
     Task<IReadOnlyList<Remote>> GetRemotesAsync();
 
@@ -234,7 +234,7 @@ public interface IGitModule
 
     void SaveBlobAs(string saveAs, string blob, CancellationToken cancellationToken = default);
     Task SaveBlobAsAsync(string saveAs, string blob, CancellationToken cancellationToken = default);
-    Task<(char Code, ObjectId? CommitId)> GetSuperprojectCurrentCheckoutAsync();
+    Task<(char Code, ObjectId CommitId)> GetSuperprojectCurrentCheckoutAsync();
     Task<Patch?> GetCurrentChangesAsync(string? fileName, string? oldFileName, bool staged, string extraDiffArguments, Encoding? encoding = null, bool noLocks = false);
     Task<string?> GetFileContentsAsync(GitItemStatus file);
     IReadOnlyList<GitStash> GetStashes(bool noLocks);
@@ -266,8 +266,8 @@ public interface IGitModule
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The result for the command.</returns>
     Task<ExecutionResult> GetSingleDifftoolAsync(
-        ObjectId? firstId,
-        ObjectId? secondId,
+        ObjectId firstId,
+        ObjectId secondId,
         string? fileName,
         string? oldFileName,
         ArgumentString extraDiffArguments,
@@ -278,8 +278,8 @@ public interface IGitModule
         CancellationToken cancellationToken);
 
     Task<(Patch? Patch, string? ErrorMessage)> GetSingleDiffAsync(
-            ObjectId? firstId,
-            ObjectId? secondId,
+            ObjectId firstId,
+            ObjectId secondId,
             string? fileName,
             string? oldFileName,
             string extraDiffArguments,
@@ -325,8 +325,8 @@ public interface IGitModule
     Task<ExecutionResult> GetRangeDiffAsync(
         ObjectId firstId,
         ObjectId secondId,
-        ObjectId? firstBase,
-        ObjectId? secondBase,
+        ObjectId firstBase,
+        ObjectId secondBase,
         string extraDiffArguments,
         string? pathFilter,
         bool useGitColoring,
@@ -338,14 +338,14 @@ public interface IGitModule
     string ApplyPatch(string dirText, ArgumentString arguments);
     bool InTheMiddleOfRebase();
     bool InTheMiddleOfMerge();
-    IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(ObjectId? firstId,
-        ObjectId? secondId,
-        ObjectId? parentToSecond,
+    IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(ObjectId firstId,
+        ObjectId secondId,
+        ObjectId parentToSecond,
         bool excludeSkipWorktreeFiles = true, // applies to StagedStatus.WorkTree or StagedStatus.Index only
         UntrackedFilesMode untrackedFilesMode = UntrackedFilesMode.Default, // ditto
         CancellationToken cancellationToken = default);
     IReadOnlyList<GitItemStatus> GetIndexFilesWithSubmodulesStatus();
-    ObjectId? GetFileBlobHash(string fileName, ObjectId objectId);
+    ObjectId GetFileBlobHash(string fileName, ObjectId objectId);
     void OpenFilesWithDifftool(string? firstGitCommit, string? secondGitCommit, string? customTool);
     IReadOnlyList<string> GetIgnoredFiles(IEnumerable<string> ignorePatterns);
     void UnlockIndex(bool includeSubmodules);
@@ -353,10 +353,10 @@ public interface IGitModule
     ArgumentString FetchCmd(string? remote, string? remoteBranch, string? localBranch, bool? fetchTags = false, bool isUnshallow = false, bool pruneRemoteBranches = false, bool pruneRemoteBranchesAndTags = false);
     void RunGui();
     void RunGitK();
-    ObjectId? GetMergeBase(ObjectId a, ObjectId b);
+    ObjectId GetMergeBase(ObjectId a, ObjectId b);
     (int? First, int? Second) GetCommitRangeDiffCount(ObjectId firstId, ObjectId secondId);
     IReadOnlyList<GitItemStatus> GetCombinedDiffFileList(ObjectId mergeCommitObjectId);
-    IReadOnlyList<GitItemStatus> GetTreeFiles(ObjectId treeGuid, bool full, CancellationToken cancellationToken = default);
+    IReadOnlyList<GitItemStatus> GetTreeFiles(ObjectId treeId, bool full, CancellationToken cancellationToken = default);
     IReadOnlyList<string> GetFullTree(string id);
 
     /// <summary>
@@ -388,7 +388,7 @@ public interface IGitModule
     /// <param name="status">List with GitItemStatus</param>
     public void GetSubmoduleCurrentStatus(IReadOnlyList<GitItemStatus> status);
 
-    bool ResetChanges(ObjectId? resetId, IReadOnlyList<GitItemStatus> selectedItems, bool resetAndDelete, IFullPathResolver fullPathResolver, out StringBuilder output, Action<BatchProgressEventArgs>? progressAction);
+    bool ResetChanges(ObjectId resetId, IReadOnlyList<GitItemStatus> selectedItems, bool resetAndDelete, IFullPathResolver fullPathResolver, out StringBuilder output, Action<BatchProgressEventArgs>? progressAction);
     bool HasSubmodules();
     void OpenWithDifftool(string? filename, string? oldFileName = "", string? firstRevision = GitRevision.IndexGuid, string? secondRevision = GitRevision.WorkTreeGuid, string? extraDiffArguments = null, bool isTracked = true, string? customTool = null);
     void OpenWithDifftoolDirDiff(string? firstRevision, string? secondRevision, string? customTool);
@@ -434,9 +434,9 @@ public interface IGitModule
     /// Performs <c>git-checkout</c> for the given files.
     /// </summary>
     /// <param name="files">The list of files to checkout.</param>
-    /// <param name="revision">The revision to checkout; <see langword="null"/> is handled as <c>HEAD</c>.</param>
+    /// <param name="objectId">The objectId to checkout; the default (zero) <see cref="ObjectId"/> is handled as <c>HEAD</c>.</param>
     /// <param name="force">Indicates whether to perform a forced checkout.</param>
-    string CheckoutFiles(IReadOnlyList<string> files, ObjectId? revision, bool force);
+    string CheckoutFiles(IReadOnlyList<string> files, ObjectId objectId, bool force);
 
     void DeleteTag(string tagName);
 
@@ -486,7 +486,7 @@ public interface IGitModule
     IGitVersion GitVersion { get; }
 
     bool GetCombinedDiffContent(
-            ObjectId revisionOfMergeCommit,
+            ObjectId objectIdOfMergeCommit,
             string filePath,
             string extraArgs,
             Encoding encoding,

--- a/src/app/GitExtensions.Extensibility/Git/IGitUICommands.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitUICommands.cs
@@ -46,8 +46,8 @@ public interface IGitUICommands : IServiceProvider
     bool StartArchiveDialog(IWin32Window? owner = null, GitRevision? revision = null, GitRevision? revision2 = null, string? path = null);
     void StartBatchFileProcessDialog(string batchFile);
     bool StartBrowseDialog(IWin32Window? owner, BrowseArguments? args = null);
-    bool StartCheckoutBranch(IWin32Window? owner, IReadOnlyList<ObjectId>? containRevisions);
-    bool StartCheckoutBranch(IWin32Window? owner, string branch = "", bool remote = false, IReadOnlyList<ObjectId>? containRevisions = null);
+    bool StartCheckoutBranch(IWin32Window? owner, IReadOnlyList<ObjectId>? containObjectIds);
+    bool StartCheckoutBranch(IWin32Window? owner, string branch = "", bool remote = false, IReadOnlyList<ObjectId>? containObjectIds = null);
     bool StartCheckoutRemoteBranch(IWin32Window? owner, string branch);
     bool StartCheckoutRevisionDialog(IWin32Window? owner, string? revision = null);
     bool StartCherryPickDialog(IWin32Window? owner = null, GitRevision? revision = null);
@@ -60,7 +60,7 @@ public interface IGitUICommands : IServiceProvider
     bool StartCommandLineProcessDialog(IWin32Window? owner, string? command, ArgumentString arguments);
     bool StartCommitDialog(IWin32Window? owner, string? commitMessage = null, bool showOnlyWhenChanges = false);
     bool StartCompareRevisionsDialog(IWin32Window? owner = null);
-    bool StartCreateBranchDialog(IWin32Window? owner = null, ObjectId? objectId = null, string? newBranchNamePrefix = null);
+    bool StartCreateBranchDialog(IWin32Window? owner = null, ObjectId objectId = default, string? newBranchNamePrefix = null);
     bool StartCreateBranchDialog(IWin32Window? owner, string? branch);
     void StartCreatePullRequest(IWin32Window? owner);
     void StartCreatePullRequest(IWin32Window? owner, IRepositoryHostPlugin gitHoster, string? chooseRemote = null, string? chooseBranch = null);

--- a/src/app/GitExtensions.Extensibility/Git/ObjectId.cs
+++ b/src/app/GitExtensions.Extensibility/Git/ObjectId.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Text.RegularExpressions;
 
 namespace GitExtensions.Extensibility.Git;
@@ -17,7 +17,7 @@ namespace GitExtensions.Extensibility.Git;
 ///  enabling direct hex conversion and SIMD-accelerated equality and comparison via
 ///  <see cref="MemoryExtensions.SequenceEqual{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/>.</para>
 /// </remarks>
-public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpanFormattable
+public readonly struct ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpanFormattable
 {
     /// <summary>
     /// A set of valid hex characters for validating input strings without allocating.
@@ -26,8 +26,6 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     /// Note that this set contains only lowercase characters, since uppercase hex is not valid for our purposes.
     /// </remarks>
     private static readonly SearchValues<char> _hexChars = SearchValues.Create("0123456789abcdef");
-
-    private static readonly Random _random = new();
 
     /// <summary>
     /// Gets the artificial ObjectId used to represent working directory tree (unstaged) changes.
@@ -45,17 +43,63 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     public static ObjectId CombinedDiffId { get; } = Parse("3333333333333333333333333333333333333333");
 
     /// <summary>
-    /// Produces an <see cref="ObjectId"/> populated with random bytes.
+    ///  Produces an <see cref="ObjectId"/> populated with random bytes.
     /// </summary>
     [Pure]
     public static ObjectId Random()
     {
         Sha1 data = default;
-        _random.NextBytes((Span<byte>)data);
+        System.Random.Shared.NextBytes((Span<byte>)data);
         return new ObjectId(data);
     }
 
-    public bool IsArtificial => this == WorkTreeId || this == IndexId || this == CombinedDiffId;
+    /// <summary>
+    ///  Gets whether this instance is the default (all-zeroes) value.
+    ///  A zero ObjectId interpretation depends on the context:
+    ///  - Value not yet set.
+    ///  - Empty, should not be added to Git commands.
+    ///  - Parsing failed, the input was illegal.
+    /// </summary>
+    public bool IsZero
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ref byte start = ref Unsafe.As<Sha1, byte>(ref Unsafe.AsRef(in _data));
+            return Vector128.LoadUnsafe(ref start) == Vector128<byte>.Zero
+                && Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref start, 16)) == 0;
+        }
+    }
+
+    /// <summary>
+    ///  Gets whether this instance represents a commit internal to Git Extensions only,
+    ///  used to describe states such as the working directory or index.
+    /// </summary>
+    public bool IsArtificial
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ref uint start = ref Unsafe.As<Sha1, uint>(ref Unsafe.AsRef(in _data));
+            uint last4Bytes = Unsafe.Add(ref start, 4);
+
+            // Artificial IDs are 0x11, 0x22, or 0x33 repeated across all 20 bytes.
+            // The last-uint check eliminates real hashes before the SIMD comparison for the first 16 bytes.
+            if (last4Bytes is not (0x1111_1111u or 0x2222_2222u or 0x3333_3333u))
+            {
+                return false;
+            }
+
+            Vector128<uint> splat = Vector128.Create(last4Bytes);
+            return Vector128.LoadUnsafe(ref start) == splat;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether this instance does not represent a real git object — either
+    /// the default (all-zeroes) value or one of the artificial sentinel values.
+    /// </summary>
+    public bool IsZeroOrArtificial => IsZero || IsArtificial;
 
     private const int _sha1ByteCount = 20;
     public const int Sha1CharCount = 40;
@@ -91,7 +135,7 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     [Pure]
     public static ObjectId Parse(string s)
     {
-        if (s?.Length is not Sha1CharCount || !TryParse(s.AsSpan(), out ObjectId? id))
+        if (s?.Length is not Sha1CharCount || !TryParse(s.AsSpan(), out ObjectId id))
         {
             throw new FormatException($"Unable to parse object ID \"{s}\".");
         }
@@ -113,7 +157,7 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     [Pure]
     public static ObjectId Parse(string s, Capture capture)
     {
-        if (s is null || capture?.Length is not Sha1CharCount || !TryParse(s.AsSpan(capture.Index, capture.Length), out ObjectId? id))
+        if (s is null || capture?.Length is not Sha1CharCount || !TryParse(s.AsSpan(capture.Index, capture.Length), out ObjectId id))
         {
             throw new FormatException($"Unable to parse object ID \"{s}\".");
         }
@@ -130,9 +174,9 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     /// overload <see cref="TryParse(string,int,out ObjectId)"/>.
     /// </remarks>
     /// <param name="s">The string to try parsing from.</param>
-    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <c>null</c> if parsing was unsuccessful.</param>
+    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <see langword="default"/> if parsing was unsuccessful.</param>
     /// <returns><c>true</c> if parsing was successful, otherwise <c>false</c>.</returns>
-    public static bool TryParse(string? s, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(string? s, out ObjectId objectId)
     {
         if (s is null)
         {
@@ -153,9 +197,9 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     /// </remarks>
     /// <param name="s">The string to try parsing from.</param>
     /// <param name="offset">The position within <paramref name="s"/> to start parsing from.</param>
-    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <c>null</c> if parsing was unsuccessful.</param>
+    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <see langword="default"/> if parsing was unsuccessful.</param>
     /// <returns><c>true</c> if parsing was successful, otherwise <c>false</c>.</returns>
-    public static bool TryParse(string? s, int offset, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(string? s, int offset, out ObjectId objectId)
     {
         if (s is null || s.Length - offset < Sha1CharCount)
         {
@@ -176,7 +220,7 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
     /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
     [Pure]
-    public static bool TryParse(in ReadOnlySpan<char> hex, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(in ReadOnlySpan<char> hex, out ObjectId objectId)
     {
         if (hex.Length != Sha1CharCount)
         {
@@ -205,7 +249,7 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
     /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
     /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
     [Pure]
-    public static bool TryParse(in ReadOnlySpan<byte> hex, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(in ReadOnlySpan<byte> hex, out ObjectId objectId)
     {
         if (hex.Length != Sha1CharCount)
         {
@@ -249,13 +293,9 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
 
     #region IComparable<ObjectId>
 
-    public int CompareTo(ObjectId? other)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int CompareTo(ObjectId other)
     {
-        if (other is null)
-        {
-            return 1;
-        }
-
         return ((ReadOnlySpan<byte>)_data).SequenceCompareTo(other._data);
     }
 
@@ -324,10 +364,8 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
 
     #region ISpanFormattable
 
-    /// <inheritdoc />
     string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
 
-    /// <inheritdoc />
     bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
         if (destination.Length < Sha1CharCount)
@@ -344,24 +382,21 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>, ISpa
 
     #region Equality and hashing
 
-    /// <inheritdoc />
-    public bool Equals(ObjectId? other)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(ObjectId other)
     {
-        return other is not null &&
-               ((ReadOnlySpan<byte>)_data).SequenceEqual(other._data);
+        return ((ReadOnlySpan<byte>)_data).SequenceEqual(other._data);
     }
 
-    /// <inheritdoc />
     public override bool Equals(object? obj) => obj is ObjectId id && Equals(id);
 
-    /// <inheritdoc />
     public override int GetHashCode()
     {
-        return Unsafe.ReadUnaligned<int>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)_data));
+        return Unsafe.ReadUnaligned<int>(ref Unsafe.As<Sha1, byte>(ref Unsafe.AsRef(in _data)));
     }
 
-    public static bool operator ==(ObjectId? left, ObjectId? right) => Equals(left, right);
-    public static bool operator !=(ObjectId? left, ObjectId? right) => !Equals(left, right);
+    public static bool operator ==(ObjectId left, ObjectId right) => left.Equals(right);
+    public static bool operator !=(ObjectId left, ObjectId right) => !left.Equals(right);
 
     #endregion
 }

--- a/src/app/GitExtensions.Extensibility/IBrowseRepo.cs
+++ b/src/app/GitExtensions.Extensibility/IBrowseRepo.cs
@@ -9,5 +9,5 @@ public interface IBrowseRepo
     IReadOnlyList<GitRevision> GetSelectedRevisions();
     Point GetQuickItemSelectorLocation();
     void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false);
-    void SetWorkingDir(string? path, ObjectId? selectedId = null, ObjectId? firstId = null);
+    void SetWorkingDir(string? path, ObjectId selectedId = default, ObjectId firstId = default);
 }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -52,16 +52,16 @@ public sealed partial class FormBisect : GitModuleForm
 
         return;
 
-        void BisectRange(ObjectId startRevision, ObjectId endRevision)
+        void BisectRange(ObjectId startObjectId, ObjectId endObjectId)
         {
-            ArgumentString command = Commands.ContinueBisect(GitBisectOption.Good, startRevision);
+            ArgumentString command = Commands.ContinueBisect(GitBisectOption.Good, startObjectId);
             bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (!success)
             {
                 return;
             }
 
-            command = Commands.ContinueBisect(GitBisectOption.Bad, endRevision);
+            command = Commands.ContinueBisect(GitBisectOption.Bad, endObjectId);
             FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
         }
     }

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -43,7 +43,7 @@ public sealed partial class FormGoToCommit : GitModuleForm
     /// <summary>
     /// returns null if revision does not exist (could not be revparsed).
     /// </summary>
-    public ObjectId? ValidateAndGetSelectedRevision()
+    public ObjectId ValidateAndGetSelectedObjectId()
     {
         return Module.RevParse(_selectedRevision!);
     }
@@ -206,8 +206,8 @@ public sealed partial class FormGoToCommit : GitModuleForm
             return;
         }
 
-        ObjectId? guid = Module.RevParse(text);
-        if (guid is not null)
+        ObjectId objectId = Module.RevParse(text);
+        if (!objectId.IsZero)
         {
             textboxCommitExpression.Text = text;
             textboxCommitExpression.SelectAll();

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -9,7 +9,7 @@ partial class FormBrowse
 {
     // This file is dedicated to init logic for FormBrowse revisiong grid control
 
-    private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId, bool isFileHistoryMode)
+    private void InitRevisionGrid(ObjectId selectedId, ObjectId firstId, bool isFileHistoryMode)
     {
         RevisionGrid.ArtificialChanged += (_, _) => RefreshGitStatusMonitor();
 

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1686,7 +1686,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         UICommands.StartCleanupRepositoryDialog(this);
     }
 
-    public void SetWorkingDir(string? path, ObjectId? selectedId = null, ObjectId? firstId = null)
+    public void SetWorkingDir(string? path, ObjectId selectedId = default, ObjectId firstId = default)
     {
         RevisionGrid.SelectedId = selectedId;
         RevisionGrid.FirstId = firstId;
@@ -1771,7 +1771,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
 
     private void CreateBranchToolStripMenuItemClick(object sender, EventArgs e)
     {
-        UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId);
+        UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId ?? default);
     }
 
     private void editGitAttributesToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1829,7 +1829,11 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         {
             foreach (IGitRef branch in GetBranches())
             {
-                Validates.NotNull(branch.ObjectId);
+                if (branch.ObjectId.IsZero)
+                {
+                    throw new InvalidOperationException($"Branch '{branch.Name}' has no ObjectId.");
+                }
+
                 bool isBranchVisible = ((ICheckRefs)RevisionGridControl).Contains(branch.ObjectId);
 
                 ToolStripItem toolStripItem = branchSelect.DropDownItems.Add(branch.Name);
@@ -2007,7 +2011,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         if (selectedRevisions.Count > 1 || (selectedRevisions.Count == 1 && selectedRevisions[0].IsArtificial))
         {
             GitRevision potentialRevision = selectedRevisions[0];
-            ObjectId? targetCommit = potentialRevision.IsArtificial ? RevisionGrid.CurrentCheckout : potentialRevision.ObjectId;
+            ObjectId targetCommit = potentialRevision.IsArtificial ? RevisionGrid.CurrentCheckout : potentialRevision.ObjectId;
             RevisionGrid.SetSelectedRevision(targetCommit);
         }
 
@@ -2112,7 +2116,7 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
             case Command.GoToParent: RestoreFileStatusListFocus(() => RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToParent)); break;
             case Command.PullOrFetch: DoPull(pullAction: AppSettings.FormPullAction, isSilent: false); break;
             case Command.Push: UICommands.StartPushDialog(this, pushOnShow: ModifierKeys.HasFlag(Keys.Shift)); break;
-            case Command.CreateBranch: UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId); break;
+            case Command.CreateBranch: UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId ?? default); break;
             case Command.MergeBranches: UICommands.StartMergeBranchDialog(this, null); break;
             case Command.CreateTag: UICommands.StartCreateTagDialog(this, RevisionGrid.LatestSelectedRevision); break;
             case Command.Rebase: rebaseToolStripMenuItem.PerformClick(); break;
@@ -2428,9 +2432,9 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         {
             case "gotocommit":
                 Validates.NotNull(e.Data);
-                if (!Module.TryResolvePartialCommitId(e.Data, out ObjectId? commitId) || !RevisionGrid.SetSelectedRevision(commitId))
+                if (!Module.TryResolvePartialCommitId(e.Data, out ObjectId commitId) || !RevisionGrid.SetSelectedRevision(commitId))
                 {
-                    if (commitId is null)
+                    if (commitId.IsZero)
                     {
                         return;
                     }

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -28,7 +28,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
     private readonly TranslationString _resetCaption = new("Reset branch");
     #endregion
 
-    private readonly IReadOnlyList<ObjectId>? _containRevisions;
+    private readonly IReadOnlyList<ObjectId>? _containObjectIds;
     private readonly bool _isLoading;
     private readonly string _rbResetBranchDefaultText;
     private TranslationString _invalidBranchName = new("An existing branch must be selected.");
@@ -43,7 +43,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
     private IReadOnlyList<IGitRef>? _localBranches;
     private IReadOnlyList<IGitRef>? _remoteBranches;
 
-    public FormCheckoutBranch(IGitUICommands commands, string branch, bool remote, IReadOnlyList<ObjectId>? containRevisions = null)
+    public FormCheckoutBranch(IGitUICommands commands, string branch, bool remote, IReadOnlyList<ObjectId>? containObjectIds = null)
         : base(commands, true)
     {
         _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
@@ -57,7 +57,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
 
         try
         {
-            _containRevisions = containRevisions;
+            _containObjectIds = containObjectIds;
 
             LocalBranch.Checked = !remote;
             Remotebranch.Checked = remote;
@@ -71,7 +71,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
                 Branches.SelectedItem = branch;
             }
 
-            if (containRevisions is not null)
+            if (_containObjectIds is not null)
             {
                 if (Branches.Items.Count == 0)
                 {
@@ -193,7 +193,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
 
         IEnumerable<string> branchNames;
 
-        if (_containRevisions is null)
+        if (_containObjectIds is null)
         {
             IEnumerable<IGitRef> branches = LocalBranch.Checked ? GetLocalBranches() : GetRemoteBranches();
 
@@ -201,12 +201,12 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
         }
         else
         {
-            branchNames = GetContainsRevisionBranches();
+            branchNames = GetContainsObjectIdBranches();
         }
 
         Branches.Items.AddRange([.. branchNames.Where(name => !string.IsNullOrWhiteSpace(name))]);
 
-        if (_containRevisions is not null && Branches.Items.Count == 1)
+        if (_containObjectIds is not null && Branches.Items.Count == 1)
         {
             Branches.SelectedIndex = 0;
         }
@@ -215,12 +215,12 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
             Branches.Text = null;
         }
 
-        IReadOnlyList<string> GetContainsRevisionBranches()
+        IReadOnlyList<string> GetContainsObjectIdBranches()
         {
             HashSet<string> result = [];
-            if (_containRevisions.Count > 0)
+            if (_containObjectIds.Count > 0)
             {
-                IEnumerable<string> branches = Module.GetAllBranchesWhichContainGivenCommit(_containRevisions[0],
+                IEnumerable<string> branches = Module.GetAllBranchesWhichContainGivenCommit(_containObjectIds[0],
                                                                                             getLocal: LocalBranch.Checked,
                                                                                             getRemote: !LocalBranch.Checked,
                                                                                             cancellationToken: default)
@@ -229,11 +229,11 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
                 result.UnionWith(branches);
             }
 
-            for (int index = 1; index < _containRevisions.Count; index++)
+            for (int index = 1; index < _containObjectIds.Count; index++)
             {
-                ObjectId containRevision = _containRevisions[index];
+                ObjectId containObjectId = _containObjectIds[index];
                 IEnumerable<string> branches =
-                    Module.GetAllBranchesWhichContainGivenCommit(containRevision,
+                    Module.GetAllBranchesWhichContainGivenCommit(containObjectId,
                                                                  getLocal: LocalBranch.Checked,
                                                                  getRemote: !LocalBranch.Checked,
                                                                  cancellationToken: default)
@@ -290,16 +290,16 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
             {
                 IGitRef localBranchRef = GetLocalBranchRef(_localBranchName);
                 IGitRef remoteBranchRef = GetRemoteBranchRef(branchName);
-                if (localBranchRef is not null && remoteBranchRef is not null && localBranchRef.ObjectId is not null && remoteBranchRef.ObjectId is not null)
+                if (localBranchRef is not null && remoteBranchRef is not null && !localBranchRef.ObjectId.IsZero && !remoteBranchRef.ObjectId.IsZero)
                 {
-                    ObjectId? mergeBaseGuid = Module.GetMergeBase(localBranchRef.ObjectId, remoteBranchRef.ObjectId);
-                    bool isResetFastForward = localBranchRef.ObjectId == mergeBaseGuid;
+                    ObjectId mergeBaseId = Module.GetMergeBase(localBranchRef.ObjectId, remoteBranchRef.ObjectId);
+                    bool isResetFastForward = localBranchRef.ObjectId == mergeBaseId;
 
                     if (!isResetFastForward)
                     {
-                        string mergeBaseText = mergeBaseGuid is null
+                        string mergeBaseText = mergeBaseId.IsZero
                             ? "merge base"
-                            : mergeBaseGuid.ToShortString();
+                            : mergeBaseId.ToShortString();
 
                         string warningMessage = string.Format(_resetNonFastForwardBranch.Text, _localBranchName, mergeBaseText);
 
@@ -346,7 +346,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
             }
         }
 
-        ObjectId? originalId = Module.GetCurrentCheckout();
+        ObjectId originalId = Module.GetCurrentCheckout();
 
         bool success = ScriptsRunner.RunEventScripts(ScriptEvent.BeforeCheckout, this);
         if (!success)
@@ -388,7 +388,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
                 }
             }
 
-            ObjectId? currentId = Module.GetCurrentCheckout();
+            ObjectId currentId = Module.GetCurrentCheckout();
 
             if (originalId != currentId)
             {
@@ -482,8 +482,8 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
                 // not applicable if there is no checkout yet
                 string aheadBehindInfo = "";
 
-                ObjectId? currentCheckout = Module.GetCurrentCheckout();
-                if (currentCheckout is not null)
+                ObjectId currentCheckout = Module.GetCurrentCheckout();
+                if (!currentCheckout.IsZero)
                 {
                     aheadBehindInfo = Module.GetCommitCountString(currentCheckout, branch);
                 }

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
@@ -30,17 +30,17 @@ public partial class FormCheckoutRevision : GitExtensionsDialog
     {
         try
         {
-            ObjectId? selectedObjectId = commitPickerSmallControl1.SelectedObjectId;
+            ObjectId selectedObjectId = commitPickerSmallControl1.SelectedObjectId;
 
-            if (selectedObjectId is null)
+            if (selectedObjectId.IsZero)
             {
                 MessageBoxes.Show(this, _noRevisionSelectedMsgBox.Text, _noRevisionSelectedMsgBoxCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            ObjectId? checkedOutObjectId = Module.GetCurrentCheckout();
+            ObjectId checkedOutObjectId = Module.GetCurrentCheckout();
 
-            DebugHelpers.Assert(checkedOutObjectId is not null, "checkedOutObjectId is not null");
+            DebugHelpers.Assert(!checkedOutObjectId.IsZero, "checkedOutObjectId is not zero");
 
             bool success = ScriptsRunner.RunEventScripts(ScriptEvent.BeforeCheckout, this);
             if (!success)

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.InteropServices;
@@ -908,7 +908,7 @@ public sealed partial class FormCommit : GitModuleForm
 
         void UpdateMergeHead()
         {
-            _isMergeCommit = Module.RevParse("MERGE_HEAD") is not null;
+            _isMergeCommit = !Module.RevParse("MERGE_HEAD").IsZero;
         }
     }
 
@@ -1215,15 +1215,15 @@ public sealed partial class FormCommit : GitModuleForm
 
                 if (result == btnCheckout)
                 {
-                    ObjectId[]? revisions = _editedCommit is not null ? [_editedCommit.ObjectId] : null;
-                    if (!UICommands.StartCheckoutBranch(this, revisions))
+                    ObjectId[]? objectIds = _editedCommit is not null ? [_editedCommit.ObjectId] : null;
+                    if (!UICommands.StartCheckoutBranch(this, objectIds))
                     {
                         return;
                     }
                 }
                 else if (result == btnCreate)
                 {
-                    if (!UICommands.StartCreateBranchDialog(this, _editedCommit?.ObjectId))
+                    if (!UICommands.StartCreateBranchDialog(this, _editedCommit?.ObjectId ?? default))
                     {
                         return;
                     }
@@ -1733,8 +1733,8 @@ public sealed partial class FormCommit : GitModuleForm
     {
         GitRevision? headRev;
         GitRevision indexRev;
-        ObjectId? headId = Module.RevParse("HEAD");
-        if (headId is not null)
+        ObjectId headId = Module.RevParse("HEAD");
+        if (!headId.IsZero)
         {
             headRev = new GitRevision(headId);
             indexRev = new GitRevision(ObjectId.IndexId) { ParentIds = new[] { headId } };
@@ -1745,7 +1745,7 @@ public sealed partial class FormCommit : GitModuleForm
             indexRev = new GitRevision(ObjectId.IndexId);
         }
 
-        GitRevision workTreeRev = new(ObjectId.WorkTreeId) { ParentIds = new[] { ObjectId.IndexId } };
+        GitRevision workTreeRev = new(ObjectId.WorkTreeId) { ParentIds = [ObjectId.IndexId] };
         return (headRev, indexRev, workTreeRev);
     }
 
@@ -2732,7 +2732,7 @@ public sealed partial class FormCommit : GitModuleForm
             ReplaceMessage(Module.GetPreviousCommitMessages(count: 1, revision: "HEAD", authorPattern: string.Empty).FirstOrDefault()?.Trim()!);
         }
 
-        ResetSoft.Enabled = ResetSoft.Visible && Amend.Checked && Module.RevParse(_resetSoftRevision) is not null;
+        ResetSoft.Enabled = ResetSoft.Visible && Amend.Checked && !Module.RevParse(_resetSoftRevision).IsZero;
 
         if (AppSettings.CommitAndPushForcedWhenAmend)
         {

--- a/src/app/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -4,7 +4,7 @@ namespace GitUI.CommandsDialogs;
 
 public partial class FormCompareToBranch : GitModuleForm
 {
-    public FormCompareToBranch(IGitUICommands commands, ObjectId? selectedCommit)
+    public FormCompareToBranch(IGitUICommands commands, ObjectId selectedCommit)
         : base(commands)
     {
         MinimizeBox = false;
@@ -13,7 +13,7 @@ public partial class FormCompareToBranch : GitModuleForm
         InitializeComponent();
         InitializeComplete();
 
-        branchSelector.Initialize(remote: true, containRevisions: null);
+        branchSelector.Initialize(remote: true, containObjectIds: null);
         branchSelector.CommitToCompare = selectedCommit;
         Activated += OnActivated;
     }

--- a/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -23,7 +23,7 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
     public bool UserAbleToChangeRevision { get; set; } = true;
     public bool CouldBeOrphan { get; set; } = true;
 
-    public FormCreateBranch(IGitUICommands commands, ObjectId? objectId, string? newBranchNamePrefix = null)
+    public FormCreateBranch(IGitUICommands commands, ObjectId objectId, string? newBranchNamePrefix = null)
         : base(commands, enablePositionRestore: false)
     {
         InitializeComponent();
@@ -36,15 +36,19 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
 
         grpOrphan.AutoSize = true;
 
-        if (objectId?.IsArtificial is true)
+        if (objectId.IsArtificial)
         {
-            objectId = null;
+            objectId = default;
         }
 
         commitSummaryUserControl1.Revision = null;
 
-        objectId ??= Module.GetCurrentCheckout();
-        if (objectId is not null)
+        if (objectId.IsZero)
+        {
+            objectId = Module.GetCurrentCheckout();
+        }
+
+        if (!objectId.IsZero)
         {
             commitPicker.SetSelectedCommitHash(objectId.ToString());
 
@@ -120,12 +124,12 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
         // if the user hits [Enter] at any point, we need to trigger BranchNameTextBox Leave event
         cmdOk.Focus();
 
-        ObjectId? objectId = null;
+        ObjectId objectId = default;
 
         if (!chkCreateOrphan.Checked)
         {
             objectId = commitPicker.SelectedObjectId;
-            if (objectId is null)
+            if (objectId.IsZeroOrArtificial)
             {
                 MessageBoxes.Show(this, _noRevisionSelected.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 DialogResult = DialogResult.None;
@@ -150,11 +154,11 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
 
         try
         {
-            ObjectId? originalHash = Module.GetCurrentCheckout();
+            ObjectId originalHash = Module.GetCurrentCheckout();
 
             ArgumentString command = chkCreateOrphan.Checked
                 ? Commands.CreateOrphan(branchName, objectId)
-                : Commands.Branch(branchName, objectId!.ToString(), chkCheckoutAfterCreate.Checked);
+                : Commands.Branch(branchName, objectId, chkCheckoutAfterCreate.Checked);
 
             bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (chkCreateOrphan.Checked && success && chkClearOrphan.Checked)

--- a/src/app/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -1,4 +1,4 @@
-using GitCommands.Git;
+﻿using GitCommands.Git;
 using GitCommands.Git.Extensions;
 using GitCommands.Git.Tag;
 using GitExtensions.Extensibility;
@@ -22,7 +22,7 @@ public sealed partial class FormCreateTag : GitModuleForm
     private readonly IGitTagController _gitTagController;
     private string _currentRemote = "";
 
-    public FormCreateTag(IGitUICommands commands, ObjectId? objectId)
+    public FormCreateTag(IGitUICommands commands, ObjectId objectId)
         : base(commands)
     {
         InitializeComponent();
@@ -33,13 +33,17 @@ public sealed partial class FormCreateTag : GitModuleForm
 
         tagMessage.MistakeFont = new Font(tagMessage.MistakeFont, FontStyle.Underline);
 
-        if (objectId?.IsArtificial is true)
+        if (objectId.IsArtificial)
         {
-            objectId = null;
+            objectId = default;
         }
 
-        objectId ??= Module.GetCurrentCheckout();
-        if (objectId is not null)
+        if (objectId.IsZero)
+        {
+            objectId = Module.GetCurrentCheckout();
+        }
+
+        if (!objectId.IsZero)
         {
             commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
         }
@@ -78,9 +82,9 @@ public sealed partial class FormCreateTag : GitModuleForm
 
     private string CreateTag()
     {
-        ObjectId? objectId = commitPickerSmallControl1.SelectedObjectId;
+        ObjectId objectId = commitPickerSmallControl1.SelectedObjectId;
 
-        if (objectId is null)
+        if (objectId.IsZero)
         {
             MessageBoxes.Show(this, _noRevisionSelected.Text, _messageCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return "";

--- a/src/app/GitUI/CommandsDialogs/FormDiff.cs
+++ b/src/app/GitUI/CommandsDialogs/FormDiff.cs
@@ -19,7 +19,7 @@ public partial class FormDiff : GitModuleForm
     private GitRevision? _firstRevision;
     private GitRevision? _secondRevision;
     private readonly GitRevision? _mergeBase;
-    private Lazy<ObjectId?> _currentHead;
+    private Lazy<ObjectId> _currentHead;
 
     private readonly IGitRevisionTester _revisionTester;
     private readonly IFileStatusListContextMenuController _revisionDiffContextMenuController;
@@ -61,16 +61,16 @@ public partial class FormDiff : GitModuleForm
         // _mergeBase is not changed if first/second is changed
         // similar, _currentHead is not updated if changed in Browse
         _currentHead = new(() => Module.GetCurrentCheckout());
-        ObjectId? firstMergeId = firstId.IsArtificial ? _currentHead.Value : firstId;
-        ObjectId? secondMergeId = secondId.IsArtificial ? _currentHead.Value : secondId;
-        if (firstMergeId is null || secondMergeId is null || firstMergeId == secondMergeId)
+        ObjectId firstMergeId = firstId.IsArtificial ? _currentHead.Value : firstId;
+        ObjectId secondMergeId = secondId.IsArtificial ? _currentHead.Value : secondId;
+        if (firstMergeId.IsZero || secondMergeId.IsZero || firstMergeId == secondMergeId)
         {
             _mergeBase = null;
         }
         else
         {
-            ObjectId? mergeBase = Module.GetMergeBase(firstMergeId, secondMergeId);
-            _mergeBase = mergeBase is not null ? new GitRevision(mergeBase) : null;
+            ObjectId mergeBase = Module.GetMergeBase(firstMergeId, secondMergeId);
+            _mergeBase = mergeBase.IsZero ? null : new GitRevision(mergeBase);
         }
 
         ckCompareToMergeBase.Text = $"{_ckCompareToMergeBase} ({_mergeBase?.ObjectId.ToShortString()})";
@@ -221,8 +221,8 @@ public partial class FormDiff : GitModuleForm
         if (form.ShowDialog(this) == DialogResult.OK)
         {
             displayStr = form.BranchName;
-            ObjectId? objectId = Module.RevParse(form.BranchName!);
-            revision = objectId is null ? null : new GitRevision(objectId);
+            ObjectId objectId = Module.RevParse(form.BranchName!);
+            revision = objectId.IsZero ? null : new GitRevision(objectId);
             PopulateDiffFiles();
         }
     }

--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -78,7 +78,7 @@ public sealed partial class FormFileHistory : GitModuleForm, IRevisionGridFileUp
 
         Blame.ConfigureRepositoryHostPlugin(PluginRegistry.TryGetGitHosterForModule(Module));
 
-        RevisionGrid.SelectedId = revision?.ObjectId;
+        RevisionGrid.SelectedId = revision is null ? default : revision.ObjectId;
         RevisionGrid.ShowBuildServerInfo = true;
         RevisionGrid.FilePathByObjectId = [];
 
@@ -229,7 +229,7 @@ public sealed partial class FormFileHistory : GitModuleForm, IRevisionGridFileUp
             return null;
         }
 
-        ObjectId? objectId = rev.IsArtificial ? RevisionGrid.CurrentCheckout : rev.ObjectId;
+        ObjectId objectId = rev.IsArtificial ? RevisionGrid.CurrentCheckout : rev.ObjectId;
 
         return RevisionGrid.GetRevisionFileName(FileName, objectId);
     }
@@ -270,7 +270,7 @@ public sealed partial class FormFileHistory : GitModuleForm, IRevisionGridFileUp
         bool isFolder = fileName.EndsWith('/');
         bool fileAvailable
             = !isFolder && (revision.IsArtificial ? File.Exists(fileName)
-            : Module.GetFileBlobHash(fileName, revision.ObjectId) is not null);
+            : !Module.GetFileBlobHash(fileName, revision.ObjectId).IsZero);
 
         SetTitle(alternativeFileName: fileName);
 
@@ -554,7 +554,7 @@ public sealed partial class FormFileHistory : GitModuleForm, IRevisionGridFileUp
         if (e.Command == "gotocommit")
         {
             Validates.NotNull(e.Data);
-            if (Module.TryResolvePartialCommitId(e.Data, out ObjectId? commitId))
+            if (Module.TryResolvePartialCommitId(e.Data, out ObjectId commitId))
             {
                 if (!RevisionGrid.SetSelectedRevision(commitId))
                 {

--- a/src/app/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/src/app/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -26,16 +26,16 @@ public sealed partial class FormMergeSubmodule : GitModuleForm
     {
         ConflictData item = ThreadHelper.JoinableTaskFactory.Run(() => Module.GetConflictAsync(_filename));
 
-        tbBase.Text = item.Base.ObjectId?.ToString() ?? _deleted.Text;
-        tbLocal.Text = item.Local.ObjectId?.ToString() ?? _deleted.Text;
-        tbRemote.Text = item.Remote.ObjectId?.ToString() ?? _deleted.Text;
-        tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout()?.ToString() ?? "";
-        btCheckoutBranch.Enabled = item.Base.ObjectId is not null && item.Remote.ObjectId is not null;
+        tbBase.Text = item.Base.ObjectId.IsZero ? _deleted.Text : item.Base.ObjectId.ToString();
+        tbLocal.Text = item.Local.ObjectId.IsZero ? _deleted.Text : item.Local.ObjectId.ToString();
+        tbRemote.Text = item.Remote.ObjectId.IsZero ? _deleted.Text : item.Remote.ObjectId.ToString();
+        tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout() is { IsZero: false } id ? id.ToString() : "";
+        btCheckoutBranch.Enabled = !item.Base.ObjectId.IsZero && !item.Remote.ObjectId.IsZero;
     }
 
     private void btRefresh_Click(object sender, EventArgs e)
     {
-        tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout()?.ToString() ?? "";
+        tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout() is { IsZero: false } id ? id.ToString() : "";
     }
 
     private void StageSubmodule()

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -894,7 +894,7 @@ public partial class FormPush : GitModuleForm
             // Solution: when pushing a branch that doesn't exist on the remote, ask what to do
             Validates.NotNull(_currentBranchName);
             Validates.NotNull(_selectedRemote.Name);
-            GitRef currentBranch = new(Module, null, _currentBranchName, _selectedRemote.Name);
+            GitRef currentBranch = new(Module, default, _currentBranchName, _selectedRemote.Name);
             _NO_TRANSLATE_Branch.Items.Add(currentBranch);
             _NO_TRANSLATE_Branch.SelectedItem = currentBranch;
         }

--- a/src/app/GitUI/CommandsDialogs/FormRebase.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRebase.cs
@@ -1,4 +1,4 @@
-using GitCommands;
+﻿using GitCommands;
 using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -405,8 +405,8 @@ public partial class FormRebase : GitExtensionsDialog
         try
         {
             AppSettings.ShowStashes = false;
-            ObjectId? firstParent = UICommands.Module.RevParse("HEAD~");
-            string preSelectedCommit = !string.IsNullOrWhiteSpace(txtFrom.Text) ? txtFrom.Text : firstParent?.ToString() ?? string.Empty;
+            ObjectId firstParent = UICommands.Module.RevParse("HEAD~");
+            string preSelectedCommit = !string.IsNullOrWhiteSpace(txtFrom.Text) ? txtFrom.Text : firstParent.IsZero ? string.Empty : firstParent.ToString();
 
             string? mergeBaseCommitId = null;
 
@@ -414,9 +414,10 @@ public partial class FormRebase : GitExtensionsDialog
             {
                 try
                 {
-                    ObjectId? commit1 = UICommands.Module.RevParse(cboBranches.Text);
-                    ObjectId? commit2 = UICommands.Module.RevParse("HEAD");
-                    mergeBaseCommitId = UICommands.Module.GetMergeBase(commit1!, commit2!)?.ToString();
+                    ObjectId commit1 = UICommands.Module.RevParse(cboBranches.Text);
+                    ObjectId commit2 = UICommands.Module.RevParse("HEAD");
+                    ObjectId mergeBase = UICommands.Module.GetMergeBase(commit1, commit2);
+                    mergeBaseCommitId = mergeBase.IsZero ? null : mergeBase.ToString();
                 }
                 catch (Exception)
                 {

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -775,7 +775,7 @@ public partial class FormResolveConflicts : GitModuleForm
     private string GetLocalSideString() => _inTheMiddleOfRebase ? _theirs.Text : _ours.Text;
 
     private string GetShortHash(ConflictedFileData item)
-        => $"@{(item.ObjectId is null ? _deleted.Text : item.ObjectId.ToShortString())}";
+        => $"@{(item.ObjectId.IsZero ? _deleted.Text : item.ObjectId.ToShortString())}";
 
     private void ConflictedFiles_SelectionChanged(object? sender, EventArgs e)
     {

--- a/src/app/GitUI/CommandsDialogs/FormStash.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.cs
@@ -246,12 +246,12 @@ public sealed partial class FormStash : GitModuleForm
         {
             // FileStatusList has no interface for both worktree<-index, index<-HEAD at the same time
             // Must be handled when displaying
-            ObjectId? headId = Module.RevParse("HEAD");
+            ObjectId headId = Module.RevParse("HEAD");
             GitRevision workTreeRev = new(ObjectId.WorkTreeId)
             {
                 ParentIds = new[] { ObjectId.IndexId }
             };
-            if (headId is null)
+            if (headId.IsZero)
             {
                 // Likely a detached head
                 Stashed.SetDiffs(null, workTreeRev, gitItemStatuses);
@@ -270,13 +270,17 @@ public sealed partial class FormStash : GitModuleForm
         }
         else
         {
-            ObjectId? firstId = Module.RevParse(gitStash.Name + "^");
-            GitRevision? firstRev = firstId is null ? null : new(firstId);
+            ObjectId firstId = Module.RevParse(gitStash.Name + "^");
+            GitRevision? firstRev = firstId.IsZero ? null : new(firstId);
 
-            ObjectId? selectedId = Module.RevParse(gitStash.Name);
-            Validates.NotNull(selectedId);
+            ObjectId selectedId = Module.RevParse(gitStash.Name);
+            if (selectedId.IsZero)
+            {
+                throw new InvalidOperationException("selectedId must not be zero");
+            }
+
             GitRevision secondRev = new(selectedId);
-            if (firstId is not null)
+            if (!firstId.IsZero)
             {
                 secondRev.ParentIds = new[] { firstId };
             }

--- a/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -54,7 +54,7 @@ partial class FormVerify
         /// <summary>
         /// Id (SHA-1 hash) of parent commit to the lost object.
         /// </summary>
-        public ObjectId? Parent { get; private set; }
+        public ObjectId Parent { get; private set; }
 
         /// <summary>
         /// Diagnostics and object type.
@@ -75,7 +75,12 @@ partial class FormVerify
             // TODO use enum for RawType
             ObjectType = objectType;
             RawType = rawType;
-            ObjectId = objectId ?? throw new ArgumentNullException(nameof(objectId));
+            if (objectId.IsZero)
+            {
+                throw new ArgumentNullException(nameof(objectId));
+            }
+
+            ObjectId = objectId;
         }
 
         /// <summary>

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -1,4 +1,4 @@
-using GitCommands.Git;
+﻿using GitCommands.Git;
 using GitCommands.Git.Tag;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
@@ -541,9 +541,9 @@ public sealed partial class FormVerify : GitModuleForm
         if (Warnings?.SelectedRows.Count is > 0 && Warnings.SelectedRows[0].DataBoundItem is not null)
         {
             LostObject lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem!;
-            ObjectId? parent = lostObject.Parent;
+            ObjectId parent = lostObject.Parent;
 
-            if (parent is not null)
+            if (!parent.IsZero)
             {
                 ClipboardUtil.TrySetText(parent.ToString());
             }

--- a/src/app/GitUI/CommandsDialogs/IRevisionGridInfo.cs
+++ b/src/app/GitUI/CommandsDialogs/IRevisionGridInfo.cs
@@ -1,11 +1,11 @@
-using GitExtensions.Extensibility.Git;
+﻿using GitExtensions.Extensibility.Git;
 using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs;
 
 public interface IRevisionGridInfo
 {
-    ObjectId? CurrentCheckout { get; }
+    ObjectId CurrentCheckout { get; }
     GitRevision GetRevision(ObjectId objectId);
     GitRevision? GetActualRevision(ObjectId objectId);
     GitRevision GetActualRevision(GitRevision revision);

--- a/src/app/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
+++ b/src/app/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
@@ -1,8 +1,8 @@
-using GitExtensions.Extensibility.Git;
+﻿using GitExtensions.Extensibility.Git;
 
 namespace GitUI.CommandsDialogs;
 
 public interface IRevisionGridUpdate
 {
-    bool SetSelectedRevision(ObjectId? commitId, bool toggleSelection = false, bool updateNavigationHistory = true);
+    bool SetSelectedRevision(ObjectId commitId, bool toggleSelection = false, bool updateNavigationHistory = true);
 }

--- a/src/app/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
+++ b/src/app/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
@@ -83,7 +83,7 @@ public class RememberFileContextMenuController
     /// <param name="isSecondRevision">true if second revision is used.</param>
     /// <returns>A Git commitish.</returns>
     [Pure]
-    public string? GetGitCommit(Func<string, ObjectId, ObjectId?>? getFileBlobHash, FileStatusItem? item, bool isSecondRevision)
+    public string? GetGitCommit(Func<string, ObjectId, ObjectId>? getFileBlobHash, FileStatusItem? item, bool isSecondRevision)
     {
         if (item is null)
         {
@@ -94,8 +94,8 @@ public class RememberFileContextMenuController
                 ? item.Item.OldName
                 : item.Item.Name)
             ?.ToPosixPath();
-        ObjectId? id = (isSecondRevision ? item.SecondRevision : item.FirstRevision)?.ObjectId;
-        if (string.IsNullOrWhiteSpace(name) || id is null)
+        ObjectId id = (isSecondRevision ? item.SecondRevision : item.FirstRevision)?.ObjectId ?? default;
+        if (string.IsNullOrWhiteSpace(name) || id.IsZero)
         {
             return null;
         }
@@ -110,7 +110,8 @@ public class RememberFileContextMenuController
         {
             // Must be referenced by blob - treeid is mutable.
             // File name presented in difftool will be blob or the other file
-            return getFileBlobHash?.Invoke(name, id)?.ToString();
+            ObjectId blobHash = getFileBlobHash?.Invoke(name, id) ?? default;
+            return blobHash.IsZero ? null : blobHash.ToString();
         }
 
         // commit:path

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -389,8 +389,8 @@ public partial class ViewPullRequestsForm : GitModuleForm
         List<GitItemStatus> giss = [];
 
         // baseSha is the sha of the merge to ("master") sha, the commit to be firstId
-        GitRevision? firstRev = ObjectId.TryParse(baseSha, out ObjectId? firstId) ? new GitRevision(firstId) : null;
-        GitRevision? secondRev = ObjectId.TryParse(secondSha, out ObjectId? secondId) ? new GitRevision(secondId) : null;
+        GitRevision? firstRev = ObjectId.TryParse(baseSha, out ObjectId firstId) ? new GitRevision(firstId) : null;
+        GitRevision? secondRev = ObjectId.TryParse(secondSha, out ObjectId secondId) ? new GitRevision(secondId) : null;
         if (secondRev is null)
         {
             MessageBoxes.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -339,7 +339,7 @@ public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUp
             filterFileInGrid: FilterFileInGrid,
             openInFileTreeTab_AsBlame: OpenInFileTreeTab,
             refreshParent: RequestRefresh,
-            getCurrentRevision: () => _revisionGridInfo?.GetRevision(_revisionGridInfo.CurrentCheckout!)!,
+            getCurrentRevision: () => _revisionGridInfo?.GetRevision(_revisionGridInfo.CurrentCheckout)!,
             getLineNumber: () => BlameControl.Visible ? BlameControl.CurrentFileLine : DiffText.CurrentFileLine,
             getSelectedText: DiffText.GetSelectedText,
             getSupportLinePatching: () => DiffText.SupportLinePatching);
@@ -382,9 +382,9 @@ public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUp
         base.Dispose(disposing);
     }
 
-    private string DescribeRevision(ObjectId? objectId, int maxLength = 0)
+    private string DescribeRevision(ObjectId objectId, int maxLength = 0)
     {
-        if (objectId is null)
+        if (objectId.IsZero)
         {
             // No parent at all, present as working directory
             return ResourceManager.TranslatedStrings.Workspace;
@@ -451,7 +451,7 @@ public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUp
         }
 
         GitRevision? rev = DiffFiles.SelectedItem.SecondRevision.IsArtificial
-            ? _revisionGridInfo!.GetActualRevision(_revisionGridInfo.CurrentCheckout!)
+            ? _revisionGridInfo!.GetActualRevision(_revisionGridInfo.CurrentCheckout)
             : DiffFiles.SelectedItem.SecondRevision;
         await BlameControl.LoadBlameAsync(rev!, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGridInfo, revisionGridFileUpdate: this,
             controlToMask: null, DiffText.Encoding, line, cancellationTokenSequence: _viewChangesSequence);

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Net;
 using System.Reactive.Linq;
 using System.Text;
@@ -537,7 +537,7 @@ public partial class CommitInfo : GitModuleControl
                 _tags = tags;
             }
 
-            async Task LoadBranchInfoAsync(ObjectId revision)
+            async Task LoadBranchInfoAsync(ObjectId objectId)
             {
                 await TaskScheduler.Default;
 
@@ -548,7 +548,7 @@ public partial class CommitInfo : GitModuleControl
                 // Include remote branches if requested
                 bool getRemote = AppSettings.CommitInfoShowContainedInBranchesRemote ||
                                  AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal;
-                List<string> branches = [.. Module.GetAllBranchesWhichContainGivenCommit(revision, getLocal, getRemote, cancellationToken)];
+                List<string> branches = [.. Module.GetAllBranchesWhichContainGivenCommit(objectId, getLocal, getRemote, cancellationToken)];
 
                 await this.SwitchToMainThreadAsync(cancellationToken);
                 _branches = branches;

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -697,27 +697,27 @@ public partial class FileViewer : GitModuleControl
     }
 
     /// <summary>
-    /// View the git item with the TreeGuid.
+    /// View the git item with the TreeId.
     /// </summary>
-    /// <param name="file">GitItem file, with TreeGuid.</param>
-    /// <param name="objectId">Revision to present. Can be null if file.TreeGuid is set.</param>
+    /// <param name="file">GitItem file, with TreeId.</param>
+    /// <param name="objectId">Revision to present. Can be the zero <see cref="ObjectId"/> if file.TreeId is set.</param>
     /// <param name="item">Metadata for line patching and presentation.</param>
     /// <param name="line">The line to display.</param>
     /// <param name="openWithDifftool">difftool command</param>
     /// <returns>Task to view the item</returns>
     private Task ViewGitItemAsync(GitItemStatus file,
-        ObjectId? objectId,
+        ObjectId objectId,
         FileStatusItem? item,
         int? line,
         Action? openWithDifftool,
         CancellationToken cancellationToken = default)
     {
         // set fields possibly not set from git-diff (etc); treeGuid and IsSubmodule.
-        // (git-status does not report submodule, IsSubmodule is not set if not TreeGuid is)
+        // (git-status does not report submodule, IsSubmodule is not set if not TreeId is)
         // treeId (blobId) is only recalculated if required.
-        ObjectId? blobId = GetUpdateTreeId(file, objectId, cancellationToken);
+        ObjectId blobId = GetUpdateTreeId(file, objectId, cancellationToken);
 
-        return blobId is null
+        return blobId.IsZero
             ? ViewFileAsync(file.Name, file.IsSubmodule, item, line, openWithDifftool, cancellationToken)
             : ViewItemAsync(
                 file.Name,
@@ -786,7 +786,7 @@ public partial class FileViewer : GitModuleControl
         // Especially, if GE is invoked as git-config core.editor when rebasing,
         // another Git command must not be called (will fail the rebase).
         if (!isSubmodule
-            && (item is null || item.Item.TreeGuid is null)
+            && (item is null || item.Item.TreeId.IsZero)
             && (fileName.EndsWith('/') || Directory.Exists(fullPath)))
         {
             if (!GitModule.IsValidGitWorkingDir(fullPath))
@@ -959,9 +959,9 @@ public partial class FileViewer : GitModuleControl
         StagedStatus stagedStatus = _viewItem?.Item?.Staged ?? StagedStatus.Unknown;
         if (stagedStatus == StagedStatus.Unknown)
         {
-            stagedStatus = GitModule.GetStagedStatus(_viewItem?.FirstRevision?.ObjectId,
-                _viewItem?.SecondRevision?.ObjectId,
-                _viewItem?.SecondRevision?.FirstParentId);
+            stagedStatus = GitModule.GetStagedStatus(_viewItem?.FirstRevision?.ObjectId ?? default,
+                _viewItem?.SecondRevision?.ObjectId ?? default,
+                _viewItem?.SecondRevision?.FirstParentId ?? default);
             if (_viewItem?.Item is not null)
             {
                 _viewItem.Item.Staged = stagedStatus;
@@ -1604,21 +1604,21 @@ public partial class FileViewer : GitModuleControl
     /// <param fileName="cancellationToken">The cancellation token.</param>
     /// <returns>the current TreeId (normally blob id, could be commit id) to be used.
     /// For worktree null is always returned also if there is a treeid (that really applies to the index)</returns>
-    public ObjectId? GetUpdateTreeId(GitItemStatus file,
-        ObjectId? commitId,
+    public ObjectId GetUpdateTreeId(GitItemStatus file,
+        ObjectId commitId,
         CancellationToken cancellationToken = default)
     {
-        if (file.TreeGuid is not null && commitId?.IsArtificial is false)
+        if (!file.TreeId.IsZero && !commitId.IsArtificial)
         {
             // current value is immutable (and IsSubmodule should have been set)
-            return file.TreeGuid;
+            return file.TreeId;
         }
 
-        if (commitId == ObjectId.WorkTreeId && (file.TreeGuid is not null || file.IsSubmodule))
+        if (commitId == ObjectId.WorkTreeId && (!file.TreeId.IsZero || file.IsSubmodule))
         {
             // treeId already calculated, no point in doing it again.
             // (if treeId is set, it means that IsSubmodule is set).
-            return null;
+            return default;
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -1627,11 +1627,11 @@ public partial class FileViewer : GitModuleControl
         {
             IObjectGitItem gitItem = items[0];
             file.IsSubmodule = gitItem.ObjectType == GitObjectType.Commit;
-            file.TreeGuid = gitItem.ObjectId;
-            return commitId == ObjectId.WorkTreeId ? null : file.TreeGuid;
+            file.TreeId = gitItem.ObjectId;
+            return commitId == ObjectId.WorkTreeId ? default : file.TreeId;
         }
 
-        return null;
+        return default;
     }
 
     /// <summary>
@@ -1702,7 +1702,7 @@ public partial class FileViewer : GitModuleControl
         {
             Validates.NotNull(FilePreamble);
 
-            ObjectId? itemBlobId = GetUpdateTreeId(_viewItem.Item, _viewItem.SecondRevision.ObjectId);
+            ObjectId itemBlobId = GetUpdateTreeId(_viewItem.Item, _viewItem.SecondRevision.ObjectId);
             patch = PatchManager.GetSelectedLinesAsNewPatch(
                 Module,
                 _viewItem.Item.Name,
@@ -1712,7 +1712,7 @@ public partial class FileViewer : GitModuleControl
                 Encoding,
                 reset: false,
                 FilePreamble,
-                itemBlobId?.ToString());
+                itemBlobId.ToString());
         }
         else
         {
@@ -1765,7 +1765,7 @@ public partial class FileViewer : GitModuleControl
         {
             Validates.NotNull(FilePreamble);
 
-            ObjectId? itemBlobId = GetUpdateTreeId(_viewItem.Item, _viewItem.SecondRevision.ObjectId);
+            ObjectId itemBlobId = GetUpdateTreeId(_viewItem.Item, _viewItem.SecondRevision.ObjectId);
             patch = PatchManager.GetSelectedLinesAsNewPatch(
                 Module,
                 _viewItem.Item.Name,
@@ -1775,7 +1775,7 @@ public partial class FileViewer : GitModuleControl
                 Encoding,
                 reset: true,
                 FilePreamble,
-                itemBlobId?.ToString());
+                itemBlobId.ToString());
         }
         else if (currentItemStaged)
         {
@@ -1839,7 +1839,7 @@ public partial class FileViewer : GitModuleControl
         {
             Validates.NotNull(FilePreamble);
 
-            ObjectId? itemBlobId = reverse ? GetUpdateTreeId(_viewItem.Item, _viewItem.SecondRevision.ObjectId) : null;
+            ObjectId itemBlobId = reverse ? GetUpdateTreeId(_viewItem.Item, _viewItem.SecondRevision.ObjectId) : default;
             patch = PatchManager.GetSelectedLinesAsNewPatch(
                 Module,
                 _viewItem.Item.Name,
@@ -1849,7 +1849,7 @@ public partial class FileViewer : GitModuleControl
                 Encoding,
                 reset: reverse,
                 FilePreamble,
-                itemBlobId?.ToString());
+                itemBlobId.ToString());
         }
         else if (!reverse)
         {

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -178,8 +178,8 @@ public sealed class GitUICommands : IGitUICommands
 
     public bool StartResetCurrentBranchDialog(IWin32Window? owner, string branch)
     {
-        ObjectId? objectId = Module.RevParse(branch);
-        if (objectId is null)
+        ObjectId objectId = Module.RevParse(branch);
+        if (objectId.IsZero)
         {
             MessageBoxes.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
@@ -462,18 +462,18 @@ public sealed class GitUICommands : IGitUICommands
 
     #region Checkout
 
-    public bool StartCheckoutBranch(IWin32Window? owner, string branch = "", bool remote = false, IReadOnlyList<ObjectId>? containRevisions = null)
+    public bool StartCheckoutBranch(IWin32Window? owner, string branch = "", bool remote = false, IReadOnlyList<ObjectId>? containObjectIds = null)
     {
         return DoActionOnRepo(owner, action: () =>
         {
-            using FormCheckoutBranch form = new(this, branch, remote, containRevisions);
+            using FormCheckoutBranch form = new(this, branch, remote, containObjectIds);
             return form.DoDefaultActionOrShow(owner) != DialogResult.Cancel;
         }, preEvent: PreCheckoutBranch, postEvent: PostCheckoutBranch);
     }
 
-    public bool StartCheckoutBranch(IWin32Window? owner, IReadOnlyList<ObjectId>? containRevisions)
+    public bool StartCheckoutBranch(IWin32Window? owner, IReadOnlyList<ObjectId>? containObjectIds)
     {
-        return StartCheckoutBranch(owner, "", false, containRevisions);
+        return StartCheckoutBranch(owner, "", false, containObjectIds);
     }
 
     public bool StartCheckoutRemoteBranch(IWin32Window? owner, string branch)
@@ -498,7 +498,7 @@ public sealed class GitUICommands : IGitUICommands
     /// <param name="workingDir">The working directory for the new process.</param>
     /// <param name="selectedId">The optional commit to be selected.</param>
     /// <param name="firstId">The first commit to be selected, the first commit in a diff.</param>
-    internal static void LaunchBrowse(string workingDir = "", ObjectId? selectedId = null, ObjectId? firstId = null)
+    internal static void LaunchBrowse(string workingDir = "", ObjectId selectedId = default, ObjectId firstId = default)
     {
         if (!Directory.Exists(workingDir))
         {
@@ -508,16 +508,16 @@ public sealed class GitUICommands : IGitUICommands
 
         StringBuilder arguments = new("browse");
 
-        if (selectedId is null)
+        if (selectedId.IsZero)
         {
             selectedId = firstId;
-            firstId = null;
+            firstId = default;
         }
 
-        if (selectedId is not null)
+        if (!selectedId.IsZero)
         {
             arguments.Append(" -commit=").Append(selectedId);
-            if (firstId is not null)
+            if (!firstId.IsZero)
             {
                 arguments.Append(',').Append(firstId);
             }
@@ -549,8 +549,8 @@ public sealed class GitUICommands : IGitUICommands
 
     public bool StartCreateBranchDialog(IWin32Window? owner, string? branch)
     {
-        ObjectId? objectId = Module.RevParse(branch!);
-        if (objectId is null)
+        ObjectId objectId = Module.RevParse(branch!);
+        if (objectId.IsZero)
         {
             MessageBoxes.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
@@ -559,9 +559,9 @@ public sealed class GitUICommands : IGitUICommands
         return StartCreateBranchDialog(owner, objectId);
     }
 
-    public bool StartCreateBranchDialog(IWin32Window? owner = null, ObjectId? objectId = null, string? newBranchNamePrefix = null)
+    public bool StartCreateBranchDialog(IWin32Window? owner = null, ObjectId objectId = default, string? newBranchNamePrefix = null)
     {
-        if (Module.IsBareRepository() || objectId?.IsArtificial is true)
+        if (Module.IsBareRepository() || objectId.IsArtificial)
         {
             return false;
         }
@@ -901,7 +901,7 @@ public sealed class GitUICommands : IGitUICommands
                 return false;
             }
 
-            Module.ResetChanges(resetId: null, selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out StringBuilder output, progressAction: null);
+            Module.ResetChanges(resetId: default, selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out StringBuilder output, progressAction: null);
             if (output.Length > 0)
             {
                 MessageBoxes.Show(owner: null, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -1013,7 +1013,7 @@ public sealed class GitUICommands : IGitUICommands
 
         bool Action()
         {
-            using FormCreateTag form = new(this, revision?.ObjectId);
+            using FormCreateTag form = new(this, revision?.ObjectId ?? default);
             return form.ShowDialog(owner) == DialogResult.OK;
         }
 
@@ -1723,7 +1723,7 @@ public sealed class GitUICommands : IGitUICommands
                 });
         }
 
-        if (TryGetObjectIds(arg, Module, out ObjectId? selectedId, out ObjectId? firstId))
+        if (TryGetObjectIds(arg, Module, out ObjectId selectedId, out ObjectId firstId))
         {
             return StartBrowseDialog(owner: null,
                 new BrowseArguments
@@ -1739,22 +1739,22 @@ public sealed class GitUICommands : IGitUICommands
         Console.Error.WriteLine($"No commit found matching: {arg}");
         return false;
 
-        static bool TryGetObjectIds(string arg, IGitModule module, out ObjectId? selectedId, out ObjectId? firstId)
+        static bool TryGetObjectIds(string arg, IGitModule module, out ObjectId selectedId, out ObjectId firstId)
         {
-            selectedId = null;
-            firstId = null;
+            selectedId = default;
+            firstId = default;
             foreach (string part in arg.LazySplit(','))
             {
-                if (!module.TryResolvePartialCommitId(part, out ObjectId? objectId))
+                if (!module.TryResolvePartialCommitId(part, out ObjectId objectId))
                 {
                     return false;
                 }
 
-                if (selectedId is null)
+                if (selectedId.IsZero)
                 {
                     selectedId = objectId;
                 }
-                else if (firstId is null)
+                else if (firstId.IsZero)
                 {
                     firstId = objectId;
 
@@ -1852,7 +1852,7 @@ public sealed class GitUICommands : IGitUICommands
         GitRevision? revision = null;
         if (args.Count > 3)
         {
-            if (!ObjectId.TryParse(args[3], out ObjectId? objectId))
+            if (!ObjectId.TryParse(args[3], out ObjectId objectId))
             {
                 return false;
             }
@@ -1882,7 +1882,7 @@ public sealed class GitUICommands : IGitUICommands
                              {
                                  RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
                                  PathFilter = fileHistoryFileName,
-                                 SelectedId = revision?.ObjectId,
+                                 SelectedId = revision?.ObjectId ?? default,
                                  IsFileHistoryMode = true
                              }));
         }

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Git;
@@ -55,11 +55,11 @@ public static partial class GitUIExtensions
             return;
         }
 
-        ObjectId? firstId = item.FirstRevision?.ObjectId ?? item.SecondRevision.FirstParentId;
+        ObjectId firstId = item.FirstRevision?.ObjectId ?? item.SecondRevision.FirstParentId;
 
         openWithDiffTool ??= OpenWithDiffTool;
 
-        if (forceFileView || (!item.Item.IsSubmodule && (item.Item.IsNew || firstId is null || (!item.Item.IsDeleted && FileHelper.IsImage(item.Item.Name)))))
+        if (forceFileView || (!item.Item.IsSubmodule && (item.Item.IsNew || firstId.IsZero || (!item.Item.IsDeleted && FileHelper.IsImage(item.Item.Name)))))
         {
             // View blob guid from revision, or file for worktree
             await fileViewer.ViewGitItemAsync(item, line, openWithDiffTool, cancellationToken: cancellationToken);
@@ -70,13 +70,13 @@ public static partial class GitUIExtensions
         {
             // Git range-diff has cubic runtime complexity and can be slow and memory consuming,
             // give an indication of what is going on
-            string range = item.BaseA is null || item.BaseB is null
+            string range = item.BaseA.IsZero || item.BaseB.IsZero
                 ? $"{firstId}...{item.SecondRevision.ObjectId}"
                 : $"{item.BaseA}..{firstId} {item.BaseB}..{item.SecondRevision.ObjectId}";
             await fileViewer.ViewTextAsync(fileName: null, $"git range-diff {range} -- {additionalCommandInfo}", cancellationToken: cancellationToken);
 
             ExecutionResult result = await fileViewer.Module.GetRangeDiffAsync(
-                    firstId!,
+                    firstId,
                     item.SecondRevision.ObjectId,
                     item.BaseA,
                     item.BaseB,
@@ -174,7 +174,7 @@ public static partial class GitUIExtensions
 
         if (AppSettings.DiffDisplayAppearance.Value == GitCommands.Settings.DiffDisplayAppearance.Difftastic && fileViewer.IsDifftasticEnabled.Value)
         {
-            bool isTracked = item.Item.IsTracked || (item.Item.TreeGuid is not null && item.SecondRevision.ObjectId is not null);
+            bool isTracked = item.Item.IsTracked || (!item.Item.TreeId.IsZero && !item.SecondRevision.ObjectId.IsZero);
             (ArgumentString diffArgs, string extraCacheKey) = fileViewer.GetDifftasticArguments();
 
             // set file name as null to not change the restore lineno
@@ -200,7 +200,7 @@ public static partial class GitUIExtensions
         }
 
         // diff of text file
-        string selectedPatch = (await GetSelectedPatchAsync(fileViewer, firstId!, item.SecondRevision.ObjectId, item.Item, cancellationToken))
+        string selectedPatch = (await GetSelectedPatchAsync(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item, cancellationToken))
             ?? defaultText;
 
         await fileViewer.ViewPatchAsync(item, text: selectedPatch, line: line, openWithDifftool: openWithDiffTool, cancellationToken: cancellationToken);
@@ -211,7 +211,7 @@ public static partial class GitUIExtensions
             fileViewer.Module.OpenWithDifftool(
                 item.Item.Name,
                 item.Item.OldName,
-                firstId?.ToString(),
+                firstId.IsZero ? null : firstId.ToString(),
                 item.SecondRevision.ObjectId.ToString(),
                 isTracked: item.Item.IsTracked);
         }
@@ -261,15 +261,15 @@ public static partial class GitUIExtensions
             static async Task<(Patch? patch, string? errorMessage)> GetItemPatchAsync(
                 IGitModule module,
                 GitItemStatus file,
-                ObjectId? firstId,
-                ObjectId? secondId,
+                ObjectId firstId,
+                ObjectId secondId,
                 string diffArgs,
                 bool useGitColoring,
                 Encoding encoding,
                 CancellationToken cancellationToken)
             {
                 // Files with tree guid should be presented with normal diff
-                bool isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
+                bool isTracked = file.IsTracked || (!file.TreeId.IsZero && !secondId.IsZero);
 
                 return await module.GetSingleDiffAsync(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked,
                     useGitColoring,

--- a/src/app/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/src/app/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -30,8 +30,8 @@ public partial class FormChooseCommit : GitModuleForm
 
         if (!string.IsNullOrEmpty(preselectCommit))
         {
-            ObjectId? objectId = Module.RevParse(preselectCommit);
-            if (objectId is not null)
+            ObjectId objectId = Module.RevParse(preselectCommit);
+            if (!objectId.IsZero)
             {
                 revisionGrid.SelectedId = objectId;
             }

--- a/src/app/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/src/app/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -4,7 +4,7 @@ namespace GitUI.HelperDialogs;
 
 public sealed partial class FormCommitDiff : GitModuleForm
 {
-    public FormCommitDiff(IGitUICommands commands, ObjectId? objectId)
+    public FormCommitDiff(IGitUICommands commands, ObjectId objectId)
         : base(commands)
     {
         InitializeComponent();

--- a/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -82,7 +82,7 @@ public partial class FormResetCurrentBranch : GitModuleForm
         {
             if (MessageBoxes.Show(this, _resetHardWarning.Text, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
             {
-                ObjectId? currentCheckout = Module.GetCurrentCheckout();
+                ObjectId currentCheckout = Module.GetCurrentCheckout();
                 bool success = FormProcess.ShowDialog(this, UICommands, arguments: Commands.Reset(ResetMode.Hard, Revision.Guid, quiet: false), Module.WorkingDir, input: null, useDialogSettings: true);
                 if (success)
                 {

--- a/src/app/GitUI/LeftPanel/BaseBranchLeafNode.cs
+++ b/src/app/GitUI/LeftPanel/BaseBranchLeafNode.cs
@@ -10,7 +10,7 @@ internal abstract class BaseBranchLeafNode : BaseRevisionNode
 
     private bool _isMerged = false;
 
-    public BaseBranchLeafNode(Tree tree, in ObjectId? objectId, string fullPath, bool visible, string imageKeyUnmerged, string imageKeyMerged)
+    public BaseBranchLeafNode(Tree tree, in ObjectId objectId, string fullPath, bool visible, string imageKeyUnmerged, string imageKeyMerged)
         : base(tree, fullPath, visible)
     {
         ObjectId = objectId;

--- a/src/app/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/src/app/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -50,7 +50,7 @@ internal abstract class BaseRevisionNode : Node
     /// <summary>
     /// ObjectId for nodes with a revision.
     /// </summary>
-    public ObjectId? ObjectId { get; init; }
+    public ObjectId ObjectId { get; init; }
 
     public override void ApplyStyle()
     {
@@ -111,7 +111,7 @@ internal abstract class BaseRevisionNode : Node
 
     protected virtual void SelectRevision()
     {
-        if (ObjectId is not null)
+        if (!ObjectId.IsZero)
         {
             GoToRevision(ObjectId.ToString());
         }

--- a/src/app/GitUI/LeftPanel/BaseRevisionTree.cs
+++ b/src/app/GitUI/LeftPanel/BaseRevisionTree.cs
@@ -54,7 +54,7 @@ internal abstract class BaseRevisionTree : Tree
             foreach (BaseRevisionNode node in Nodes.DepthEnumerator<BaseRevisionNode>())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (node.ObjectId is null)
+                if (node.ObjectId.IsZero)
                 {
                     continue;
                 }

--- a/src/app/GitUI/LeftPanel/BranchPathNode.cs
+++ b/src/app/GitUI/LeftPanel/BranchPathNode.cs
@@ -24,6 +24,6 @@ internal sealed class BranchPathNode : BasePathNode
     public void CreateBranch()
     {
         string newBranchNamePrefix = FullPath + PathSeparator;
-        UICommands.StartCreateBranchDialog(ParentWindow(), objectId: null, newBranchNamePrefix);
+        UICommands.StartCreateBranchDialog(ParentWindow(), objectId: default, newBranchNamePrefix);
     }
 }

--- a/src/app/GitUI/LeftPanel/LocalBranchNode.cs
+++ b/src/app/GitUI/LeftPanel/LocalBranchNode.cs
@@ -8,7 +8,7 @@ namespace GitUI.LeftPanel;
 [DebuggerDisplay("(Local) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {Visible}")]
 internal class LocalBranchNode : BaseBranchLeafNode, IGitRefActions, ICanRename, ICanDelete
 {
-    public LocalBranchNode(Tree tree, in ObjectId? objectId, string fullPath, bool isCurrent, bool visible)
+    public LocalBranchNode(Tree tree, in ObjectId objectId, string fullPath, bool isCurrent, bool visible)
         : base(tree, objectId, fullPath, visible, nameof(Images.BranchLocal), nameof(Images.BranchLocalMerged))
     {
         IsCurrent = isCurrent;

--- a/src/app/GitUI/LeftPanel/LocalBranchTree.cs
+++ b/src/app/GitUI/LeftPanel/LocalBranchTree.cs
@@ -59,7 +59,10 @@ internal sealed class LocalBranchTree : BaseRefTree
         {
             token.ThrowIfCancellationRequested();
 
-            Validates.NotNull(branch.ObjectId);
+            if (branch.ObjectId.IsZero)
+            {
+                throw new InvalidOperationException($"Branch '{branch.Name}' has no ObjectId.");
+            }
 
             LocalBranchNode localBranchNode = new(this, branch.ObjectId, branch.Name, branch.Name == currentBranch, visible: true);
 

--- a/src/app/GitUI/LeftPanel/RemoteBranchTree.cs
+++ b/src/app/GitUI/LeftPanel/RemoteBranchTree.cs
@@ -35,7 +35,10 @@ internal sealed class RemoteBranchTree : BaseRefTree
         {
             token.ThrowIfCancellationRequested();
 
-            Validates.NotNull(branch.ObjectId);
+            if (branch.ObjectId.IsZero)
+            {
+                throw new InvalidOperationException($"Branch '{branch.Name}' has no ObjectId.");
+            }
 
             string remoteName = branch.Name.SubstringUntil('/');
             if (remoteByName.TryGetValue(remoteName, out Remote remote))

--- a/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/src/app/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -332,11 +332,11 @@ public sealed partial class RepoObjectsTree : GitModuleControl
             }
         });
 
-        static ObjectId? GetSelectedNodeObjectId(TreeNode treeNode)
+        static ObjectId GetSelectedNodeObjectId(TreeNode treeNode)
         {
             // Local or remote branch nodes or tag nodes
-            return Node.GetNodeSafe<BaseBranchLeafNode>(treeNode)?.ObjectId ??
-                Node.GetNodeSafe<TagNode>(treeNode)?.ObjectId;
+            ObjectId fromBranch = Node.GetNodeSafe<BaseBranchLeafNode>(treeNode)?.ObjectId ?? default;
+            return !fromBranch.IsZero ? fromBranch : Node.GetNodeSafe<TagNode>(treeNode)?.ObjectId ?? default;
         }
     }
 

--- a/src/app/GitUI/LeftPanel/StashNode.cs
+++ b/src/app/GitUI/LeftPanel/StashNode.cs
@@ -8,7 +8,7 @@ namespace GitUI.LeftPanel;
 [DebuggerDisplay("(Tag) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {Visible}")]
 internal sealed class StashNode : BaseRevisionNode
 {
-    public StashNode(Tree tree, in ObjectId? objectId, string reflogSelector, string subject, bool visible)
+    public StashNode(Tree tree, in ObjectId objectId, string reflogSelector, string subject, bool visible)
         : base(tree, reflogSelector.RemovePrefix("refs/"), visible)
     {
         ObjectId = objectId;

--- a/src/app/GitUI/LeftPanel/SubmoduleNode.cs
+++ b/src/app/GitUI/LeftPanel/SubmoduleNode.cs
@@ -81,20 +81,20 @@ internal sealed class SubmoduleNode : Node
             return;
         }
 
-        ObjectId? selected;
-        ObjectId? first;
+        ObjectId selected;
+        ObjectId first;
         if (IsCurrent)
         {
             // Get the current (most likely) selections from the grid
             IReadOnlyList<GitRevision> revs = UICommands.BrowseRepo?.GetSelectedRevisions() ?? [];
-            selected = revs.Count > 0 ? revs[0].ObjectId : null;
-            first = revs.Count > 1 ? revs[^1].ObjectId : null;
+            selected = revs.Count > 0 ? revs[0].ObjectId : default;
+            first = revs.Count > 1 ? revs[^1].ObjectId : default;
         }
         else
         {
             // Try select a "diff" from the expected commit to worktree for a submodule
             selected = ObjectId.WorkTreeId;
-            first = Info?.Detailed?.RawStatus?.OldCommit;
+            first = Info?.Detailed?.RawStatus?.OldCommit ?? default;
         }
 
         GitUICommands.LaunchBrowse(workingDir: Info!.Path.EnsureTrailingPathSeparator(), selected, first);

--- a/src/app/GitUI/LeftPanel/TagNode.cs
+++ b/src/app/GitUI/LeftPanel/TagNode.cs
@@ -8,7 +8,7 @@ namespace GitUI.LeftPanel;
 [DebuggerDisplay("(Tag) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {Visible}")]
 internal sealed class TagNode : BaseRevisionNode, IGitRefActions, ICanDelete
 {
-    public TagNode(Tree tree, in ObjectId? objectId, string fullPath, bool visible)
+    public TagNode(Tree tree, in ObjectId objectId, string fullPath, bool visible)
         : base(tree, fullPath, visible)
     {
         ObjectId = objectId;

--- a/src/app/GitUI/RevisionDiffInfoProvider.cs
+++ b/src/app/GitUI/RevisionDiffInfoProvider.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using GitExtensions.Extensibility.Git;
 using GitUIPluginInterfaces;
 
@@ -105,7 +105,7 @@ public static class RevisionDiffInfoProvider
 
         static string GetParentRef(GitRevision revision)
         {
-            return revision.FirstParentId?.ToString() ?? revision.Guid + '^';
+            return revision.FirstParentId.IsZero ? revision.Guid + '^' : revision.FirstParentId.ToString();
         }
     }
 }

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -39,7 +39,7 @@ public sealed partial class BlameControl : GitModuleControl
     private GitBlame? _blame;
     private IRevisionGridInfo? _revisionGridInfo;
     private IRevisionGridFileUpdate? _revisionGridFileUpdate;
-    private ObjectId? _blameId;
+    private ObjectId _blameId;
     private string? _fileName;
     private Encoding? _encoding;
     private int _lastTooltipX = int.MinValue;
@@ -558,7 +558,10 @@ public sealed partial class BlameControl : GitModuleControl
     private void contextMenu_Opened(object sender, EventArgs e)
     {
         Validates.NotNull(_fileName);
-        Validates.NotNull(_blameId);
+        if (_blameId.IsZero)
+        {
+            throw new InvalidOperationException("_blameId must not be zero");
+        }
 
         contextMenu.Tag = new GitBlameContext(_fileName, _lineIndex, GetBlameLine(), _blameId);
 
@@ -589,7 +592,7 @@ public sealed partial class BlameControl : GitModuleControl
         return;
 
         bool RevisionHasParent(GitRevision? revision)
-            => (revision?.HasParent is true) && (_revisionGridInfo?.GetRevision(revision!.FirstParentId!) is not null);
+            => (revision?.HasParent is true) && (_revisionGridInfo?.GetRevision(revision!.FirstParentId) is not null);
     }
 
     private GitBlameCommit? GetBlameCommit()
@@ -674,7 +677,7 @@ public sealed partial class BlameControl : GitModuleControl
         int originalLineNumberOfPreviousBlame = _gitBlameParser.GetOriginalLineInPreviousCommit(selectedRevision!, blameInfo.Filename!, finalLineNumberOfPreviousBlame);
 
         GitBlameLine blameLine = new(_lastBlameLine.Commit, finalLineNumberOfPreviousBlame, originalLineNumberOfPreviousBlame, "Dummy Git blame line used only to store the good 'originLineNumber' value to display and select it");
-        BlameRevision(selectedRevision!.FirstParentId!, blameInfo.Filename!, blameLine);
+        BlameRevision(selectedRevision!.FirstParentId, blameInfo.Filename!, blameLine);
     }
 
     /// <summary>

--- a/src/app/GitUI/UserControls/BranchSelector.cs
+++ b/src/app/GitUI/UserControls/BranchSelector.cs
@@ -10,10 +10,10 @@ public partial class BranchSelector : GitModuleControl
     public event EventHandler? SelectedIndexChanged;
 
     private readonly bool _isLoading;
-    private IReadOnlyList<ObjectId>? _containRevisions;
+    private IReadOnlyList<ObjectId>? _containObjectIds;
     private string[]? _localBranches;
     private string[]? _remoteBranches;
-    public ObjectId? CommitToCompare;
+    public ObjectId CommitToCompare;
 
     public BranchSelector()
     {
@@ -34,16 +34,16 @@ public partial class BranchSelector : GitModuleControl
     public string SelectedBranchName => Branches.Text;
     public override string Text => Branches.Text;
 
-    public void Initialize(bool remote, IReadOnlyList<ObjectId>? containRevisions)
+    public void Initialize(bool remote, IReadOnlyList<ObjectId>? containObjectIds)
     {
         lbChanges.Text = "";
         LocalBranch.Checked = !remote;
         Remotebranch.Checked = remote;
 
-        _containRevisions = containRevisions;
+        _containObjectIds = containObjectIds;
 
         Branches.Items.Clear();
-        Branches.Items.AddRange(_containRevisions is not null
+        Branches.Items.AddRange(_containObjectIds is not null
             ? GetContainsRevisionBranches()
             : LocalBranch.Checked
                 ? GetLocalBranches()
@@ -51,7 +51,7 @@ public partial class BranchSelector : GitModuleControl
 
         Branches.ResizeDropDownWidth();
 
-        if (_containRevisions is not null && Branches.Items.Count == 1)
+        if (_containObjectIds is not null && Branches.Items.Count == 1)
         {
             Branches.SelectedIndex = 0;
         }
@@ -74,10 +74,10 @@ public partial class BranchSelector : GitModuleControl
         {
             HashSet<string> result = [];
 
-            if (_containRevisions.Count > 0)
+            if (_containObjectIds.Count > 0)
             {
                 IEnumerable<string> branches =
-                    Module.GetAllBranchesWhichContainGivenCommit(_containRevisions[0],
+                    Module.GetAllBranchesWhichContainGivenCommit(_containObjectIds[0],
                                                                  getLocal: LocalBranch.Checked,
                                                                  getRemote: !LocalBranch.Checked,
                                                                  cancellationToken: default)
@@ -86,11 +86,11 @@ public partial class BranchSelector : GitModuleControl
                 result.UnionWith(branches);
             }
 
-            for (int index = 1; index < _containRevisions.Count; index++)
+            for (int index = 1; index < _containObjectIds.Count; index++)
             {
-                ObjectId containRevision = _containRevisions[index];
+                ObjectId containObjectId = _containObjectIds[index];
                 IEnumerable<string> branches =
-                    Module.GetAllBranchesWhichContainGivenCommit(containRevision,
+                    Module.GetAllBranchesWhichContainGivenCommit(containObjectId,
                                                                  getLocal: LocalBranch.Checked,
                                                                  getRemote: !LocalBranch.Checked,
                                                                  cancellationToken: default)
@@ -115,9 +115,9 @@ public partial class BranchSelector : GitModuleControl
         else
         {
             string branchName = SelectedBranchName;
-            ObjectId? currentCheckout = CommitToCompare ?? Module.GetCurrentCheckout();
+            ObjectId currentCheckout = CommitToCompare.IsZero ? Module.GetCurrentCheckout() : CommitToCompare;
 
-            if (currentCheckout is null)
+            if (currentCheckout.IsZero)
             {
                 lbChanges.Text = "";
                 return;

--- a/src/app/GitUI/UserControls/CommitDiff.cs
+++ b/src/app/GitUI/UserControls/CommitDiff.cs
@@ -41,7 +41,7 @@ public partial class CommitDiff : GitModuleControl
         DiffText.ScrollToTop();
     }
 
-    public void SetRevision(ObjectId? objectId, string? fileToSelect)
+    public void SetRevision(ObjectId objectId, string? fileToSelect)
     {
         // We cannot use the GitRevision from revision grid. When a filtered commit list
         // is shown (file history/normal filter) the parent guids are not the 'real' parents,

--- a/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using GitExtensions.Extensibility.Git;
 using GitUI.HelperDialogs;
 
@@ -19,18 +19,18 @@ public partial class CommitPickerSmallControl : GitModuleControl
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public ObjectId? SelectedObjectId { get; private set; }
+    public ObjectId SelectedObjectId { get; private set; }
 
     /// <summary>
     /// shows a message box if commitHash is invalid.
     /// </summary>
     public void SetSelectedCommitHash(string? commitHash)
     {
-        ObjectId? oldCommitHash = SelectedObjectId;
+        ObjectId oldCommitHash = SelectedObjectId;
 
         SelectedObjectId = Module.RevParse(commitHash!);
 
-        if (SelectedObjectId is null && !string.IsNullOrWhiteSpace(commitHash))
+        if (SelectedObjectId.IsZero && !string.IsNullOrWhiteSpace(commitHash))
         {
             SelectedObjectId = oldCommitHash;
             MessageBoxes.Show("The given commit hash is not valid for this repository and was therefore discarded.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -44,23 +44,24 @@ public partial class CommitPickerSmallControl : GitModuleControl
 
         lbCommits.Text = "";
 
-        if (SelectedObjectId is null || isArtificialCommitForEmptyRepo)
+        if (SelectedObjectId.IsZero || isArtificialCommitForEmptyRepo)
         {
             textBoxCommitHash.Text = "";
         }
         else
         {
-            textBoxCommitHash.Text = SelectedObjectId.ToShortString();
+            ObjectId selectedObjectId = SelectedObjectId;
+            textBoxCommitHash.Text = selectedObjectId.ToShortString();
             ThreadHelper.FileAndForget(async () =>
                 {
-                    ObjectId? currentCheckout = Module.GetCurrentCheckout();
+                    ObjectId currentCheckout = Module.GetCurrentCheckout();
 
-                    if (currentCheckout is null)
+                    if (currentCheckout.IsZero)
                     {
                         return;
                     }
 
-                    string toRef = SelectedObjectId.IsArtificial ? "HEAD" : SelectedObjectId.ToString();
+                    string toRef = selectedObjectId.IsArtificial ? "HEAD" : selectedObjectId.ToString();
                     string text = Module.GetCommitCountString(currentCheckout, toRef);
 
                     await this.SwitchToMainThreadAsync();
@@ -72,7 +73,7 @@ public partial class CommitPickerSmallControl : GitModuleControl
 
     private void buttonPickCommit_Click(object sender, EventArgs e)
     {
-        using FormChooseCommit chooseForm = new(UICommands, SelectedObjectId?.ToString());
+        using FormChooseCommit chooseForm = new(UICommands, SelectedObjectId.IsZero ? null : SelectedObjectId.ToString());
         if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
         {
             SetSelectedCommitHash(chooseForm.SelectedRevision.Guid);

--- a/src/app/GitUI/UserControls/FileStatusDiffCalculator.FileStatusDiffCalculatorInfo.cs
+++ b/src/app/GitUI/UserControls/FileStatusDiffCalculator.FileStatusDiffCalculatorInfo.cs
@@ -7,7 +7,7 @@ partial class FileStatusDiffCalculator
 {
     private record struct FileStatusDiffCalculatorInfo(
         IReadOnlyList<GitRevision> Revisions,
-        ObjectId? HeadId,
+        ObjectId HeadId,
         bool AllowMultiDiff,
         bool FileTreeMode,
         string GrepArguments,

--- a/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -30,7 +30,7 @@ public sealed partial class FileStatusDiffCalculator
 
     public void SetDiff(
         IReadOnlyList<GitRevision> revisions,
-        ObjectId? headId,
+        ObjectId headId,
         bool allowMultiDiff,
         bool showSkipWorktreeFiles = false,
         bool showUntrackedFiles = true)
@@ -81,7 +81,7 @@ public sealed partial class FileStatusDiffCalculator
     private List<FileStatusWithDescription> CalculateDiffs(
         IReadOnlyList<GitRevision> revisions,
         GitRevision selectedRev,
-        ObjectId? headId,
+        ObjectId headId,
         bool allowMultiDiff,
         bool showSkipWorktreeFiles,
         UntrackedFilesMode untrackedFilesMode,
@@ -104,11 +104,11 @@ public sealed partial class FileStatusDiffCalculator
                     .Take(multipleParents)
                     .Where(parentId => !(multipleParents == 3 && DescribeRevision?.Invoke(parentId).Contains(": untracked files on ") is true))
                     .Select(parentId =>
-                        new FileStatusWithDescription(
-                            firstRev: new GitRevision(parentId),
-                            secondRev: selectedRev,
-                            summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(parentId),
-                            statuses: module.GetDiffFilesWithSubmodulesStatus(parentId, selectedRev.ObjectId, actualRev.ParentIds[0], !showSkipWorktreeFiles, untrackedFilesMode, cancellationToken))));
+                                new FileStatusWithDescription(
+                                    firstRev: new GitRevision(parentId),
+                                    secondRev: selectedRev,
+                                    summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(parentId),
+                                    statuses: module.GetDiffFilesWithSubmodulesStatus(parentId, selectedRev.ObjectId, actualRev.ParentIds[0], !showSkipWorktreeFiles, untrackedFilesMode, cancellationToken))));
             }
             else
             {
@@ -116,13 +116,13 @@ public sealed partial class FileStatusDiffCalculator
                     firstRev: null,
                     secondRev: selectedRev,
                     summary: GetDescriptionForRevision(selectedRev.ObjectId),
-                    statuses: selectedRev.TreeGuid is null
+                    statuses: selectedRev.TreeId.IsZero
 
                         // likely index commit without HEAD
-                        ? module.GetDiffFilesWithSubmodulesStatus(firstId: null, selectedRev.ObjectId, parentToSecond: null, cancellationToken: cancellationToken)
+                        ? module.GetDiffFilesWithSubmodulesStatus(firstId: default, selectedRev.ObjectId, parentToSecond: default, cancellationToken: cancellationToken)
 
                         // No parent for the initial commit, show files and explicitly set IsNew
-                        : module.GetTreeFiles(selectedRev.TreeGuid, full: true, cancellationToken)
+                        : module.GetTreeFiles(selectedRev.TreeId, full: true, cancellationToken)
                             .Select(i =>
                             {
                                 i.IsNew = true;
@@ -168,9 +168,9 @@ public sealed partial class FileStatusDiffCalculator
         }
 
         // Get merge base commit, use HEAD for artificial
-        ObjectId? firstRevHead = GetRevisionOrHead(firstRev, headId!);
-        ObjectId? selectedRevHead = GetRevisionOrHead(selectedRev, headId!);
-        ObjectId? baseRevId = null;
+        ObjectId firstRevHead = GetRevisionOrHead(firstRev, headId);
+        ObjectId selectedRevHead = GetRevisionOrHead(selectedRev, headId);
+        ObjectId baseRevId = default;
         if (revisions.Count != 3)
         {
             baseRevId = GetMergeBase(firstRevHead, selectedRevHead);
@@ -189,44 +189,44 @@ public sealed partial class FileStatusDiffCalculator
         }
 
         // If four selected: check if two ranges are selected
-        ObjectId? baseA = null;
-        ObjectId? baseB = null;
+        ObjectId baseA = default;
+        ObjectId baseB = default;
 
         // Check for separate branches (note that artificial commits both have HEAD as BASE)
-        if (baseRevId is not null)
+        if (!baseRevId.IsZero)
         {
             // Two/Three: Check that the selections are in separate branches
             if (revisions.Count < 4)
             {
                 if (baseRevId == firstRevHead || baseRevId == selectedRevHead)
                 {
-                    baseRevId = null;
+                    baseRevId = default;
                 }
             }
 
             // Four: Two ranges must be selected
             else
             {
-                baseA = GetMergeBase(GetRevisionOrHead(revisions[3], headId!), firstRevHead);
+                baseA = GetMergeBase(GetRevisionOrHead(revisions[3], headId), firstRevHead);
                 if (baseA == revisions[3].ObjectId)
                 {
-                    baseB = GetMergeBase(GetRevisionOrHead(revisions[1], headId!), selectedRevHead);
+                    baseB = GetMergeBase(GetRevisionOrHead(revisions[1], headId), selectedRevHead);
                     if (baseB != revisions[1].ObjectId)
                     {
-                        baseB = null;
+                        baseB = default;
                     }
                 }
 
-                if (baseB is null)
+                if (baseB.IsZero)
                 {
                     // baseA/baseB were not ranges, this is no merge base
-                    baseRevId = null;
-                    baseA = null;
+                    baseRevId = default;
+                    baseA = default;
                 }
             }
         }
 
-        if (baseRevId is null)
+        if (baseRevId.IsZero)
         {
             // No variant of range diff, show multi diff
             fileStatusDescs.AddRange(
@@ -306,11 +306,11 @@ public sealed partial class FileStatusDiffCalculator
 
         return fileStatusDescs;
 
-        ObjectId? GetMergeBase(ObjectId? a, ObjectId? b)
+        ObjectId GetMergeBase(ObjectId a, ObjectId b)
         {
-            if (a is null || b is null || a == b)
+            if (a.IsZero || b.IsZero || a == b)
             {
-                return null;
+                return default;
             }
 
             return module.GetMergeBase(a, b);

--- a/src/app/GitUI/UserControls/FileStatusItem.cs
+++ b/src/app/GitUI/UserControls/FileStatusItem.cs
@@ -5,7 +5,7 @@ namespace GitUI.UserControls;
 
 public sealed class FileStatusItem
 {
-    public FileStatusItem(GitRevision? firstRev, GitRevision secondRev, GitItemStatus item, ObjectId? baseA = null, ObjectId? baseB = null)
+    public FileStatusItem(GitRevision? firstRev, GitRevision secondRev, GitItemStatus item, ObjectId baseA = default, ObjectId baseB = default)
     {
         FirstRevision = firstRev;
         SecondRevision = secondRev ?? throw new ArgumentNullException(nameof(secondRev));
@@ -29,12 +29,12 @@ public sealed class FileStatusItem
     /// <summary>
     /// If ranges are selected, the first commit (base) for <see cref="FirstRevision"/> (head).
     /// </summary>
-    public ObjectId? BaseA { get; }
+    public ObjectId BaseA { get; }
 
     /// <summary>
     /// If ranges are selected, the first commit (base) for <see cref="SecondRevision"/> (head).
     /// </summary>
-    public ObjectId? BaseB { get; }
+    public ObjectId BaseB { get; }
 
     /// <summary>
     /// The status item in the list.

--- a/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Extended;
@@ -200,7 +200,7 @@ partial class FileStatusList
     /// <param name="parentId">The parent commit id.</param>
     /// <param name="selectedItems">The selected file status items.</param>
     /// <returns><see langword="true"/> if it is possible to reset to first id.</returns>
-    private static bool CanResetToFirst(ObjectId? parentId, IEnumerable<FileStatusItem> selectedItems)
+    private static bool CanResetToFirst(ObjectId parentId, IEnumerable<FileStatusItem> selectedItems)
     {
         return CanResetToSecond(parentId) || (parentId == ObjectId.IndexId && selectedItems.SecondIds().All(i => i == ObjectId.WorkTreeId));
     }
@@ -210,7 +210,7 @@ partial class FileStatusList
     /// </summary>
     /// <param name="resetId">The selected commit id.</param>
     /// <returns><see langword="true"/> if it is possible to reset to first id.</returns>
-    private static bool CanResetToSecond(ObjectId? resetId) => resetId?.IsArtificial is false;
+    private static bool CanResetToSecond(ObjectId resetId) => !resetId.IsZeroOrArtificial;
 
     private void CherryPickChanges_Click(object sender, EventArgs e)
     {
@@ -290,7 +290,7 @@ partial class FileStatusList
     {
         return parents.Count switch
         {
-            1 => GetDescriptionForRevision(parents[0]?.ObjectId),
+            1 => GetDescriptionForRevision(parents[0]?.ObjectId ?? default(ObjectId)),
             > 1 => _multipleDescription.Text,
             _ => null
         };
@@ -617,8 +617,8 @@ partial class FileStatusList
     {
         // Multiple parent/child can be selected, only the the first is shown.
         // The only artificial commit that can be reset to is Index<-WorkTree
-        ObjectId? selectedId = SelectedItems.SecondIds().FirstOrDefault();
-        ObjectId? parentId = SelectedItems.FirstIds().FirstOrDefault();
+        ObjectId selectedId = SelectedItems.SecondIds().FirstOrDefault();
+        ObjectId parentId = SelectedItems.FirstIds().FirstOrDefault();
 
         bool canResetToSecond = CanResetToSecond(selectedId);
         tsmiResetFileToSelected.Enabled = canResetToSecond;
@@ -1089,9 +1089,9 @@ partial class FileStatusList
 
         ThreadHelper.FileAndForget(async () =>
         {
-            ObjectId? blob = Module.GetFileBlobHash(item.Item.Name, item.SecondRevision.ObjectId);
+            ObjectId blob = Module.GetFileBlobHash(item.Item.Name, item.SecondRevision.ObjectId);
 
-            if (blob is null)
+            if (blob.IsZero)
             {
                 return;
             }

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -316,7 +316,7 @@ public sealed partial class FileStatusList : GitModuleControl
         }
     }
 
-    public void Bind(Action refreshArtificial, bool canAutoRefresh = false, Func<ObjectId?, string>? describeRevision = null, Func<GitRevision, GitRevision>? getActualRevision = null, bool isFileTreeMode = false)
+    public void Bind(Action refreshArtificial, bool canAutoRefresh = false, Func<ObjectId, string>? describeRevision = null, Func<GitRevision, GitRevision>? getActualRevision = null, bool isFileTreeMode = false)
     {
         btnRefresh.Click += (s, e) => refreshArtificial();
         btnRefresh.Visible = true;
@@ -432,7 +432,7 @@ public sealed partial class FileStatusList : GitModuleControl
 
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [Browsable(false)]
-    public Func<ObjectId?, string>? DescribeRevision { get; set; }
+    public Func<ObjectId, string>? DescribeRevision { get; set; }
 
     public bool FilterFilesByNameRegexFocused => cboFilterComboBox.Focused;
     public bool FindInCommitFilesGitGrepActive => !string.IsNullOrEmpty(cboFindInCommitFilesGitGrep.Text);
@@ -832,11 +832,11 @@ public sealed partial class FileStatusList : GitModuleControl
         FileStatusListLoading();
         UpdateToolbar(revisions);
         _enableDisablingShowDiffForAllParents = true;
-        _diffCalculator.SetDiff(revisions, headId: null, allowMultiDiff: false);
+        _diffCalculator.SetDiff(revisions, headId: default(ObjectId), allowMultiDiff: false);
         UpdateFileStatusListView(_diffCalculator.Calculate(prevList: [], refreshDiff: true, refreshGrep: false, cancellationToken), cancellationToken: cancellationToken);
     }
 
-    public async Task SetDiffsAsync(IReadOnlyList<GitRevision> revisions, ObjectId? headId, CancellationToken cancellationToken)
+    public async Task SetDiffsAsync(IReadOnlyList<GitRevision> revisions, ObjectId headId, CancellationToken cancellationToken)
     {
         FileStatusListLoading();
         UpdateToolbar(revisions);
@@ -921,7 +921,7 @@ public sealed partial class FileStatusList : GitModuleControl
             new(
                 firstRev: firstRev,
                 secondRev: secondRev,
-                summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(firstRev?.ObjectId),
+                summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(firstRev?.ObjectId ?? default(ObjectId)),
                 statuses: items)
         });
     }
@@ -932,9 +932,8 @@ public sealed partial class FileStatusList : GitModuleControl
         UpdateFileStatusListView([]);
     }
 
-    private string? GetDescriptionForRevision(ObjectId? objectId)
+    private string? GetDescriptionForRevision(ObjectId objectId)
         => DescribeRevision is not null ? DescribeRevision(objectId)
-            : objectId is null ? ""
             : objectId == ObjectId.WorkTreeId ? ResourceManager.TranslatedStrings.Workspace
             : objectId == ObjectId.IndexId ? ResourceManager.TranslatedStrings.Index
             : objectId.ToShortString();
@@ -1040,10 +1039,10 @@ public sealed partial class FileStatusList : GitModuleControl
             ? await task.ConfigureAwait(false)
             : null;
 
-        ObjectId? selectedId = SelectedItem.SecondRevision?.ObjectId == ObjectId.WorkTreeId
+        ObjectId selectedId = SelectedItem.SecondRevision?.ObjectId == ObjectId.WorkTreeId
             ? ObjectId.WorkTreeId
-            : status?.Commit;
-        ObjectId? firstId = status?.OldCommit;
+            : status?.Commit ?? default;
+        ObjectId firstId = status?.OldCommit ?? default;
 
         string path = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator()) ?? "";
         if (!Directory.Exists(path))

--- a/src/app/GitUI/UserControls/FileStatusWithDescription.cs
+++ b/src/app/GitUI/UserControls/FileStatusWithDescription.cs
@@ -1,4 +1,4 @@
-using GitExtensions.Extensibility.Git;
+﻿using GitExtensions.Extensibility.Git;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
 
@@ -6,7 +6,7 @@ namespace GitUI;
 
 public class FileStatusWithDescription
 {
-    public FileStatusWithDescription(GitRevision? firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses, ObjectId? baseA = null, ObjectId? baseB = null, string iconName = nameof(Images.Diff))
+    public FileStatusWithDescription(GitRevision? firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses, ObjectId baseA = default, ObjectId baseB = default, string iconName = nameof(Images.Diff))
     {
         FirstRev = firstRev;
         SecondRev = secondRev ?? throw new ArgumentNullException(nameof(secondRev));
@@ -21,7 +21,7 @@ public class FileStatusWithDescription
     public GitRevision SecondRev { get; }
     public string Summary { get; }
     public IReadOnlyList<GitItemStatus> Statuses { get; }
-    public ObjectId? BaseA { get; }
-    public ObjectId? BaseB { get; }
+    public ObjectId BaseA { get; }
+    public ObjectId BaseB { get; }
     public string IconName { get; }
 }

--- a/src/app/GitUI/UserControls/FilterToolBar.cs
+++ b/src/app/GitUI/UserControls/FilterToolBar.cs
@@ -93,8 +93,8 @@ internal partial class FilterToolBar : ToolStripEx
                 else
                 {
                     string gitref = branch.StartsWith('^') ? branch[1..] : branch;
-                    ObjectId? oid = GetModule().RevParse(gitref);
-                    if (oid is null)
+                    ObjectId oid = GetModule().RevParse(gitref);
+                    if (oid.IsZero)
                     {
                         TaskDialogPage page = new()
                         {

--- a/src/app/GitUI/UserControls/GitBlameParser.cs
+++ b/src/app/GitUI/UserControls/GitBlameParser.cs
@@ -26,9 +26,9 @@ internal partial class GitBlameParser : IGitBlameParser
 
     public int GetOriginalLineInPreviousCommit(GitRevision selectedBlamedRevision, string filename, int selectedLine)
     {
-        ObjectId? parentId = selectedBlamedRevision.FirstParentId;
+        ObjectId parentId = selectedBlamedRevision.FirstParentId;
 
-        if (parentId is null)
+        if (parentId.IsZero)
         {
             return selectedLine;
         }

--- a/src/app/GitUI/UserControls/PatchFile.cs
+++ b/src/app/GitUI/UserControls/PatchFile.cs
@@ -10,7 +10,7 @@ public sealed class PatchFile
 
     public string? Action { get; set; }
     public string? Name { get; set; }
-    public ObjectId? ObjectId { get; set; }
+    public ObjectId ObjectId { get; set; }
 
     public string? Author { get; set; }
 

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Net.Mail;
 using System.Text.RegularExpressions;
@@ -129,20 +129,18 @@ public partial class PatchGrid : GitModuleControl
             bool isApplying = currentCommitShortHash is not null && commitHash.StartsWith(currentCommitShortHash);
             isCurrentFound |= isApplying;
 
-            ObjectId? objectId;
+            ObjectId objectId;
             if (data is not null)
             {
                 objectId = data.ObjectId;
             }
             else
             {
-                if (!ObjectId.TryParse(parts[1], out ObjectId? parsedId))
+                if (!ObjectId.TryParse(parts[1], out objectId))
                 {
                     Trace.Write($"PatchGrid: GetInteractiveRebasePatchFiles: Unable to parse commit hash '{parts[1]}' from '{todoCommits}'. Skipping this entry.");
                     continue;
                 }
-
-                objectId = parsedId;
             }
 
             patchFiles.Add(new PatchFile
@@ -399,10 +397,10 @@ public partial class PatchGrid : GitModuleControl
 
         PatchFile? patchFile = (PatchFile?)Patches.SelectedRows[0].DataBoundItem;
 
-        if (patchFile?.ObjectId?.IsArtificial is false)
+        if (patchFile?.ObjectId is { IsZeroOrArtificial: false } patchObjectId)
         {
             // Normal commit selected
-            UICommands.StartFormCommitDiff(patchFile.ObjectId);
+            UICommands.StartFormCommitDiff(patchObjectId);
             return;
         }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -104,7 +104,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
             // Draw super project references (for submodules)
             DrawSuperprojectInfo(e, spi, revision, style, messageBounds, ref offset);
 
-            if (spi.Refs is not null && revision.ObjectId is not null &&
+            if (spi.Refs is not null && !revision.ObjectId.IsZero &&
                 spi.Refs.TryGetValue(revision.ObjectId, out IReadOnlyList<IGitRef>? refs))
             {
                 superprojectRefs.AddRange(refs);

--- a/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -296,7 +296,7 @@ public record FilterInfo
         return searchParametersChanged;
     }
 
-    public ArgumentString GetRevisionFilter(Lazy<ObjectId?> currentCheckout)
+    public ArgumentString GetRevisionFilter(Lazy<ObjectId> currentCheckout)
     {
         if (IsRaw)
         {
@@ -418,7 +418,7 @@ public record FilterInfo
     /// </summary>
     /// <param name="filter">ArgumentBuilder arg</param>
     /// <param name="currentCheckout">Commit currently checked out</param>
-    private void GetBranchRevisionFilter(ArgumentBuilder filter, Lazy<ObjectId?> currentCheckout)
+    private void GetBranchRevisionFilter(ArgumentBuilder filter, Lazy<ObjectId> currentCheckout)
     {
         if (ShowOnlyFirstParent)
         {
@@ -431,7 +431,7 @@ public record FilterInfo
             filter.Add("--reflog");
         }
 
-        if (IsShowCurrentBranchOnlyChecked && currentCheckout.Value is not null)
+        if (IsShowCurrentBranchOnlyChecked && !currentCheckout.Value.IsZero)
         {
             // Git default with no options
 

--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -111,7 +111,7 @@ public class RevisionGraph : IRevisionGraphRowProvider
     public int Count { get; private set; }
 
     public bool OnlyFirstParent { get; set; }
-    public ObjectId HeadId { get; set; } = null!;
+    public ObjectId HeadId { get; set; }
 
     /// <summary>
     /// Checks whether the given hash is present in the graph.

--- a/src/app/GitUI/UserControls/RevisionGrid/ParentChildNavigationHistory.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/ParentChildNavigationHistory.cs
@@ -10,14 +10,14 @@ internal sealed class ParentChildNavigationHistory
         Child
     }
 
-    private readonly Action<ObjectId?> _setSelectedRevision;
+    private readonly Action<ObjectId> _setSelectedObjectId;
     private NavigationDirection? _direction;
     private readonly Stack<ObjectId> _childHistory = new();
     private readonly Stack<ObjectId> _parentHistory = new();
 
-    public ParentChildNavigationHistory(Action<ObjectId?> setSelectedRevision)
+    public ParentChildNavigationHistory(Action<ObjectId> setSelectedObjectId)
     {
-        _setSelectedRevision = setSelectedRevision;
+        _setSelectedObjectId = setSelectedObjectId;
     }
 
     public bool HasPreviousChild => _childHistory.Count > 0;
@@ -35,17 +35,17 @@ internal sealed class ParentChildNavigationHistory
         Navigate(current, child, NavigationDirection.Child);
     }
 
-    public void NavigateToChild(ObjectId current, ObjectId? child)
+    public void NavigateToChild(ObjectId current, ObjectId child)
     {
         Navigate(current, child, NavigationDirection.Child);
     }
 
-    public void NavigateToParent(ObjectId current, ObjectId? parent)
+    public void NavigateToParent(ObjectId current, ObjectId parent)
     {
         Navigate(current, parent, NavigationDirection.Parent);
     }
 
-    private void Navigate(ObjectId current, ObjectId? to, NavigationDirection direction)
+    private void Navigate(ObjectId current, ObjectId to, NavigationDirection direction)
     {
         _direction = direction;
         if (direction == NavigationDirection.Child)
@@ -57,7 +57,7 @@ internal sealed class ParentChildNavigationHistory
             _childHistory.Push(current);
         }
 
-        _setSelectedRevision(to);
+        _setSelectedObjectId(to);
         _direction = null;
     }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/RefContextMenuContext.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RefContextMenus/RefContextMenuContext.cs
@@ -12,7 +12,7 @@ internal sealed class RefContextMenuContext
     public required IGitUICommands UICommands { get; init; }
     public required Form? ParentForm { get; init; }
     public required string CurrentBranchRef { get; init; }
-    public required ObjectId? CurrentCheckout { get; init; }
+    public required ObjectId CurrentCheckout { get; init; }
     public required bool IsBareRepository { get; init; }
     public required Func<IGitRef, string> GetRefUnambiguousName { get; init; }
     public required Func<GitRevision?> GetLatestSelectedRevision { get; init; }

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -854,9 +854,9 @@ public sealed partial class RevisionDataGridView : DataGridView
         return _revisionGraph.TryGetNode(objectId, out RevisionGraphRevision? node) ? node.GitRevision : null;
     }
 
-    public int? TryGetRevisionIndex(ObjectId? objectId)
+    public int? TryGetRevisionIndex(ObjectId objectId)
     {
-        return objectId is not null && _revisionGraph.TryGetRowIndex(objectId, out int index) ? index : null;
+        return !objectId.IsZero && _revisionGraph.TryGetRowIndex(objectId, out int index) ? index : null;
     }
 
     public IReadOnlyList<ObjectId> GetRevisionChildren(ObjectId objectId)
@@ -897,10 +897,10 @@ public sealed partial class RevisionDataGridView : DataGridView
 
                 break;
             case Keys.Control | Keys.C:
-                IReadOnlyList<ObjectId>? selectedRevisions = SelectedObjectIds;
-                if (selectedRevisions?.Count is > 0)
+                IReadOnlyList<ObjectId>? selectedObjectIds = SelectedObjectIds;
+                if (selectedObjectIds?.Count is > 0)
                 {
-                    ClipboardUtil.TrySetText(string.Join(Environment.NewLine, selectedRevisions));
+                    ClipboardUtil.TrySetText(string.Join(Environment.NewLine, selectedObjectIds));
                 }
 
                 break;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -177,7 +177,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
     // NOTE internal properties aren't serialised by the WinForms designer
 
-    internal ObjectId? CurrentCheckout { get; private set; }
+    internal ObjectId CurrentCheckout { get; private set; }
     internal Lazy<string> CurrentBranch { get; private set; } = new(() => "");
     internal FilterInfo CurrentFilter => _filterInfo;
     internal bool ShowUncommittedChangesIfPossible { get; set; } = true;
@@ -187,12 +187,12 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
     /// <summary>
     /// The last selected commit in the grid (with related CommitInfo in Browse).
     /// </summary>
-    internal ObjectId? SelectedId { private get; set; }
+    internal ObjectId SelectedId { private get; set; }
 
     /// <summary>
     /// The first selected, the first commit in a diff.
     /// </summary>
-    internal ObjectId? FirstId { private get; set; }
+    internal ObjectId FirstId { private get; set; }
 
     internal RevisionGridMenuCommands MenuCommands { get; }
 
@@ -258,7 +258,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         {
             if (!SetSelectedRevision(commitId))
             {
-                MessageBoxes.RevisionFilteredInGrid(this, commitId!);
+                MessageBoxes.RevisionFilteredInGrid(this, commitId);
             }
         });
         _authorHighlighting = new AuthorRevisionHighlighting();
@@ -638,7 +638,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
     /// <param name="commitId">Id of the revision to select.</param>
     /// <param name="toggleSelection">Toggle if the selected state for the revision.</param>
     /// <returns><c>true</c> if the required revision was found and selected, otherwise <c>false</c>.</returns>
-    public bool SetSelectedRevision(ObjectId? commitId, bool toggleSelection = false, bool updateNavigationHistory = true)
+    public bool SetSelectedRevision(ObjectId commitId, bool toggleSelection = false, bool updateNavigationHistory = true)
     {
         _gridView.ClearToBeSelected();
         if (_gridView.TryGetRevisionIndex(commitId) is not int index || index < 0 || index >= _gridView.RowCount)
@@ -646,7 +646,11 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             return false;
         }
 
-        Validates.NotNull(commitId);
+        if (commitId.IsZero)
+        {
+            throw new ArgumentException("Value cannot be a zero ObjectId.", nameof(commitId));
+        }
+
         SetSelectedIndex(_gridView, index, toggleSelection);
         if (updateNavigationHistory)
         {
@@ -794,13 +798,13 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             .ToList();
     }
 
-    private (ObjectId? firstId, GitRevision? selectedRev) GetFirstAndSelected()
+    private (ObjectId firstId, GitRevision? selectedRev) GetFirstAndSelected()
     {
         IReadOnlyList<GitRevision> revisions = GetSelectedRevisions();
 
         return revisions.Count switch
         {
-            0 => (null, null),
+            0 => (default, null),
             1 => (firstId: revisions[0].FirstParentId, selectedRev: revisions[0]),
             _ => (firstId: revisions[^1].ObjectId, selectedRev: revisions[0])
         };
@@ -1022,10 +1026,10 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 ? getUnfilteredRefs.Value.FirstOrDefault(i => i.CompleteName == $"{GitRefName.RefsHeadsPrefix}{CurrentBranch.Value}")
                 : null);
 
-            Lazy<ObjectId?> currentCheckout = new(() =>
+            Lazy<ObjectId> currentCheckout = new(() =>
                 headRef.Value?.ObjectId ?? capturedModule.GetCurrentCheckout());
 
-            ObjectId? previousCheckout = CurrentCheckout;
+            ObjectId previousCheckout = CurrentCheckout;
 
             bool showStashes = AppSettings.ShowStashes;
 
@@ -1039,28 +1043,24 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 CurrentCheckout = currentCheckout.Value;
                 if (CurrentCheckout != previousCheckout)
                 {
-                    if (CurrentCheckout is null)
-                    {
-                        currentlySelectedObjectIds = null;
-                    }
-                    else
-                    {
-                        currentlySelectedObjectIds = new List<ObjectId> { CurrentCheckout };
-                    }
+                    currentlySelectedObjectIds = CurrentCheckout.IsZero
+                        ? null
+                        : new List<ObjectId> { CurrentCheckout };
                 }
 
                 // Exclude the 'stash' ref, it is specially handled when stashes are shown
                 refsByObjectId = (showStashes
                     ? getUnfilteredRefs.Value.Where(r => r.CompleteName != GitRefName.RefsStashPrefix)
                     : getUnfilteredRefs.Value)
-                    .ToLookup(gitRef => gitRef.ObjectId)!;
+                    .Where(gitRef => !gitRef.ObjectId.IsZero)
+                    .ToLookup(gitRef => gitRef.ObjectId);
                 cancellationToken.ThrowIfCancellationRequested();
                 ResetNavigationHistory();
                 UpdateSelectedRef(capturedModule, getUnfilteredRefs.Value, headRef.Value);
                 _gridView.ToBeSelectedObjectIds = GetToBeSelectedRevisions(CurrentCheckout, currentlySelectedObjectIds)!;
 
                 _gridView._revisionGraph.OnlyFirstParent = _filterInfo.ShowOnlyFirstParent;
-                _gridView._revisionGraph.HeadId = CurrentCheckout!;
+                _gridView._revisionGraph.HeadId = CurrentCheckout;
 
                 // Allow add revisions to the grid
                 semaphoreUpdateGrid.Release();
@@ -1101,8 +1101,9 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                             return;
                         }
 
-                        // "stash" commits to insert (before regular commits)
-                        stashesByParentId = getStashRevs.Value.ToLookup(r => r.FirstParentId!);
+                        stashesByParentId = getStashRevs.Value
+                            .Where(r => !r.FirstParentId.IsZero)
+                            .ToLookup(r => r.FirstParentId);
 
                         // "untracked" commits to insert (parent to "stash" commits)
                         Dictionary<ObjectId, ObjectId> untrackedIdByStashId = getStashRevs.Value
@@ -1122,8 +1123,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                         foreach (GitRevision stash in getStashRevs.Value)
                         {
                             stash.ParentIds = untrackedByStashId!.ContainsKey(stash.ObjectId)
-                                ? [stash.FirstParentId!, stash.ParentIds![2]]
-                                : [stash.FirstParentId!];
+                                ? [stash.FirstParentId, stash.ParentIds![2]]
+                                : [stash.FirstParentId];
                         }
                     }
                     catch
@@ -1337,7 +1338,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 // Look up any refs associated with this revision
                 revision.Refs = refsByObjectId![revision.ObjectId].AsReadOnlyList();
 
-                if (!headIsHandled && (revision.ObjectId.Equals(CurrentCheckout) || CurrentCheckout is null))
+                if (!headIsHandled && (revision.ObjectId.Equals(CurrentCheckout) || CurrentCheckout.IsZero))
                 {
                     // Insert artificial worktree/index just before HEAD (CurrentCheckout)
                     // If grid is filtered and HEAD not visible, insert in OnRevisionReadCompleted()
@@ -1393,7 +1394,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 CommitUnixTime = 0,
                 CommitterEmail = userEmail,
                 Subject = ResourceManager.TranslatedStrings.Index,
-                ParentIds = CurrentCheckout is null ? null : new[] { CurrentCheckout },
+                ParentIds = CurrentCheckout.IsZero ? null : new[] { CurrentCheckout },
                 Notes = ""
             };
 
@@ -1462,7 +1463,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 IReadOnlyList<ObjectId>? headParents = null;
                 if (!headIsHandled && ShowArtificialRevisions())
                 {
-                    if (CurrentCheckout is not null)
+                    if (!CurrentCheckout.IsZero)
                     {
                         // Not found, so search for its parents
                         headParents = TryGetParents(Module, _filterInfo, CurrentCheckout).ToList();
@@ -1529,7 +1530,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             }
 
             SuperProjectInfo spi = new();
-            (char code, ObjectId? commit) = await gitModule.GetSuperprojectCurrentCheckoutAsync().ConfigureAwait(false);
+            (char code, ObjectId commit) = await gitModule.GetSuperprojectCurrentCheckoutAsync().ConfigureAwait(false);
             if (code == 'U')
             {
                 // return local and remote hashes
@@ -1549,8 +1550,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             if (refs is not null)
             {
                 spi.Refs = refs
-                    .Where(a => a.Value is not null && a.Value.ObjectId is not null)
-                    .GroupBy(a => a.Value!.ObjectId!)
+                    .Where(a => a.Value is not null && !a.Value.ObjectId.IsZero)
+                    .GroupBy(a => a.Value!.ObjectId)
                     .ToDictionary(gr => gr.Key, gr => gr.Select(a => a.Key).AsReadOnlyList());
             }
 
@@ -1565,29 +1566,29 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         /// The SelectedId is the last selected commit in the grid (with related CommitInfo in Browse).
         /// The FirstId is first selected, the first commit in a diff.
         /// </summary>
-        IReadOnlyList<ObjectId>? GetToBeSelectedRevisions(ObjectId? currentCheckout, IReadOnlyList<ObjectId>? currentlySelectedObjectIds)
+        IReadOnlyList<ObjectId>? GetToBeSelectedRevisions(ObjectId currentCheckout, IReadOnlyList<ObjectId>? currentlySelectedObjectIds)
 #pragma warning restore CS1587 // XML comment is not placed on a valid language element
         {
-            if (SelectedId is not null)
+            if (!SelectedId.IsZero)
             {
                 IReadOnlyList<ObjectId>? toBeSelectedObjectIds;
-                if (FirstId is not null)
+                if (!FirstId.IsZero)
                 {
                     toBeSelectedObjectIds = new ObjectId[] { FirstId, SelectedId };
-                    FirstId = null;
+                    FirstId = default;
                 }
                 else
                 {
                     toBeSelectedObjectIds = new ObjectId[] { SelectedId };
                 }
 
-                SelectedId = null;
+                SelectedId = default;
                 return toBeSelectedObjectIds;
             }
 
             return currentlySelectedObjectIds?.Count is > 0
                 ? currentlySelectedObjectIds
-                : currentCheckout is null
+                : currentCheckout.IsZero
                     ? []
                     : new ObjectId[] { currentCheckout };
         }
@@ -1605,7 +1606,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             ExecutionResult result = module.GitExecutable.Execute(args, throwOnErrorExit: false);
             foreach (string line in result.StandardOutput.LazySplit('\n'))
             {
-                if (ObjectId.TryParse(line, out ObjectId? parentId))
+                if (ObjectId.TryParse(line, out ObjectId parentId))
                 {
                     yield return parentId;
                 }
@@ -1619,9 +1620,9 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
     /// <param name="path">The path to the file to get the name of</param>
     /// <param name="objectId">The revision to get the file name in</param>
     /// <returns>The name of the file at <paramref name="path"/> in revision identified by <paramref name="objectId"/>; <see langword="null"/> if not available.</returns>
-    public string? GetRevisionFileName(string path, ObjectId? objectId)
+    public string? GetRevisionFileName(string path, ObjectId objectId)
     {
-        if (objectId is null)
+        if (objectId.IsZero)
         {
             return null;
         }
@@ -1659,7 +1660,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         LazyStringSplit lines = result.StandardOutput.LazySplit('\n');
 
-        ObjectId? currentObjectId = null;
+        ObjectId currentObjectId = default;
 
         foreach (string? line in lines.Select(GitModule.ReEncodeFileNameFromLossless))
         {
@@ -1671,17 +1672,21 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
             if (line.StartsWith(_objectIdPrefix))
             {
-                if (line.Length < ObjectId.Sha1CharCount + _objectIdPrefix.Length
-                    || !ObjectId.TryParse(line, offset: _objectIdPrefix.Length, out currentObjectId))
+                if (line.Length >= ObjectId.Sha1CharCount + _objectIdPrefix.Length
+                    && ObjectId.TryParse(line, offset: _objectIdPrefix.Length, out ObjectId parsedId))
+                {
+                    currentObjectId = parsedId;
+                }
+                else
                 {
                     // Parse error, ignore
-                    currentObjectId = null;
+                    currentObjectId = default;
                 }
 
                 continue;
             }
 
-            if (currentObjectId is null)
+            if (currentObjectId.IsZero)
             {
                 // Parsing has failed, ignore
                 continue;
@@ -1722,12 +1727,12 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         _selectionTimer.Stop();
         _selectionTimer.Start();
 
-        (ObjectId? first, GitRevision? selected) = GetFirstAndSelected();
+        (ObjectId first, GitRevision? selected) = GetFirstAndSelected();
 
         compareToWorkingDirectoryMenuItem.Enabled = selected is not null && selected.ObjectId != ObjectId.WorkTreeId;
         compareWithCurrentBranchToolStripMenuItem.Enabled = !string.IsNullOrWhiteSpace(CurrentBranch.Value);
-        compareSelectedCommitsMenuItem.Enabled = first is not null && selected is not null;
-        openCommitsWithDiffToolMenuItem.Enabled = first is not null && selected is not null;
+        compareSelectedCommitsMenuItem.Enabled = !first.IsZero && selected is not null;
+        openCommitsWithDiffToolMenuItem.Enabled = !first.IsZero && selected is not null;
 
         IReadOnlyList<GitRevision> selectedRevisions = GetSelectedRevisions();
         HighlightRevisionsByAuthor(selectedRevisions);
@@ -1970,7 +1975,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         UICommands.DoActionOnRepo(() =>
         {
-            using FormCreateTag form = new(UICommands, revision?.ObjectId);
+            using FormCreateTag form = new(UICommands, revision?.ObjectId ?? default);
             return form.ShowDialog(ParentForm) == DialogResult.OK;
         });
     }
@@ -2009,7 +2014,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         UICommands.DoActionOnRepo(() =>
         {
-            using FormCreateBranch form = new(UICommands, revision?.ObjectId);
+            using FormCreateBranch form = new(UICommands, revision?.ObjectId ?? default);
             return form.ShowDialog(ParentForm) == DialogResult.OK;
         });
     }
@@ -2830,21 +2835,25 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
     internal void ToggleBetweenArtificialAndHeadCommits()
     {
-        GoToRef(GetIdToSelect()?.ToString(), showNoRevisionMsg: false);
+        ObjectId idToGoTo = GetIdToSelect();
+        GoToRef(idToGoTo.IsZero ? null : idToGoTo.ToString(), showNoRevisionMsg: false);
         ToggledBetweenArtificialAndHeadCommits?.Invoke(this, EventArgs.Empty);
         return;
 
-        ObjectId? GetIdToSelect()
+        ObjectId GetIdToSelect()
         {
             // Try up to 3 possibilities in the circle: WorkTree -> Index -> Head -> (WorkTree).
-            ObjectId? idToSelect = LatestSelectedRevision?.ObjectId;
+            ObjectId idToSelect = LatestSelectedRevision?.ObjectId ?? default;
             for (int i = 0; i < 3; ++i)
             {
                 idToSelect = GetNextIdToSelect(idToSelect);
-                if (idToSelect is null
+                if (idToSelect.IsZero)
+                {
+                    continue;
+                }
 
-                    // WorkTree and Index are skipped if and only if we do retrieve the ChangeCount info (only for artificial) and HasChanges returns false.
-                    || (AppSettings.ShowGitStatusForArtificialCommits && (GetChangeCount(idToSelect)?.HasChanges is false)))
+                // WorkTree and Index are skipped if and only if we do retrieve the ChangeCount info (only for artificial) and HasChanges returns false.
+                if (AppSettings.ShowGitStatusForArtificialCommits && (GetChangeCount(idToSelect)?.HasChanges is false))
                 {
                     continue;
                 }
@@ -2860,7 +2869,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
             return CurrentCheckout;
 
-            ObjectId? GetNextIdToSelect(ObjectId? id)
+            ObjectId GetNextIdToSelect(ObjectId id)
                 => id == ObjectId.WorkTreeId ? ObjectId.IndexId
                  : id == ObjectId.IndexId ? CurrentCheckout
                  : ObjectId.WorkTreeId;
@@ -3001,12 +3010,12 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         GitRevision revision = revisions[^1];
         while (revision!.IsArtificial)
         {
-            revision = GetRevision(revision.FirstParentId!)!;
+            revision = GetRevision(revision.FirstParentId)!;
         }
 
         do
         {
-            GitRevision? prevRev = GetRevision(revision.FirstParentId!);
+            GitRevision? prevRev = GetRevision(revision.FirstParentId);
             if (prevRev == null)
             {
                 break;
@@ -3030,8 +3039,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         // => Fill with HEAD to if less than two normal revisions (it is OK to compare HEAD HEAD)
         List<ObjectId> revisions = [.. GetSelectedRevisions().Select(i => i.ObjectId).Where(i => !i.IsArtificial)];
         bool hasArtificial = GetSelectedRevisions().Any(i => i.IsArtificial);
-        ObjectId? headId = Module.RevParse("HEAD");
-        if (headId is null || (revisions.Count == 0 && !hasArtificial))
+        ObjectId headId = Module.RevParse("HEAD");
+        if (headId.IsZero || (revisions.Count == 0 && !hasArtificial))
         {
             return;
         }
@@ -3100,8 +3109,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             refName = sha1;
         }
 
-        ObjectId? commitId = Module.RevParse(refName);
-        if (commitId is not null)
+        ObjectId commitId = Module.RevParse(refName);
+        if (!commitId.IsZero)
         {
             if (!SetSelectedRevision(commitId, toggleSelection) && showNoRevisionMsg)
             {
@@ -3158,8 +3167,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         if (form.ShowDialog(ParentForm) == DialogResult.OK)
         {
             Validates.NotNull(form.BranchName);
-            ObjectId? baseCommit = Module.RevParse(form.BranchName);
-            if (baseCommit is null)
+            ObjectId baseCommit = Module.RevParse(form.BranchName);
+            if (baseCommit.IsZero)
             {
                 MessageBoxes.ShowError(this, _noRevisionFoundError.Text);
                 return;
@@ -3171,7 +3180,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
     private void CompareWithCurrentBranchToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        if (string.IsNullOrWhiteSpace(CurrentBranch.Value) || CurrentCheckout is null)
+        if (string.IsNullOrWhiteSpace(CurrentBranch.Value) || CurrentCheckout.IsZero)
         {
             MessageBoxes.Show(this, "No branch is currently selected", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
@@ -3228,9 +3237,9 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
     private void compareSelectedCommitsMenuItem_Click(object sender, EventArgs e)
     {
-        (ObjectId? firstId, GitRevision? selected) = GetFirstAndSelected();
+        (ObjectId firstId, GitRevision? selected) = GetFirstAndSelected();
 
-        if (selected is not null && firstId is not null)
+        if (selected is not null && !firstId.IsZero)
         {
             string firstSubject = GetRevision(firstId)?.Subject ?? "";
             ShowFormDiff(firstId, selected.ObjectId, firstSubject, selected.Subject);
@@ -3256,10 +3265,10 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
     public void DiffSelectedCommitsWithDifftool(string? customTool = null)
     {
-        (ObjectId? first, GitRevision? selected) = GetFirstAndSelected();
+        (ObjectId first, GitRevision? selected) = GetFirstAndSelected();
         if (selected is not null)
         {
-            Module.OpenWithDifftoolDirDiff(first?.ToString(), selected.ObjectId.ToString(), customTool: customTool);
+            Module.OpenWithDifftoolDirDiff(first.IsZero ? null : first.ToString(), selected.ObjectId.ToString(), customTool: customTool);
         }
     }
 
@@ -3314,7 +3323,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         string rebaseCmd = Commands.Rebase(new Commands.RebaseOptions()
         {
-            BranchName = GetActualRevision(LatestSelectedRevision)?.FirstParentId?.ToString(),
+            BranchName = GetActualRevision(LatestSelectedRevision)?.FirstParentId is { IsZero: false } fid ? fid.ToString() : null,
             Interactive = true,
             AutoStash = true,
             SupportRebaseMerges = Module.GitVersion.SupportRebaseMerges
@@ -3411,7 +3420,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             case Command.SelectCurrentRevision:
                 if (!SetSelectedRevision(CurrentCheckout))
                 {
-                    MessageBoxes.RevisionFilteredInGrid(this, CurrentCheckout!);
+                    MessageBoxes.RevisionFilteredInGrid(this, CurrentCheckout);
                 }
 
                 break;
@@ -3454,7 +3463,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
     IReadOnlyList<GitRevision> IRevisionGridInfo.GetSelectedRevisions()
         => GetSelectedRevisions();
 
-    ObjectId? IRevisionGridInfo.CurrentCheckout => CurrentCheckout;
+    ObjectId IRevisionGridInfo.CurrentCheckout => CurrentCheckout;
 
     string IRevisionGridInfo.GetCurrentBranch() => CurrentBranch.Value;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -523,9 +523,9 @@ internal class RevisionGridMenuCommands : MenuCommandsBase
             return;
         }
 
-        ObjectId? commitId = formGoToCommit.ValidateAndGetSelectedRevision();
+        ObjectId commitId = formGoToCommit.ValidateAndGetSelectedObjectId();
 
-        if (commitId is not null)
+        if (!commitId.IsZero)
         {
             if (!_revisionGrid.SetSelectedRevision(commitId))
             {

--- a/src/app/GitUI/UserControls/RevisionGrid/SuperProjectInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/SuperProjectInfo.cs
@@ -1,12 +1,12 @@
-using GitExtensions.Extensibility.Git;
+﻿using GitExtensions.Extensibility.Git;
 
 namespace GitUI;
 
 internal sealed class SuperProjectInfo
 {
-    public ObjectId? CurrentCommit { get; set; }
-    public ObjectId? ConflictBase { get; set; }
-    public ObjectId? ConflictRemote { get; set; }
-    public ObjectId? ConflictLocal { get; set; }
+    public ObjectId CurrentCommit { get; set; }
+    public ObjectId ConflictBase { get; set; }
+    public ObjectId ConflictRemote { get; set; }
+    public ObjectId ConflictLocal { get; set; }
     public IReadOnlyDictionary<ObjectId, IReadOnlyList<IGitRef>>? Refs { get; set; }
 }

--- a/src/app/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
+++ b/src/app/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
@@ -56,7 +56,7 @@ public sealed class CommitDataBodyRenderer : ICommitDataBodyRenderer
             return hash;
         }
 
-        if (!module.TryResolvePartialCommitId(hash, out ObjectId? fullHash))
+        if (!module.TryResolvePartialCommitId(hash, out ObjectId fullHash))
         {
             return hash;
         }

--- a/src/app/ResourceManager/SubmoduleResources.cs
+++ b/src/app/ResourceManager/SubmoduleResources.cs
@@ -53,11 +53,11 @@ public static partial class SubmoduleResources
         StringBuilder sb = new();
         sb.AppendLine($"Submodule {status.Name}");
 
-        if (status.OldCommit != status.Commit && status.OldCommit is not null)
+        if (status.OldCommit != status.Commit && !status.OldCommit.IsZero)
         {
             sb.AppendLine();
             sb.Append("From:\t");
-            sb.AppendLine(status.OldCommit?.ToString() ?? "null");
+            sb.AppendLine(status.OldCommit.ToString());
 
             // Submodule directory must exist to run commands, unknown otherwise
             if (status.OldCommitData is not null)
@@ -72,14 +72,14 @@ public static partial class SubmoduleResources
             }
         }
 
-        if (status.Commit is not null)
+        if (!status.Commit.IsZero)
         {
             sb.AppendLine();
             string dirty = !status.IsDirty ? "" : " (dirty)";
 
             // Note: add spaces to get "To" aligned the same as From
             sb.Append(status.OldCommit != status.Commit ? "To:  \t" : "Commit:\t");
-            sb.AppendLine((status.Commit?.ToString() ?? "null") + dirty);
+            sb.AppendLine(status.Commit.ToString() + dirty);
 
             if (status.CommitData is not null)
             {
@@ -137,7 +137,7 @@ public static partial class SubmoduleResources
             sb.AppendLine($"Commits: {addedRemoved}");
         }
 
-        if (status.Commit is not null && status.OldCommit is not null && gitModule.IsValidGitWorkingDir())
+        if (!status.Commit.IsZero && !status.OldCommit.IsZero && gitModule.IsValidGitWorkingDir())
         {
             const int maxLimitedLines = 5;
             if (status.IsDirty)

--- a/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -137,7 +137,11 @@ internal sealed class AppVeyorAdapter : IBuildServerAdapter
             List<AppVeyorBuildInfo> filteredBuilds = [];
             foreach (AppVeyorBuildInfo build in allBuilds.OrderByDescending(b => b.StartDate))
             {
-                Validates.NotNull(build.CommitId);
+                if (build.CommitId.IsZero)
+                {
+                    continue;
+                }
+
                 if (!_fetchBuilds.Contains(build.CommitId))
                 {
                     filteredBuilds.Add(build);
@@ -195,7 +199,7 @@ internal sealed class AppVeyorAdapter : IBuildServerAdapter
             {
                 string? commitHash = GetNodeString(b["pullRequestHeadCommitId"])
                     ?? GetNodeString(b["commitId"]);
-                if (!ObjectId.TryParse(commitHash, out ObjectId? objectId) || !_isCommitInRevisionGrid(objectId))
+                if (!ObjectId.TryParse(commitHash, out ObjectId objectId) || !_isCommitInRevisionGrid(objectId))
                 {
                     continue;
                 }
@@ -217,7 +221,7 @@ internal sealed class AppVeyorAdapter : IBuildServerAdapter
                     BuildId = GetNodeString(b["buildId"]),
                     Branch = GetNodeString(b["branch"]),
                     CommitId = objectId,
-                    CommitHashList = new[] { objectId },
+                    CommitHashList = [objectId],
                     Status = status,
                     StartDate = b["started"]?.GetValue<DateTime>() ?? DateTime.MinValue,
                     BaseWebUrl = baseWebUrl,

--- a/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorBuildInfo.cs
+++ b/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorBuildInfo.cs
@@ -1,4 +1,4 @@
-using GitExtensions.Extensibility.BuildServerIntegration;
+﻿using GitExtensions.Extensibility.BuildServerIntegration;
 using GitExtensions.Extensibility.Git;
 using GitUIPluginInterfaces.BuildServerIntegration;
 
@@ -11,7 +11,7 @@ public sealed class AppVeyorBuildInfo : BuildInfo
     private int _buildProgressCount;
 
     public string? BuildId { get; set; }
-    public ObjectId? CommitId { get; set; }
+    public ObjectId CommitId { get; set; }
     public string? AppVeyorBuildReportUrl { get; set; }
     public string? Branch { get; set; }
     public string? BaseApiUrl { get; set; }

--- a/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/src/plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -184,7 +184,7 @@ public partial class FormGitStatistics : GitExtensionsFormBase
             void LoadLinesOfCodeForModule(IGitModule module)
             {
                 List<string> filesToCheck = [.. module
-                    .GetTree(commitId: null, full: true)
+                    .GetTree(commitId: default, full: true)
                     .Select(file => Path.Combine(module.WorkingDir, file.Name))];
 
                 _lineCounter.FindAndAnalyzeCodeFiles(_codeFilePattern, DirectoriesToIgnore, filesToCheck);

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -468,7 +468,7 @@ public class FormCommitTests
         const string originalCommitMessage = "commit to be amended by reset soft";
         const string amendedCommitMessage = "replacement commit";
 
-        ObjectId? previousCommitId = _commands.Module.RevParse("HEAD");
+        ObjectId previousCommitId = _commands.Module.RevParse("HEAD");
         string originalCommitHash = _referenceRepository.CreateCommit(originalCommitMessage, "original content", "theFile");
 
         RunFormTest(form =>
@@ -500,7 +500,7 @@ public class FormCommitTests
             Application.DoEvents();
             AsyncTestHelper.JoinPendingOperations();
 
-            _commands.Module.RevParse("HEAD").Should().Be(previousCommitId!);
+            _commands.Module.RevParse("HEAD").Should().Be(previousCommitId);
             ta.Amend.Enabled.Should().BeFalse();
             ta.Amend.Checked.Should().BeFalse();
             ta.CommitAndPush.BackColor.ToArgb().Should().Be(forceBackColor);

--- a/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
@@ -128,7 +128,7 @@ public class ScriptRunnerTests
         _exampleScript.Command = "cmd";
         _exampleScript.Arguments = "/c echo {cHash}";
 
-        _module.GetCurrentCheckout().Returns((ObjectId?)null);
+        _module.GetCurrentCheckout().Returns(default(ObjectId));
 
         ExceptionAssertions<UserExternalOperationException> ex = ((Action)(() => ExecuteRunScript(_exampleScript, _mockForm, _commands, ScriptOptionsProviderBase.Default))).Should()
             .Throw<UserExternalOperationException>();

--- a/tests/app/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
@@ -238,16 +238,6 @@ public sealed class ArgumentBuilderExtensionsTests
         })).Should().Throw<ArgumentException>();
     }
 
-    [TestCase(null)]
-    public void Handle_null_objectid(ObjectId? id)
-    {
-        ArgumentBuilder args =
-        [
-            id
-        ];
-        "".Should().Be(args.ToString());
-    }
-
     [Test]
     public void Add_ForcePushOptions_ensure_all_switches_are_handled()
     {

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.CreateTag.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.CreateTag.cs
@@ -23,10 +23,10 @@ partial class CommandsTests
     }
 
     [Test]
-    public void Validate_should_throw_if_tag_revision_invalid()
+    public void GitCreateTagArgs_should_throw_if_tag_revision_invalid()
     {
-        GitCreateTagArgs args = new(TagName, null!);
-        ((Action)(() => Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath))).Should().Throw<ArgumentException>();
+        Action act = () => new GitCreateTagArgs(TagName, ObjectId.IndexId);
+        act.Should().Throw<ArgumentException>();
     }
 
     [TestCase(null)]

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -53,12 +53,10 @@ public partial class CommandsTests
     public void BranchCmd()
     {
         // TODO split this into BranchCmd and CheckoutCmd
-
-        Commands.Branch("branch", "revision", checkout: true).Arguments.Should().Be("checkout -b \"branch\" \"revision\"");
-        Commands.Branch("branch", "revision", checkout: false).Arguments.Should().Be("branch \"branch\" \"revision\"");
-        Commands.Branch("branch", null!, checkout: true).Arguments.Should().Be("checkout -b \"branch\"");
-        Commands.Branch("branch", "", checkout: true).Arguments.Should().Be("checkout -b \"branch\"");
-        Commands.Branch("branch", "  ", checkout: true).Arguments.Should().Be("checkout -b \"branch\"");
+        ObjectId objectId = ObjectId.Random();
+        Commands.Branch("branch", objectId, checkout: true).Arguments.Should().Be($"checkout -b \"branch\" {objectId}");
+        Commands.Branch("branch", objectId, checkout: false).Arguments.Should().Be($"branch \"branch\" {objectId}");
+        Commands.Branch("branch", default, checkout: true).Arguments.Should().Be("checkout -b \"branch\"");
     }
 
     [Test]

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Check_that_spaces_are_not_trimmed_in_file_names.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Check_that_spaces_are_not_trimmed_in_file_names.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,
@@ -69,7 +75,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Check_that_the_staged_status_is_None_if_not_IndexWorkTree1.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Check_that_the_staged_status_is_None_if_not_IndexWorkTree1.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Check_that_the_staged_status_is_None_if_not_IndexWorkTree2.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Check_that_the_staged_status_is_None_if_not_IndexWorkTree2.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Ignore_unmerged_in_conflict_if_revision_is_work_tree.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Ignore_unmerged_in_conflict_if_revision_is_work_tree.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Include_unmerged_in_conflict_if_revision_is_index.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Include_unmerged_in_conflict_if_revision_is_index.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Rename_with_spaces.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.GetDiffChangedFilesFromString_testName=Rename_with_spaces.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": "100",
     "Staged": 1,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": "70",
     "Staged": 1,
     "DiffStatus": 0,
@@ -69,7 +75,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,
@@ -100,7 +109,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 1,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetDefaultStatus.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetDefaultStatus.verified.json
@@ -6,7 +6,10 @@
     "Value": ""
   },
   "ErrorMessage": null,
-  "TreeGuid": null,
+  "TreeId": {
+    "IsZero": true,
+    "IsArtificial": false
+  },
   "RenameCopyPercentage": null,
   "Staged": 2,
   "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=added_by_them.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=added_by_them.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=added_by_us.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=added_by_us.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=both_added.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=both_added.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=both_deleted.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=both_deleted.verified.json
@@ -7,7 +7,10 @@
       "Value": "GitUI/CommandsDialogs"
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": "GitUI/CommandsDialogs"
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=both_modified.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=both_modified.verified.json
@@ -7,7 +7,10 @@
       "Value": "GitUI/CommandsDialogs"
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=deleted_by_them.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=deleted_by_them.verified.json
@@ -7,7 +7,10 @@
       "Value": "GitUI/CommandsDialogs"
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": "GitUI/CommandsDialogs"
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=deleted_by_us.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=deleted_by_us.verified.json
@@ -7,7 +7,10 @@
       "Value": "GitUI/CommandsDialogs"
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": "GitUI/CommandsDialogs"
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_ignored_files.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_ignored_files.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_modified_files.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_modified_files.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_staged_files.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_staged_files.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 3,
     "DiffStatus": 0,
@@ -69,7 +75,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_untracked_files.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_untracked_files.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_with_spaces.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString_testName=status_with_spaces.verified.json
@@ -7,7 +7,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,
@@ -38,7 +41,10 @@
       "Value": ""
     },
     "ErrorMessage": null,
-    "TreeGuid": null,
+    "TreeId": {
+      "IsZero": true,
+      "IsArtificial": false
+    },
     "RenameCopyPercentage": null,
     "Staged": 2,
     "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_deleted.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_deleted.verified.json
@@ -6,7 +6,10 @@
     "Value": ""
   },
   "ErrorMessage": null,
-  "TreeGuid": null,
+  "TreeId": {
+    "IsZero": true,
+    "IsArtificial": false
+  },
   "RenameCopyPercentage": null,
   "Staged": 0,
   "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_getdefaults.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_getdefaults.verified.json
@@ -6,7 +6,10 @@
     "Value": ""
   },
   "ErrorMessage": null,
-  "TreeGuid": null,
+  "TreeId": {
+    "IsZero": true,
+    "IsArtificial": false
+  },
   "RenameCopyPercentage": null,
   "Staged": 2,
   "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_new.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_new.verified.json
@@ -6,7 +6,10 @@
     "Value": ""
   },
   "ErrorMessage": null,
-  "TreeGuid": null,
+  "TreeId": {
+    "IsZero": true,
+    "IsArtificial": false
+  },
   "RenameCopyPercentage": null,
   "Staged": 0,
   "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_none.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_none.verified.json
@@ -6,7 +6,10 @@
     "Value": ""
   },
   "ErrorMessage": null,
-  "TreeGuid": null,
+  "TreeId": {
+    "IsZero": true,
+    "IsArtificial": false
+  },
   "RenameCopyPercentage": null,
   "Staged": 0,
   "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_renamed.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_renamed.verified.json
@@ -6,7 +6,10 @@
     "Value": ""
   },
   "ErrorMessage": null,
-  "TreeGuid": null,
+  "TreeId": {
+    "IsZero": true,
+    "IsArtificial": false
+  },
   "RenameCopyPercentage": null,
   "Staged": 0,
   "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_unmerged.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.ReverseSelection_expected_changes_unmerged.verified.json
@@ -6,7 +6,10 @@
     "Value": ""
   },
   "ErrorMessage": null,
-  "TreeGuid": null,
+  "TreeId": {
+    "IsZero": true,
+    "IsArtificial": false
+  },
   "RenameCopyPercentage": null,
   "Staged": 0,
   "DiffStatus": 0,

--- a/tests/app/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 using System.Text.RegularExpressions;
-using AwesomeAssertions;
 using GitExtensions.Extensibility.Git;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
@@ -22,8 +21,8 @@ public sealed partial class ObjectIdTests
     [TestCase("0123456789abcdef0123456789abcdef01234567")]
     public void TryParse_handles_valid_hashes(string sha1)
     {
-        ObjectId.TryParse(sha1, out ObjectId? id).Should().BeTrue();
-        id!.ToString().Should().Be(sha1.ToLower());
+        ObjectId.TryParse(sha1, out ObjectId id).Should().BeTrue();
+        id.ToString().Should().Be(sha1.ToLower());
     }
 
     [TestCase("00000000000000000000000000000000000000")]
@@ -45,8 +44,8 @@ public sealed partial class ObjectIdTests
     [TestCase("__0102030405060708091011121314151617181920__", 2)]
     public void TryParse_with_offset_handles_valid_hashes(string sha1, int offset)
     {
-        ObjectId.TryParse(sha1, offset, out ObjectId? id).Should().BeTrue();
-        id!.ToString().Should().Be(sha1.Substring(offset, 40));
+        ObjectId.TryParse(sha1, offset, out ObjectId id).Should().BeTrue();
+        id.ToString().Should().Be(sha1.Substring(offset, 40));
     }
 
     [TestCase("0000000000000000000000000000000000000000")]
@@ -205,7 +204,7 @@ public sealed partial class ObjectIdTests
     {
         byte[] sourceBytes = Encoding.ASCII.GetBytes(source);
 
-        ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId? id).Should().Be(expected is not null);
+        ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId id).Should().Be(expected is not null);
 
         if (expected is not null)
         {
@@ -214,19 +213,20 @@ public sealed partial class ObjectIdTests
     }
 
     [TestCase(NonHexAscii, 0, null)]
-    public void TryParse_bytes_throws_with_illegal_input(string source, int offset, [CanBeNull] string? expected)
+    public void TryParse_returns_false_zero_with_illegal_input(string source, int offset, [CanBeNull] string? expected)
     {
         byte[] sourceBytes = Encoding.ASCII.GetBytes(source);
-        ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId? id).Should().Be(expected is not null);
+        ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId objectId).Should().Be(expected is not null);
+        objectId.IsZero.Should().BeTrue();
     }
 
     [Test]
     public void TryParse_returns_false_when_array_null()
     {
-        ObjectId.TryParse(default, out ObjectId? objectId).Should().BeFalse();
-        objectId.Should().BeNull();
+        ObjectId.TryParse(default, out ObjectId objectId).Should().BeFalse();
+        objectId.IsZero.Should().BeTrue();
         ObjectId.TryParse(default(Span<byte>), out objectId).Should().BeFalse();
-        objectId.Should().BeNull();
+        objectId.IsZero.Should().BeTrue();
     }
 
     [Test]
@@ -234,8 +234,8 @@ public sealed partial class ObjectIdTests
     {
         byte[] bytes = new byte[ObjectId.Sha1CharCount];
 
-        ObjectId.TryParse(bytes.AsSpan(1), out ObjectId? objectId).Should().BeFalse();
-        objectId.Should().BeNull();
+        ObjectId.TryParse(bytes.AsSpan(1), out ObjectId objectId).Should().BeFalse();
+        objectId.IsZero.Should().BeTrue();
     }
 
     [Test]
@@ -343,11 +343,11 @@ public sealed partial class ObjectIdTests
     }
 
     [Test]
-    public void CompareTo_returns_positive_for_null()
+    public void CompareTo_returns_positive_for_zero()
     {
         ObjectId id = ObjectId.Parse("0102030405060708091011121314151617181920");
 
-        id.CompareTo(null).Should().BePositive();
+        id.CompareTo(default).Should().BePositive();
     }
 
     [Test]
@@ -364,9 +364,9 @@ public sealed partial class ObjectIdTests
     public void TryParse_bytes_roundtrips_correctly(string sha1)
     {
         byte[] asciiBytes = Encoding.ASCII.GetBytes(sha1);
-        ObjectId.TryParse(asciiBytes.AsSpan(), out ObjectId? id).Should().BeTrue();
+        ObjectId.TryParse((ReadOnlySpan<byte>)asciiBytes.AsSpan(), out ObjectId id).Should().BeTrue();
 
-        id!.ToString().Should().Be(sha1);
+        id.ToString().Should().Be(sha1);
     }
 
     [Test]
@@ -376,7 +376,7 @@ public sealed partial class ObjectIdTests
 
         // Convert.FromHexString accepts uppercase, so this will parse successfully.
         // SHA-1 strings are always lowercase in git output, and ToString normalises to lowercase.
-        ObjectId.TryParse(asciiBytes.AsSpan(), out ObjectId? id).Should().BeTrue();
-        id!.ToString().Should().Be("abcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        ObjectId.TryParse((ReadOnlySpan<byte>)asciiBytes.AsSpan(), out ObjectId id).Should().BeTrue();
+        id.ToString().Should().Be("abcdefabcdefabcdefabcdefabcdefabcdefabcd");
     }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
@@ -70,7 +70,7 @@ public class SubmoduleHelpersTest
 
         status.Commit.Should().Be(ObjectId.Parse("05321769f039f39fa7f6748e8f30d5c8f157c7dc"));
         status.Name.Should().Be(fileName);
-        status.OldCommit.Should().BeNull();
+        status.OldCommit.IsZero.Should().BeTrue();
         status.OldName.Should().Be("Externals/ICSharpCode.TextEditor");
 
         // With user customized `diff.srcPrefix` and `diff.dstPrefix` settings: Submodule name with spaces in the name

--- a/tests/app/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
@@ -80,6 +80,6 @@ public class GitTagControllerTest
 
     private static GitCreateTagArgs CreateAnnotatedTagArgs()
     {
-        return new GitCreateTagArgs("tagname", ObjectId.Parse("0000000000000000000000000000000000000000"), TagOperation.Annotate, "hello world");
+        return new GitCreateTagArgs("tagname", ObjectId.Random(), TagOperation.Annotate, "hello world");
     }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -214,16 +214,16 @@ public sealed partial class GitModuleTests
     [TestCase(null)]
     [TestCase("")]
     [TestCase("\t")]
-    public void RevParse_should_return_null_if_invalid(string? revisionExpression)
+    public void RevParse_should_return_zero_if_invalid(string? revisionExpression)
     {
-        _gitModule.RevParse(revisionExpression).Should().BeNull();
+        _gitModule.RevParse(revisionExpression).IsZero.Should().BeTrue();
     }
 
     [Test]
-    public void RevParse_should_return_null_if_revisionExpression_exceeds_260_symbols()
+    public void RevParse_should_return_zero_if_revisionExpression_exceeds_260_symbols()
     {
         string revisionExpression = new('a', 261);
-        _gitModule.RevParse(revisionExpression).Should().BeNull();
+        _gitModule.RevParse(revisionExpression).IsZero.Should().BeTrue();
     }
 
     [Test]
@@ -244,12 +244,12 @@ public sealed partial class GitModuleTests
     }
 
     [Test]
-    public void RevParse_should_query_git_and_return_null_if_invalid_response()
+    public void RevParse_should_query_git_and_return_zero_if_invalid_response()
     {
         string revisionExpression = "11111";
         using (_executable.StageOutput($"rev-parse --quiet --verify \"{revisionExpression}~0\"", "foo bar", 0))
         {
-            _gitModule.RevParse(revisionExpression).Should().BeNull();
+            _gitModule.RevParse(revisionExpression).IsZero.Should().BeTrue();
         }
     }
 
@@ -257,18 +257,18 @@ public sealed partial class GitModuleTests
     [TestCase("error: something went wrong")]
     [TestCase("HEAD")]
     [TestCase("master")]
-    public void GetCurrentCheckout_should_query_git_and_return_null_if_response_is_not_sha(string msg)
+    public void GetCurrentCheckout_should_query_git_and_return_zero_if_response_is_not_sha(string msg)
     {
         using (_executable.StageOutput($"rev-parse HEAD", msg, 0))
         {
-            _gitModule.GetCurrentCheckout().Should().BeNull();
+            _gitModule.GetCurrentCheckout().IsZero.Should().BeTrue();
         }
     }
 
     [Test]
     public void GetCurrentCheckout_should_query_git_and_return_sha_for_HEAD()
     {
-        ObjectId? objectId;
+        ObjectId objectId;
         string headId = "69a7c7a40230346778e7eebed809773a6bc45268";
 
         using (_executable.StageOutput("rev-parse HEAD", headId))
@@ -276,7 +276,7 @@ public sealed partial class GitModuleTests
             objectId = _gitModule.GetCurrentCheckout();
         }
 
-        objectId?.ToString().Should().Be(headId);
+        objectId.ToString().Should().Be(headId);
     }
 
     [Test]
@@ -427,9 +427,9 @@ public sealed partial class GitModuleTests
         await moduleTestHelperSuper.Module.GitExecutable.GetOutputAsync(@"add ""sub repo""");
         await moduleTestHelperSuper.Module.GitExecutable.GetOutputAsync(@"commit -am ""Update submodule ref""");
 
-        (char code, ObjectId? commitId) = await moduleSub.GetSuperprojectCurrentCheckoutAsync();
+        (char code, ObjectId commitId) = await moduleSub.GetSuperprojectCurrentCheckoutAsync();
         code.Should().Be(' ');
-        commitId?.ToString().Should().Be(commitRef);
+        commitId.ToString().Should().Be(commitRef);
     }
 
     [TestCase(false, @"stash list")]

--- a/tests/app/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
@@ -23,13 +23,11 @@ public class GitRevisionInfoProviderTests
     }
 
     [Test]
-    public void LoadChildren_should_throw_if_ObjectId_is_null()
+    public void LoadChildren_should_throw_if_ObjectId_is_zero()
     {
         IGitItem item = Substitute.For<IGitItem>();
 
-        // ObjectId checks input, use Try to get an illegal value
-        ObjectId.TryParse("", out ObjectId? objectId);
-        item.ObjectId.Returns(objectId);
+        item.ObjectId.Returns(default(ObjectId));
 
         ((Action)(() => _provider.LoadChildren(item))).Should().Throw<ArgumentException>();
     }

--- a/tests/app/UnitTests/GitCommands.Tests/Properties/VerifyModuleInitializer.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Properties/VerifyModuleInitializer.cs
@@ -1,10 +1,14 @@
 ﻿using System.Runtime.CompilerServices;
+using GitExtensions.Extensibility.Git;
 
 namespace GitCommandsTests.Properties;
 
 internal class VerifyModuleInitializer
 {
     [ModuleInitializer]
-    public static void Init() =>
+    public static void Init()
+    {
         VerifierSettings.UseStrictJson();
+        VerifierSettings.IgnoreMembers(nameof(ObjectId.IsZeroOrArtificial));
+    }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=empty_commit.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=empty_commit.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "af0537262373a24bcf2b8b1f68447540776f3703",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=multi_pathfilter.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=multi_pathfilter.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "5899baad9014356f7a334da660a7b304b4b00da2",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=no_subject.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=no_subject.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=normal.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=normal.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_data.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_data.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_empty.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_empty.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": "stash{0}",
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector_empty.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector_empty.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=simple_pathfilter.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=simple_pathfilter.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_no_body.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_no_body.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "6668f89f67eb51e823b3868d90c404c570698204",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Drew Noakes",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_starts_with_newline.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_starts_with_newline.verified.json
@@ -1,9 +1,11 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "8452225978d76fc1a95b2fdc4a5b6dca16658ad6",
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "IEVin",
@@ -24,5 +26,8 @@
   "IsStash": false,
   "ReflogSelector": null,
   "HasParent": false,
-  "FirstParentId": null
+  "FirstParentId": {
+    "IsZero": true,
+    "IsArtificial": false
+  }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=vertical_tab.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=vertical_tab.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
-  "TreeGuid": {
+  "TreeId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/RememberFileContextMenuControllerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/RememberFileContextMenuControllerTests.cs
@@ -163,7 +163,7 @@ public class RememberFileContextMenuControllerTests
         FileStatusItem item = new(
             firstRev: rev,
             secondRev: index,
-            item: new GitItemStatus(name) { TreeGuid = ObjectId.Random() });
+            item: new GitItemStatus(name) { TreeId = ObjectId.Random() });
         _rememberFileContextMenuController.GetGitCommit(GetFileBlobHash, item, true).Should().Be(ObjectId.IndexId.ToString());
     }
 
@@ -176,7 +176,7 @@ public class RememberFileContextMenuControllerTests
         FileStatusItem item = new(
             firstRev: rev,
             secondRev: index,
-            item: new GitItemStatus(name) { TreeGuid = null });
+            item: new GitItemStatus(name) { TreeId = default });
         _rememberFileContextMenuController.GetGitCommit(GetFileBlobHash, item, true).Should().Be(ObjectId.IndexId.ToString());
     }
 

--- a/tests/app/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Design;
+using System.ComponentModel.Design;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
@@ -263,7 +263,7 @@ public class ScriptOptionsParserTests
     {
         string option = "sRemoteBranch";
         string branch = remoteName + '/' + branchName;
-        List<IGitRef> remoteBranches = [new GitRef(null!, null, branch)];
+        List<IGitRef> remoteBranches = [new GitRef(null!, default, branch)];
 
         string? result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
             arguments: "{" + option + "}", option,
@@ -282,7 +282,7 @@ public class ScriptOptionsParserTests
     {
         string option = "sRemoteBranchName";
         string branch = remoteName + '/' + branchName;
-        List<IGitRef> remoteBranches = [new GitRef(null!, null, branch)];
+        List<IGitRef> remoteBranches = [new GitRef(null!, default, branch)];
 
         string? result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
             arguments: "{" + option + "}", option,
@@ -301,7 +301,7 @@ public class ScriptOptionsParserTests
     {
         string option = "cRemoteBranch";
         string branch = remoteName + '/' + branchName;
-        List<IGitRef> remoteBranches = [new GitRef(null!, null, branch)];
+        List<IGitRef> remoteBranches = [new GitRef(null!, default, branch)];
 
         string? result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
             arguments: "{" + option + "}", option,
@@ -320,7 +320,7 @@ public class ScriptOptionsParserTests
     {
         string option = "cRemoteBranchName";
         string branch = remoteName + '/' + branchName;
-        List<IGitRef> remoteBranches = [new GitRef(null!, null, branch)];
+        List<IGitRef> remoteBranches = [new GitRef(null!, default, branch)];
 
         string? result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
             arguments: "{" + option + "}", option,

--- a/tests/app/UnitTests/GitUI.Tests/Script/ScriptsManagerScriptRunnerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/Script/ScriptsManagerScriptRunnerTests.cs
@@ -76,7 +76,7 @@ public class ScriptsManagerScriptRunnerTests
     [Test]
     public void Parse_should_parse_userInput_with_default_value_as_expression_containing_arguments_inside()
     {
-        _module.GetRevision(null, Arg.Any<bool>(), Arg.Any<bool>()).Returns(new GitRevision(ObjectId.Parse("79b9792ca4db3d01d7c0f2cd95419dd53665ec41")));
+        _module.GetRevision(default, Arg.Any<bool>(), Arg.Any<bool>()).Returns(new GitRevision(ObjectId.Parse("79b9792ca4db3d01d7c0f2cd95419dd53665ec41")));
         _commands.GetService<ISimplePromptCreator>().Returns(new SimplePromptCreatorForTest(("input label1", "file_79b9792ca4db3d01d7c0f2cd95419dd53665ec41.bak", "file_foo.bak")));
         (string? arguments, bool abort, bool cancel) result = ScriptRunner.ParseUserInputs("script_name", "{UserInput:input label1=file_{HEAD}.bak}", _commands,
             owner: null!, scriptOptionsProvider: _scriptOptionsProvider);

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -191,7 +191,7 @@ public class BlameControlTests
         {
             DateTime lineDate = lineDates[index];
             yield return new GitBlameLine(
-                new GitBlameCommit(null!, "Author1", "@Author1", lineDate, string.Empty,
+                new GitBlameCommit(ObjectId.Random(), "Author1", "@Author1", lineDate, string.Empty,
                     "Commiter", "@Committer", lineDate, string.Empty, "Summary1", "file"),
                 index + 1, index + 1, "text");
         }

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -938,7 +938,7 @@ public class FilterInfoTests
         };
 
         filterInfo.GetSummary().Should().Be(expectedSummary);
-        filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random())).ToString().Should().Be(expectedArgs);
+        filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => ObjectId.Random())).ToString().Should().Be(expectedArgs);
     }
 
     [TestCase(false, false, "branchFilter")]
@@ -959,7 +959,7 @@ public class FilterInfoTests
             BranchFilter = branchFilter
         };
 
-        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));
+        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => ObjectId.Random()));
 
         if (showRefLog)
         {
@@ -996,7 +996,7 @@ public class FilterInfoTests
             BranchFilter = branchFilter
         };
 
-        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));
+        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => ObjectId.Random()));
 
         if (expectBranches)
         {
@@ -1018,7 +1018,7 @@ public class FilterInfoTests
             CommitsLimit = maxCount,
             ByCommitsLimit = true
         };
-        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));
+        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => ObjectId.Random()));
 
         if (expected)
         {
@@ -1039,7 +1039,7 @@ public class FilterInfoTests
             ShowOnlyFirstParent = expected
         };
 
-        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));
+        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => ObjectId.Random()));
 
         if (expected)
         {
@@ -1060,7 +1060,7 @@ public class FilterInfoTests
             HideMergeCommits = expected
         };
 
-        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));
+        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => ObjectId.Random()));
 
         if (expected)
         {
@@ -1120,9 +1120,9 @@ public class FilterInfoTests
             ByBranchFilter = showFilteredBranches,
             BranchFilter = branchFilter
         };
-        ObjectId? objectId = isValidCheckout ? ObjectId.Random() : null;
-        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => objectId));
-        bool showAll = !(showCurrentBranchOnly && objectId is not null)
+        ObjectId objectId = isValidCheckout ? ObjectId.Random() : default;
+        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => objectId));
+        bool showAll = !(showCurrentBranchOnly && !objectId.IsZero)
             && !(!showCurrentBranchOnly && showFilteredBranches && !string.IsNullOrWhiteSpace(branchFilter));
 
         try
@@ -1154,14 +1154,14 @@ public class FilterInfoTests
                 args.ToString().Should().NotMatchRegex(@"(^|\s)--exclude=refs/sessions/\*\*($|\s)");
             }
 
-            if (showCurrentBranchOnly && objectId is not null)
+            if (showCurrentBranchOnly && !objectId.IsZero)
             {
-                string head = Regex.Escape(objectId?.ToString()!);
+                string head = Regex.Escape(objectId.ToString());
                 args.ToString().Should().MatchRegex(@$"(^|\s){head}($|\s)");
             }
 
             string stash = Regex.Escape($"--glob={"refs/stas[h]"}");
-            if (showStash && ((showCurrentBranchOnly && objectId is not null)
+            if (showStash && ((showCurrentBranchOnly && !objectId.IsZero)
                 || (!showCurrentBranchOnly && showFilteredBranches && !string.IsNullOrWhiteSpace(branchFilter))))
             {
                 args.ToString().Should().MatchRegex(@$"(^|\s){stash}($|\s)");
@@ -1197,7 +1197,7 @@ public class FilterInfoTests
             Message = message,
             ByMessage = true
         };
-        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));
+        string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId>(() => ObjectId.Random()));
         string summary = filterInfo.GetSummary();
 
         if (expectGrep)

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitUI;
 using GitUI.UserControls.RevisionGrid.Graph;
@@ -315,12 +315,12 @@ public class LaneInfoProviderTests
         // real
         _mergeCommitNode.GetTestAccessor().AddParent(_innerCommitNode);
         _innerCommitNode.GetTestAccessor().AddParent(_realCommitNode);
-        _realCommitNode.GitRevision!.Refs = [new GitRef(null!, null, GitRefName.RefsTagsPrefix + "tag_shall_be_ignored")];
+        _realCommitNode.GitRevision!.Refs = [new GitRef(null!, default, GitRefName.RefsTagsPrefix + "tag_shall_be_ignored")];
         _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false, (RevisionGraphRevision?)null));
 
-        Check(new GitRef(null!, null, GitRefName.RefsHeadsPrefix + "local_branch"));
-        Check(new GitRef(null!, null, GitRefName.RefsRemotesPrefix + "remote_branch", "origin"));
-        Check(new GitRef(null!, null, GitRefName.RefsStashPrefix + "@0"));
+        Check(new GitRef(null!, default, GitRefName.RefsHeadsPrefix + "local_branch"));
+        Check(new GitRef(null!, default, GitRefName.RefsRemotesPrefix + "remote_branch", "origin"));
+        Check(new GitRef(null!, default, GitRefName.RefsStashPrefix + "@0"));
 
         return;
 
@@ -370,7 +370,7 @@ public class LaneInfoProviderTests
         string into = MergeSubjectsWithDecoding[2];
         _mergeCommitNode.GitRevision!.Subject = subject;
 
-        GitRef gitRef = new(null!, null, GitRefName.RefsHeadsPrefix + "local_branch");
+        GitRef gitRef = new(null!, default, GitRefName.RefsHeadsPrefix + "local_branch");
         _mergeCommitNode.GitRevision!.Refs = [gitRef];
 
         GetLaneInfo_should_display(_realCommitNode, into);
@@ -453,12 +453,12 @@ public class LaneInfoProviderTests
         // |
         // real (parent)
         _innerCommitNode.AddParent(_realCommitNode);
-        _realCommitNode.GitRevision!.Refs = [new GitRef(null!, null, GitRefName.RefsTagsPrefix + "tag_shall_be_ignored")];
+        _realCommitNode.GitRevision!.Refs = [new GitRef(null!, default, GitRefName.RefsTagsPrefix + "tag_shall_be_ignored")];
         _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false, _innerCommitNode));
 
-        Check(new GitRef(null!, null, GitRefName.RefsHeadsPrefix + "local_branch"));
-        Check(new GitRef(null!, null, GitRefName.RefsRemotesPrefix + "remote_branch", "origin"));
-        Check(new GitRef(null!, null, GitRefName.RefsStashPrefix + "@0"));
+        Check(new GitRef(null!, default, GitRefName.RefsHeadsPrefix + "local_branch"));
+        Check(new GitRef(null!, default, GitRefName.RefsRemotesPrefix + "remote_branch", "origin"));
+        Check(new GitRef(null!, default, GitRefName.RefsStashPrefix + "@0"));
 
         return;
 

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProviderTests.cs
@@ -8,7 +8,7 @@ public class LocalBranchContextMenuProviderTests
     private LocalBranchContextMenuProvider _provider = null!;
     private IGitUICommands _uiCommands = null!;
     private RefContextMenuContext _context = null!;
-    private ObjectId _currentCheckout = null!;
+    private ObjectId _currentCheckout = ObjectId.Random();
 
     [SetUp]
     public void Setup()

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProviderTests.cs
@@ -8,7 +8,7 @@ public class RemoteBranchContextMenuProviderTests
     private RemoteBranchContextMenuProvider _provider = null!;
     private IGitUICommands _uiCommands = null!;
     private RefContextMenuContext _context = null!;
-    private ObjectId _currentCheckout = null!;
+    private ObjectId _currentCheckout = ObjectId.Random();
 
     [SetUp]
     public void Setup()

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/TagContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/TagContextMenuProviderTests.cs
@@ -8,7 +8,7 @@ public class TagContextMenuProviderTests
     private TagContextMenuProvider _provider = null!;
     private IGitUICommands _uiCommands = null!;
     private RefContextMenuContext _context = null!;
-    private ObjectId _currentCheckout = null!;
+    private ObjectId _currentCheckout = ObjectId.Random();
 
     [SetUp]
     public void Setup()

--- a/tests/app/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
+++ b/tests/app/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
@@ -16,14 +16,14 @@ public class CommitDataHeaderRendererIntegrationTests
     [SetUp]
     public void Setup()
     {
-        ObjectId commitGuid = ObjectId.Random();
+        ObjectId commitId = ObjectId.Random();
         ObjectId parentId1 = ObjectId.Random();
         ObjectId parentId2 = ObjectId.Random();
         DateTime authorTime = DateTime.UtcNow.AddDays(-3);
         DateTime commitTime = DateTime.UtcNow.AddDays(-2);
 
         _data = new CommitData(
-            commitGuid,
+            commitId,
             new[] { parentId1, parentId2 },
             "John Doe (Acme Inc) <John.Doe@test.com>", authorTime,
             "Jane Doe <Jane.Doe@test.com>", commitTime,


### PR DESCRIPTION
Followup to #12978
Improves loading time for 100K commits with 0.8s and 25 ms for GE according to https://github.com/gitextensions/gitextensions/pull/12978#issuecomment-4227168549
May also simplify migration to support sha256

## Proposed changes

Most work was done by @drewnoakes The first commit is his private commit with a correction to tests to make it compile.
That part changes the sealed class to a struct, the core change.
However, that part keeps Object? handling. In the commit it is mostly file, but over time it will be impossible to handle "is null" and .IsZero checks in parallel.
These changes was partly done with CoPilot, partly manual.
Many changes were changed two times, both in first part and the removal of ObjectId? so it does make sense to review and merge as one very big commit.
The intermediate commits are included.

This PR is very big and hard to review. If we are to release a 7.0 in a while, it comes late.
However, it will be a lot of extra job to maintain this outside master, it will be rotten very soon.
So I would like to consider including it.
@gitextensions/git-extensions-team to give comments.

I have used the first commit for some time (and it seems like @mstv has done too).
The second part has less testing, but submitting it now for review at least.

--

BREAKING CHANGE: ObjectId is now a value type. Nullable ObjectId
(ObjectId?) is now Nullable<ObjectId> rather than a nullable reference.
TryParse out parameters changed from ObjectId? to ObjectId.

Convert ObjectId from sealed class to readonly struct, eliminating heap
allocations in hot paths (revision parsing, graph building, blame).

Key changes:
- sealed class → readonly struct
- Add IsZero property for default (all-zeroes) sentinel detection
- Add IsZeroOrArtificial for unified 'not a real commit' check
- TryParse signatures: out ObjectId? → out ObjectId (drop [NotNullWhen])
- TryResolvePartialCommitId: out ObjectId? → out ObjectId
- Validate non-zero ObjectId in GitRevision constructor
- Validate non-zero/non-artificial ObjectId in GitCreateTagArgs constructor
- Add non-nullable Add(ObjectId) overload to ArgumentBuilderExtensions
- Fix RevisionReader IsArtificial guard (was incorrectly gated on cache)
- Document why IGitItem.ObjectId remains nullable (GitRef.NoHead) *Changed in second part*
- Add explicit IGitItem.ObjectId implementations where needed
- Rename GitSubmoduleInfo param: currentCommitGuid → currentCommitId
- Restore throwing behavior in FormBrowse for branches without ObjectId
- Exclude IsZeroOrArtificial from Verify snapshots via IgnoreMembers
- Update all Verify snapshots for IsZero property addition

--

Remove all use of ObjectId? , consistently us .IsZero to handle unset and illegal.
The meaning of IsZero varies in the app. In GitArgument IsZero is translated to nothing and artificial are illegal, in other artificial have a special handling.

## Test methodology <!-- How did you ensure quality? -->

Tests adopted

## Merge strategy

Very likely squash merge, with an updated commot message

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
