### PR TITLE
Feature/textbox word boundaries

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -229,3 +229,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/05/04, Henr1k80, Henrik Gedionsen, Henrik.Gedionsen[.@)gmail.com
 2026/05/06, LeeRedfield, Chiong Ngek Lee, chiongngeklee@gmail.com
 2026/06/01, becm, Marc Becker, becm@gmx.de
+2026/06/29, xen2, Virgile Bello, virgile.bello(at)gmail.com

--- a/contributors.txt
+++ b/contributors.txt
@@ -234,3 +234,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/08/04, AlexThunder1989, Alexander Karlsson, alexthunder(at)gmail.com
 2026/08/20, vovodroid, Arthur Pirozhkov, qa23d-vvdge(at)yahoo.com
 2026/08/21, gusarov, Dmitry Gusarov, Dmitry.Gusarov@gmail.com
+2026/06/29, xen2, Virgile Bello, virgile.bello(at)gmail.com

--- a/src/app/BugReporter/BugReportForm.cs
+++ b/src/app/BugReporter/BugReportForm.cs
@@ -72,6 +72,7 @@ Send report?");
 
         this.AdjustForDpiScaling();
         this.EnableRemoveWordHotkey();
+        this.EnableProperWordBoundaries();
 
         toolTip.SetToolTip(btnCopy, _toolTipCopy.Text);
         toolTip.SetToolTip(sendAndQuitButton, _toolTipSendQuit.Text);

--- a/src/app/BugReporter/ExceptionDetailView.cs
+++ b/src/app/BugReporter/ExceptionDetailView.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using GitUI;
+
 namespace BugReporter;
 
 internal partial class ExceptionDetailView : Form
@@ -11,6 +13,7 @@ internal partial class ExceptionDetailView : Form
     public ExceptionDetailView()
     {
         InitializeComponent();
+        this.EnableProperWordBoundaries();
     }
 
     internal void ShowDialog(string property, string info)

--- a/src/app/GitExtUtils/GitExtUtils.csproj
+++ b/src/app/GitExtUtils/GitExtUtils.csproj
@@ -6,7 +6,10 @@
 
   <ItemGroup>
     <Compile Include="..\GitUI\Interops\BOOL.cs" Link="GitUI\Interops\BOOL.cs" />
+    <Compile Include="..\GitUI\Interops\Libraries.cs" Link="GitUI\Interops\Libraries.cs" />
+    <Compile Include="..\GitUI\Interops\Messages.cs" Link="GitUI\Interops\Messages.cs" />
     <Compile Include="..\GitUI\Interops\RECT.cs" Link="GitUI\Interops\RECT.cs" />
+    <Compile Include="..\GitUI\Interops\User32\SendMessageW.cs" Link="GitUI\Interops\User32\SendMessageW.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/app/GitExtUtils/GitUI/ComboBoxExtensions.cs
+++ b/src/app/GitExtUtils/GitUI/ComboBoxExtensions.cs
@@ -1,4 +1,5 @@
-﻿using GitExtUtils.GitUI;
+﻿using System.Runtime.CompilerServices;
+using GitExtUtils.GitUI;
 
 namespace GitUI;
 
@@ -94,11 +95,11 @@ public static class ComboBoxExtensions
             ?.ToString();
     }
 
