### PR TITLE
feat(RevisionGrid): Improve label hover hit-test

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -203,7 +203,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
             if (stashRect != Rectangle.Empty)
             {
                 hitInfos ??= RentHitInfoList();
-                hitInfos.Add(new RefLabelHitInfo(stashRect, GitRef: null, StashReflogSelector: revision.ReflogSelector));
+                hitInfos.Add(new RefLabelHitInfo(stashRect, RefLabelShape.Rect, PointWidth: 0, GitRef: null, StashReflogSelector: revision.ReflogSelector));
             }
         }
 
@@ -326,19 +326,14 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
             // Register hit-boxes.
             hitInfos ??= RentHitInfoList();
-            hitInfos.Add(new RefLabelHitInfo(branchRect, gitRef, StashReflogSelector: null));
+            hitInfos.Add(new RefLabelHitInfo(branchRect, shape1, pointWidth, gitRef, StashReflogSelector: null));
 
             if (nestledRect == Rectangle.Empty)
             {
                 return;
             }
 
-            // The visible nestled area starts at the notch tip.
-            int nestledVisibleLeft = nestledRect.X + pointWidth - 1;
-            hitInfos.Add(new RefLabelHitInfo(
-                nestledRect with { X = nestledVisibleLeft, Width = nestledRect.Right - nestledVisibleLeft },
-                nestledRef,
-                StashReflogSelector: null));
+            hitInfos.Add(new RefLabelHitInfo(nestledRect, shape2, pointWidth, nestledRef, StashReflogSelector: null));
         }
 
         void DrawSeparateRef(
@@ -362,7 +357,10 @@ internal sealed class MessageColumnProvider : ColumnProvider
             if (refRect != Rectangle.Empty)
             {
                 hitInfos ??= RentHitInfoList();
-                hitInfos.Add(new RefLabelHitInfo(refRect, gitRef, StashReflogSelector: null));
+                int pointWidth = shape == RefLabelShape.Rect
+                    ? 0
+                    : RevisionGridRefRenderer.GetPointWidth(gitRef.IsSelected ? style.BoldFont : style.NormalFont, e.Graphics!);
+                hitInfos.Add(new RefLabelHitInfo(refRect, shape, pointWidth, gitRef, StashReflogSelector: null));
             }
         }
     }
@@ -939,7 +937,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
         foreach (RefLabelHitInfo hitInfo in hitInfos)
         {
-            if (hitInfo.Bounds.Contains(gridClientPoint))
+            if (hitInfo.Contains(gridClientPoint))
             {
                 return hitInfo;
             }

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/RefLabelHitInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/RefLabelHitInfo.cs
@@ -8,4 +8,54 @@ namespace GitUI.UserControls.RevisionGrid.Columns;
 ///  enabling hit-testing for mouse hover and context menu interactions.
 ///  Exactly one of <see cref="GitRef"/> or <see cref="StashReflogSelector"/> will be non-null.
 /// </summary>
-internal readonly record struct RefLabelHitInfo(Rectangle Bounds, IGitRef? GitRef, string? StashReflogSelector);
+/// <param name="Bounds">The label's bounding rectangle in DataGridView client coordinates.</param>
+/// <param name="Shape">
+///  The drawn capsule shape. For point/notch shapes the interlocking diagonal edge - not the
+///  bounding rectangle - determines ownership.
+/// </param>
+/// <param name="PointWidth">The depth of the point/notch in pixels; unused for <see cref="RefLabelShape.Rect"/>.</param>
+/// <param name="GitRef">The ref this label represents.</param>
+/// <param name="StashReflogSelector">The stash reflog selector.</param>
+internal readonly record struct RefLabelHitInfo(Rectangle Bounds, RefLabelShape Shape, int PointWidth, IGitRef? GitRef, string? StashReflogSelector)
+{
+    /// <summary>
+    ///  Tests whether <paramref name="point"/> falls inside the label, honouring the slanted
+    ///  point/notch edge so adjacent nestled capsules split along their shared diagonal.
+    /// </summary>
+    public bool Contains(Point point)
+    {
+        if (point.X < Bounds.Left || point.X >= Bounds.Right || point.Y < Bounds.Top || point.Y >= Bounds.Bottom)
+        {
+            return false;
+        }
+
+        int halfHeight = Bounds.Height / 2;
+        if (PointWidth <= 0 || Shape == RefLabelShape.Rect || halfHeight <= 0)
+        {
+            return true;
+        }
+
+        // Distance from the vertical centre, where the point tip / notch tip sits.
+        int dy = Math.Min(Math.Abs(point.Y - (Bounds.Top + halfHeight)), halfHeight);
+
+        // Horizontal extent of the slant at this row: 0 at the tip row, PointWidth at the top/bottom rows.
+        int slant = PointWidth * dy / halfHeight;
+
+        return Shape switch
+        {
+            // Convex tip at Right (mid row); top/bottom corners step back by PointWidth.
+            RefLabelShape.PointRight => point.X <= Bounds.Right - slant,
+
+            // Concave tip indented to Right - PointWidth (mid row); opens out to Right at top/bottom.
+            RefLabelShape.NotchRight => point.X <= Bounds.Right - PointWidth + slant,
+
+            // Convex tip at Left (mid row); top/bottom corners step in by PointWidth.
+            RefLabelShape.PointLeft => point.X >= Bounds.Left + slant,
+
+            // Concave tip indented to Left + PointWidth (mid row); opens out to Left at top/bottom.
+            RefLabelShape.NotchLeft => point.X >= Bounds.Left + PointWidth - slant,
+
+            _ => true
+        };
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Store `RefLabelShape` within `RefLabelHitInfo` as well as pointy end's width to be able to determine the label under a hit-point precisely

The hit-test code is tailored to the shape of the label/point but at the same time it's efficient and we don't need to store a `GraphicsPath` for a more generic hit-testing.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

While the mouse-pointer is over the ahead/behind part of the label, the branch-name part is highlighted
<img width="538" height="175" alt="highlight" src="https://github.com/user-attachments/assets/7cf6c4fe-fa77-45eb-b4cf-20e79438ead2" />


### After

<img width="554" height="116" alt="finer-highlight" src="https://github.com/user-attachments/assets/10f2bd3b-2275-447c-84db-7d1939a8b8eb" />


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11 200% scaled

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
