### PR TITLE
fix: checkout branch --track

### DIFF
--- a/src/app/GitCommands/Git/Commands.cs
+++ b/src/app/GitCommands/Git/Commands.cs
@@ -17,10 +17,10 @@ public static partial class Commands
         return new GitCommand(accessesRemote: false, changesRepoState: true,
             new GitArgumentBuilder("checkout")
             {
-                { localChanges == LocalChangesAction.Merge, "--merge" },
-                { localChanges == LocalChangesAction.Reset, "--force" },
-                { remote && newBranchMode == CheckoutNewBranchMode.Create, $"-b {newBranchName.Quote()}" },
-                { remote && newBranchMode == CheckoutNewBranchMode.Reset, $"-B {newBranchName.Quote()}" },
+                { localChanges is LocalChangesAction.Merge, "--merge" },
+                { localChanges is LocalChangesAction.Reset, "--force" },
+                { remote && newBranchMode is CheckoutNewBranchMode.Create, $"-b {newBranchName.Quote()}" },
+                { remote && newBranchMode is CheckoutNewBranchMode.Reset, $"-B {newBranchName.Quote()}" },
                 { remote && (newBranchMode is CheckoutNewBranchMode.Create), "--track" },
                 branchName.QuoteNE()
             });

--- a/src/app/GitCommands/Git/Commands.cs
+++ b/src/app/GitCommands/Git/Commands.cs
@@ -21,6 +21,7 @@ public static partial class Commands
                 { localChanges == LocalChangesAction.Reset, "--force" },
                 { remote && newBranchMode == CheckoutNewBranchMode.Create, $"-b {newBranchName.Quote()}" },
                 { remote && newBranchMode == CheckoutNewBranchMode.Reset, $"-B {newBranchName.Quote()}" },
+                { remote && (newBranchMode is CheckoutNewBranchMode.Create), "--track" },
                 branchName.QuoteNE()
             });
     }

--- a/src/app/GitCommands/Git/Commands.cs
+++ b/src/app/GitCommands/Git/Commands.cs
@@ -21,7 +21,7 @@ public static partial class Commands
                 { localChanges is LocalChangesAction.Reset, "--force" },
                 { remote && newBranchMode is CheckoutNewBranchMode.Create, $"-b {newBranchName.Quote()}" },
                 { remote && newBranchMode is CheckoutNewBranchMode.Reset, $"-B {newBranchName.Quote()}" },
-                { remote && (newBranchMode is CheckoutNewBranchMode.Create), "--track" },
+                { remote && newBranchMode is CheckoutNewBranchMode.Create, "--track" },
                 branchName.QuoteNE()
             });
     }

--- a/tests/app/UnitTests/GitCommands.Tests/Git/Commands/GitCheckoutBranchCmdTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/Commands/GitCheckoutBranchCmdTest.cs
@@ -36,7 +36,7 @@ public sealed class GitCheckoutBranchCmdTest
 
         Commands.CheckoutBranch("branchName", remote: false, LocalChangesAction.Merge).Arguments.Should().Be("checkout --merge \"branchName\"");
 
-        Commands.CheckoutBranch("branchName", remote: true, LocalChangesAction.Merge, CheckoutNewBranchMode.Create, "newBranchName").Arguments.Should().Be("checkout --merge -b \"newBranchName\" \"branchName\"");
+        Commands.CheckoutBranch("branchName", remote: true, LocalChangesAction.Merge, CheckoutNewBranchMode.Create, "newBranchName").Arguments.Should().Be("checkout --merge -b \"newBranchName\" --track \"branchName\"");
 
         Commands.CheckoutBranch("branchName", remote: true, LocalChangesAction.Merge, CheckoutNewBranchMode.Reset, "newBranchName").Arguments.Should().Be("checkout --merge -B \"newBranchName\" \"branchName\"");
 
@@ -44,7 +44,7 @@ public sealed class GitCheckoutBranchCmdTest
 
         Commands.CheckoutBranch("branchName", remote: false, LocalChangesAction.Reset).Arguments.Should().Be("checkout --force \"branchName\"");
 
-        Commands.CheckoutBranch("branchName", remote: true, LocalChangesAction.Reset, CheckoutNewBranchMode.Create, "newBranchName").Arguments.Should().Be("checkout --force -b \"newBranchName\" \"branchName\"");
+        Commands.CheckoutBranch("branchName", remote: true, LocalChangesAction.Reset, CheckoutNewBranchMode.Create, "newBranchName").Arguments.Should().Be("checkout --force -b \"newBranchName\" --track \"branchName\"");
 
         Commands.CheckoutBranch("branchName", remote: true, LocalChangesAction.Reset, CheckoutNewBranchMode.Reset, "newBranchName").Arguments.Should().Be("checkout --force -B \"newBranchName\" \"branchName\"");
     }


### PR DESCRIPTION
## Proposed changes

Add remote track also for branched where --guess is not applied.
https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt---trackdirectinherit

The default suggested name like remote/local/branch is not unique so I normally set a custom name, tracking is then not always enabled.

## Test methodology <!-- How did you ensure quality? -->

updated tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