-    private static unsafe int CalculateVerticalScrollBarWidth(ComboBox comboBox)
+    private static int CalculateVerticalScrollBarWidth(ComboBox comboBox)
     {
-        NativeMethods.COMBOBOXINFO cboInfo = new() { cbSize = (uint)sizeof(NativeMethods.COMBOBOXINFO) };
+        NativeMethods.COMBOBOXINFO cboInfo = new() { cbSize = (uint)Unsafe.SizeOf<NativeMethods.COMBOBOXINFO>() };
 
-        if (NativeMethods.GetComboBoxInfo(comboBox.Handle, &cboInfo) != Interop.BOOL.TRUE)
+        if (NativeMethods.GetComboBoxInfo(comboBox.Handle, ref cboInfo) != Interop.BOOL.TRUE)
         {
             return 0;
         }

--- a/src/app/GitExtUtils/GitUI/Interops/User32/GetComboBoxInfo.cs
+++ b/src/app/GitExtUtils/GitUI/Interops/User32/GetComboBoxInfo.cs
@@ -6,5 +6,5 @@ namespace System;
 internal static partial class NativeMethods
 {
     [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
-    internal static unsafe extern BOOL GetComboBoxInfo(nint hWnd, COMBOBOXINFO* pcbi);
+    internal static extern BOOL GetComboBoxInfo(nint hWnd, ref COMBOBOXINFO pcbi);
 }

--- a/src/app/GitExtUtils/GitUI/TextBoxWordBreakExtensions.cs
+++ b/src/app/GitExtUtils/GitUI/TextBoxWordBreakExtensions.cs
@@ -1,0 +1,440 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace GitUI;
+
+/// <summary>
+/// Makes Ctrl+Left/Right, Ctrl+Shift+Left/Right and double-click word selection treat
+/// punctuation such as '/', ':', '.', '(' and ')' as word boundaries in plain text boxes
+/// and editable combo boxes, matching the behavior of the commit message rich text box.
+/// </summary>
+/// <remarks>
+/// <para>
+/// By default the Win32 edit control only breaks on whitespace, so Ctrl+Left/Right
+/// jumps over whole paths or identifiers and double-click selects them whole.
+/// </para>
+/// <para>
+/// '_', '+' and '-' are treated as word characters, matching <c>SpellCheckerHelper.IsSeparator</c>
+/// used elsewhere for double-click word selection and autocomplete.
+/// </para>
+/// </remarks>
+public static class TextBoxWordBreakExtensions
+{
+    /// <summary>
+    ///  Walks the descendants of <paramref name="control"/> and enables punctuation-aware
+    ///  word selection on every plain <see cref="TextBoxBase"/> (excluding
+    ///  <see cref="RichTextBox"/>) and editable <see cref="ComboBox"/> found.
+    /// </summary>
+    /// <remarks>
+    ///  After calling this, Ctrl+Left/Right and Ctrl+Shift+Left/Right stop at punctuation
+    ///  rather than only at whitespace, double-click selects the run between punctuation
+    ///  boundaries, and triple-click selects the entire text. Safe to call more than once
+    ///  for the same control (handlers are detached before being re-attached). Called from
+    ///  shared form bases such as <c>GitExtensionsFormBase</c>; individual dialogs only need
+    ///  to call it themselves when they do not inherit from one.
+    /// </remarks>
+    public static void EnableProperWordBoundaries(this Control control)
+    {
+        ArgumentNullException.ThrowIfNull(control);
+
+        if (LicenseManager.UsageMode == LicenseUsageMode.Designtime)
+        {
+            return;
+        }
+
+        // RichTextBox (such as the commit message editor) is intentionally excluded: the
+        // underlying RichEdit control already breaks on punctuation and selects a line on
+        // triple-click, so it needs none of this and that behavior must not be overridden.
+        foreach (Control textInput in control.FindDescendants().Where(c => c is ComboBox || c is TextBoxBase and not RichTextBox))
+        {
+            // Detach first so it is safe to call this for both a form and a control it hosts
+            // without handling the keystroke twice.
+            textInput.KeyDown -= HandleKeyDown;
+            textInput.MouseDown -= HandleMouseDown;
+            textInput.MouseUp -= HandleMouseUp;
+            textInput.Disposed -= HandleDisposed;
+
+            textInput.KeyDown += HandleKeyDown;
+            textInput.MouseDown += HandleMouseDown;
+            textInput.MouseUp += HandleMouseUp;
+            textInput.Disposed += HandleDisposed;
+
+            if (textInput is ComboBox comboBox)
+            {
+                // A ComboBox's editable text lives in a separate child Win32 edit control,
+                // so it needs its own double-click handling (see HookComboBoxEditControl).
+                HookComboBoxEditControl(comboBox);
+            }
+        }
+    }
+
+    // Tracks the fixed end (anchor) of the selection so Ctrl+Shift+Left/Right can extend
+    // from the correct side. WinForms does not expose which end the caret is on.
+    private static readonly ConditionalWeakTable<Control, StrongBox<int>> _anchors = new();
+
+    /// <summary>Keeps the native subclass of each editable ComboBox's child edit control alive.</summary>
+    private static readonly ConditionalWeakTable<ComboBox, ComboBoxEditWindow> _comboBoxEditWindows = new();
+
+    private static void HandleDisposed(object? sender, EventArgs e)
+    {
+        Control control = (Control)sender!;
+        control.Disposed -= HandleDisposed;
+        control.KeyDown -= HandleKeyDown;
+        control.MouseDown -= HandleMouseDown;
+        control.MouseUp -= HandleMouseUp;
+        _anchors.Remove(control);
+
+        if (control is not ComboBox comboBox)
+        {
+            return;
+        }
+
+        comboBox.HandleCreated -= HandleComboBoxHandleCreated;
+        if (_comboBoxEditWindows.TryGetValue(comboBox, out ComboBoxEditWindow? editWindow))
+        {
+            editWindow.ReleaseHandle();
+            _comboBoxEditWindows.Remove(comboBox);
+        }
+    }
+
+    private static void HookComboBoxEditControl(ComboBox comboBox)
+    {
+        comboBox.HandleCreated -= HandleComboBoxHandleCreated;
+        comboBox.HandleCreated += HandleComboBoxHandleCreated;
+
+        if (comboBox.IsHandleCreated)
+        {
+            AttachComboBoxEditWindow(comboBox);
+        }
+    }
+
+    private static void HandleComboBoxHandleCreated(object? sender, EventArgs e)
+        => AttachComboBoxEditWindow((ComboBox)sender!);
+
+    private static void AttachComboBoxEditWindow(ComboBox comboBox)
+    {
+        if (comboBox.DropDownStyle == ComboBoxStyle.DropDownList)
+        {
+            return;
+        }
+
+        NativeMethods.COMBOBOXINFO info = new() { cbSize = (uint)Unsafe.SizeOf<NativeMethods.COMBOBOXINFO>() };
+        if (NativeMethods.GetComboBoxInfo(comboBox.Handle, ref info) != Interop.BOOL.TRUE || info.hwndEdit == IntPtr.Zero)
+        {
+            return;
+        }
+
+        if (_comboBoxEditWindows.TryGetValue(comboBox, out ComboBoxEditWindow? editWindow))
+        {
+            // The ComboBox's handle (and therefore its child edit handle) can be recreated
+            // by WinForms; rebind the subclass to the new edit window when that happens.
+            if (editWindow.Handle != info.hwndEdit)
+            {
+                if (editWindow.Handle != IntPtr.Zero)
+                {
+                    editWindow.ReleaseHandle();
+                }
+
+                editWindow.AssignHandle(info.hwndEdit);
+            }
+        }
+        else
+        {
+            _comboBoxEditWindows.Add(comboBox, new ComboBoxEditWindow(comboBox, info.hwndEdit));
+        }
+    }
+
+    private static void HandleMouseDown(object? sender, MouseEventArgs e)
+    {
+        // TextBoxBase suppresses the MouseDoubleClick event (StandardDoubleClick style is off),
+        // but MouseDown still fires with Clicks == 2 for the second click. ComboBox is handled
+        // separately via its child edit control (see ComboBoxEditWindow).
+        if (e.Clicks == 2 && sender is TextBoxBase textBox)
+        {
+            // The base class has already applied its default whitespace-only word selection,
+            // so this replaces it with one that respects punctuation boundaries.
+            SelectWordAt(textBox, textBox.Text, textBox.GetCharIndexFromPosition(e.Location));
+        }
+    }
+
+    private static void SelectWordAt(Control control, string text, int index)
+    {
+        if (index < 0 || index >= text.Length)
+        {
+            return;
+        }
+
+        (int start, int end) = GetWordAt(text, index);
+        SetSelectionStart(control, start);
+        SetSelectionLength(control, end - start);
+        SetAnchor(control, start);
+    }
+
+    private static void HandleMouseUp(object? sender, MouseEventArgs e)
+    {
+        // A click collapses the selection; the anchor is wherever the caret landed.
+        Control control = (Control)sender!;
+        if (GetSelectionLength(control) == 0)
+        {
+            SetAnchor(control, GetSelectionStart(control));
+        }
+    }
+
+    private static void HandleKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (!e.Control || e.Alt || (e.KeyCode != Keys.Left && e.KeyCode != Keys.Right))
+        {
+            return;
+        }
+
+        Control control = (Control)sender!;
+        if (control is ComboBox { DropDownStyle: ComboBoxStyle.DropDownList })
+        {
+            return;
+        }
+
+        bool left = e.KeyCode == Keys.Left;
+        bool extend = e.Shift;
+        string text = control.Text;
+        int selectionStart = GetSelectionStart(control);
+        int selectionLength = GetSelectionLength(control);
+
+        (int anchor, int caret) = ResolveAnchorAndCaret(control, selectionStart, selectionLength, left);
+        int target = left ? FindPreviousBoundary(text, caret) : FindNextBoundary(text, caret);
+
+        e.Handled = true;
+        e.SuppressKeyPress = true;
+
+        if (extend)
+        {
+            SetSelectionStart(control, Math.Min(anchor, target));
+            SetSelectionLength(control, Math.Abs(target - anchor));
+            SetAnchor(control, anchor);
+        }
+        else
+        {
+            SetSelectionStart(control, target);
+            SetSelectionLength(control, 0);
+            SetAnchor(control, target);
+        }
+    }
+
+    /// <summary>Finds the start of the word at or before <paramref name="position"/>.</summary>
+    private static int FindPreviousBoundary(string text, int position)
+    {
+        for (int i = Math.Min(position, text.Length) - 1; i > 0; i--)
+        {
+            if (IsWordStart(text, i))
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>Finds the start of the next word after <paramref name="position"/>.</summary>
+    private static int FindNextBoundary(string text, int position)
+    {
+        for (int i = position + 1; i < text.Length; i++)
+        {
+            if (IsWordStart(text, i))
+            {
+                return i;
+            }
+        }
+
+        return text.Length;
+    }
+
+    /// <summary>
+    ///  Returns the <c>[Start, End)</c> range of the run of same-class characters
+    ///  containing <paramref name="index"/> (the word, punctuation run or whitespace run).
+    /// </summary>
+    private static (int Start, int End) GetWordAt(string text, int index)
+    {
+        if (index < 0 || index >= text.Length)
+        {
+            return (index, index);
+        }
+
+        char type = GetCharType(text[index]);
+
+        int start = index;
+        while (start > 0 && GetCharType(text[start - 1]) == type)
+        {
+            start--;
+        }
+
+        int end = index + 1;
+        while (end < text.Length && GetCharType(text[end]) == type)
+        {
+            end++;
+        }
+
+        return (start, end);
+    }
+
+    /// <summary>
+    ///  A boundary is a transition into a non-whitespace character class, mirroring the
+    ///  logic in <see cref="ControlHotkeyExtensions.EnableRemoveWordHotkey"/>.
+    /// </summary>
+    private static bool IsWordStart(string text, int index)
+    {
+        char current = GetCharType(text[index]);
+        return current != ' ' && current != GetCharType(text[index - 1]);
+    }
+
+    private static char GetCharType(char c)
+    {
+        if (char.IsLetterOrDigit(c) || c is '_' or '+' or '-')
+        {
+            return 'w';
+        }
+
+        if (char.IsWhiteSpace(c))
+        {
+            return ' ';
+        }
+
+        // Each distinct punctuation character is its own class so Ctrl+Left/Right stops
+        // between e.g. ')' and ':' as well as at letters.
+        return c;
+    }
+
+    /// <summary>
+    ///  Works out which end of the current selection the caret sits on, so Ctrl+Shift+Arrow can
+    ///  extend from the correct side. WinForms does not expose this directly.
+    /// </summary>
+    private static (int Anchor, int Caret) ResolveAnchorAndCaret(Control control, int selectionStart, int selectionLength, bool left)
+    {
+        if (selectionLength == 0)
+        {
+            return (selectionStart, selectionStart);
+        }
+
+        int selectionEnd = selectionStart + selectionLength;
+        int stored = GetAnchor(control);
+        if (stored == selectionStart)
+        {
+            return (selectionStart, selectionEnd);
+        }
+
+        if (stored == selectionEnd)
+        {
+            return (selectionEnd, selectionStart);
+        }
+
+        // No reliable anchor (e.g. selection made with Shift+Arrow): grow outward in the
+        // direction pressed.
+        return left
+            ? (selectionEnd, selectionStart)
+            : (selectionStart, selectionEnd);
+    }
+
+    private static int GetAnchor(Control control)
+        => _anchors.TryGetValue(control, out StrongBox<int>? box) ? box.Value : -1;
+
+    private static void SetAnchor(Control control, int value)
+    {
+        if (_anchors.TryGetValue(control, out StrongBox<int>? box))
+        {
+            box.Value = value;
+        }
+        else
+        {
+            _anchors.Add(control, new StrongBox<int>(value));
+        }
+    }
+
+    private static int GetSelectionStart(Control control)
+        => control switch
+        {
+            TextBoxBase t => t.SelectionStart,
+            ComboBox cb => cb.SelectionStart,
+            _ => throw new NotSupportedException()
+        };
+
+    private static void SetSelectionStart(Control control, int value)
+    {
+        switch (control)
+        {
+            case TextBoxBase t:
+                t.SelectionStart = value;
+                break;
+            case ComboBox cb:
+                cb.SelectionStart = value;
+                break;
+            default:
+                throw new NotSupportedException();
+        }
+    }
+
+    private static int GetSelectionLength(Control control)
+        => control switch
+        {
+            TextBoxBase t => t.SelectionLength,
+            ComboBox cb => cb.SelectionLength,
+            _ => throw new NotSupportedException()
+        };
+
+    private static void SetSelectionLength(Control control, int value)
+    {
+        switch (control)
+        {
+            case TextBoxBase t:
+                t.SelectionLength = value;
+                break;
+            case ComboBox cb:
+                cb.SelectionLength = value;
+                break;
+            default:
+                throw new NotSupportedException();
+        }
+    }
+
+    /// <summary>
+    ///  Subclasses the child edit control of an editable <see cref="ComboBox"/> to apply
+    ///  punctuation-aware word selection on double-click, which the ComboBox itself does not
+    ///  surface (it has no <c>GetCharIndexFromPosition</c> and raises no usable mouse events
+    ///  for its edit area).
+    /// </summary>
+    private sealed class ComboBoxEditWindow : NativeWindow
+    {
+        private readonly ComboBox _comboBox;
+
+        public ComboBoxEditWindow(ComboBox comboBox, IntPtr editHandle)
+        {
+            _comboBox = comboBox;
+            AssignHandle(editHandle);
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            // Let the edit control apply its default selection first, then refine it.
+            base.WndProc(ref m);
+
+            if (m.Msg == NativeMethods.WM_LBUTTONDBLCLK)
+            {
+                // m.LParam holds the click position in the edit control's client coordinates.
+                int charPos = NativeMethods.SendMessageW(Handle, NativeMethods.EM_CHARFROMPOS, IntPtr.Zero, m.LParam).ToInt32();
+                int index = unchecked((short)(charPos & 0xFFFF));
+                SelectWordAt(_comboBox, _comboBox.Text, index);
+            }
+        }
+    }
+
+#pragma warning disable S3218 // TestAccessor mirrors private members under their original names so tests read naturally.
+    internal static class TestAccessor
+    {
+        public static int FindPreviousBoundary(string text, int position) =>
+            TextBoxWordBreakExtensions.FindPreviousBoundary(text, position);
+
+        public static int FindNextBoundary(string text, int position) =>
+            TextBoxWordBreakExtensions.FindNextBoundary(text, position);
+
+        public static (int Start, int End) GetWordAt(string text, int index) =>
+            TextBoxWordBreakExtensions.GetWordAt(text, index);
+    }
+#pragma warning restore S3218
+}

--- a/src/app/GitExtUtils/GitUI/TextBoxWordBreakExtensions.cs
+++ b/src/app/GitExtUtils/GitUI/TextBoxWordBreakExtensions.cs
@@ -4,18 +4,19 @@ using System.Runtime.CompilerServices;
 namespace GitUI;
 
 /// <summary>
-/// Makes Ctrl+Left/Right, Ctrl+Shift+Left/Right and double-click word selection treat
-/// punctuation such as '/', ':', '.', '(' and ')' as word boundaries in plain text boxes
-/// and editable combo boxes, matching the behavior of the commit message rich text box.
+///  Makes Ctrl+Left/Right, Ctrl+Shift+Left/Right and double-click word selection treat
+///  punctuation such as '/', ':', '.', '(' and ')' as word boundaries in plain text boxes
+///  and editable combo boxes, matching the behavior of the commit message rich text box.
+///  Triple-click selects the whole text.
 /// </summary>
 /// <remarks>
 /// <para>
-/// By default the Win32 edit control only breaks on whitespace, so Ctrl+Left/Right
-/// jumps over whole paths or identifiers and double-click selects them whole.
+///  By default the Win32 edit control only breaks on whitespace, so Ctrl+Left/Right
+///  jumps over whole paths or identifiers and double-click selects them whole.
 /// </para>
 /// <para>
-/// '_', '+' and '-' are treated as word characters, matching <c>SpellCheckerHelper.IsSeparator</c>
-/// used elsewhere for double-click word selection and autocomplete.
+///  '_', '+' and '-' are treated as word characters, matching <c>SpellCheckerHelper.IsSeparator</c>
+///  used elsewhere for double-click word selection and autocomplete.
 /// </para>
 /// </remarks>
 public static class TextBoxWordBreakExtensions
@@ -68,12 +69,34 @@ public static class TextBoxWordBreakExtensions
         }
     }
 
-    // Tracks the fixed end (anchor) of the selection so Ctrl+Shift+Left/Right can extend
-    // from the correct side. WinForms does not expose which end the caret is on.
-    private static readonly ConditionalWeakTable<Control, StrongBox<int>> _anchors = new();
+    /// <summary>
+    ///  Per-control state: the fixed end (anchor) of the selection so Ctrl+Shift+Left/Right can
+    ///  extend from the correct side (WinForms does not expose which end the caret is on), plus
+    ///  the time and location of the last double-click used to detect a triple-click.
+    /// </summary>
+    private static readonly ConditionalWeakTable<Control, WordSelectionState> _state = new();
 
     /// <summary>Keeps the native subclass of each editable ComboBox's child edit control alive.</summary>
     private static readonly ConditionalWeakTable<ComboBox, ComboBoxEditWindow> _comboBoxEditWindows = new();
+
+    private sealed class WordSelectionState
+    {
+        public int Anchor { get; set; }
+        public long LastDoubleClickTicks { get; set; }
+        public Point LastDoubleClickLocation { get; set; }
+
+        /// <summary>
+        ///  The selection the current click gesture intends (caret for a single click, word for a
+        ///  double-click, whole text for a triple-click), reasserted on the following mouse-up so it
+        ///  wins over the native edit control's drag-extend (see <see cref="HandleMouseUp"/>).
+        ///  <c>-1</c> when there is nothing to reassert.
+        /// </summary>
+        public int PendingStart { get; set; } = -1;
+        public int PendingLength { get; set; }
+
+        /// <summary>Mouse-down location of the pending gesture, to tell a stationary click from a drag.</summary>
+        public Point PendingDownLocation { get; set; }
+    }
 
     private static void HandleDisposed(object? sender, EventArgs e)
     {
@@ -82,7 +105,7 @@ public static class TextBoxWordBreakExtensions
         control.KeyDown -= HandleKeyDown;
         control.MouseDown -= HandleMouseDown;
         control.MouseUp -= HandleMouseUp;
-        _anchors.Remove(control);
+        _state.Remove(control);
 
         if (control is not ComboBox comboBox)
         {
@@ -149,35 +172,133 @@ public static class TextBoxWordBreakExtensions
         // TextBoxBase suppresses the MouseDoubleClick event (StandardDoubleClick style is off),
         // but MouseDown still fires with Clicks == 2 for the second click. ComboBox is handled
         // separately via its child edit control (see ComboBoxEditWindow).
-        if (e.Clicks == 2 && sender is TextBoxBase textBox)
+        if (sender is not TextBoxBase textBox)
+        {
+            return;
+        }
+
+        if (e.Clicks == 2)
         {
             // The base class has already applied its default whitespace-only word selection,
             // so this replaces it with one that respects punctuation boundaries.
-            SelectWordAt(textBox, textBox.Text, textBox.GetCharIndexFromPosition(e.Location));
+            (int Start, int Length) word = SelectWordAt(textBox, textBox.Text, textBox.GetCharIndexFromPosition(e.Location));
+            SetPendingSelection(textBox, word.Start, word.Length, e.Location);
+            RecordDoubleClick(textBox, e.Location);
+        }
+        else if (e.Clicks == 1 && IsTripleClick(textBox, e.Location))
+        {
+            textBox.SelectAll();
+            SetAnchor(textBox, 0);
+            SetPendingSelection(textBox, 0, textBox.TextLength, e.Location);
+        }
+        else if (e.Clicks == 1)
+        {
+            // Plain click: remember the caret target so a native drag-extend from a stale anchor
+            // (e.g. one left at 0 by a prior Select All) can be collapsed back on mouse-up.
+            SetPendingSelection(textBox, textBox.GetCharIndexFromPosition(e.Location), 0, e.Location);
         }
     }
 
-    private static void SelectWordAt(Control control, string text, int index)
+    /// <summary>
+    ///  Selects the punctuation-delimited word at <paramref name="index"/> and returns the
+    ///  applied <c>[Start, Length]</c>, or <c>(-1, 0)</c> if <paramref name="index"/> is out of range.
+    /// </summary>
+    private static (int Start, int Length) SelectWordAt(Control control, string text, int index)
     {
         if (index < 0 || index >= text.Length)
         {
-            return;
+            return (-1, 0);
         }
 
         (int start, int end) = GetWordAt(text, index);
         SetSelectionStart(control, start);
         SetSelectionLength(control, end - start);
         SetAnchor(control, start);
+        return (start, end - start);
     }
 
     private static void HandleMouseUp(object? sender, MouseEventArgs e)
     {
-        // A click collapses the selection; the anchor is wherever the caret landed.
         Control control = (Control)sender!;
+
+        // While the button is held, the native edit control drag-extends the selection from its
+        // anchor on any WM_MOUSEMOVE: after a double-click that grows it back to the whole
+        // whitespace-delimited run, and after a Select All (anchor left at 0) it grows it to
+        // [0, cursor]. Reasserting the gesture's intended selection here, on its final event,
+        // makes our selection win regardless of that or any event-ordering race.
+        if (TryReapplyPendingSelection(control, e.Location))
+        {
+            return;
+        }
+
+        // A click collapses the selection; the anchor is wherever the caret landed.
         if (GetSelectionLength(control) == 0)
         {
             SetAnchor(control, GetSelectionStart(control));
         }
+    }
+
+    private static void SetPendingSelection(Control control, int start, int length, Point downLocation)
+    {
+        if (start < 0)
+        {
+            return;
+        }
+
+        WordSelectionState state = _state.GetOrCreateValue(control);
+        state.PendingStart = start;
+        state.PendingLength = length;
+        state.PendingDownLocation = downLocation;
+    }
+
+    /// <summary>
+    ///  Reasserts the selection the current click gesture intended (unless the pointer moved far
+    ///  enough since mouse-down to be a genuine drag) and consumes it. Returns whether a pending
+    ///  selection was present.
+    /// </summary>
+    /// <remarks>
+    ///  <paramref name="upLocation"/> is the mouse-up position, in the same coordinate space as the
+    ///  recorded mouse-down. Beyond the drag threshold the user is drag-selecting, so the native
+    ///  selection is left untouched. A plain click that placed a collapsed caret is likewise left
+    ///  alone; only a selection the native drag-extend actually corrupted is restored.
+    /// </remarks>
+    private static bool TryReapplyPendingSelection(Control control, Point upLocation)
+    {
+        if (!_state.TryGetValue(control, out WordSelectionState? state) || state.PendingStart < 0)
+        {
+            return false;
+        }
+
+        int start = state.PendingStart;
+        int length = state.PendingLength;
+        Point down = state.PendingDownLocation;
+        state.PendingStart = -1;
+
+        Size slop = SystemInformation.DragSize;
+        if (Math.Abs(upLocation.X - down.X) > slop.Width || Math.Abs(upLocation.Y - down.Y) > slop.Height)
+        {
+            return true;
+        }
+
+        int currentStart = GetSelectionStart(control);
+        int currentLength = GetSelectionLength(control);
+
+        // A plain click intends a collapsed caret; leave the native caret where it landed (only
+        // its selection would be reasserted, and there is none), just record the anchor there.
+        if (length == 0 && currentLength == 0)
+        {
+            SetAnchor(control, currentStart);
+            return true;
+        }
+
+        if (currentStart != start || currentLength != length)
+        {
+            SetSelectionStart(control, start);
+            SetSelectionLength(control, length);
+        }
+
+        SetAnchor(control, start);
+        return true;
     }
 
     private static void HandleKeyDown(object? sender, KeyEventArgs e)
@@ -333,18 +454,43 @@ public static class TextBoxWordBreakExtensions
     }
 
     private static int GetAnchor(Control control)
-        => _anchors.TryGetValue(control, out StrongBox<int>? box) ? box.Value : -1;
+        => _state.TryGetValue(control, out WordSelectionState? state) ? state.Anchor : -1;
 
     private static void SetAnchor(Control control, int value)
+        => _state.GetOrCreateValue(control).Anchor = value;
+
+    private static void RecordDoubleClick(Control control, Point location)
     {
-        if (_anchors.TryGetValue(control, out StrongBox<int>? box))
+        WordSelectionState state = _state.GetOrCreateValue(control);
+        state.LastDoubleClickTicks = Environment.TickCount64;
+        state.LastDoubleClickLocation = location;
+    }
+
+    /// <summary>
+    ///  Windows has no triple-click message, so a click that lands shortly after a double-click
+    ///  and near the same spot is treated as the third click. The recorded double-click is
+    ///  consumed so a further click does not re-trigger.
+    /// </summary>
+    private static bool IsTripleClick(Control control, Point location)
+    {
+        if (!_state.TryGetValue(control, out WordSelectionState? state) || state.LastDoubleClickTicks == 0)
         {
-            box.Value = value;
+            return false;
         }
-        else
+
+        long elapsed = Environment.TickCount64 - state.LastDoubleClickTicks;
+        Size slop = SystemInformation.DoubleClickSize;
+        bool isTripleClick = elapsed >= 0
+            && elapsed <= SystemInformation.DoubleClickTime
+            && Math.Abs(location.X - state.LastDoubleClickLocation.X) <= slop.Width
+            && Math.Abs(location.Y - state.LastDoubleClickLocation.Y) <= slop.Height;
+
+        if (isTripleClick)
         {
-            _anchors.Add(control, new StrongBox<int>(value));
+            state.LastDoubleClickTicks = 0;
         }
+
+        return isTripleClick;
     }
 
     private static int GetSelectionStart(Control control)
@@ -414,13 +560,47 @@ public static class TextBoxWordBreakExtensions
             // Let the edit control apply its default selection first, then refine it.
             base.WndProc(ref m);
 
-            if (m.Msg == NativeMethods.WM_LBUTTONDBLCLK)
+            switch (m.Msg)
             {
-                // m.LParam holds the click position in the edit control's client coordinates.
-                int charPos = NativeMethods.SendMessageW(Handle, NativeMethods.EM_CHARFROMPOS, IntPtr.Zero, m.LParam).ToInt32();
-                int index = unchecked((short)(charPos & 0xFFFF));
-                SelectWordAt(_comboBox, _comboBox.Text, index);
+                case NativeMethods.WM_LBUTTONDBLCLK:
+                {
+                    (int Start, int Length) word = SelectWordAt(_comboBox, _comboBox.Text, CharIndexFromPosition(m.LParam));
+                    SetPendingSelection(_comboBox, word.Start, word.Length, m.LParam.ToPoint());
+                    RecordDoubleClick(_comboBox, m.LParam.ToPoint());
+                    break;
+                }
+
+                case NativeMethods.WM_LBUTTONUP:
+                {
+                    // Reassert the click gesture's selection over the edit control's drag-extend
+                    // (see HandleMouseUp).
+                    TryReapplyPendingSelection(_comboBox, m.LParam.ToPoint());
+                    break;
+                }
+
+                case NativeMethods.WM_LBUTTONDOWN when IsTripleClick(_comboBox, m.LParam.ToPoint()):
+                {
+                    _comboBox.SelectAll();
+                    SetAnchor(_comboBox, 0);
+                    SetPendingSelection(_comboBox, 0, _comboBox.Text.Length, m.LParam.ToPoint());
+                    break;
+                }
+
+                case NativeMethods.WM_LBUTTONDOWN:
+                {
+                    // Plain click: remember the caret target so a native drag-extend from a stale
+                    // anchor (e.g. one left at 0 by a prior Select All) is collapsed back on mouse-up.
+                    SetPendingSelection(_comboBox, CharIndexFromPosition(m.LParam), 0, m.LParam.ToPoint());
+                    break;
+                }
             }
+        }
+
+        /// <summary>Maps a packed click position (an <c>m.LParam</c>, in edit-control client coordinates) to a character index.</summary>
+        private int CharIndexFromPosition(IntPtr packedPosition)
+        {
+            int charPos = NativeMethods.SendMessageW(Handle, NativeMethods.EM_CHARFROMPOS, IntPtr.Zero, packedPosition).ToInt32();
+            return unchecked((short)(charPos & 0xFFFF));
         }
     }
 

