### PR TITLE
feat: hide fetch-all UI when there is only one remote

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -58,6 +58,8 @@ partial class FormBrowse
 
         InsertFetchPullShortcuts();
 
+        toolStripButtonPull.DropDownOpening += (_, _) => UpdateFetchAllVisibility();
+
         WorkaroundToolbarLocationBug();
 
         return;
@@ -321,6 +323,30 @@ partial class FormBrowse
         }
 
         UpdateTooltipWithShortcut(toolStripButtonPull, Command.QuickPullOrFetch);
+    }
+
+    /// <summary>
+    ///  Hides "Fetch all" item when there is only one remote,
+    ///  since it is redundant with the single-remote "Fetch" command.
+    /// </summary>
+    private void UpdateFetchAllVisibility()
+    {
+        bool hasMultipleRemotes = Module.IsValidGitWorkingDir() && Module.GetRemoteNames().Count > 1;
+
+        // Toolbar button drop down menu
+        fetchAllToolStripMenuItem.Visible = hasMultipleRemotes;
+
+        // Update the "set default pull action" submenu items
+        if (setDefaultPullButtonActionToolStripMenuItem.DropDown is ToolStripDropDownMenu setDefaultMenu)
+        {
+            foreach (ToolStripItem item in setDefaultMenu.Items)
+            {
+                if (item.Tag is GitPullAction.FetchAll)
+                {
+                    item.Visible = hasMultipleRemotes;
+                }
+            }
+        }
     }
 
     private Brush UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -978,6 +978,12 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
             toolStripButtonPull.Enabled = validBrowseDir;
             toolStripButtonPush.Enabled = validBrowseDir;
             toolStripButtonPush.ResetBeforeUpdate();
+
+            if (validBrowseDir)
+            {
+                UpdateFetchAllVisibility();
+            }
+
             dashboardToolStripMenuItem.Visible = isDashboard;
             pluginsToolStripMenuItem.Visible = validBrowseDir;
             repositoryToolStripMenuItem.Visible = validBrowseDir;


### PR DESCRIPTION
## Proposed changes

I have got the question what multiple remotes means several times. Users in corporate environments without private forks never use multiple remotes.

When only a single remote is configured, the "Fetch all" and
"Fetch and prune all" menu items, toolbar buttons, and default-action
options are hidden to reduce UI clutter. They reappear automatically
when multiple remotes are present.

Affected locations:
- Pull button dropdown menu
- Toolbar shortcut buttons
- "Set default pull action" submenu

For optional toolbar shortcut buttons, disable the buttons only,
as the enabling is separate.

For the left panel root node, the text still says All for the top level, no change.

--
Another @drewnoakes feature, I had to tweak it some though.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

I have setup an additional PruneAll button below (for no reason as the default is PruneAll).

### Before

<img width="467" height="319" alt="image" src="https://github.com/user-attachments/assets/c6705fc2-e663-4767-bb7a-4dd0a4bc8670" />

### After

Multiple remotes as above.

The additional button and the default.
~~disabled button is not great, but I expect that not to be used much anyway. The alternative is to keep it visible, if you have added it, you maybe use it for both remote/single?~~

<img width="482" height="222" alt="image" src="https://github.com/user-attachments/assets/fdb3a035-01c6-4d75-ab56-e3fae5eaf3a1" />

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
