### PR TITLE
Fix regex pattern for rejected push detection

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -541,7 +541,7 @@ public partial class FormPush : GitModuleForm
 
         // if push was rejected, offer force push and for current branch also pull/merge
         // Note that the Git output contains color codes etc too
-        Regex isRejected = new($"! \\[rejected\\] .* ((?<currBranch>{Regex.Escape(_currentBranchName!)})|.*) -> ");
+        Regex isRejected = new($"! \\[rejected\\]\\s*((?<currBranch>{Regex.Escape(_currentBranchName!)})|.*) -> ");
         Match match = isRejected.Match(form.GetOutputString());
         if (match.Success && !Module.IsBareRepository())
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes
We have a mechanism during stale push to offer force-push, but sometimes it doesn't detect change due to whitespaces being rendered weirdly. This PR fixes that by changing regex to accept any whitespaces in-between. I believe that regex is still robust.

From https://github.com/gitextensions/gitextensions/pull/13035#discussion_r3261722455

> I have noticed, too, that offering force push was broken before adding mintty, but have not analyzed.
> The following should accept text inbetween as before:
>`         Regex isRejected = new(@$"! \[rejected\\]\s(.*\s)?((?<currBranch>{Regex.Escape(_currentBranchName!)})|.*) -> ");`

@mstv Creating a separate PR as you suggested. I do believe that current regex is sufficient. It fixed the issue entirely and I suggest to not have `.*`, as I didn't really see anything else appearing there. 

I also wouldn't request "at least one space" - it's probably safe and I could try to test with it, but you never know which sequences are rendered to the terminal. But given that we have whitespaces only surrounded by text, it's safe enough for me.


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
