### PR TITLE
feat(FormFixHome): Detect alternative global git config

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -228,3 +228,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/02/19, apoorvdarshan, Apoorv Darshan, ad13dtu(at)gmail.com
 2026/05/04, Henr1k80, Henrik Gedionsen, Henrik.Gedionsen[.@)gmail.com
 2026/05/06, LeeRedfield, Chiong Ngek Lee, chiongngeklee@gmail.com
+2026/06/01, becm, Marc Becker, becm@gmx.de

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -33,8 +33,13 @@ public partial class FormFixHome : GitExtensionsForm
         InitializeComplete();
     }
 
-    private static bool HasGlobalGitConfig(string path)
+    private static bool HasGlobalGitConfig(string? path)
     {
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+        {
+            return false;
+        }
+
         // Check default Git config location
         string gitConfigFile = Path.Join(path, ".gitconfig");
         if (File.Exists(gitConfigFile))
@@ -97,15 +102,14 @@ public partial class FormFixHome : GitExtensionsForm
                 return false;
             }
 
-            string[] candidates =
-            [
-                        Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User)!,
-                        Environment.GetEnvironmentVariable("HOMEDRIVE") + Environment.GetEnvironmentVariable("HOMEPATH"),
-                        Environment.GetEnvironmentVariable("USERPROFILE")!,
-                        Environment.GetFolderPath(Environment.SpecialFolder.Personal)
+            string?[] candidates = [
+                Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User),
+                Environment.GetEnvironmentVariable("HOMEDRIVE") + Environment.GetEnvironmentVariable("HOMEPATH"),
+                Environment.GetEnvironmentVariable("USERPROFILE"),
+                Environment.GetFolderPath(Environment.SpecialFolder.Personal)
             ];
 
-            foreach (string candidate in candidates)
+            foreach (string? candidate in candidates)
             {
                 if (HasGlobalGitConfig(candidate))
                 {
@@ -175,7 +179,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string? userHomeDir = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
-            if (!string.IsNullOrEmpty(userHomeDir) && HasGlobalGitConfig(userHomeDir))
+            if (HasGlobalGitConfig(userHomeDir))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
@@ -193,7 +197,7 @@ public partial class FormFixHome : GitExtensionsForm
         {
             string path = Environment.GetEnvironmentVariable("HOMEDRIVE") +
                        Environment.GetEnvironmentVariable("HOMEPATH");
-            if (!string.IsNullOrEmpty(path) && HasGlobalGitConfig(path))
+            if (HasGlobalGitConfig(path))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
@@ -210,7 +214,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string? path = Environment.GetEnvironmentVariable("USERPROFILE");
-            if (!string.IsNullOrEmpty(path) && HasGlobalGitConfig(path))
+            if (HasGlobalGitConfig(path))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 userprofileHome.Checked = true;
@@ -227,7 +231,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            if (!string.IsNullOrEmpty(path) && HasGlobalGitConfig(path))
+            if (HasGlobalGitConfig(path))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
                     "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -290,4 +290,9 @@ public partial class FormFixHome : GitExtensionsForm
             otherHomeDir.Text = userSelectedPath;
         }
     }
+
+    internal static class TestAccessor
+    {
+        public static bool HasGlobalGitConfig(string path) => FormFixHome.HasGlobalGitConfig(path);
+    }
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -33,6 +33,47 @@ public partial class FormFixHome : GitExtensionsForm
         InitializeComplete();
     }
 
