### PR TITLE
feat: "Reset Changes" and "Commit" working directory context menu (#9…

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -227,3 +227,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/01/09, jmg2k, Jonas Guss, 44924601+jmg2k@users.noreply.github.com
 2026/02/19, apoorvdarshan, Apoorv Darshan, ad13dtu(at)gmail.com
 2026/05/04, Henr1k80, Henrik Gedionsen, Henrik.Gedionsen[.@)gmail.com
+2026/05/06, LeeRedfield, Chiong Ngek Lee, chiongngeklee@gmail.com

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -9534,6 +9534,10 @@ Reset the filter via View &gt; Show all branches.</source>
         <source>Cherr&amp;y pick this commit...</source>
         <target />
       </trans-unit>
+      <trans-unit id="commitToolStripMenuItem.Text">
+        <source>&amp;Commit</source>
+        <target />
+      </trans-unit>
       <trans-unit id="compareSelectedCommitsMenuItem.Text">
         <source>Compare &amp;selected commits</source>
         <target />
@@ -9652,6 +9656,10 @@ Reset the filter via View &gt; Show all branches.</source>
       </trans-unit>
       <trans-unit id="resetAnotherBranchToHereToolStripMenuItem.Text">
         <source>Reset an&amp;other branch to here...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="resetChangesToolStripMenuItem.Text">
+        <source>&amp;Reset changes</source>
         <target />
       </trans-unit>
       <trans-unit id="resetCurrentBranchToHereToolStripMenuItem.Text">

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -38,6 +38,8 @@ partial class RevisionGridControl
         mergeBranchToolStripMenuItem = new ToolStripMenuItem();
         resetCurrentBranchToHereToolStripMenuItem = new ToolStripMenuItem();
         resetAnotherBranchToHereToolStripMenuItem = new ToolStripMenuItem();
+        resetChangesToolStripMenuItem = new ToolStripMenuItem();
+        commitToolStripMenuItem = new ToolStripMenuItem();
         rebaseOnToolStripMenuItem = new ToolStripMenuItem();
         sepBranch = new ToolStripSeparator();
         createNewBranchToolStripMenuItem = new ToolStripMenuItem();
@@ -138,6 +140,8 @@ partial class RevisionGridControl
         rebaseOnToolStripMenuItem,
         resetCurrentBranchToHereToolStripMenuItem,
         sepBranch,
+        resetChangesToolStripMenuItem,
+        commitToolStripMenuItem,
         createNewBranchToolStripMenuItem,
         resetAnotherBranchToHereToolStripMenuItem,
         renameBranchToolStripMenuItem,
@@ -274,8 +278,24 @@ partial class RevisionGridControl
         resetCurrentBranchToHereToolStripMenuItem.Text = "Reset c&urrent branch to here...";
         resetCurrentBranchToHereToolStripMenuItem.Click += ResetCurrentBranchToHereToolStripMenuItemClick;
         // 
-        // resetAnotherBranchToHereToolStripMenuItem
+        // resetChangesToolStripMenuItem
+        //
+        resetChangesToolStripMenuItem.Image = Properties.Images.ResetWorkingDirChanges;
+        resetChangesToolStripMenuItem.Name = "resetChangesToolStripMenuItem";
+        resetChangesToolStripMenuItem.Size = new Size(223, 22);
+        resetChangesToolStripMenuItem.Text = "&Reset changes";
+        resetChangesToolStripMenuItem.Click += ResetChangesToolStripMenuItemClick;
         // 
+        // commitToolStripMenuItem
+        //
+        commitToolStripMenuItem.Image = Properties.Images.RepoStateDirty;
+        commitToolStripMenuItem.Name = "commitToolStripMenuItem";
+        commitToolStripMenuItem.Size = new Size(223, 22);
+        commitToolStripMenuItem.Text = "&Commit";
+        commitToolStripMenuItem.Click += CommitToolStripMenuItemClick;
+        //
+        // resetAnotherBranchToHereToolStripMenuItem
+        //
         resetAnotherBranchToHereToolStripMenuItem.Image = Properties.Images.ResetAnotherBranchToHere;
         resetAnotherBranchToHereToolStripMenuItem.Name = "resetAnotherBranchToHereToolStripMenuItem";
         resetAnotherBranchToHereToolStripMenuItem.Size = new Size(223, 22);
@@ -655,6 +675,8 @@ partial class RevisionGridControl
     private ToolStripMenuItem tsmiPushBranch;
     private ToolStripMenuItem resetCurrentBranchToHereToolStripMenuItem;
     private ToolStripMenuItem resetAnotherBranchToHereToolStripMenuItem;
+    private ToolStripMenuItem resetChangesToolStripMenuItem;
+    private ToolStripMenuItem commitToolStripMenuItem;
     private GitUI.UserControls.RevisionGrid.CopyContextMenuItem copyToClipboardToolStripMenuItem;
     private ToolStripSeparator sepBisect;
     private ToolStripSeparator sepCompare;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -208,6 +208,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         const bool top = false;
         const bool advanced = true;
         _contextMenuItems = [
+            (resetChangesToolStripMenuItem, top),
+            (commitToolStripMenuItem, top),
             (markRevisionAsBadToolStripMenuItem, top),
             (markRevisionAsGoodToolStripMenuItem, top),
             (bisectSkipRevisionToolStripMenuItem, top),
@@ -2032,6 +2034,17 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         });
     }
 
