### PR TITLE
fix(remote branch prefix): Allow trailing slash

### DIFF
--- a/src/app/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/src/app/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -117,7 +117,7 @@ internal sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
 
         // rule #2 is not applicable
         // rule #6 runs as second last to ensure no consecutive '/' are left after previous normalisations
-        branchName = Rule06(branchName);
+        branchName = Rule06(branchName, options);
         branchName = Rule01(branchName, options);
 
         return branchName;
@@ -199,8 +199,9 @@ internal sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
     ///  Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
     /// </summary>
     /// <param name="branchName">Name of the branch.</param>
+    /// <param name="options">The options.</param>
     /// <returns>Normalised branch name.</returns>
-    internal static string Rule06(string branchName)
+    internal static string Rule06(string branchName, GitBranchNameOptions options)
     {
         branchName = Rule06Regex.Replace(branchName, "/");
         if (branchName.StartsWith('/'))
@@ -208,7 +209,7 @@ internal sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
             branchName = branchName[1..];
         }
 
-        if (branchName.EndsWith('/'))
+        if (!options.AllowTrailingSlash && branchName.EndsWith('/'))
         {
             branchName = branchName[..^1];
         }

--- a/src/app/GitCommands/Git/GitBranchNameOptions.cs
+++ b/src/app/GitCommands/Git/GitBranchNameOptions.cs
@@ -1,12 +1,20 @@
 ﻿namespace GitCommands.Git;
 
 /// <summary>
-/// Options used by <see cref="GitBranchNameNormaliser"/> to ensures compliance with the GIT branch naming conventions.
+///  Options used by <see cref="GitBranchNameNormaliser"/> to ensures compliance with the GIT branch naming conventions.
 /// </summary>
 public sealed class GitBranchNameOptions
 {
-    public GitBranchNameOptions(string? replacementToken)
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="GitBranchNameOptions"/> class.
+    /// </summary>
+    /// <param name="replacementToken">The character which will replace all invalid characters in git branch name.</param>
+    /// <param name="allowTrailingSlash">Indicates whether a trailing slash is allowed in the branch name, e.g. in case of a branch prefix.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the replacement token is invalid.</exception>
+    public GitBranchNameOptions(string? replacementToken, bool allowTrailingSlash = false)
     {
+        AllowTrailingSlash = allowTrailingSlash;
+
         if (!string.IsNullOrEmpty(replacementToken))
         {
             if (replacementToken.Length > 1)
@@ -24,7 +32,12 @@ public sealed class GitBranchNameOptions
     }
 
     /// <summary>
-    /// Gets the character which will replace all invalid characters in git branch name.
+    ///  Indicates whether a trailing slash is allowed in the branch name, e.g. in case of a branch prefix.
+    /// </summary>
+    public bool AllowTrailingSlash { get; }
+
+    /// <summary>
+    ///  Gets the character which will replace all invalid characters in git branch name.
     /// </summary>
     /// <seealso cref="GitBranchNameNormaliser"/>.
     public string ReplacementToken { get; }

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -159,7 +159,8 @@ Inactive remote is completely invisible to git.");
 
         static string NormalisePrefix(string prefix, IGitBranchNameNormaliser branchNameNormaliser)
         {
-            const string dummyBranchName = "branch_for_normalization";
+            // Without a branch appended, the normaliser would remove a trailing slash from the prefix
+            const string dummyBranchName = "branch_for_prefix_normalisation";
             string normalised = branchNameNormaliser.Normalise($"{prefix}{dummyBranchName}", new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol));
             if (normalised.EndsWith(dummyBranchName, StringComparison.Ordinal))
             {

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using GitCommands;
+﻿using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.Remotes;
@@ -112,7 +111,8 @@ Inactive remote is completely invisible to git.");
         InitializeComplete();
 
         _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
-        txtRemotePrefix.Leave += (_, _) => txtRemotePrefix.Text = NormalisePrefix(txtRemotePrefix.Text, _branchNameNormaliser);
+        GitBranchNameOptions options = new(replacementToken: AppSettings.AutoNormaliseSymbol, allowTrailingSlash: true);
+        txtRemotePrefix.Leave += (_, _) => txtRemotePrefix.Text = _branchNameNormaliser.Normalise(txtRemotePrefix.Text, options);
 
         btnRemoteColor.BackColor = Color.Transparent;
 
@@ -154,22 +154,6 @@ Inactive remote is completely invisible to git.");
             resizeDebounceTimer.Stop();
             resizeDebounceTimer.Start();
         };
-
-        return;
-
-        static string NormalisePrefix(string prefix, IGitBranchNameNormaliser branchNameNormaliser)
-        {
-            // Append a dummy branch name so the normaliser does not remove a trailing slash from the prefix
-            const string dummyBranchName = "branch_for_prefix_normalisation";
-            string normalised = branchNameNormaliser.Normalise($"{prefix}{dummyBranchName}", new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol));
-            if (normalised.EndsWith(dummyBranchName, StringComparison.Ordinal))
-            {
-                return normalised[..^dummyBranchName.Length];
-            }
-
-            Trace.WriteLine(@$"Normalised branch name should end with the dummy branch name. Normalised: ""{normalised}"", Dummy branch name: ""{dummyBranchName}""");
-            return prefix;
-        }
     }
 
     private void AutoResizeRemotesColumn()

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.Diagnostics;
+using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.Remotes;
@@ -158,14 +159,15 @@ Inactive remote is completely invisible to git.");
 
         static string NormalisePrefix(string prefix, IGitBranchNameNormaliser branchNameNormaliser)
         {
-            const string dummyBranchName = nameof(dummyBranchName);
+            const string dummyBranchName = "branch_for_normalization";
             string normalised = branchNameNormaliser.Normalise($"{prefix}{dummyBranchName}", new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol));
             if (normalised.EndsWith(dummyBranchName, StringComparison.Ordinal))
             {
-                return normalised[0..(normalised.Length - dummyBranchName.Length)];
+                return normalised[..^dummyBranchName.Length];
             }
 
