### PR TITLE
feat(FindFiles): Case-insensitive CamelHumps search

### DIFF
--- a/src/app/GitUI/FindFilePredicateProvider.cs
+++ b/src/app/GitUI/FindFilePredicateProvider.cs
@@ -1,4 +1,6 @@
-﻿using GitCommands;
+﻿using System.Text;
+using System.Text.RegularExpressions;
+using GitCommands;
 
 namespace GitUI;
 
@@ -13,6 +15,8 @@ public interface IFindFilePredicateProvider
 
 public sealed class FindFilePredicateProvider : IFindFilePredicateProvider
 {
+    private static readonly StringBuilder sb = new(20);
+
     public Func<string?, bool> Get(string searchPattern, string workingDir)
     {
         ArgumentNullException.ThrowIfNull(searchPattern);
@@ -27,7 +31,25 @@ public sealed class FindFilePredicateProvider : IFindFilePredicateProvider
             return fileName => fileName?.StartsWith(pattern, StringComparison.OrdinalIgnoreCase) is true;
         }
 
+        Regex camelHumpsRegex = BuildRegexCamelHumps(pattern);
+
         // Method Contains have no override with StringComparison parameter
-        return fileName => fileName?.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) is >= 0;
+        return fileName => fileName != null && (fileName.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) is >= 0 || camelHumpsRegex.IsMatch(fileName));
+    }
+
+    private static Regex BuildRegexCamelHumps(string searchPattern)
+    {
+        sb.Clear();
+        foreach (char c in searchPattern)
+        {
+            if (c == '/' || char.IsUpper(c) || char.IsAsciiDigit(c))
+            {
+                sb.Append(".*");
+            }
+
+            sb.Append(c);
+        }
+
+        return new Regex(sb.ToString(), RegexOptions.ExplicitCapture | RegexOptions.NonBacktracking);
     }
 }


### PR DESCRIPTION

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="479" height="151" alt="image" src="https://github.com/user-attachments/assets/3b71deaa-9909-4a11-8aa3-fe275a37e4dc" />

### After

<img width="419" height="175" alt="image" src="https://github.com/user-attachments/assets/f70049ea-6933-4fad-a277-60f16d7d0458" />

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 4d78689de8e722dda1a78bafc507250969f92d5c (Dirty)
- Git 2.52.0.windows.1 (recommended: 2.53.0 or later)
- Microsoft Windows NT 10.0.26100.0
- .NET 10.0.9
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