+    private void ResetChangesToolStripMenuItemClick(object sender, EventArgs e)
+    {
+        UICommands.StartResetChangesDialog(this, Module.GetWorkTreeFiles(), onlyWorkTree: false);
+        ArtificialChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void CommitToolStripMenuItemClick(object sender, EventArgs e)
+    {
+        UICommands.StartCommitDialog(this);
+    }
+
     private void ResetAnotherBranchToHereToolStripMenuItemClick(object sender, EventArgs e)
     {
         if (LatestSelectedRevision is null)
@@ -2319,6 +2332,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         SetEnabled(createNewBranchToolStripMenuItem, !bareRepositoryOrArtificial);
         SetEnabled(resetCurrentBranchToHereToolStripMenuItem, !bareRepositoryOrArtificial);
         SetEnabled(resetAnotherBranchToHereToolStripMenuItem, !bareRepositoryOrArtificial);
+        SetEnabled(resetChangesToolStripMenuItem, revision.IsArtificial);
+        SetEnabled(commitToolStripMenuItem, revision.IsArtificial);
         SetEnabled(archiveRevisionToolStripMenuItem, !revision.IsArtificial);
         SetEnabled(createTagToolStripMenuItem, !revision.IsArtificial);
 
@@ -3152,11 +3167,17 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         SetShortcutString(compareToBaseToolStripMenuItem, Command.CompareToBase);
         SetShortcutString(compareToWorkingDirectoryMenuItem, Command.CompareToWorkingDirectory);
         SetShortcutString(compareSelectedCommitsMenuItem, Command.CompareSelectedCommits);
+        SetShortcutString(commitToolStripMenuItem, FormBrowse.Command.Commit);
     }
 
     private void SetShortcutString(ToolStripMenuItem item, Command command)
     {
         item.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(command);
+    }
+
+    private void SetShortcutString(ToolStripMenuItem item, FormBrowse.Command command)
+    {
+        item.ShortcutKeyDisplayString = GetHotkeys(FormBrowse.HotkeySettingsName).GetShortcutDisplay(command);
     }
 
     private void ShowFormDiff(ObjectId baseCommitSha, ObjectId headCommitSha, string baseCommitDisplayStr, string headCommitDisplayStr)


### PR DESCRIPTION
Add the following items to context menu when user right-clicks on `Commit index` or `Working directory`:
- `Reset Changes`: reset staged and unstaged changes
- `Commit`: open commit dialog

## Screenshot

<img width="528" height="162" alt="Screenshot (7)" src="https://github.com/user-attachments/assets/78bbd271-6d2f-45f9-ad19-ac10571c8014" />

## Test methodology

- manually

## Test environment(s)

- GIT 2.54
- Windows 11

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