--- a/src/app/GitExtUtils/GitUI/TextBoxWordBreakExtensions.cs
+++ b/src/app/GitExtUtils/GitUI/TextBoxWordBreakExtensions.cs
@@ -4,18 +4,19 @@ using System.Runtime.CompilerServices;
 namespace GitUI;
 
 /// <summary>
-/// Makes Ctrl+Left/Right, Ctrl+Shift+Left/Right and double-click word selection treat
-/// punctuation such as '/', ':', '.', '(' and ')' as word boundaries in plain text boxes
-/// and editable combo boxes, matching the behavior of the commit message rich text box.
+///  Makes Ctrl+Left/Right, Ctrl+Shift+Left/Right and double-click word selection treat
+///  punctuation such as '/', ':', '.', '(' and ')' as word boundaries in plain text boxes
+///  and editable combo boxes, matching the behavior of the commit message rich text box.
+///  Triple-click selects the whole text.
 /// </summary>
 /// <remarks>
 /// <para>
-/// By default the Win32 edit control only breaks on whitespace, so Ctrl+Left/Right
-/// jumps over whole paths or identifiers and double-click selects them whole.
+///  By default the Win32 edit control only breaks on whitespace, so Ctrl+Left/Right
+///  jumps over whole paths or identifiers and double-click selects them whole.
 /// </para>
 /// <para>
