### PR TITLE
ci: Enable display of test errors

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -152,4 +152,4 @@ jobs:
         name: Test Results
         path: '**/*.trx'
         reporter: dotnet-trx
-        max-annotations: 0
+        max-annotations: 50 // do not increase over the allowed maximum of 50


### PR DESCRIPTION
Addresses https://github.com/gitextensions/gitextensions/pull/13058#discussion_r3252913862

## Proposed changes

- `.github/workflows/pr-build.yml`: set `max-annotations` to the allowed maximum

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- next CI build with failing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).