+    private static bool HasGlobalGitConfig(string path)
+    {
+        // Check default Git config location
+        string gitConfig = Path.Join(path, ".gitconfig");
+        if (File.Exists(gitConfig))
+        {
+            try
+            {
+                using FileStream fs = File.Open(gitConfig, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                return true;
+            }
+            catch
+            {
+                // Ignore permission or access problem
+            }
+        }
+
+        // Check compatible location of XDG_CONFIG_HOME for "path" as potential HOME directory
+        string xdgConfigDir = Path.Join(path, ".config");
+        string? xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        if (string.IsNullOrEmpty(xdgConfigHome) || xdgConfigHome.Equals(xdgConfigDir))
+        {
+            // Consider alternative Git config file
+            string xdgGitConfig = Path.Join(xdgConfigDir, "git/config");
+            if (File.Exists(xdgGitConfig))
+            {
+                try
+                {
+                    using FileStream fs = File.Open(xdgGitConfig, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    return true;
+                }
+                catch
+                {
+                    // Ignore permission or access problem
+                }
+            }
+        }
+
+        return false;
+    }
+
     private static bool IsFixHome()
     {
         try
@@ -43,15 +84,9 @@ public partial class FormFixHome : GitExtensionsForm
                 return true;
             }
 
-            try
+            if (HasGlobalGitConfig(home))
             {
-                using FileStream fs = File.Open(Path.Join(home, ".gitconfig"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-
-                // file is readable, no further checks
                 return false;
-            }
-            catch (IOException)
-            {
             }
 
             string[] candidates =
@@ -64,19 +99,14 @@ public partial class FormFixHome : GitExtensionsForm
 
             foreach (string candidate in candidates)
             {
-                try
+                if (HasGlobalGitConfig(candidate))
                 {
-                    if (!string.IsNullOrEmpty(candidate) &&
-                        File.Exists(Path.Join(candidate, ".gitconfig")))
-                    {
-                        return true;
-                    }
-                }
-                catch
-                {
-                    // ignore
+                    return true;
                 }
             }
+
+            // No (better) candidates for HOME directory available
+            return false;
         }
         catch
         {
@@ -85,8 +115,6 @@ public partial class FormFixHome : GitExtensionsForm
             // this manually.
             return true;
         }
-
-        return false;
     }
 
     public void ShowIfUserWant()
@@ -139,7 +167,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string? userHomeDir = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
-            if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(Path.Join(userHomeDir, ".gitconfig")))
+            if (!string.IsNullOrEmpty(userHomeDir) && HasGlobalGitConfig(userHomeDir))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
@@ -157,7 +185,7 @@ public partial class FormFixHome : GitExtensionsForm
         {
             string path = Environment.GetEnvironmentVariable("HOMEDRIVE") +
                        Environment.GetEnvironmentVariable("HOMEPATH");
-            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Join(path, ".gitconfig")))
+            if (!string.IsNullOrEmpty(path) && HasGlobalGitConfig(path))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
@@ -174,7 +202,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string? path = Environment.GetEnvironmentVariable("USERPROFILE");
-            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Join(path, ".gitconfig")))
+            if (!string.IsNullOrEmpty(path) && HasGlobalGitConfig(path))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 userprofileHome.Checked = true;
@@ -191,7 +219,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Join(path, ".gitconfig")))
+            if (!string.IsNullOrEmpty(path) && HasGlobalGitConfig(path))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
                     "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -42,17 +42,9 @@ public partial class FormFixHome : GitExtensionsForm
 
         // Check default Git config location
         string gitConfigFile = Path.Join(path, ".gitconfig");
-        if (File.Exists(gitConfigFile))
+        if (CanReadFile(gitConfigFile))
         {
-            try
-            {
-                using FileStream fs = File.Open(gitConfigFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                return true;
-            }
-            catch
-            {
-                // Ignore permission or access problem
-            }
+            return true;
         }
 
         // Check presence of XDG config directory
@@ -62,29 +54,40 @@ public partial class FormFixHome : GitExtensionsForm
             return false;
         }
 