-/// '_', '+' and '-' are treated as word characters, matching <c>SpellCheckerHelper.IsSeparator</c>
-/// used elsewhere for double-click word selection and autocomplete.
+///  '_', '+' and '-' are treated as word characters, matching <c>SpellCheckerHelper.IsSeparator</c>
+///  used elsewhere for double-click word selection and autocomplete.
 /// </para>
 /// </remarks>
 public static class TextBoxWordBreakExtensions
@@ -45,7 +46,9 @@ public static class TextBoxWordBreakExtensions
         // RichTextBox (such as the commit message editor) is intentionally excluded: the
         // underlying RichEdit control already breaks on punctuation and selects a line on
         // triple-click, so it needs none of this and that behavior must not be overridden.
-        foreach (Control textInput in control.FindDescendants().Where(c => c is ComboBox || c is TextBoxBase and not RichTextBox))
+        // DropDownList combo boxes have no editable text, so they are excluded as well.
+        foreach (Control textInput in control.FindDescendants()
+            .Where(c => c is ComboBox { DropDownStyle: not ComboBoxStyle.DropDownList } || c is TextBoxBase and not RichTextBox))
         {
             // Detach first so it is safe to call this for both a form and a control it hosts
             // without handling the keystroke twice.
@@ -68,12 +71,34 @@ public static class TextBoxWordBreakExtensions
         }
     }
 