-            throw new InvalidOperationException(@$"Normalised branch name should end with the dummy branch name. Normalised: ""{normalised}"", Dummy branch name: ""{dummyBranchName}""");
+            Trace.WriteLine(@$"Normalised branch name should end with the dummy branch name. Normalised: ""{normalised}"", Dummy branch name: ""{dummyBranchName}""");
+            return prefix;
         }
     }
 

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -111,7 +111,7 @@ Inactive remote is completely invisible to git.");
         InitializeComplete();
 
         _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
-        txtRemotePrefix.Leave += (sender, e) => txtRemotePrefix.Text = _branchNameNormaliser.Normalise(txtRemotePrefix.Text, new(AppSettings.AutoNormaliseSymbol));
+        txtRemotePrefix.Leave += (_, _) => txtRemotePrefix.Text = NormalisePrefix(txtRemotePrefix.Text, _branchNameNormaliser);
 
         btnRemoteColor.BackColor = Color.Transparent;
 
@@ -153,6 +153,20 @@ Inactive remote is completely invisible to git.");
             resizeDebounceTimer.Stop();
             resizeDebounceTimer.Start();
         };
+
+        return;
+
+        static string NormalisePrefix(string prefix, IGitBranchNameNormaliser branchNameNormaliser)
+        {
+            const string dummyBranchName = nameof(dummyBranchName);
+            string normalised = branchNameNormaliser.Normalise($"{prefix}{dummyBranchName}", new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol));
+            if (normalised.EndsWith(dummyBranchName, StringComparison.Ordinal))
+            {
+                return normalised[0..(normalised.Length - dummyBranchName.Length)];
+            }
+
+            throw new InvalidOperationException(@$"Normalised branch name should end with the dummy branch name. Normalised: ""{normalised}"", Dummy branch name: ""{dummyBranchName}""");
+        }
     }
 
     private void AutoResizeRemotesColumn()

--- a/src/app/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRemotes.cs
@@ -159,7 +159,7 @@ Inactive remote is completely invisible to git.");
 
         static string NormalisePrefix(string prefix, IGitBranchNameNormaliser branchNameNormaliser)
         {
-            // Without a branch appended, the normaliser would remove a trailing slash from the prefix
+            // Append a dummy branch name so the normaliser does not remove a trailing slash from the prefix
             const string dummyBranchName = "branch_for_prefix_normalisation";
             string normalised = branchNameNormaliser.Normalise($"{prefix}{dummyBranchName}", new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol));
             if (normalised.EndsWith(dummyBranchName, StringComparison.Ordinal))

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
@@ -106,7 +106,7 @@ public class FormRemotesTests
         AppSettings.AlwaysShowAdvOpt = true;
 
         IGitBranchNameNormaliser branchNameNormaliser = _commands.GetRequiredService<IGitBranchNameNormaliser>();
