### PR TITLE
fix(FormCommit): Avoid empty diff on multi-selection

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1536,8 +1536,9 @@ public sealed partial class FormCommit : GitModuleForm
 
         Staged.ClearSelected();
 
-        _currentSelection = Unstaged.SelectedItems.Items().ToList();
-        FileStatusItem? item = Unstaged.SelectedItem;
+        FileStatusItem[] selectedItems = Unstaged.SelectedItems.ToArray();
+        _currentSelection = selectedItems.Items().ToArray();
+        FileStatusItem? item = selectedItems.Contains(Unstaged.FocusedItem) ? Unstaged.FocusedItem : selectedItems.FirstOrDefault();
         ShowChanges(item, staged: false);
     }
 
@@ -1801,8 +1802,9 @@ public sealed partial class FormCommit : GitModuleForm
 
         Unstaged.ClearSelected();
 
-        _currentSelection = Staged.SelectedItems.Items().ToList();
-        FileStatusItem? item = Staged.SelectedItem;
+        FileStatusItem[] selectedItems = Staged.SelectedItems.ToArray();
+        _currentSelection = selectedItems.Items().ToArray();
+        FileStatusItem? item = selectedItems.Contains(Staged.FocusedItem) ? Staged.FocusedItem : selectedItems.FirstOrDefault();
         ShowChanges(item, staged: true);
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13126

## Proposed changes

`FormCommit` with multi-selection of files:
- Show diff of focused file if it is selected, otherwise the first file of the selection
  for both `Unstaged` and `Staged`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

empty diff

### After

non-empty diff

## Test methodology <!-- How did you ensure quality? -->

- manually

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).