### PR TITLE
fix(SubmoduleHelpers): Support quoted filenames

### DIFF
--- a/src/app/GitCommands/Git/SubmoduleHelpers.cs
+++ b/src/app/GitCommands/Git/SubmoduleHelpers.cs
@@ -7,7 +7,7 @@ namespace GitCommands.Git;
 
 public static partial class SubmoduleHelpers
 {
-    [GeneratedRegex(@"diff --git\s+[ab]/(?<filenamea>.+)\s+[ba]/(?<filenameb>.+)", RegexOptions.ExplicitCapture)]
+    [GeneratedRegex(@"diff --git\s+""?[ab]/(?<filenamea>[^""]+)""?\s+""?[ba]/(?<filenameb>[^""]+)""?", RegexOptions.ExplicitCapture)]
     private static partial Regex DiffCommandRegex { get; }
     [GeneratedRegex(@"diff --cc (?<filenamea>.+)", RegexOptions.ExplicitCapture)]
     private static partial Regex CombinedDiffCommandRegex { get; }

--- a/tests/app/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
@@ -47,9 +47,9 @@ public class SubmoduleHelpersTest
         status.OldCommit.Should().Be(ObjectId.Parse("2fb88514cfdc37a2708c24f71eca71c424b8d402"));
         status.OldName.Should().Be(fileName);
 
-        // Submodule name in reverse diff, rename
+        // Submodule name in reverse diff, rename, names quoted which can happen if they contain unicode
 
-        text = "diff --git b/Externals/conemu-inside-b a/Externals/conemu-inside-a\nindex a17ea0c..b5a3d51 160000\n--- b/Externals/conemu-inside-b\n+++ a/Externals/conemu-inside-a\n@@ -1 +1 @@\n-Subproject commit a17ea0c8ebe9d8cd7e634ba44559adffe633c11d\n+Subproject commit b5a3d51777c85a9aeee534c382b5ccbb86b485d3\n";
+        text = "diff --git \"b/Externals/conemu-inside-b\" \"a/Externals/conemu-inside-a\"\nindex a17ea0c..b5a3d51 160000\n--- b/Externals/conemu-inside-b\n+++ a/Externals/conemu-inside-a\n@@ -1 +1 @@\n-Subproject commit a17ea0c8ebe9d8cd7e634ba44559adffe633c11d\n+Subproject commit b5a3d51777c85a9aeee534c382b5ccbb86b485d3\n";
         fileName = "Externals/conemu-inside-b";
         submodule = testModule.GetSubmodule(fileName);
         commitDataManager = new(() => submodule);


### PR DESCRIPTION
Fixes #13082

## Proposed changes

`SubmoduleHelpers.DiffCommandRegex`: Also match quoted filenames.

The line to be parsed for the affected repo is `diff --git "a/Субмодули" "b/Субмодули"`.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually with repo provided in issue

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).