### PR TITLE
FormCommit: Hardcode a shortcut to recenter form

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -206,6 +206,7 @@ public sealed partial class FormCommit : GitModuleForm
         _editedCommit = editedCommit;
 
         InitializeComponent();
+        KeyDown += FormCommit_KeyDown;
 
         _currentFilesList = Unstaged;
 
@@ -389,6 +390,37 @@ public sealed partial class FormCommit : GitModuleForm
             splitLeft.Panel2.Padding = padding;
             splitRight.Panel1.Padding = padding;
             splitRight.Panel2.Padding = padding;
+        }
+    }
+
+    private void FormCommit_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.C && e.Modifiers == (Keys.Control | Keys.Alt | Keys.Shift))
+        {
+            const int margin = 10;
+            StartPosition = FormStartPosition.Manual;
+            WindowState = FormWindowState.Normal;
+            if (Owner is not null)
+            {
+                Left = Owner.Left + margin;
+                Top = Owner.Top + margin;
+            }
+            else
+            {
+                Rectangle? primaryScreen = Screen.PrimaryScreen?.Bounds;
+                if (primaryScreen is not null)
+                {
+                    Left = primaryScreen.Value.Left + margin;
+                    Top = primaryScreen.Value.Top + margin;
+                }
+                else
+                {
+                    Left = margin;
+                    Top = margin;
+                }
+            }
+
+            e.Handled = true;
         }
     }
 


### PR DESCRIPTION
when it is lost outside of the screen

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Workaround for #13123 (and a lot before)

Pressing `ctrl+alt+shift+c` will move the window to position (10,10)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
