### PR TITLE
refactor: Remove nullability of ISetting<T>.Value

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -502,8 +502,8 @@ public static partial class AppSettings
     /// </summary>
     public static string GetEffectiveConEmuStyle()
     {
-        string? style = ConEmuStyle.Value;
-        return style is null || style == ConEmuStyleDefault
+        string style = ConEmuStyle.Value;
+        return style == ConEmuStyleDefault
             ? Application.IsDarkModeEnabled ? ConEmuStyleDark : ConEmuStyleLight
             : style;
     }

--- a/src/app/GitCommands/Settings/ISetting.cs
+++ b/src/app/GitCommands/Settings/ISetting.cs
@@ -8,20 +8,15 @@ public interface ISetting<T>
     string Name { get; }
 
     /// <summary>
-    ///  Default value for setting type.
-    ///  For nullable except "string" is default(T).
-    ///  For "string" is the defaultValue ?? string.Empty from constructor.
-    ///  For non nullable is the defaultValue from constructor.
+    ///  Default value for the setting.
     /// </summary>
-    T? Default { get; }
+    T Default { get; }
 
     /// <summary>
     ///  Value of the setting.
-    ///  For nullable except "string" is the value from storage.
-    ///  For "string" is the value from storage or <see cref="Default"/>.
-    ///  For non nullable is the value from storage or <see cref="Default"/>.
+    ///  Is the value from storage, or <see cref="Default"/> if absent.
     /// </summary>
-    T? Value { get; set; }
+    T Value { get; set; }
 
     /// <summary>
     ///  Full name of the setting.

--- a/src/app/GitCommands/Settings/RuntimeSetting.cs
+++ b/src/app/GitCommands/Settings/RuntimeSetting.cs
@@ -16,30 +16,19 @@ public interface IRuntimeSetting<T> : ISetting<T>, IRuntimeSetting
 ///  Represents a setting which has to be explicitly saved, if changed at runtime.
 /// </summary>
 /// <typeparam name="T">The type of setting.</typeparam>
-public class RuntimeSetting<T> : IRuntimeSetting<T>
+/// <param name="persistentSetting">The <see cref="ISetting{T}"/> instance used to persist the default value of the setting.</param>
+public class RuntimeSetting<T>(ISetting<T> persistentSetting) : IRuntimeSetting<T>
 {
     private bool _loaded;
-    private readonly ISetting<T> _persistentSetting;
-    private T? _value = default;
+    private T _value = persistentSetting.Default;
 
-    /// <summary>
-    ///  Initializes a new instance of the <see cref="RuntimeSetting{T}"/> class.
-    /// </summary>
-    /// <param name="persistentSetting">
-    ///  The <see cref="ISetting{T}"/> instance used to persist the default value of the setting.
-    /// </param>
-    public RuntimeSetting(ISetting<T> persistentSetting)
-    {
-        _persistentSetting = persistentSetting;
-    }
+    public T Default => persistentSetting.Default;
 
-    public T Default => _persistentSetting.Default!;
+    public string FullPath => persistentSetting.FullPath;
 
-    public string FullPath => _persistentSetting.FullPath;
+    public string Name => persistentSetting.Name;
 
-    public string Name => _persistentSetting.Name;
-
-    public T? Value
+    public T Value
     {
         get => GetValue();
         set
@@ -60,12 +49,12 @@ public class RuntimeSetting<T> : IRuntimeSetting<T>
             Reload();
         }
 
-        return _value!;
+        return _value;
     }
 
     public void Reload()
     {
-        Value = _persistentSetting.Value;
+        Value = persistentSetting.Value;
         _loaded = true;
     }
 
@@ -73,12 +62,12 @@ public class RuntimeSetting<T> : IRuntimeSetting<T>
 
     public void Save()
     {
-        _persistentSetting.Value = Value;
+        persistentSetting.Value = Value;
     }
 
     /// <summary>
     ///  Implicit conversion for direct access to the RuntimeSetting value.
     /// </summary>
     /// <param name="setting">The RuntimeSetting whose value is returned as conversion result.</param>
-    public static implicit operator T(RuntimeSetting<T> setting) => setting.Value!;
+    public static implicit operator T(RuntimeSetting<T> setting) => setting.Value;
 }

