### PR TITLE
fix(save selected as): Support top-level files

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -54,9 +54,14 @@ internal sealed class RevisionDiffController(Func<IGitModule> getModule, IFullPa
 
         void SaveMultipleFiles(List<FileStatusItem> selectedFiles)
         {
-            string? baseSourceDirectory = _fullPathResolver.Resolve(GetLongestCommonPath(selectedFiles)).EnsureTrailingPathSeparator();
+            string longestCommonPath = GetLongestCommonPath(selectedFiles);
+            string? baseSourceDirectory = _fullPathResolver.Resolve(longestCommonPath.Length == 0 ? "." : longestCommonPath).EnsureTrailingPathSeparator();
+            if (baseSourceDirectory is null)
+            {
+                throw new ExternalOperationException(innerException: new DirectoryNotFoundException(@$"Could not resolve common relative path ""{longestCommonPath}"" in ""{_getModule().WorkingDir}""."));
+            }
 
-            string? selectedPath = userSelection(baseSourceDirectory!);
+            string? selectedPath = userSelection(baseSourceDirectory);
             if (selectedPath is null)
             {
                 // User has cancelled the selection

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -103,7 +103,7 @@ public class RevisionDiffControllerTests
 
         _controller.SaveFiles(files, userSelection);
 
-        _fullPathResolver.Received(1).Resolve("");
+        _fullPathResolver.Received(1).Resolve(".");
         _fullPathResolver.Received(0).Resolve(item1.Item.Name);
         _fullPathResolver.Received(0).Resolve(item2.Item.Name);
         _module.Received(0).SaveBlobAs(Arg.Any<string>(), Arg.Any<string>());
@@ -123,7 +123,7 @@ public class RevisionDiffControllerTests
             item2,
         ];
 
-        _fullPathResolver.Resolve("").Returns(x => "c:\\temp\\");
+        _fullPathResolver.Resolve(".").Returns(x => "c:\\temp\\");
         _fullPathResolver.Resolve(item1.Item.Name).Returns(x => "c:\\temp\\item1.txt");
         _fullPathResolver.Resolve(item2.Item.Name).Returns(x => "c:\\temp\\folder1\\item2.txt");
         _fullPathResolver.Resolve(item3.Item.Name).Returns(x => "c:\\temp\\folder1\\folder2\\item3.txt");
@@ -132,7 +132,7 @@ public class RevisionDiffControllerTests
 
         _controller.SaveFiles(files, userSelection);
 
-        _fullPathResolver.Received(1).Resolve("");
+        _fullPathResolver.Received(1).Resolve(".");
         _fullPathResolver.Received(1).Resolve(item1.Item.Name);
         _fullPathResolver.Received(1).Resolve(item2.Item.Name);
         _fullPathResolver.Received(1).Resolve(item3.Item.Name);
@@ -156,7 +156,7 @@ public class RevisionDiffControllerTests
             item3,
         ];
 
-        _fullPathResolver.Resolve("").Returns(x => "c:\\temp\\");
+        _fullPathResolver.Resolve(".").Returns(x => "c:\\temp\\");
         _fullPathResolver.Resolve(item1.Item.Name).Returns(x => "c:\\temp\\item1.txt");
         _fullPathResolver.Resolve(item2.Item.Name).Returns(x => "c:\\temp\\folder1\\item2.txt");
         _fullPathResolver.Resolve(item3.Item.Name).Returns(x => "c:\\temp\\folder1\\folder2\\item3.txt");
@@ -165,7 +165,7 @@ public class RevisionDiffControllerTests
 
         _controller.SaveFiles(files, userSelection);
 
-        _fullPathResolver.Received(1).Resolve("");
+        _fullPathResolver.Received(1).Resolve(".");
         _fullPathResolver.Received(1).Resolve(item1.Item.Name);
         _fullPathResolver.Received(1).Resolve(item2.Item.Name);
         _fullPathResolver.Received(1).Resolve(item3.Item.Name);


### PR DESCRIPTION
Fixes #13069
Addendum to #12658

## Proposed changes

`RevisionDiffController`:
- Turn empty string returned by `GetLongestCommonPath` into "." before resolving directory
- Throw `EOE` if result is still `null` instead of `!`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapt existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).