-        branchNameNormaliser.Normalise("invalid branch name", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-name");
+        branchNameNormaliser.Normalise("invalid branch namebranch_for_normalization", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-namebranch_for_normalization");
 
         RunFormTest(
             form =>

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
@@ -106,7 +106,7 @@ public class FormRemotesTests
         AppSettings.AlwaysShowAdvOpt = true;
 
         IGitBranchNameNormaliser branchNameNormaliser = _commands.GetRequiredService<IGitBranchNameNormaliser>();
-        branchNameNormaliser.Normalise("invalid branch namebranch_for_normalization", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-namebranch_for_normalization");
+        branchNameNormaliser.Normalise("invalid branch prefix/branch_for_prefix_normalisation", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-prefix/branch_for_prefix_normalisation");
 
         RunFormTest(
             form =>
@@ -114,10 +114,10 @@ public class FormRemotesTests
                 FormRemotes.TestAccessor accessor = form.GetTestAccessor();
 
                 accessor.RemotePrefix.Focus();
-                accessor.RemotePrefix.Text = "invalid branch name";
+                accessor.RemotePrefix.Text = "invalid branch prefix/";
                 accessor.RemoteName.Focus();
 
-                accessor.RemotePrefix.Text.Should().Be("invalid-branch-name");
+                accessor.RemotePrefix.Text.Should().Be("invalid-branch-prefix/");
             });
     }
 

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormRemotesTests.cs
@@ -106,7 +106,7 @@ public class FormRemotesTests
         AppSettings.AlwaysShowAdvOpt = true;
 
         IGitBranchNameNormaliser branchNameNormaliser = _commands.GetRequiredService<IGitBranchNameNormaliser>();
-        branchNameNormaliser.Normalise("invalid branch prefix/branch_for_prefix_normalisation", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-prefix/branch_for_prefix_normalisation");
+        branchNameNormaliser.Normalise("invalid branch prefix/", Arg.Any<GitBranchNameOptions>()).Returns("invalid-branch-prefix/");
 
         RunFormTest(
             form =>

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitBranchNameNormaliserTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitBranchNameNormaliserTest.cs
@@ -93,14 +93,19 @@ public sealed class GitBranchNameNormaliserTest
     }
 
     // Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
-    [TestCase("test/", "test")]
-    [TestCase("/test", "test")]
-    [TestCase("/test/", "test")]
-    [TestCase("/test/test/", "test/test")]
-    [TestCase("///test///test///", "test/test")]
-    public void Normalise_rule06(string input, string expected)
+    [TestCase("test/", false, "test")]
+    [TestCase("test/", true, "test/")]
+    [TestCase("/test", false, "test")]
+    [TestCase("/test/", false, "test")]
+    [TestCase("/test/", true, "test/")]
+    [TestCase("/test/test/", false, "test/test")]
+    [TestCase("/test/test/", true, "test/test/")]
+    [TestCase("///test///test///", false, "test/test")]
+    [TestCase("///test///test///", true, "test/test/")]
+    public void Normalise_rule06(string input, bool allowTrailingSlash, string expected)
     {
-        GitBranchNameNormaliser.Rule06(input).Should().Be(expected);
+        GitBranchNameOptions options = new(replacementToken: "_", allowTrailingSlash);
+        GitBranchNameNormaliser.Rule06(input, options).Should().Be(expected);
     }
 
     // Branch name end with a dot '.'.


### PR DESCRIPTION
Addendum to #12989

## Proposed changes

- `GitBranchNameOptions`: Add property `AllowTrailingSlash`
- `GitBranchNameNormaliser`: Apply `GitBranchNameOptions.AllowTrailingSlash` in `Rule06`
- `FormRemotes`: Normalize branch name prefix with `allowTrailingSlash: true`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually
- extend existing test so it would fail without the change
- add tests for the option

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).