### PR TITLE
ci: add CLA sign-off check workflow for pull requests

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,236 @@
+name: CLA Check
+
+# Validates that the author of a pull request has signed the project's Certificate of Origin by adding themselves to `contributors.txt`.
+#
+# The `contributors.txt` file is evaluated as it would be after the PR is merged: it is read from the PR head when the PR modifies the file
+# (so a sign-off being added within the PR is recognized), and from the latest base branch otherwise (so a sign-off merged via another PR
+# is recognized, and a sign-off removed from the base correctly invalidates PRs that never touched the file). Only the plain text file is
+# read via the API, no code from the fork is executed, so this remains safe to run with the elevated `pull_request_target` token.
+#
+# The result is published as a `CLA` commit status on the pull request head so it can be required via branch protection. A push to the
+# default branch re-validates all open pull requests, so merging a sign-off elsewhere flips affected pull requests to passing without them
+# needing to push to their branch. Configure the `CLA` status context (not this job) as the required status check.
+on:
+  # `pull_request_target` runs in the context of the base repository and is granted a read/write token even for pull requests from forks,
+  # which is required to manage labels on community contributions.
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+  # When commits land on the default branch (for example, another pull request that adds a sign-off is merged), re-validate every open
+  # pull request so a now-signed contributor's check flips to passing without them having to push to their own branch.
+  push:
+    branches: [master]
+    paths: [contributors.txt]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  # Required to publish the CLA result as a commit status that branch
+  # protection can require and that either trigger can update.
+  statuses: write
+
+concurrency:
+  # Serialize per pull request for PR events; for push events, key on the commit
+  # so the default-branch re-validation is not cancelled by PR runs.
+  group: cla-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  NEEDS_CLA_LABEL: ":scroll: status: needs cla"
+  CONTRIBUTORS_FILE: "contributors.txt"
+  # Commit status context that branch protection should require.
+  CLA_STATUS_CONTEXT: "CLA"
+
+jobs:
+  validate-cla:
+    # Do not run on forks of the project; labels only make sense upstream.
+    if: ${{ github.repository_owner == 'gitextensions' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate contributor sign-off
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const needsClaLabel = process.env.NEEDS_CLA_LABEL;
+            const contributorsFile = process.env.CONTRIBUTORS_FILE;
+            const statusContext = process.env.CLA_STATUS_CONTEXT;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Read contributors.txt from a given ref. Returns the file content, or null when the file could not be read from that ref.
+            const readContributors = async (ref) => {
+              try {
+                const { data: file } = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path: contributorsFile,
+                  ref,
+                });
+                if (Array.isArray(file) || file.type !== 'file') {
+                  core.warning(`'${contributorsFile}' is not a file at '${ref}'.`);
+                  return null;
+                }
+                return Buffer.from(file.content, file.encoding).toString('utf8');
+              } catch (error) {
+                core.warning(`Unable to read '${contributorsFile}' from '${ref}'.`);
+                core.warning(error);
+                return null;
+              }
+            };
+
+            // Extract the lowercased GitHub ids that have signed from the contributors.txt content. Entries look like:
+            //   YYYY/MM/DD, github id, Full name, email
+            // The GitHub id is the second comma-separated column.
+            const parseSignedIds = (content) => {
+              const ids = new Set();
+              for (const line of content.split(/\r?\n/)) {
+                const match = line.match(/^\s*\d{4}\/\d{2}\/\d{2}\s*,\s*([^,]+?)\s*,/);
+                if (match) {
+                  ids.add(match[1].trim().toLowerCase());
+                }
+              }
+              return ids;
+            };
+
+            // Validate a single pull request: update its labels and publish the CLA commit status on its head commit.
+            // Returns one of 'signed' | 'unsigned' | 'error'.
+            const validatePullRequest = async (pr) => {
+              const author = pr.user.login;
+
+              // Bot accounts (e.g. dependabot[bot]) cannot sign the contributors certification and are not human contributors, so they are exempt.
+              if (pr.user.type === 'Bot' || author.endsWith('[bot]')) {
+                core.info(`PR #${pr.number}: skipping check for bot account '${author}'.`);
+                await github.rest.repos.createCommitStatus({
+                  owner,
+                  repo,
+                  sha: pr.head.sha,
+                  context: statusContext,
+                  state: 'success',
+                  description: 'Exempt bot account.',
+                });
+                return 'signed';
+              }
+
+              // Evaluate contributors.txt as it would be AFTER the PR is merged:
+              //  - If the PR modifies contributors.txt, read it from the PR head (so a sign-off being added within this PR is recognized).
+              //  - Otherwise, read it from the latest base branch (so a sign-off merged via another PR is recognized, and a sign-off
+              //    removed from the base correctly invalidates PRs that never touched the file).
+              // The base branch name (pr.base.ref) is used rather than the snapshot commit (pr.base.sha) so re-runs pick up the latest base.
+              const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+              const prModifiesContributors = changedFiles.some(f => f.filename === contributorsFile);
+              const sourceRef = prModifiesContributors ? pr.head.sha : pr.base.ref;
+              const sourceLabel = prModifiesContributors ? 'PR head' : 'base branch';
+              const content = await readContributors(sourceRef);
+
+              if (content === null) {
+                core.warning(`Unable to read '${contributorsFile}' from ${sourceLabel} for PR #${pr.number}; leaving status unchanged.`);
+                return 'error';
+              }
+
+              const signedIds = parseSignedIds(content);
+              const hasSigned = signedIds.has(author.toLowerCase());
+              core.info(`PR #${pr.number}: author '${author}' signed contributors certification (source: ${sourceLabel}): ${hasSigned}`);
+
+              const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                owner,
+                repo,
+                issue_number: pr.number,
+              });
+              const currentLabelNames = currentLabels.map(l => l.name);
+
+              const addLabel = async (name) => {
+                if (!currentLabelNames.includes(name)) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    labels: [name],
+                  });
+                  core.info(`PR #${pr.number}: added label '${name}'.`);
+                }
+              };
+
+              const removeLabel = async (name) => {
+                if (currentLabelNames.includes(name)) {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    name,
+                  });
+                  core.info(`PR #${pr.number}: removed label '${name}'.`);
+                }
+              };
+
+              if (hasSigned) {
+                await removeLabel(needsClaLabel);
+              } else {
+                await addLabel(needsClaLabel);
+              }
+
+              // Publish the result as a commit status on the PR head so it can be required via branch protection and updated from either
+              // trigger (the pull request event or a push to the default branch).
+              await github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha: pr.head.sha,
+                context: statusContext,
+                state: hasSigned ? 'success' : 'failure',
+                description: hasSigned
+                  ? 'Contributor sign-off found.'
+                  : `@${author} has not signed the contributors certification.`,
+              });
+
+              return hasSigned ? 'signed' : 'unsigned';
+            };
+
+            if (context.eventName === 'push') {
+              // A commit landed on the default branch (possibly merging a sign-off). Re-validate every open pull request so newly signed
+              // contributors pass without having to update their own branch.
+              const pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+              core.info(`Re-validating ${pulls.length} open pull request(s).`);
+              // Note: inside validatePullRequest, contributors.txt is read from pr.base.ref (branch name) rather than pr.base.sha (snapshot commit).
+              // This ensures the sign-off that just landed is visible even though these PR objects were fetched before that commit existed.
+              // Process in concurrent batches to avoid serially waiting on each API round-trip while still bounding the number of
+              // in-flight requests to stay within GitHub's rate limits.
+              const concurrency = 5;
+              for (let i = 0; i < pulls.length; i += concurrency) {
+                const batch = pulls.slice(i, i + concurrency);
+                const results = await Promise.allSettled(batch.map(pr => validatePullRequest(pr)));
+                for (let j = 0; j < results.length; j++) {
+                  if (results[j].status === 'rejected') {
+                    // Do not let one problematic pull request fail the whole batch.
+                    core.warning(`Failed to validate PR #${batch[j].number}.`);
+                    core.warning(results[j].reason);
+                  }
+                }
+              }
+              return;
+            }
+
+            // pull_request_target event: validate just the triggering pull request.
+            const pr = context.payload.pull_request;
+            const result = await validatePullRequest(pr);
+            if (result === 'error') {
+              // Could not read contributors.txt; fail so the run is retried.
+              core.setFailed(`Unable to read '${contributorsFile}' for PR #${pr.number}.`);
+            } else if (result === 'unsigned') {
+              // Fail the check so the pull request run is visibly red. The authoritative required status for branch protection is the
+              // '${statusContext}' commit status set above.
+              core.setFailed(
+                `@${pr.user.login} has not signed the contributors certification. ` +
+                `Please add your sign-off to '${contributorsFile}' ` +
+                `(see the instructions at the top of that file).`
+              );
+            }


### PR DESCRIPTION
Validates that the PR author has added their sign-off to contributors.txt.

Applies `📜 status: needs cla` and fails the check when missing. Runs on PR opened, reopened and synchronize.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
