### PR TITLE
fix: copilot to mention extensibility changes in reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,7 @@ git submodule update --init --recursive
 * Files must have CRLF line endings.
 * When creating or modifying code, follow all StyleCop analyzer rules.
 * Test changes locally or verify StyleCop compliance before committing when possible.
+* When reviewing, mention if files in src/app/GitExtensions.Extensibility/ are modified, as these affect the plugin interface version in https://github.com/gitextensions/gitextensions.extensibility.
 
 ## Comments
 


### PR DESCRIPTION
## Proposed changes

https://github.com/gitextensions/gitextensions/pull/13035#discussion_r3399292524

Something else that should be mentioned in reviews?
A separate section?

## Test methodology <!-- How did you ensure quality? -->

none

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
