### PR TITLE
feat(RevisionGrid): Preview amend on Ctrl+click

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2011,11 +2011,17 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                         // Let DataGridView's native Ctrl+click processing select this revision again.
                         // And let the related ref be added to the selection afterwards.
                         _gridView.ClearSelection();
-                        this.InvokeAndForget(async () =>
+                        BeginInvoke(() =>
                         {
-                            await Task.Delay(100);
                             GoToRelatedRef(gitRef, toggleSelection: true);
-                            _gridView.FirstDisplayedScrollingRowIndex = topRow;
+                            try
+                            {
+                                _gridView.FirstDisplayedScrollingRowIndex = topRow;
+                            }
+                            catch
+                            {
+                                // ignore
+                            }
                         });
                         return;
                     }
@@ -3254,7 +3260,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             }
             else
             {
-                GoToRef(gitRef.IsRemote ? aheadBehindData.Branch : aheadBehindData.RemoteRef, showNoRevisionMsg: true);
+                GoToRef(gitRef.IsRemote ? aheadBehindData.Branch : aheadBehindData.RemoteRef, showNoRevisionMsg: true, toggleSelection);
             }
         }
     }

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2005,11 +2005,11 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
                 if (hitInfo?.GitRef is { } gitRef)
                 {
-                    bool isVirtualRef = gitRef.Guid is null;
-                    if (isVirtualRef)
+                    bool isVirtualAheadBehingRef = gitRef.Guid is null;
+                    if (isVirtualAheadBehingRef)
                     {
-                        // Let DataGridView's native Ctrl+click processing select this revision again.
-                        // And let the related ref be added to the selection afterwards.
+                        // Let the related ref be added to the selection afterwards in order to simulate standard Ctrl+click behavior.
+                        // For this, let DataGridView's native Ctrl+click processing select this revision again first.
                         _gridView.ClearSelection();
                         BeginInvoke(() =>
                         {

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2001,16 +2001,43 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
             if (addRelatedRefToSelection)
             {
+                int topRow = _gridView.FirstDisplayedScrollingRowIndex;
+
                 if (hitInfo?.GitRef is { } gitRef)
                 {
-                    int topRow = _gridView.FirstDisplayedScrollingRowIndex;
-                    GoToRelatedRef(gitRef);
+                    bool isVirtualRef = gitRef.Guid is null;
+                    if (isVirtualRef)
+                    {
+                        // Let DataGridView's native Ctrl+click processing select this revision again.
+                        // And let the related ref be added to the selection afterwards.
+                        _gridView.ClearSelection();
+                        this.InvokeAndForget(async () =>
+                        {
+                            await Task.Delay(100);
+                            GoToRelatedRef(gitRef, toggleSelection: true);
+                            _gridView.FirstDisplayedScrollingRowIndex = topRow;
+                        });
+                        return;
+                    }
 
-                    // The related revision is now selected. Return early so that the DataGridView's
-                    // native Ctrl+click processing adds the clicked row to the selection (instead of
-                    // toggling it off again, which would happen if we selected it here first).
-                    _gridView.FirstDisplayedScrollingRowIndex = topRow;
+                    // Select the related ref.
+                    GoToRelatedRef(gitRef);
                 }
+                else if (GetRevision(e.RowIndex) is { IsArtificial: true })
+                {
+                    // Diff with the previous revision as amend preview.
+                    GoToRef("HEAD~1", showNoRevisionMsg: false);
+                }
+                else
+                {
+                    return;
+                }
+
+                // The related or the previous revision is now selected. Return early so that the DataGridView's
+                // native Ctrl+click processing adds the clicked row to the selection (instead of
+                // toggling it off again, which would happen if we selected it here first).
+
+                _gridView.FirstDisplayedScrollingRowIndex = topRow;
 
                 return;
             }
@@ -3206,7 +3233,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         }
     }
 
-    private void GoToRelatedRef(IGitRef gitRef, Action<string>? handleGone = null)
+    private void GoToRelatedRef(IGitRef gitRef, Action<string>? handleGone = null, bool toggleSelection = false)
     {
         if (gitRef.Guid is null)
         {
@@ -3216,7 +3243,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             }
             else
             {
-                GoToRef(gitRef.CompleteName, showNoRevisionMsg: true);
+                GoToRef(gitRef.CompleteName, showNoRevisionMsg: true, toggleSelection);
             }
         }
         else if (_messageColumnProvider.GetAheadBehindData(gitRef.IsRemote, gitRef.CompleteName) is { } aheadBehindData)


### PR DESCRIPTION
Fixes #13125

## Proposed changes

`RevisionGridControl.OnGridViewCellMouseDown`:
- Reverse diff on Ctrl+click on ahead/behind label
  (Ctrl+click on branch label is not changed so the diff can easily be inverted now)
- Preview "amend" on Ctrl+click on (already selected) artificial commit

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

**After Ctrl+click selected revision**

### Before

<img width="510" height="131" alt="image" src="https://github.com/user-attachments/assets/4b399651-66bf-49f9-9bb1-3c73a2819e5f" />

<img width="510" height="131" alt="image" src="https://github.com/user-attachments/assets/54ac1b91-d2d6-4679-a931-ce45d9d7bfe7" />

### After: Preview of "Amend commit"

<img width="514" height="131" alt="image" src="https://github.com/user-attachments/assets/f1ed9fb3-b084-460f-b1ea-ebddd7d97b05" />

<img width="514" height="131" alt="image" src="https://github.com/user-attachments/assets/88693c9c-3a7c-4128-aabc-f99f4fc1b806" />

### Before

<img width="1007" height="659" alt="image" src="https://github.com/user-attachments/assets/380856ef-c49d-4b0a-94fb-b43044e81c35" />

### After: Related ref is added to selection as second

<img width="1007" height="659" alt="image" src="https://github.com/user-attachments/assets/01bd4dd9-c88c-4cfb-b1a1-5df087472164" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).