### PR TITLE
fix: dispose Process handles

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -3720,7 +3720,15 @@ public sealed partial class GitModule : IGitModule
 
         if (OperatingSystem.IsWindows())
         {
-            return Process.GetProcessesByName("git").Length > 0;
+            // Dispose each Process handle immediately
+            Process[] processes = Process.GetProcessesByName("git");
+            bool running = processes.Length > 0;
+            foreach (Process p in processes)
+            {
+                p.Dispose();
+            }
+
+            return running;
         }
 
         // Get processes by "ps" command.

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -3720,7 +3720,6 @@ public sealed partial class GitModule : IGitModule
 
         if (OperatingSystem.IsWindows())
         {
-            // Dispose each Process handle immediately
             Process[] processes = Process.GetProcessesByName("git");
             bool running = processes.Length > 0;
             foreach (Process p in processes)

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -2282,8 +2282,8 @@ public static partial class AppSettings
         {
             if (_isDesignMode is null)
             {
-                string processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? "").ToLowerInvariant();
-                _isDesignMode = processName.Contains("devenv") || processName.Contains("designtoolsserver");
+                string processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? string.Empty);
+                _isDesignMode = processName.Contains("devenv", StringComparison.OrdinalIgnoreCase) || processName.Contains("designtoolsserver", StringComparison.OrdinalIgnoreCase);
             }
 
             return _isDesignMode.Value;

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -2282,7 +2282,7 @@ public static partial class AppSettings
         {
             if (_isDesignMode is null)
             {
-                string processName = Process.GetCurrentProcess().ProcessName.ToLowerInvariant();
+                string processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? "").ToLowerInvariant();
                 _isDesignMode = processName.Contains("devenv") || processName.Contains("designtoolsserver");
             }
 

--- a/src/app/GitCommands/Utils/EnvUtils.cs
+++ b/src/app/GitCommands/Utils/EnvUtils.cs
@@ -11,12 +11,7 @@ public static class EnvUtils
             return false;
         }
 
-        Process currentProcess = Process.GetCurrentProcess();
-        if (currentProcess is null)
-        {
-            return false;
-        }
-
+        using Process currentProcess = Process.GetCurrentProcess();
         return currentProcess.MainWindowHandle != IntPtr.Zero;
     }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/ShellExtension/ShellExtensionManager.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/ShellExtension/ShellExtensionManager.cs
@@ -84,7 +84,7 @@ public static class ShellExtensionManager
                     Verb = "RunAs",
                     UseShellExecute = true
                 };
-                Process? process = Process.Start(pi);
+                using Process? process = Process.Start(pi);
                 process?.WaitForExit();
                 if (process?.ExitCode is not 0)
                 {

--- a/src/app/GitUI/Infrastructure/PuttyHelpers.cs
+++ b/src/app/GitUI/Infrastructure/PuttyHelpers.cs
@@ -89,7 +89,14 @@ public static class PuttyHelpers
         static bool IsPageantRunning()
         {
             string pageantProcName = Path.GetFileNameWithoutExtension(AppSettings.Pageant);
-            return Process.GetProcessesByName(pageantProcName).Length != 0;
+            Process[] processes = Process.GetProcessesByName(pageantProcName);
+            bool running = processes.Length != 0;
+            foreach (Process p in processes)
+            {
+                p.Dispose();
+            }
+
+            return running;
         }
     }
 

--- a/src/app/ResourceManager/GitExtensionsControlInitialiser.cs
+++ b/src/app/ResourceManager/GitExtensionsControlInitialiser.cs
@@ -45,8 +45,8 @@ internal sealed class GitExtensionsControlInitialiser
         {
             if (_isDesignMode is null)
             {
-                string processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? "").ToLowerInvariant();
-                _isDesignMode = processName.Contains("devenv") || processName.Contains("designtoolsserver");
+                string processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? string.Empty);
+                _isDesignMode = processName.Contains("devenv", StringComparison.OrdinalIgnoreCase) || processName.Contains("designtoolsserver", StringComparison.OrdinalIgnoreCase);
             }
 
             return _isDesignMode.Value;

--- a/src/app/ResourceManager/GitExtensionsControlInitialiser.cs
+++ b/src/app/ResourceManager/GitExtensionsControlInitialiser.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using GitCommands;
+﻿using GitCommands;
 using GitExtensions.Extensibility.Translations;
 using GitUI;
 
@@ -46,7 +45,7 @@ internal sealed class GitExtensionsControlInitialiser
         {
             if (_isDesignMode is null)
             {
-                string processName = Process.GetCurrentProcess().ProcessName.ToLowerInvariant();
+                string processName = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? "").ToLowerInvariant();
                 _isDesignMode = processName.Contains("devenv") || processName.Contains("designtoolsserver");
             }
 


### PR DESCRIPTION
Fixes #13131

## Proposed changes

avoid flooding the finalizer queue
Similar situations investigated.

CoPilot reports:

In .NET 10, the GC handles finalizable objects more aggressively, making this previously-latent resource leak visibly impact throughput — you were essentially stress-testing the finalizer thread on every poll.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
