### PR TITLE
fix(create repo): Pass ServiceProvider

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormInit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormInit.cs
@@ -1,4 +1,4 @@
-using GitCommands;
+﻿using GitCommands;
 using GitCommands.UserRepositoryHistory;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -22,8 +22,14 @@ public partial class FormInit : GitExtensionsDialog
 
     private readonly EventHandler<GitModuleEventArgs>? _gitModuleChanged;
 
-    public FormInit(string dir, EventHandler<GitModuleEventArgs>? gitModuleChanged)
-        : base(commands: null, enablePositionRestore: true)
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="FormInit"/> class.
+    /// </summary>
+    /// <param name="commands">The <see cref="IGitUICommands"/> instance, mainly in its role as <see cref="IServiceProvider"/>.</param>
+    /// <param name="dir">The initial directory path.</param>
+    /// <param name="gitModuleChanged">The event handler for Git module changes.</param>
+    public FormInit(IGitUICommands commands, string dir, EventHandler<GitModuleEventArgs>? gitModuleChanged)
+        : base(commands, enablePositionRestore: true)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
 

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -710,7 +710,7 @@ public sealed class GitUICommands : IGitUICommands
         {
             dir ??= Module.IsValidGitWorkingDir() ? Module.WorkingDir : string.Empty;
 
-            using FormInit frm = new(dir, gitModuleChanged);
+            using FormInit frm = new(this, dir, gitModuleChanged);
             frm.ShowDialog(owner);
             return true;
         }


### PR DESCRIPTION
Fixes #13079
and possible earlier reports

## Proposed changes

- `GitUICommands.StartInitializeDialog`: Pass `this` to `FormInit` so that it can use the ServiceProvider.
- `FormInit`: Initialize `UICommands`.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).