-    // Tracks the fixed end (anchor) of the selection so Ctrl+Shift+Left/Right can extend
-    // from the correct side. WinForms does not expose which end the caret is on.
-    private static readonly ConditionalWeakTable<Control, StrongBox<int>> _anchors = new();
+    /// <summary>
+    ///  Per-control state: the selection anchor (for Ctrl+Shift+Left/Right), the last double-click
+    ///  time and location (for triple-click detection), and the pending selection reasserted on
+    ///  mouse-up. See <see cref="WordSelectionState"/>.
+    /// </summary>
+    private static readonly ConditionalWeakTable<Control, WordSelectionState> _state = new();
 
     /// <summary>Keeps the native subclass of each editable ComboBox's child edit control alive.</summary>
     private static readonly ConditionalWeakTable<ComboBox, ComboBoxEditWindow> _comboBoxEditWindows = new();
+
+    private sealed class WordSelectionState
+    {
+        public int Anchor { get; set; }
+        public long LastDoubleClickTicks { get; set; }
+        public Point LastDoubleClickLocation { get; set; }
+
+        /// <summary>
+        ///  The selection the current click gesture intends (caret for a single click, word for a
+        ///  double-click, whole text for a triple-click), reasserted on the following mouse-up so it
+        ///  wins over the native edit control's drag-extend (see <see cref="HandleMouseUp"/>).
+        ///  <c>-1</c> when there is nothing to reassert.
+        /// </summary>
+        public int PendingStart { get; set; } = -1;
+        public int PendingLength { get; set; }
+
+        /// <summary>Mouse-down location of the pending gesture, to tell a stationary click from a drag.</summary>
+        public Point PendingDownLocation { get; set; }
+    }
 
     private static void HandleDisposed(object? sender, EventArgs e)
     {
@@ -82,7 +107,7 @@ public static class TextBoxWordBreakExtensions
         control.KeyDown -= HandleKeyDown;
         control.MouseDown -= HandleMouseDown;
         control.MouseUp -= HandleMouseUp;
-        _anchors.Remove(control);
+        _state.Remove(control);
 
         if (control is not ComboBox comboBox)
         {
@@ -149,46 +174,172 @@ public static class TextBoxWordBreakExtensions
         // TextBoxBase suppresses the MouseDoubleClick event (StandardDoubleClick style is off),
         // but MouseDown still fires with Clicks == 2 for the second click. ComboBox is handled
         // separately via its child edit control (see ComboBoxEditWindow).
-        if (e.Clicks == 2 && sender is TextBoxBase textBox)
+        if (sender is not TextBoxBase textBox)
+        {
+            return;
+        }
+
+        // Only the left button drives caret/selection gestures. Right- and middle-clicks must not
+        // queue a pending selection, or mouse-up would collapse an existing selection (e.g. the one
+        // the context menu is about to act on).
+        if (e.Button != MouseButtons.Left)
+        {
+            return;
+        }
+
+        if (e.Clicks == 2)
         {
             // The base class has already applied its default whitespace-only word selection,
             // so this replaces it with one that respects punctuation boundaries.
-            SelectWordAt(textBox, textBox.Text, textBox.GetCharIndexFromPosition(e.Location));
+            (int Start, int Length) word = SelectWordAt(textBox, textBox.Text, textBox.GetCharIndexFromPosition(e.Location));
+            SetPendingSelection(textBox, word.Start, word.Length, e.Location);
+            RecordDoubleClick(textBox, e.Location);
+        }
+        else if (e.Clicks == 1 && IsTripleClick(textBox, e.Location))
+        {
+            textBox.SelectAll();
+            SetAnchor(textBox, 0);
+            SetPendingSelection(textBox, 0, textBox.TextLength, e.Location);
+        }
+        else if (e.Clicks == 1 && (Control.ModifierKeys & Keys.Shift) == 0)
+        {
+            // Plain click: remember the caret target so a native drag-extend from a stale anchor
+            // (e.g. one left at 0 by a prior Select All) can be collapsed back on mouse-up.
+            // Shift+click is skipped: the native control extends the selection to the click, and a
+            // zero-length pending caret would collapse it back on mouse-up.
+            SetPendingSelection(textBox, textBox.GetCharIndexFromPosition(e.Location), 0, e.Location);
         }
     }
 
-    private static void SelectWordAt(Control control, string text, int index)
+    /// <summary>
+    ///  Selects the punctuation-delimited word at <paramref name="index"/> and returns the
+    ///  applied <c>[Start, Length]</c>, or <c>(-1, 0)</c> if <paramref name="index"/> is out of range.
+    /// </summary>
+    private static (int Start, int Length) SelectWordAt(Control control, string text, int index)
     {
         if (index < 0 || index >= text.Length)
         {
-            return;
+            return (-1, 0);
         }
 
         (int start, int end) = GetWordAt(text, index);
         SetSelectionStart(control, start);
         SetSelectionLength(control, end - start);
         SetAnchor(control, start);
+        return (start, end - start);
     }
 
     private static void HandleMouseUp(object? sender, MouseEventArgs e)
     {
-        // A click collapses the selection; the anchor is wherever the caret landed.
-        Control control = (Control)sender!;
-        if (GetSelectionLength(control) == 0)
-        {
-            SetAnchor(control, GetSelectionStart(control));
-        }
-    }
-
-    private static void HandleKeyDown(object? sender, KeyEventArgs e)
-    {
-        if (!e.Control || e.Alt || (e.KeyCode != Keys.Left && e.KeyCode != Keys.Right))
+        // ComboBox mouse handling lives in ComboBoxEditWindow (its edit area raises no usable
+        // mouse events); only plain TextBoxBase controls are handled here.
+        if (sender is not TextBoxBase textBox)
         {
             return;
         }
 
+        // While the button is held, the native edit control drag-extends the selection from its
+        // anchor on any WM_MOUSEMOVE: after a double-click that grows it back to the whole
+        // whitespace-delimited run, and after a Select All (anchor left at 0) it grows it to
+        // [0, cursor]. Reasserting the gesture's intended selection here, on its final event,
+        // makes our selection win regardless of that or any event-ordering race.
+        if (TryReapplyPendingSelection(textBox, e.Location))
+        {
+            return;
+        }
+
+        // A click collapses the selection; the anchor is wherever the caret landed.
+        if (GetSelectionLength(textBox) == 0)
+        {
+            SetAnchor(textBox, GetSelectionStart(textBox));
+        }
+    }
+
+    private static void SetPendingSelection(Control control, int start, int length, Point downLocation)
+    {
+        if (start < 0)
+        {
+            return;
+        }
+
+        WordSelectionState state = _state.GetOrCreateValue(control);
+        state.PendingStart = start;
+        state.PendingLength = length;
+        state.PendingDownLocation = downLocation;
+    }
+
+    /// <summary>
+    ///  Reasserts the selection the current click gesture intended (unless the pointer moved far
+    ///  enough since mouse-down to be a genuine drag) and consumes it. Returns whether a pending
+    ///  selection was present.
+    /// </summary>
+    /// <remarks>
+    ///  <paramref name="upLocation"/> is the mouse-up position, in the same coordinate space as the
+    ///  recorded mouse-down. Beyond the drag threshold the user is drag-selecting, so the native
+    ///  selection is left untouched. A plain click that placed a collapsed caret is likewise left
+    ///  alone; only a selection the native drag-extend actually corrupted is restored.
+    /// </remarks>
+    private static bool TryReapplyPendingSelection(Control control, Point upLocation)
+    {
+        if (!_state.TryGetValue(control, out WordSelectionState? state) || state.PendingStart < 0)
+        {
+            return false;
+        }
+
+        int start = state.PendingStart;
+        int length = state.PendingLength;
+        Point down = state.PendingDownLocation;
+        state.PendingStart = -1;
+
+        // The pointer moved beyond the drag rectangle (centered on the mouse-down point), so the
+        // user is drag-selecting; leave the native selection alone. The mouse-down point is the
+        // drag anchor, so record it: a right-to-left drag would otherwise leave the anchor at its
+        // default 0 and send the next Ctrl+Shift+Left/Right to the wrong end of the selection.
+        if (!CenteredRectangle(down, SystemInformation.DragSize).Contains(upLocation))
+        {
+            SetAnchor(control, start);
+            return true;
+        }
+
+        int currentStart = GetSelectionStart(control);
+        int currentLength = GetSelectionLength(control);
+
+        // A plain click intends a collapsed caret; leave the native caret where it landed (only
+        // its selection would be reasserted, and there is none), just record the anchor there.
+        if (length == 0 && currentLength == 0)
+        {
+            SetAnchor(control, currentStart);
+            return true;
+        }
+
+        if (currentStart != start || currentLength != length)
+        {
+            SetSelectionStart(control, start);
+            SetSelectionLength(control, length);
+        }
+
+        SetAnchor(control, start);
+        return true;
+    }
+
+    private static void HandleKeyDown(object? sender, KeyEventArgs e)
+    {
         Control control = (Control)sender!;
         if (control is ComboBox { DropDownStyle: ComboBoxStyle.DropDownList })
+        {
+            return;
+        }
+
+        // Record the anchor of a plain Shift+navigation selection as it begins from a collapsed
+        // caret: that caret is the end that stays fixed. Doing so lets a later Ctrl+Shift+Left/Right
+        // extend from the correct end instead of guessing the direction (see ResolveAnchorAndCaret).
+        if (e.Shift && !e.Control && !e.Alt && IsSelectionAnchorKey(e.KeyCode) && GetSelectionLength(control) == 0)
+        {
+            SetAnchor(control, GetSelectionStart(control));
+            return;
+        }
+
+        if (!e.Control || e.Alt || (e.KeyCode != Keys.Left && e.KeyCode != Keys.Right))
         {
             return;
         }
@@ -276,8 +427,10 @@ public static class TextBoxWordBreakExtensions
     }
 
     /// <summary>
-    ///  A boundary is a transition into a non-whitespace character class, mirroring the
-    ///  logic in <see cref="ControlHotkeyExtensions.EnableRemoveWordHotkey"/>.
+    ///  A boundary is a transition into a non-whitespace character class. This uses the same
+    ///  structure as <see cref="ControlHotkeyExtensions.EnableRemoveWordHotkey"/> but classifies
+    ///  <c>_</c>, <c>+</c> and <c>-</c> as word characters (see <see cref="GetCharType"/>), so that
+    ///  navigation treats identifiers such as <c>foo_bar</c> as a single word.
     /// </summary>
     private static bool IsWordStart(string text, int index)
     {
@@ -325,27 +478,66 @@ public static class TextBoxWordBreakExtensions
             return (selectionEnd, selectionStart);
         }
 
-        // No reliable anchor (e.g. selection made with Shift+Arrow): grow outward in the
-        // direction pressed.
+        // No reliable anchor (e.g. a selection that did not start from a collapsed caret, such as
+        // one made by Shift+click or Select All): grow outward in the direction pressed.
         return left
             ? (selectionEnd, selectionStart)
             : (selectionStart, selectionEnd);
     }
 
