### PR TITLE
fix(StartFileHistoryDialog): Avoid error popup

### DIFF
--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1306,6 +1306,8 @@ public sealed class GitUICommands : IGitUICommands
                 return $" -commit={revision.ObjectId}";
             }
 
+            // Avoid a race condition in FormFileHistory selecting an artificial commit.
+            // Without a hash passed, it automatically selects the first real revision.
             if (revision.IsArtificial)
             {
                 return "";

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1287,9 +1287,32 @@ public sealed class GitUICommands : IGitUICommands
 
     public void StartFileHistoryDialog(IWin32Window? owner, string fileName, GitRevision? revision = null, bool filterByRevision = false, bool showBlame = false)
     {
-        string arguments = AppSettings.UseBrowseForFileHistory.Value ? $"browse {PathFilterArg}={fileName.Quote()} -commit={revision?.ObjectId}"
-            : $"{(showBlame ? BlameHistoryCommand : FileHistoryCommand)} {fileName.Quote()} {revision?.ObjectId} {(filterByRevision ? FilterByRevisionArg : string.Empty)}";
+        bool useBrowseForFileHistory = AppSettings.UseBrowseForFileHistory.Value;
+        string arguments = useBrowseForFileHistory ? $"browse {PathFilterArg}={fileName.Quote()}{GetCommitIdArg}"
+            : $"{(showBlame ? BlameHistoryCommand : FileHistoryCommand)} {fileName.Quote()}{GetCommitIdArg()} {(filterByRevision ? FilterByRevisionArg : string.Empty)}";
         Launch(arguments, Module.WorkingDir);
+
+        return;
+
+        string GetCommitIdArg()
+        {
+            if (revision is null)
+            {
+                return "";
+            }
+
+            if (useBrowseForFileHistory)
+            {
+                return $" -commit={revision.ObjectId}";
+            }
+
+            if (revision.IsArtificial)
+            {
+                return "";
+            }
+
+            return $" {revision.ObjectId}";
+        }
     }
 
     public void OpenWithDifftool(IWin32Window? owner, IReadOnlyList<GitRevision?> revisions, string fileName, string? oldFileName, RevisionDiffKind diffKind, bool isTracked, string? customTool = null)


### PR DESCRIPTION
Fixes #12767
Fixes bug popup about missing `UICommands` in old file history if opened for artificial commit (root cause: race condition)

## Proposed changes

`GitUICommands.StartFileHistoryDialog`:
- Do not pass artificial commit id to `FileHistory`
- Omit `-commitId=` in the command arguments for `FormBrowse` if `revision` is `null`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="753" height="296" alt="image" src="https://github.com/user-attachments/assets/b481102c-1fcf-4644-bfb6-61f62405262a" />

### After

<img width="489" height="174" alt="image" src="https://github.com/user-attachments/assets/a8967fce-4a97-4ff0-8ae0-605005c7f80e" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).