### PR TITLE
Do not show merge commit editor when there are no errors

### DIFF
--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -388,6 +388,7 @@ public static partial class Commands
              // let git fail, if the file doesn't exist
             { !string.IsNullOrWhiteSpace(mergeCommitFilePath), $"-F {getPathForGitExecution(mergeCommitFilePath).Quote()}" },
             { log is not null && log.Value > 0, $"--log={log}" },
+            "--no-edit", // suppress editor prompt and accept auto-generated message
             branch
         };
     }

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -252,21 +252,21 @@ public partial class CommandsTests
     }
 
     // Don't care about permutations because the args aren't correlated
-    [TestCase(false, false, false, null, false, null, null, "merge --no-ff branch")]
-    [TestCase(true, true, true, null, true, null, null, "merge --squash --no-commit --allow-unrelated-histories branch")]
+    [TestCase(false, false, false, null, false, null, null, "merge --no-ff --no-edit branch")]
+    [TestCase(true, true, true, null, true, null, null, "merge --squash --no-commit --allow-unrelated-histories --no-edit branch")]
 
     // mergeCommitFilePath parameter
-    [TestCase(false, true, false, null, false, "", null, "merge --no-ff --squash branch")]
-    [TestCase(false, true, false, null, false, "   ", null, "merge --no-ff --squash branch")]
-    [TestCase(false, true, false, null, false, "\t", null, "merge --no-ff --squash branch")]
-    [TestCase(false, true, false, null, false, "\n", null, "merge --no-ff --squash branch")]
-    [TestCase(false, true, false, null, false, "foo", null, "merge --no-ff --squash -F \"foo\" branch")]
-    [TestCase(false, true, false, null, false, "D:\\myrepo\\.git\\file", null, "merge --no-ff --squash -F \"D:/myrepo/.git/file\" branch")]
+    [TestCase(false, true, false, null, false, "", null, "merge --no-ff --squash --no-edit branch")]
+    [TestCase(false, true, false, null, false, "   ", null, "merge --no-ff --squash --no-edit branch")]
+    [TestCase(false, true, false, null, false, "\t", null, "merge --no-ff --squash --no-edit branch")]
+    [TestCase(false, true, false, null, false, "\n", null, "merge --no-ff --squash --no-edit branch")]
+    [TestCase(false, true, false, null, false, "foo", null, "merge --no-ff --squash -F \"foo\" --no-edit branch")]
+    [TestCase(false, true, false, null, false, "D:\\myrepo\\.git\\file", null, "merge --no-ff --squash -F \"D:/myrepo/.git/file\" --no-edit branch")]
 
     // log parameter
-    [TestCase(true, true, false, null, false, null, -1, "merge --squash branch")]
-    [TestCase(true, true, false, null, false, null, 0, "merge --squash branch")]
-    [TestCase(true, true, false, null, false, null, 5, "merge --squash --log=5 branch")]
+    [TestCase(true, true, false, null, false, null, -1, "merge --squash --no-edit branch")]
+    [TestCase(true, true, false, null, false, null, 0, "merge --squash --no-edit branch")]
+    [TestCase(true, true, false, null, false, null, 5, "merge --squash --log=5 --no-edit branch")]
     public void MergeBranchCmd(bool allowFastForward, bool squash, bool noCommit, string? strategy, bool allowUnrelatedHistories, string? mergeCommitFilePath, int? log, string expected)
     {
         Commands.MergeBranch("branch", allowFastForward, squash, noCommit, strategy!, allowUnrelatedHistories, mergeCommitFilePath, PathUtil.ToPosixPath, log).Arguments.Should().Be(expected);


### PR DESCRIPTION
## Proposed changes

Currently we show merge commit editor when using ConEmu/MinTTY emulators, while for plain text we don't show it. The reason is that ConEmu/MinTTY are running in the interactive mode, while plain-text does not.

Fix that by always passing flag which disables editor. So the behavior is aligned with plain text emulator (no emulation)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

<img width="1157" height="748" alt="image" src="https://github.com/user-attachments/assets/9e3b9a72-c65f-475a-8875-ecca4c169bb0" />


I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