+    /// <summary>
+    ///  The navigation keys whose Shift+variant starts or extends a selection, so the anchor can be
+    ///  captured as such a selection begins (see <see cref="HandleKeyDown"/>).
+    /// </summary>
+    private static bool IsSelectionAnchorKey(Keys keyCode)
+        => keyCode is Keys.Left or Keys.Right or Keys.Up or Keys.Down
+            or Keys.Home or Keys.End or Keys.PageUp or Keys.PageDown;
+
     private static int GetAnchor(Control control)
-        => _anchors.TryGetValue(control, out StrongBox<int>? box) ? box.Value : -1;
+        => _state.TryGetValue(control, out WordSelectionState? state) ? state.Anchor : -1;
 
     private static void SetAnchor(Control control, int value)
+        => _state.GetOrCreateValue(control).Anchor = value;
+
+    private static void RecordDoubleClick(Control control, Point location)
     {
-        if (_anchors.TryGetValue(control, out StrongBox<int>? box))
-        {
-            box.Value = value;
-        }
-        else
-        {
-            _anchors.Add(control, new StrongBox<int>(value));
-        }
+        WordSelectionState state = _state.GetOrCreateValue(control);
+        state.LastDoubleClickTicks = Environment.TickCount64;
+        state.LastDoubleClickLocation = location;
     }
