### PR TITLE
feat(.gitignore): Support single selected folder

### DIFF
--- a/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
@@ -105,7 +105,9 @@ partial class FileStatusList
 
     private void AddFileToIgnoreFile(bool localExclude)
     {
-        string[] fileNames = [.. SelectedItems.Select(item => "/" + item.Item.Name)];
+        string[] fileNames = SelectedFolder is { Length: > 0 } selectedFolder
+            ? [$"/{selectedFolder}/"]
+            : [.. SelectedItems.Select(item => "/" + item.Item.Name)];
         if (fileNames.Length > 0 && UICommands.StartAddToGitIgnoreDialog(this, localExclude, fileNames))
         {
             RequestRefresh();


### PR DESCRIPTION
Fixes #13141
at least, the main usecase where a single folder is selected

## Proposed changes

`FileStatusList.AddFileToIgnoreFile`: Add dedicated handling for non-empty `SelectedFolder`

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).