--- a/src/app/GitCommands/Settings/Setting.cs
+++ b/src/app/GitCommands/Settings/Setting.cs
@@ -5,9 +5,9 @@ namespace GitCommands.Settings;
 
 public static class Setting
 {
-    public static ISetting<string> Create(SettingsPath settingsSource, string name, string? defaultValue)
+    public static ISetting<string> Create(SettingsPath settingsSource, string name, string defaultValue)
     {
-        return new SettingOf<string>(settingsSource, name, defaultValue ?? string.Empty);
+        return new SettingOf<string>(settingsSource, name, defaultValue);
     }
 
     public static ISetting<T> Create<T>(SettingsPath settingsSource, string name, T defaultValue)
@@ -16,67 +16,31 @@ public static class Setting
         return new SettingOf<T>(settingsSource, name, defaultValue);
     }
 
-    public static ISetting<T?> Create<T>(SettingsPath settingsSource, string name)
+    public static ISetting<T> Create<T>(SettingsPath settingsSource, string name)
         where T : struct
     {
-        return new SettingOf<T?>(settingsSource, name);
+        return new SettingOf<T>(settingsSource, name, default);
     }
 
-    private sealed class SettingOf<T>(SettingsPath settingsSource, string name, T? defaultValue = default) : ISetting<T>
+    private sealed class SettingOf<T>(SettingsPath settingsSource, string name, T defaultValue) : ISetting<T>
     {
         public string Name { get; } = name;
 
-        public T? Default { get; } = defaultValue;
+        public T Default { get; } = defaultValue;
 
-        public T? Value
+        public T Value
         {
-            get
-            {
-                object? storedValue = GetValue(Name);
-
-                if (default(T) is null)
-                {
-                    if (Type.GetTypeCode(typeof(T)) != TypeCode.String)
-                    {
-                        return (T?)storedValue;
-                    }
-                }
-
-                if (storedValue is null)
-                {
-                    return Default;
-                }
-
-                return (T)storedValue;
-            }
+            get => GetValue(Name) is { } value ? (T)value : Default;
 
             set
             {
-                object? storedValue = GetValue(Name);
-
-                if (Type.GetTypeCode(typeof(T)) == TypeCode.String)
+                object? valueToBeStored = value?.Equals(Default) is true ? null : value;
+                if (valueToBeStored == GetValue(Name))
                 {
-                    if (storedValue?.Equals((object?)value ?? string.Empty) ?? false)
-                    {
-                        return;
-                    }
-                }
-                else
-                {
-                    if (storedValue?.Equals(value) ?? ((default(T) is null) && (value is null)))
-                    {
-                        return;
-                    }
+                    return;
                 }
 
-                if (Type.GetTypeCode(typeof(T)) == TypeCode.String)
-                {
-                    SetValue(Name, (object?)value ?? string.Empty);
-                }
-                else
-                {
-                    SetValue(Name, value);
-                }
+                SetValue(Name, valueToBeStored);
             }
         }
 

--- a/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.Toolbar.cs
@@ -1,4 +1,4 @@
-using GitCommands;
+﻿using GitCommands;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
@@ -149,7 +149,7 @@ partial class FileStatusList
 
     private void FindUsingOption_Click(object sender, EventArgs e)
     {
-        AppSettings.GitGrepUserArguments.Value = ((ToolStripMenuItem)sender).Text;
+        AppSettings.GitGrepUserArguments.Value = ((ToolStripMenuItem)sender).Text ?? "";
         FindInCommitFilesGitGrep();
     }
 

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -192,8 +192,8 @@ internal sealed class AppSettingsTests
             yield return (properties[nameof(AppSettings.ShowResetAllChanges)], true, false, false);
 
             yield return (properties[nameof(AppSettings.ShowConEmuTab)], true, false, true);
-            yield return (properties[nameof(AppSettings.ConEmuStyle)], "Default", true, true);
-            yield return (properties[nameof(AppSettings.ConEmuTerminal)], "bash", true, true);
+            yield return (properties[nameof(AppSettings.ConEmuStyle)], "Default", isNotNullable, true);
+            yield return (properties[nameof(AppSettings.ConEmuTerminal)], "bash", isNotNullable, true);
             yield return (properties[nameof(AppSettings.OutputHistoryDepth)], 20, isNotNullable, isISetting);
             yield return (properties[nameof(AppSettings.OutputHistoryPanelVisible)], false, isNotNullable, isISetting);
             yield return (properties[nameof(AppSettings.ShowOutputHistoryAsTab)], true, isNotNullable, isISetting);

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -175,7 +175,6 @@ internal sealed class SettingTests
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        string? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
@@ -197,10 +196,8 @@ internal sealed class SettingTests
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, settingDefault);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(value);
         });
-
-        storedValue.Should().Be(value ?? string.Empty);
     }
 
     #endregion String Setting
@@ -208,69 +205,62 @@ internal sealed class SettingTests
     #region Bool Setting
 
     [Test]