+
+    /// <summary>
+    ///  Windows has no triple-click message, so a click that lands shortly after a double-click
+    ///  and near the same spot is treated as the third click. The recorded double-click is
+    ///  consumed so a further click does not re-trigger.
+    /// </summary>
+    private static bool IsTripleClick(Control control, Point location)
+    {
+        if (!_state.TryGetValue(control, out WordSelectionState? state) || state.LastDoubleClickTicks == 0)
+        {
+            return false;
+        }
+
+        long elapsed = Environment.TickCount64 - state.LastDoubleClickTicks;
+        bool isTripleClick = elapsed >= 0
+            && elapsed <= SystemInformation.DoubleClickTime
+            && CenteredRectangle(state.LastDoubleClickLocation, SystemInformation.DoubleClickSize).Contains(location);
+
+        if (isTripleClick)
+        {
+            state.LastDoubleClickTicks = 0;
+        }
+
+        return isTripleClick;
+    }
+
+    /// <summary>
+    ///  Builds a <paramref name="size"/>-sized rectangle centered on <paramref name="center"/>, matching
+    ///  the standard WinForms drag/double-click hit test (the system sizes are the full rectangle, with
+    ///  the reference point at its center).
+    /// </summary>
+    private static Rectangle CenteredRectangle(Point center, Size size)
+        => new(center.X - (size.Width / 2), center.Y - (size.Height / 2), size.Width, size.Height);
 
     private static int GetSelectionStart(Control control)
         => control switch
@@ -414,13 +606,55 @@ public static class TextBoxWordBreakExtensions
             // Let the edit control apply its default selection first, then refine it.
             base.WndProc(ref m);
 
-            if (m.Msg == NativeMethods.WM_LBUTTONDBLCLK)
+            switch (m.Msg)
             {
-                // m.LParam holds the click position in the edit control's client coordinates.
-                int charPos = NativeMethods.SendMessageW(Handle, NativeMethods.EM_CHARFROMPOS, IntPtr.Zero, m.LParam).ToInt32();
-                int index = unchecked((short)(charPos & 0xFFFF));
-                SelectWordAt(_comboBox, _comboBox.Text, index);
+                case NativeMethods.WM_LBUTTONDBLCLK:
+                {
+                    (int Start, int Length) word = SelectWordAt(_comboBox, _comboBox.Text, CharIndexFromPosition(m.LParam));
+                    SetPendingSelection(_comboBox, word.Start, word.Length, m.LParam.ToPoint());
+                    RecordDoubleClick(_comboBox, m.LParam.ToPoint());
+                    break;
+                }
+
+                case NativeMethods.WM_LBUTTONUP:
+                {
+                    // Reassert the click gesture's selection over the edit control's drag-extend
+                    // (see HandleMouseUp).
+                    TryReapplyPendingSelection(_comboBox, m.LParam.ToPoint());
+                    break;
+                }
+
+                case NativeMethods.WM_LBUTTONDOWN when IsTripleClick(_comboBox, m.LParam.ToPoint()):
+                {
+                    _comboBox.SelectAll();
+                    SetAnchor(_comboBox, 0);
+                    SetPendingSelection(_comboBox, 0, _comboBox.Text.Length, m.LParam.ToPoint());
+                    break;
+                }
+
+                case NativeMethods.WM_LBUTTONDOWN when (Control.ModifierKeys & Keys.Shift) == 0:
+                {
+                    // Plain click: remember the caret target so a native drag-extend from a stale
+                    // anchor (e.g. one left at 0 by a prior Select All) is collapsed back on mouse-up.
+                    // Shift+click is skipped: the edit control extends the selection to the click, and
+                    // a zero-length pending caret would collapse it back on mouse-up.
+                    SetPendingSelection(_comboBox, CharIndexFromPosition(m.LParam), 0, m.LParam.ToPoint());
+                    break;
+                }
             }
+        }
+
+        /// <summary>
+        ///  Maps a packed click position (an <c>m.LParam</c>, in edit-control client coordinates) to a
+        ///  character index, or <c>-1</c> when the point is not over any character.
+        /// </summary>
+        private int CharIndexFromPosition(IntPtr packedPosition)
+        {
+            int result = NativeMethods.SendMessageW(Handle, NativeMethods.EM_CHARFROMPOS, IntPtr.Zero, packedPosition).ToInt32();
+
+            // The character index is the unsigned LOWORD (0..65535); the HIWORD is the line. A whole
+            // result of -1 means no character, which callers treat as "out of range".
+            return result < 0 ? -1 : result & 0xFFFF;
         }
     }
 

--- a/src/app/GitUI/CommandsDialogs/SearchControl.cs
+++ b/src/app/GitUI/CommandsDialogs/SearchControl.cs
@@ -32,6 +32,8 @@ public partial class SearchControl<T> : UserControl, IDisposable where T : class
         _onSizeChanged = onSizeChanged;
         AutoFit();
 
+        this.EnableProperWordBoundaries();
+
         void CloseDropDownWhenLostFocus()
         {
             if (!txtSearchBox.Focused && !listBoxSearchResult.Focused)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -62,6 +62,11 @@ public partial class PluginSettingsPage : AutoLayoutSettingsPage
     {
         PluginSettingsPage result = Create<PluginSettingsPage>(pageHost, serviceProvider);
         result.Init(gitPlugin);
+
+        // Create<T>() enabled word boundaries before Init() generated the plugin's setting inputs,
+        // so those inputs were not yet present to be hooked. Re-run it now that they exist; it is
+        // idempotent for the controls already hooked.
+        result.EnableProperWordBoundaries();
         return result;
     }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -70,6 +70,7 @@ public abstract partial class SettingsPageBase : TranslatedControl, ISettingsPag
 
         result.AdjustForDpiScaling();
         result.EnableRemoveWordHotkey();
+        result.EnableProperWordBoundaries();
         result.FixVisualStyle();
 
         result.Init(pageHost);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/SimpleHelpDisplayDialog.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/SimpleHelpDisplayDialog.cs
@@ -5,6 +5,7 @@ public partial class SimpleHelpDisplayDialog : Form
     public SimpleHelpDisplayDialog()
     {
         InitializeComponent();
+        this.EnableProperWordBoundaries();
     }
 
     public string? DialogTitle { get; set; }

--- a/src/app/GitUI/HelperDialogs/FormBuildServerCredentials.cs
+++ b/src/app/GitUI/HelperDialogs/FormBuildServerCredentials.cs
@@ -9,6 +9,8 @@ public partial class FormBuildServerCredentials : Form
         InitializeComponent();
 
         labelHeader.Text = string.Format(labelHeader.Text, buildServerUniqueKey);
+
+        this.EnableProperWordBoundaries();
     }
 
     public IBuildServerCredentials? BuildServerCredentials { get; set; }

--- a/src/app/GitUI/Interops/Messages.cs
+++ b/src/app/GitUI/Interops/Messages.cs
@@ -5,6 +5,7 @@ internal static partial class NativeMethods
     public const int WM_USER = 0x0400;
     public const int WM_LBUTTONDOWN = 0x0201;
     public const int WM_LBUTTONUP = 0x0202;
+    public const int WM_LBUTTONDBLCLK = 0x0203;
     public const int WM_RBUTTONDOWN = 0x0204;
     public const int WM_RBUTTONUP = 0x0205;
     public const int WM_MOUSEACTIVATE = 0x21;

--- a/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
+++ b/src/app/GitUI/ScriptsEngine/SimplePrompt.cs
@@ -7,6 +7,7 @@ internal partial class SimplePrompt : Form, IUserInputPrompt
     public SimplePrompt(string? title, string? label, string? defaultValue)
     {
         InitializeComponent();
+        this.EnableProperWordBoundaries();
         txtUserInput.Text = defaultValue;
 
         if (!string.IsNullOrWhiteSpace(title))

--- a/src/app/ResourceManager/GitExtensionsFormBase.cs
+++ b/src/app/ResourceManager/GitExtensionsFormBase.cs
@@ -186,6 +186,7 @@ public class GitExtensionsFormBase : Form, ITranslate
 
         this.AdjustForDpiScaling();
         this.EnableRemoveWordHotkey();
+        this.EnableProperWordBoundaries();
     }
 
     #region Translation

