### PR TITLE
fix-issue-12926-camel-humps-1865650694615130258

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -229,3 +229,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/05/04, Henr1k80, Henrik Gedionsen, Henrik.Gedionsen[.@)gmail.com
 2026/05/06, LeeRedfield, Chiong Ngek Lee, chiongngeklee@gmail.com
 2026/06/01, becm, Marc Becker, becm@gmx.de
+2026/07/15, SparshGarg999, Sparsh Garg, sparshgarg307@gmail.com

--- a/src/app/GitUI/AutoCompletion/AutoCompleteWord.cs
+++ b/src/app/GitUI/AutoCompletion/AutoCompleteWord.cs
@@ -13,7 +13,7 @@ public class AutoCompleteWord : IEquatable<AutoCompleteWord?>
 
     public bool Matches(string typedWord)
     {
-        return Word.StartsWith(typedWord, StringComparison.OrdinalIgnoreCase) || (typedWord.All(char.IsUpper) && _camelHumps.StartsWith(typedWord));
+        return Word.StartsWith(typedWord, StringComparison.OrdinalIgnoreCase) || _camelHumps.StartsWith(typedWord, StringComparison.OrdinalIgnoreCase);
     }
 
     public bool Equals(AutoCompleteWord? other)

--- a/tests/app/UnitTests/GitUI.Tests/AutoCompletion/AutoCompleteWordTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/AutoCompletion/AutoCompleteWordTests.cs
@@ -1,0 +1,30 @@
+using System;
+using GitUI.AutoCompletion;
+using NUnit.Framework;
+
+namespace GitUITests.AutoCompletion;
+
+[TestFixture]
+public class AutoCompleteWordTests
+{
+    [TestCase("CamelHump", "CH", ExpectedResult = true)]
+    [TestCase("CamelHump", "ch", ExpectedResult = true)]
+    [TestCase("CamelHump", "cH", ExpectedResult = true)]
+    [TestCase("CamelHump", "Ch", ExpectedResult = true)]
+    [TestCase("CamelHump", "Ca", ExpectedResult = true)]
+    [TestCase("CamelHump", "ca", ExpectedResult = true)]
+    [TestCase("CamelHump", "CamelH", ExpectedResult = true)]
+    [TestCase("CamelHump", "CX", ExpectedResult = false)]
+    [TestCase("MyCamelHump", "MCH", ExpectedResult = true)]
+    [TestCase("MyCamelHump", "mch", ExpectedResult = true)]
+    [TestCase("MyCamelHump", "CH", ExpectedResult = false)]
+    [TestCase("Identifier", "i", ExpectedResult = true)]
+    [TestCase("Identifier", "I", ExpectedResult = true)]
+    [TestCase("Identifier", "id", ExpectedResult = true)]
+    [TestCase("Identifier", "Id", ExpectedResult = true)]
+    public bool Matches(string word, string typedWord)
+    {
+        var autoCompleteWord = new AutoCompleteWord(word);
+        return autoCompleteWord.Matches(typedWord);
+    }
+}

--- a/tests/app/UnitTests/GitUI.Tests/AutoCompletion/AutoCompleteWordTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/AutoCompletion/AutoCompleteWordTests.cs
@@ -1,4 +1,3 @@
-using System;
 using GitUI.AutoCompletion;
 using NUnit.Framework;
 
@@ -22,7 +21,7 @@ public class AutoCompleteWordTests
     [TestCase("Identifier", "I", ExpectedResult = true)]
     [TestCase("Identifier", "id", ExpectedResult = true)]
     [TestCase("Identifier", "Id", ExpectedResult = true)]
-    public bool Matches(string word, string typedWord)
+    public bool Matches_should_match_prefix_and_camel_humps_case_insensitive(string word, string typedWord)
     {
         var autoCompleteWord = new AutoCompleteWord(word);
         return autoCompleteWord.Matches(typedWord);


### PR DESCRIPTION

Fixes #12926

## Proposed changes

- Modified `AutoCompleteWord.Matches` logic to allow case-insensitive Camel Humps matching.
- Added a suite of NUnit test cases in `AutoCompleteWordTests.cs` to ensure case-insensitive Camel Humps and standard prefix matching both work correctly.

## Test methodology <!-- How did you ensure quality? -->

- Added new unit test cases covering various inputs (`CH`, `ch`, `cH`, etc.) to verify correct matching behavior against CamelHumps string.
- Manually verified via test script that the implementation works without regressions.

## Test environment(s) <!-- Remove any that don't apply -->

- Windows (Implicit via CI)
- .NET 8.0/9.0

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).