### PR TITLE
build(translation): Verify Transifex base files

### DIFF
--- a/setup/transifex/DownloadTransifexTranslations.ps1
+++ b/setup/transifex/DownloadTransifexTranslations.ps1
@@ -38,6 +38,7 @@ try {
     ./tx.exe pull --source -f -r git-extensions.gitui-translation-english-xlf--master
     ./tx.exe pull --source -f -r git-extensions.gitui-translation-english-plugins-xlf--master
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    $utf8WithBom = [System.Text.UTF8Encoding]::new($true)
     foreach ($fileName in @('English.xlf', 'English.Plugins.xlf')) {
         $filePath = Join-Path $PSScriptRoot $fileName
         $content = [System.IO.File]::ReadAllText($filePath, $utf8NoBom)
@@ -46,7 +47,18 @@ try {
         $content = $content -replace '&quot;', '"'
         # Transifex omits <target /> from source files; add it back to match the repo format
         $content = $content -replace '(</source>(\r?\n)[ \t]*)\r?\n', '$1<target />$2'
-        [System.IO.File]::WriteAllText($filePath, $content, $utf8NoBom)
+        # Transifex omits encoding declaration and BOM, and joins declaration and root element on one line
+        $content = $content -replace '<\?xml version="1\.0" \?><xliff', ("<?xml version=`"1.0`" encoding=`"utf-8`"?>`r`n<xliff")
+        # Normalize line endings to CRLF to match the repo format
+        $content = $content -replace '\r?\n', "`r`n"
+        [System.IO.File]::WriteAllText($filePath, $content, $utf8WithBom)
+        # Compare with the existing repo file; if different, mark as not to be committed
+        $repoFilePath = "$repoRoot/src/app/GitUI/Translation/$fileName"
+        if ((Get-FileHash $filePath).Hash -ne (Get-FileHash $repoFilePath).Hash) {
+            $content = "DO NOT COMMIT! This is just for verification that Transifex is up to date.`r`n" + $content
+            [System.IO.File]::WriteAllText($filePath, $content, $utf8WithBom)
+            Write-Host("WARNING: '$fileName' from Transifex differs from the repo version. Please verify that Transifex is up to date and do not commit the file!")
+        }
     }
     Move-Item -Path ./English.xlf         -Destination $repoRoot/src/app/GitUI/Translation/English.xlf         -Force
     Move-Item -Path ./English.Plugins.xlf -Destination $repoRoot/src/app/GitUI/Translation/English.Plugins.xlf -Force

--- a/setup/transifex/DownloadTransifexTranslations.ps1
+++ b/setup/transifex/DownloadTransifexTranslations.ps1
@@ -30,6 +30,26 @@ try {
     # 5. move translations to the destination folder
     Get-ChildItem -Path ./* -Filter *.xlf | `
         Move-Item -Destination $repoRoot/src/app/GitUI/Translation/$($_.Name) -Force
+
+    # 6. stage deletions (step 1 + 4) and new/updated translation files (step 5)
+    git -C "$repoRoot" add -A -- src/app/GitUI/Translation ':(exclude)src/app/GitUI/Translation/English*.xlf'
+
+    # 7. replace English source files for verfication that Transifex is up to date (not to be committed)
+    ./tx.exe pull --source -f -r git-extensions.gitui-translation-english-xlf--master
+    ./tx.exe pull --source -f -r git-extensions.gitui-translation-english-plugins-xlf--master
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    foreach ($fileName in @('English.xlf', 'English.Plugins.xlf')) {
+        $filePath = Join-Path $PSScriptRoot $fileName
+        $content = [System.IO.File]::ReadAllText($filePath, $utf8NoBom)
+        # Transifex encodes ' and " as XML entities in source text; reverse that to reduce diff noise
+        $content = $content -replace '&apos;', "'"
+        $content = $content -replace '&quot;', '"'
+        # Transifex omits <target /> from source files; add it back to match the repo format
+        $content = $content -replace '(</source>(\r?\n)[ \t]*)\r?\n', '$1<target />$2'
+        [System.IO.File]::WriteAllText($filePath, $content, $utf8NoBom)
+    }
+    Move-Item -Path ./English.xlf         -Destination $repoRoot/src/app/GitUI/Translation/English.xlf         -Force
+    Move-Item -Path ./English.Plugins.xlf -Destination $repoRoot/src/app/GitUI/Translation/English.Plugins.xlf -Force
 }
 finally {
     Pop-Location


### PR DESCRIPTION
Addresses 2. of #13132

## Proposed changes

`setup/transifex/DownloadTransifexTranslations.ps1`:
- Verify English files Transifex is using as base
- Stage other translation files in order to separate them from the not to be committed English files

## Screenshots

### Before

<img width="1227" height="312" alt="image" src="https://github.com/user-attachments/assets/2a4912ae-05fa-47e1-a035-6d9384922f35" />

### After

Showing `English.xlf` from Transifex (made comparable) having new translation string from `master`:

<img width="1461" height="1004" alt="image" src="https://github.com/user-attachments/assets/b6d93cc9-3bec-4ccd-9508-aa4dec084cba" />

<img width="1116" height="249" alt="image" src="https://github.com/user-attachments/assets/e1cd328f-9516-40f6-80e6-99c915cf0765" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).