--- a/tests/app/UnitTests/GitExtUtils.Tests/GitUI/TextBoxWordBreakExtensionsTests.cs
+++ b/tests/app/UnitTests/GitExtUtils.Tests/GitUI/TextBoxWordBreakExtensionsTests.cs
@@ -1,0 +1,89 @@
+﻿using GitUI;
+
+namespace GitExtUtilsTests.GitUI;
+public sealed class TextBoxWordBreakExtensionsTests
+{
+    // Path-like text: '/' and '.' are boundaries, '-' keeps a word together.
+    [TestCase("src/app/Foo-bar.cs", 0, 3)]
+    [TestCase("src/app/Foo-bar.cs", 3, 4)]
+    [TestCase("src/app/Foo-bar.cs", 4, 7)]
+    [TestCase("src/app/Foo-bar.cs", 8, 15)] // jumps over "Foo-bar" as a single word
+    [TestCase("src/app/Foo-bar.cs", 16, 18)] // last word -> end of text
+    // Consecutive punctuation: each character is its own stop.
+    [TestCase("a/.b", 0, 1)]
+    [TestCase("a/.b", 1, 2)]
+    [TestCase("a/.b", 2, 3)]
+    // Whitespace runs are skipped.
+    [TestCase("foo  bar", 0, 5)]
+    [TestCase("foo  bar", 5, 8)]
+    // Parentheses are boundaries.
+    [TestCase("(foo)", 0, 1)]
+    [TestCase("(foo)", 1, 4)]
+    // '_', '+' and '-' are word characters.
+    [TestCase("a_b+c-d", 0, 7)]
+    // At or past the end of the text.
+    [TestCase("abc", 3, 3)]
+    [TestCase("", 0, 0)]
+    public void FindNextBoundary_returns_start_of_next_word(string text, int position, int expected)
+    {
+        TextBoxWordBreakExtensions.TestAccessor.FindNextBoundary(text, position).Should().Be(expected);
+    }
+
+    [TestCase("src/app/Foo-bar.cs", 18, 16)]
+    [TestCase("src/app/Foo-bar.cs", 16, 15)]
+    [TestCase("src/app/Foo-bar.cs", 7, 4)]
+    [TestCase("src/app/Foo-bar.cs", 3, 0)]
+    [TestCase("a/.b", 4, 3)]
+    [TestCase("a/.b", 3, 2)]
+    [TestCase("a/.b", 1, 0)]
+    [TestCase("foo  bar", 8, 5)]
+    [TestCase("foo  bar", 5, 0)]
+    [TestCase("(foo)", 5, 4)]
+    [TestCase("(foo)", 4, 1)]
+    [TestCase("(foo)", 1, 0)]
+    [TestCase("a_b+c-d", 7, 0)]
+    [TestCase("abc", 0, 0)]
+    [TestCase("", 0, 0)]
+    public void FindPreviousBoundary_returns_start_of_current_or_previous_word(string text, int position, int expected)
+    {
+        TextBoxWordBreakExtensions.TestAccessor.FindPreviousBoundary(text, position).Should().Be(expected);
+    }
+
+    [Test]
+    public void FindNextBoundary_clamps_position_past_end_of_text()
+    {
+        TextBoxWordBreakExtensions.TestAccessor.FindNextBoundary("abc", 999).Should().Be(3);
+    }
+
+    [Test]
+    public void FindPreviousBoundary_clamps_position_past_end_of_text()
+    {
+        TextBoxWordBreakExtensions.TestAccessor.FindPreviousBoundary("abc", 999).Should().Be(0);
+    }
+
+    // Path-like text. Clicking anywhere in a segment selects just that segment,
+    // and "Foo-bar" stays whole because '-' is a word character.
+    [TestCase("src/app/Foo-bar.cs", 0, 0, 3)] // "src"
+    [TestCase("src/app/Foo-bar.cs", 2, 0, 3)]
+    [TestCase("src/app/Foo-bar.cs", 3, 3, 4)] // "/"
+    [TestCase("src/app/Foo-bar.cs", 5, 4, 7)] // "app"
+    [TestCase("src/app/Foo-bar.cs", 8, 8, 15)] // "Foo-bar"
+    [TestCase("src/app/Foo-bar.cs", 11, 8, 15)] // clicking the '-' still selects "Foo-bar"
+    [TestCase("src/app/Foo-bar.cs", 15, 15, 16)] // "."
+    [TestCase("src/app/Foo-bar.cs", 17, 16, 18)] // "cs"
+    // Consecutive punctuation: each character is its own run.
+    [TestCase("a/.b", 1, 1, 2)] // "/"
+    [TestCase("a/.b", 2, 2, 3)] // "."
+    // Whitespace runs select as a unit.
+    [TestCase("foo  bar", 1, 0, 3)] // "foo"
+    [TestCase("foo  bar", 3, 3, 5)] // "  "
+    [TestCase("foo  bar", 6, 5, 8)] // "bar"
+    // Out of range returns an empty range at the index.
+    [TestCase("abc", 3, 3, 3)]
+    [TestCase("abc", -1, -1, -1)]
+    [TestCase("", 0, 0, 0)]
+    public void GetWordAt_selects_the_run_containing_the_index(string text, int index, int expectedStart, int expectedEnd)
+    {
+        TextBoxWordBreakExtensions.TestAccessor.GetWordAt(text, index).Should().Be((expectedStart, expectedEnd));
+    }
+}


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13056

## Proposed changes

- Make **Ctrl+Left/Right** (and **Ctrl+Shift+Left/Right**) stop at punctuation such as `/`, `:`, `.`, `(`, `)` in plain `TextBox` / editable `ComboBox` controls, instead of jumping over whole paths or identifiers. `_`, `+`, `-` stay part of the word, matching `SpellCheckerHelper.IsSeparator` used elsewhere for double-click word selection and autocomplete.
- Make **double-click** select a punctuation-delimited word rather than the whole whitespace-separated run.
- Make **triple-click** select the entire text. (Windows has no native triple-click message — implemented by detecting a click that lands within the system double-click time and distance of the prior double-click.)
- Wired in via a single `control.EnableProperWordBoundaries()` extension method, called from `GitExtensionsFormBase`, `BugReportForm`, `ExceptionDetailView`, `SearchControl`, `SimplePrompt`, `SettingsPageBase`, `SimpleHelpDisplayDialog`, and `FormBuildServerCredentials`. `RichTextBox` is intentionally excluded — the underlying RichEdit already does both of the above correctly, so the commit-message editor is unaffected.

## Screenshots

### Before

Click at the end and Ctrl+Left

<img width="536" height="233" alt="image" src="https://github.com/user-attachments/assets/bbe490a3-50e0-4944-a6bc-f7d20dfaf100" />


Double click on middle word

<img width="427" height="174" alt="image" src="https://github.com/user-attachments/assets/5643c91d-a15c-4e2f-b9a3-3714ac332015" />


### After

Click at the end and Ctrl+Left

<img width="588" height="245" alt="image" src="https://github.com/user-attachments/assets/324ace70-8bdb-442f-a14c-953d67058721" />


Double click on middle word

<img width="414" height="163" alt="image" src="https://github.com/user-attachments/assets/6e3f3ea7-5d41-4438-878b-02c56aabb54f" />



## Test methodology

- New unit tests in `GitExtUtils.Tests/GitUI/TextBoxWordBreakExtensionsTests.cs` cover `FindPreviousBoundary`, `FindNextBoundary`, and `GetWordAt` across word ↔ punctuation ↔ whitespace transitions, including edges (start/end of text, runs of identical punctuation, mixed delimiters).
- Manual: typed `foo/bar.baz:qux(quux)` into search boxes, settings dialogs, and an editable `ComboBox`. Verified Ctrl+Right stops at each delimiter, Ctrl+Shift+Left/Right extends the selection from the correct anchor, double-click selects only the segment under the cursor, and triple-click selects the whole field.
- Verified the commit-message `RichTextBox` is untouched (still selects a line on triple-click, still uses RichEdit's native punctuation-aware word break).

## Test environment(s)

- GIT 2.53
- Windows 11

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