-        // Check compatible location of XDG_CONFIG_HOME for "path" as potential HOME directory
-        // Make issues with caseing a "user problem"
-        // Allowing case insensitive equality would depend on File System type and/or setting
+        // Check whether the XDG_CONFIG_HOME is compatible (unset or matching) with "path" being tested as potential HOME directory
+        // and contains a git config file in the according subfolder
+        // (refer to https://git-scm.com/docs/git-config#Documentation/git-config.txt-XDGCONFIGHOMEgitconfig)
+        // Make issues with casing a "user problem" (case-insensitive equality would depend on file system type)
         string? xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
         if (string.IsNullOrEmpty(xdgConfigHome) || xdgConfigHome == xdgConfigDir)
         {
             // Consider alternative Git config file
             string xdgGitConfigFile = Path.Join(xdgConfigDir, "git", "config");
-            if (File.Exists(xdgGitConfigFile))
+            if (CanReadFile(xdgGitConfigFile))
             {
-                try
-                {
-                    using FileStream fs = File.Open(xdgGitConfigFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    return true;
-                }
-                catch
-                {
-                    // Ignore permission or access problem
-                }
+                return true;
             }
         }
 
         return false;
+
+        static bool CanReadFile(string path)
+        {
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    return false;
+                }
+
+                File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite).Dispose();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 
     private static bool IsFixHome()

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -36,12 +36,12 @@ public partial class FormFixHome : GitExtensionsForm
     private static bool HasGlobalGitConfig(string path)
     {
         // Check default Git config location
-        string gitConfig = Path.Join(path, ".gitconfig");
-        if (File.Exists(gitConfig))
+        string gitConfigFile = Path.Join(path, ".gitconfig");
+        if (File.Exists(gitConfigFile))
         {
             try
             {
-                using FileStream fs = File.Open(gitConfig, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using FileStream fs = File.Open(gitConfigFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 return true;
             }
             catch
@@ -50,18 +50,26 @@ public partial class FormFixHome : GitExtensionsForm
             }
         }
 
-        // Check compatible location of XDG_CONFIG_HOME for "path" as potential HOME directory
+        // Check presence of XDG config directory
         string xdgConfigDir = Path.Join(path, ".config");
+        if (!Directory.Exists(xdgConfigDir))
+        {
+            return false;
+        }
+
+        // Check compatible location of XDG_CONFIG_HOME for "path" as potential HOME directory
+        // Make issues with caseing a "user problem"
+        // Allowing case insensitive equality would depend on File System type and/or setting
         string? xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-        if (string.IsNullOrEmpty(xdgConfigHome) || xdgConfigHome.Equals(xdgConfigDir))
+        if (string.IsNullOrEmpty(xdgConfigHome) || xdgConfigHome == xdgConfigDir)
         {
             // Consider alternative Git config file
-            string xdgGitConfig = Path.Join(xdgConfigDir, "git/config");
-            if (File.Exists(xdgGitConfig))
+            string xdgGitConfigFile = Path.Join(xdgConfigDir, "git", "config");
+            if (File.Exists(xdgGitConfigFile))
             {
                 try
                 {
-                    using FileStream fs = File.Open(xdgGitConfig, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using FileStream fs = File.Open(xdgGitConfigFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     return true;
                 }
                 catch

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -1,0 +1,49 @@
+using GitUI.CommandsDialogs.SettingsDialog.Pages;
+
+namespace GitUITests.CommandsDialogs.SettingsDialog.Pages;
+
+public static class FormFixHomeTests
+{
+    [Test]
+    public static void HasGlobalConfig()
+    {
+        string tempDirectory = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        DirectoryInfo dir = Directory.CreateDirectory(tempDirectory);
+
+        FormFixHome.TestAccessor.HasGlobalGitConfig(tempDirectory).Should().BeFalse("No config files in empty directory");
+
+        // Create XDG config file for Git
+        File.Create(Path.Join(dir.CreateSubdirectory(".config/git").ToString(), "config")).Dispose();
+
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", null);
+        FormFixHome.TestAccessor.HasGlobalGitConfig(tempDirectory).Should().BeTrue("XDG config with default environment");
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", Path.Join(tempDirectory, ".config"));
+        FormFixHome.TestAccessor.HasGlobalGitConfig(tempDirectory).Should().BeTrue("XDG config with compatible setting");
+
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", Path.Join(tempDirectory, "otherpath"));
+        FormFixHome.TestAccessor.HasGlobalGitConfig(tempDirectory).Should().BeFalse("XDG config with incompatible setting");
+
+        // Create primary Git config file
+        File.Create(Path.Join(dir.ToString(), ".gitconfig")).Dispose();
+
+        FormFixHome.TestAccessor.HasGlobalGitConfig(tempDirectory).Should().BeTrue("classic Git config present");
+
+        // Clean up temporary directory
+        DeleteRecursive(dir);
+
+        static void DeleteRecursive(DirectoryInfo path)
+        {
+            foreach (DirectoryInfo dir in path.EnumerateDirectories())
+            {
+                DeleteRecursive(dir);
+            }
+
+            foreach (FileInfo file in path.GetFiles())
+            {
+                file.Delete();
+            }
+
+            path.Delete();
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- check if [XDG_CONFIG_HOME](https://git-scm.com/docs/git-config#Documentation/git-config.txt-XDGCONFIGHOMEgitconfig) is unset or identical to `${HOME}/.config`
- if applicable, check for alternative Git config file to
  - determine default HOME directory state
  - determine validity of HOME candidates

### Before

HOME directories without `.gitconfig` but valid `.config/git/config` did not trigger detection code paths.

### After

Alternative configuration file `.config/git/config` is considered in config file search (if applicable).

## Test methodology <!-- How did you ensure quality? -->

- No popups when only `.config/git/config` is present in HOME directory
- Ignore `.config/git/config` in case XDG_CONFIG_HOME has conflicting value

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.54.0.windows.1
- Windows 10.0.26200.8457

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