-    public void Should_create_nullable_bool_setting()
+    public void Should_create_bool_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
+        ISetting<bool> setting = Setting.Create<bool>(settingsPath, settingName);
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().BeNull();
+        setting.Default.Should().BeFalse();
+        setting.Value.Should().BeFalse();
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    [TestCase(null)]
     [TestCase(false)]
     [TestCase(true)]
-    public void Should_save_nullable_bool_setting(bool? value)
+    public void Should_save_bool_setting(bool value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
+        ISetting<bool> setting = Setting.Create<bool>(settingsPath, settingName);
 
         setting.Value = value;
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
+        setting.Default.Should().BeFalse();
         setting.Value.Should().Be(value);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_bool_setting_if_value_not_exist()
+    public void Should_return_default_value_for_bool_setting_if_value_not_exist([Values] bool defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        bool? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
-            ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
+            ISetting<bool> setting = Setting.Create<bool>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_bool_setting_if_value_is_incorrect()
+    public void Should_return_default_value_for_bool_setting_if_value_is_incorrect([Values] bool defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        bool? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
@@ -290,12 +280,10 @@ internal sealed class SettingTests
 
         AppSettings.UsingContainer(container, () =>
         {
-            ISetting<bool?> setting = Setting.Create<bool>(settingsPath, settingName);
+            ISetting<bool> setting = Setting.Create<bool>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     #endregion Bool Setting
@@ -303,69 +291,63 @@ internal sealed class SettingTests
     #region Char Setting
 
     [Test]
-    public void Should_create_nullable_char_setting()
+    public void Should_create_char_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
+        ISetting<char> setting = Setting.Create<char>(settingsPath, settingName);
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().BeNull();
+        setting.Default.Should().Be('\0');
+        setting.Value.Should().Be('\0');
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    [TestCase(null)]
     [TestCase(char.MinValue)]
     [TestCase(' ')]
-    public void Should_save_nullable_char_setting(char? value)
+    [TestCase(char.MaxValue)]
+    public void Should_save_char_setting(char value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
+        ISetting<char> setting = Setting.Create<char>(settingsPath, settingName);
 
         setting.Value = value;
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
+        setting.Default.Should().Be('\0');
         setting.Value.Should().Be(value);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_char_setting_if_value_not_exist()
+    public void Should_return_default_value_for_char_setting_if_value_not_exist([Values('\0', ' ', '\uFFFF')] char defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        char? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
-            ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
+            ISetting<char> setting = Setting.Create<char>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_char_setting_if_value_is_incorrect()
+    public void Should_return_default_value_for_char_setting_if_value_is_incorrect([Values('\0', ' ', '\uFFFF')] char defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        char? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
@@ -385,12 +367,10 @@ internal sealed class SettingTests
 
         AppSettings.UsingContainer(container, () =>
         {
-            ISetting<char?> setting = Setting.Create<char>(settingsPath, settingName);
+            ISetting<char> setting = Setting.Create<char>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     #endregion Char Setting
@@ -398,70 +378,63 @@ internal sealed class SettingTests
     #region Byte Setting
 
     [Test]
-    public void Should_create_nullable_byte_setting()
+    public void Should_create_byte_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
+        ISetting<byte> setting = Setting.Create<byte>(settingsPath, settingName);
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().BeNull();
+        setting.Default.Should().Be(0);
+        setting.Value.Should().Be(0);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    [TestCase(null)]
     [TestCase(byte.MinValue)]
     [TestCase(byte.MaxValue)]
     [TestCase(0)]
-    public void Should_save_nullable_byte_setting(byte? value)
+    public void Should_save_byte_setting(byte value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
+        ISetting<byte> setting = Setting.Create<byte>(settingsPath, settingName);
 
         setting.Value = value;
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
+        setting.Default.Should().Be(0);
         setting.Value.Should().Be(value);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_byte_setting_if_value_not_exist()
+    public void Should_return_default_value_for_byte_setting_if_value_not_exist([Values(0, 1, 255)] byte defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        byte? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
-            ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
+            ISetting<byte> setting = Setting.Create<byte>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_byte_setting_if_value_is_incorrect()
+    public void Should_return_default_value_for_byte_setting_if_value_is_incorrect([Values(0, 1, 255)] byte defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        byte? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
@@ -481,12 +454,10 @@ internal sealed class SettingTests
 
         AppSettings.UsingContainer(container, () =>
         {
-            ISetting<byte?> setting = Setting.Create<byte>(settingsPath, settingName);
+            ISetting<byte> setting = Setting.Create<byte>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     #endregion Byte Setting
@@ -494,70 +465,62 @@ internal sealed class SettingTests
     #region Int Setting
 
     [Test]
-    public void Should_create_nullable_int_setting()
+    public void Should_create_int_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
+        ISetting<int> setting = Setting.Create<int>(settingsPath, settingName);
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().BeNull();
+        setting.Default.Should().Be(0);
+        setting.Value.Should().Be(0);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    [TestCase(null)]
     [TestCase(int.MinValue)]
     [TestCase(int.MaxValue)]
     [TestCase(0)]
-    public void Should_save_nullable_int_setting(int? value)
+    public void Should_save_int_setting(int value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
-
+        ISetting<int> setting = Setting.Create<int>(settingsPath, settingName);
         setting.Value = value;
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
+        setting.Default.Should().Be(0);
         setting.Value.Should().Be(value);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_int_setting_if_value_not_exist()
+    public void Should_return_default_value_for_int_setting_if_value_not_exist([Values(int.MinValue, -1, 0, 1, int.MaxValue)] int defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        int? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
-            ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
+            ISetting<int> setting = Setting.Create<int>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_int_setting_if_value_is_incorrect()
+    public void Should_return_default_value_for_int_setting_if_value_is_incorrect([Values(int.MinValue, -1, 0, 1, int.MaxValue)] int defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        int? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
@@ -577,12 +540,10 @@ internal sealed class SettingTests
 
         AppSettings.UsingContainer(container, () =>
         {
-            ISetting<int?> setting = Setting.Create<int>(settingsPath, settingName);
+            ISetting<int> setting = Setting.Create<int>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     #endregion Int Setting
@@ -590,70 +551,63 @@ internal sealed class SettingTests
     #region Float Setting
 
     [Test]
-    public void Should_create_nullable_float_setting()
+    public void Should_create_float_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
+        ISetting<float> setting = Setting.Create<float>(settingsPath, settingName);
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().BeNull();
+        setting.Default.Should().Be(0f);
+        setting.Value.Should().Be(0f);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    [TestCase(null)]
     [TestCase(float.MinValue)]
     [TestCase(float.MaxValue)]
     [TestCase(0f)]
-    public void Should_save_nullable_float_setting(float? value)
+    public void Should_save_float_setting(float value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
+        ISetting<float> setting = Setting.Create<float>(settingsPath, settingName);
 
         setting.Value = value;
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
+        setting.Default.Should().Be(0f);
         setting.Value.Should().Be(value);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_float_setting_if_value_not_exist()
+    public void Should_return_default_value_for_float_setting_if_value_not_exist([Values(0f, .1f)] float defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        float? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
-            ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
+            ISetting<float> setting = Setting.Create<float>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_float_setting_if_value_is_incorrect()
+    public void Should_return_default_value_for_float_setting_if_value_is_incorrect([Values(0f, .1f)] float defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        float? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
@@ -673,12 +627,10 @@ internal sealed class SettingTests
 
         AppSettings.UsingContainer(container, () =>
         {
-            ISetting<float?> setting = Setting.Create<float>(settingsPath, settingName);
+            ISetting<float> setting = Setting.Create<float>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     #endregion Float Setting
@@ -686,57 +638,51 @@ internal sealed class SettingTests
     #region Enum Setting
 
     [Test]
-    public void Should_create_nullable_enum_setting()
+    public void Should_create_enum_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
+        ISetting<TestEnum> setting = Setting.Create<TestEnum>(settingsPath, settingName);
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().BeNull();
+        setting.Default.Should().Be(TestEnum.First);
+        setting.Value.Should().Be(TestEnum.First);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    [TestCase(null)]
     [TestCase(TestEnum.First)]
     [TestCase(TestEnum.Second)]
-    public void Should_save_nullable_enum_setting(TestEnum? value)
+    public void Should_save_enum_setting(TestEnum value)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
+        ISetting<TestEnum> setting = Setting.Create<TestEnum>(settingsPath, settingName);
 
         setting.Value = value;
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
+        setting.Default.Should().Be(TestEnum.First);
         setting.Value.Should().Be(value);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    [TestCase(null)]
-    [TestCase(TestEnum.First)]
-    [TestCase(TestEnum.Second)]
-    public void Should_save_nullable_enum_setting_as_string(TestEnum? value)
+    public void Should_save_enum_setting_as_string([Values] TestEnum value, [Values] TestEnum defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        string? storedValue = string.Empty;
-
         AppSettings.UsingContainer(_settingContainer, () =>
         {
-            ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
+            ISetting<TestEnum> setting = Setting.Create<TestEnum>(settingsPath, settingName, defaultValue);
 
             setting.Value = value;
 
@@ -754,41 +700,34 @@ internal sealed class SettingTests
         {
             ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
 
-            storedValue = setting.Value;
+            string storedValue = setting.Value;
+            storedValue.Should().Be(value == defaultValue ? "" : value.ToString());
+            bool isNumber = int.TryParse(storedValue, out _);
+            isNumber.Should().BeFalse();
         });
-
-        bool isNumber = int.TryParse(storedValue, out _);
-
-        isNumber.Should().BeFalse();
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_enum_setting_if_value_not_exist()
+    public void Should_return_default_value_for_enum_setting_if_value_not_exist([Values] TestEnum defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        TestEnum? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
-            ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
+            ISetting<TestEnum> setting = Setting.Create<TestEnum>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     [Test]
-    public void Should_return_default_value_for_nullable_enum_setting_if_value_is_incorrect()
+    public void Should_return_default_value_for_enum_setting_if_value_is_incorrect([Values] TestEnum defaultValue)
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-
-        TestEnum? storedValue = null;
 
         AppSettings.UsingContainer(_settingContainer, () =>
         {
@@ -808,12 +747,10 @@ internal sealed class SettingTests
 
         AppSettings.UsingContainer(container, () =>
         {
-            ISetting<TestEnum?> setting = Setting.Create<TestEnum>(settingsPath, settingName);
+            ISetting<TestEnum> setting = Setting.Create<TestEnum>(settingsPath, settingName, defaultValue);
 
-            storedValue = setting.Value;
+            setting.Value.Should().Be(defaultValue);
         });
-
-        storedValue.Should().BeNull();
     }
 
     public enum TestEnum
@@ -827,28 +764,28 @@ internal sealed class SettingTests
     #region Struct Setting
 
     [Test]
-    public void Should_create_nullable_struct_setting()
+    public void Should_create_struct_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
 
-        ISetting<TestStruct?> setting = Setting.Create<TestStruct>(settingsPath, settingName);
+        ISetting<TestStruct> setting = Setting.Create<TestStruct>(settingsPath, settingName);
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
-        setting.Value.Should().BeNull();
+        setting.Default.Should().Be(default(TestStruct));
+        setting.Value.Should().Be(default(TestStruct));
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
 
     [Test]
-    public void Should_save_nullable_struct_setting()
+    public void Should_save_struct_setting()
     {
         string pathName = Guid.NewGuid().ToString();
         string settingName = Guid.NewGuid().ToString();
         AppSettingsPath settingsPath = new(pathName);
-        TestStruct? value = new TestStruct
+        TestStruct value = new TestStruct
         {
             Bool = false,
             Char = ' ',
@@ -857,13 +794,13 @@ internal sealed class SettingTests
             Float = 0f
         };
 
-        ISetting<TestStruct?> setting = Setting.Create<TestStruct>(settingsPath, settingName);
+        ISetting<TestStruct> setting = Setting.Create<TestStruct>(settingsPath, settingName);
 
         setting.Value = value;
 
         setting.Should().NotBeNull();
         setting.Name.Should().Be(settingName);
-        setting.Default.Should().BeNull();
+        setting.Default.Should().Be(default(TestStruct));
         setting.Value.Should().Be(value);
         setting.FullPath.Should().Be($"{pathName}.{settingName}");
     }
@@ -909,22 +846,15 @@ internal sealed class SettingTests
 
     private static IEnumerable<object[]> CreateStringCases()
     {
-        yield return new object[] { null! };
         yield return new object[] { string.Empty };
         yield return new object[] { "_" };
     }
 
     private static IEnumerable<object[]> SaveStringCases()
     {
-        yield return new object[] { null!, null! };
-        yield return new object[] { null!, string.Empty };
-        yield return new object[] { null!, "_" };
-
-        yield return new object[] { string.Empty, null! };
         yield return new object[] { string.Empty, string.Empty };
         yield return new object[] { string.Empty, "_" };
 
-        yield return new object[] { "_", null! };
         yield return new object[] { "_", string.Empty };
         yield return new object[] { "_", "_" };
     }


### PR DESCRIPTION
Triggered by #12959

## Proposed changes

- `ISetting<T>`: Remove nullability of properties `Value` and `DefaultValue` because not used
- `GitCommands.Settings.Setting`: Remove special handling for `string`
- `AppSettingsTests`: Fixup classification of `AppSettings.ConEmuStyle` and `AppSettings.ConEmuTerminal`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests
- turn nullable tests into non-nullable tests
- remove `null!` from `TestCaseSource`

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).