### PR TITLE
Add AI commit message generation to the commit dialog

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -229,3 +229,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/05/04, Henr1k80, Henrik Gedionsen, Henrik.Gedionsen[.@)gmail.com
 2026/05/06, LeeRedfield, Chiong Ngek Lee, chiongngeklee@gmail.com
 2026/06/01, becm, Marc Becker, becm@gmx.de
+2026/07/01, badrshs, Badr Shek Salim, shs1bader+git[.@)gmail.com

--- a/src/app/GitCommands/AiCommitMessageGenerator.cs
+++ b/src/app/GitCommands/AiCommitMessageGenerator.cs
@@ -1,0 +1,139 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using GitExtensions.Extensibility;
+
+namespace GitCommands;
+
+/// <summary>
+///  Generates a commit message from a staged diff using a user-configured OpenAI-compatible
+///  Chat Completions endpoint (<c>{baseUrl}/chat/completions</c>). The same request/response shape is
+///  accepted by OpenAI, Azure OpenAI, OpenRouter, Groq, and local servers such as Ollama, so one code
+///  path covers cloud and local models. All configuration is read from <see cref="AppSettings"/>.
+/// </summary>
+public static class AiCommitMessageGenerator
+{
+    public const string DefaultSystemPrompt =
+        """
+        You are a senior software engineer writing a git commit message for the staged diff.
+
+        Write the message in this exact shape:
+
+        1. Subject line: imperative mood, at most 50 characters, no trailing period.
+           Use a Conventional Commits prefix when it fits the change, one of:
+           feat, fix, refactor, docs, test, chore, perf, build, ci
+           (example: "fix: prevent crash when staging an empty file").
+        2. Then exactly one blank line.
+        3. Body: explain WHAT changed and, above all, WHY it changed. Hard-wrap
+           every body line at 72 characters. Use "- " bullet points when there
+           are several distinct changes.
+
+        Guidelines:
+        - Infer the intent from the diff; never invent changes that aren't there.
+        - For a small, self-explanatory change, a subject line alone is fine.
+        - Be concise and specific; avoid filler like "updated some code".
+
+        Output ONLY the raw commit message text: no markdown, no code fences, no
+        surrounding quotes, and no commentary before or after it.
+        """;
+
+    // Reused across calls; HttpClient is designed to be long-lived (avoids per-call socket churn).
+    private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(90) };
+
+    /// <summary>
+    ///  Sends <paramref name="diff"/> to the configured endpoint and returns the suggested commit message.
+    /// </summary>
+    public static async Task<string> GenerateAsync(string diff, CancellationToken cancellationToken = default)
+    {
+        string baseUrl = (AppSettings.AiCommitMessageApiBaseUrl.Value ?? string.Empty).Trim().TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException("The AI commit message API base URL is not configured (Settings > Commit dialog).");
+        }
+
+        string apiKey = (AppSettings.AiCommitMessageApiKey ?? string.Empty).Trim();
+        string model = AppSettings.AiCommitMessageModel.Value;
+        string systemPrompt = AppSettings.AiCommitMessageSystemPrompt.Value;
+
+        int maxChars = AppSettings.AiCommitMessageMaxDiffLength.Value;
+        if (maxChars > 0 && diff.Length > maxChars)
+        {
+            diff = diff[..maxChars] + "\n\n[diff truncated to fit the configured limit]";
+        }
+
+        // Note: no "temperature" is sent. Newer models (e.g. the GPT-5 family) reject any
+        // non-default temperature, and omitting it lets every OpenAI-compatible endpoint apply its
+        // own default - the system prompt already constrains the output tightly.
+        var requestBody = new
+        {
+            model,
+            messages = new object[]
+            {
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = "Here is the staged git diff. Write the commit message for it:\n\n" + diff }
+            }
+        };
+
+        string json = JsonSerializer.Serialize(requestBody);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, baseUrl + "/chat/completions")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+        if (!string.IsNullOrEmpty(apiKey))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        }
+
+        using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        string responseText = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            string details = $"The AI provider returned {(int)response.StatusCode} ({response.ReasonPhrase}).{Environment.NewLine}{Environment.NewLine}{Truncate(responseText, 1000)}";
+            throw new UserExternalOperationException(
+                "AI commit message generation failed.",
+                new ExternalOperationException(command: request.RequestUri?.ToString(), exitCode: (int)response.StatusCode, innerException: new Exception(details)));
+        }
+
+        return ExtractContent(responseText);
+    }
+
+    private static string ExtractContent(string responseText)
+    {
+        using JsonDocument doc = JsonDocument.Parse(responseText);
+        JsonElement root = doc.RootElement;
+
+        if (root.TryGetProperty("choices", out JsonElement choices)
+            && choices.ValueKind == JsonValueKind.Array
+            && choices.GetArrayLength() > 0)
+        {
+            JsonElement first = choices[0];
+            if (first.TryGetProperty("message", out JsonElement message)
+                && message.TryGetProperty("content", out JsonElement content))
+            {
+                string? text = content.GetString();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    return text.Trim();
+                }
+            }
+        }
+
+        throw new UserExternalOperationException(
+            "AI commit message generation failed.",
+            new ExternalOperationException(innerException: new Exception("The AI response did not contain a commit message (no choices[0].message.content):" + Environment.NewLine + Environment.NewLine + Truncate(responseText, 1000))));
+    }
+
+    private static string Truncate(string value, int maxLength)
+        => string.IsNullOrEmpty(value) || value.Length <= maxLength ? value : value[..maxLength] + "…";
+
+    internal static TestAccessor GetTestAccessor() => new();
+
+    internal readonly struct TestAccessor
+    {
+        internal string ExtractContent(string responseText)
+            => AiCommitMessageGenerator.ExtractContent(responseText);
+    }
+}

--- a/src/app/GitCommands/AiCommitMessageGenerator.cs
+++ b/src/app/GitCommands/AiCommitMessageGenerator.cs
@@ -100,10 +100,7 @@ public static class AiCommitMessageGenerator
         return ExtractContent(responseText);
     }
 
-    /// <summary>
-    ///  Extracts the generated commit message from a Chat Completions JSON response.
-    /// </summary>
-    public static string ExtractContent(string responseText)
+    private static string ExtractContent(string responseText)
     {
         using JsonDocument doc = JsonDocument.Parse(responseText);
         JsonElement root = doc.RootElement;
@@ -131,4 +128,9 @@ public static class AiCommitMessageGenerator
 
     private static string Truncate(string value, int maxLength)
         => value.Length <= maxLength ? value : $"{value[..maxLength]}…";
+
+    internal readonly struct TestAccessor
+    {
+        public static string ExtractContent(string responseText) => AiCommitMessageGenerator.ExtractContent(responseText);
+    }
 }

--- a/src/app/GitCommands/AiCommitMessageGenerator.cs
+++ b/src/app/GitCommands/AiCommitMessageGenerator.cs
@@ -45,13 +45,13 @@ public static class AiCommitMessageGenerator
     /// </summary>
     public static async Task<string> GenerateAsync(string diff, CancellationToken cancellationToken = default)
     {
-        string baseUrl = (AppSettings.AiCommitMessageApiBaseUrl.Value ?? string.Empty).Trim().TrimEnd('/');
+        string baseUrl = AppSettings.AiCommitMessageApiBaseUrl.Value.Trim().TrimEnd('/');
         if (string.IsNullOrWhiteSpace(baseUrl))
         {
             throw new InvalidOperationException("The AI commit message API base URL is not configured (Settings > Commit dialog).");
         }
 
-        string apiKey = (AppSettings.AiCommitMessageApiKey ?? string.Empty).Trim();
+        string apiKey = AppSettings.AiCommitMessageApiKey.Trim();
         string model = AppSettings.AiCommitMessageModel.Value;
         string systemPrompt = AppSettings.AiCommitMessageSystemPrompt.Value;
 
@@ -100,7 +100,10 @@ public static class AiCommitMessageGenerator
         return ExtractContent(responseText);
     }
 
-    private static string ExtractContent(string responseText)
+    /// <summary>
+    ///  Extracts the generated commit message from a Chat Completions JSON response.
+    /// </summary>
+    public static string ExtractContent(string responseText)
     {
         using JsonDocument doc = JsonDocument.Parse(responseText);
         JsonElement root = doc.RootElement;
@@ -123,17 +126,9 @@ public static class AiCommitMessageGenerator
 
         throw new UserExternalOperationException(
             "AI commit message generation failed.",
-            new ExternalOperationException(innerException: new Exception("The AI response did not contain a commit message (no choices[0].message.content):" + Environment.NewLine + Environment.NewLine + Truncate(responseText, 1000))));
+            new ExternalOperationException(innerException: new Exception($"The AI response did not contain a commit message (no choices[0].message.content):{Environment.NewLine}{Environment.NewLine}{Truncate(responseText, 1000)}")));
     }
 
     private static string Truncate(string value, int maxLength)
-        => string.IsNullOrEmpty(value) || value.Length <= maxLength ? value : value[..maxLength] + "…";
-
-    internal static TestAccessor GetTestAccessor() => new();
-
-    internal readonly struct TestAccessor
-    {
-        internal string ExtractContent(string responseText)
-            => AiCommitMessageGenerator.ExtractContent(responseText);
-    }
+        => value.Length <= maxLength ? value : $"{value[..maxLength]}…";
 }

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -37,6 +37,7 @@ public static partial class AppSettings
     public static DistributedSettings SettingsContainer { get; private set; }
 
     private static readonly SettingsPath AppearanceSettingsPath = new AppSettingsPath("Appearance");
+    private static readonly SettingsPath AiCommitMessageSettingsPath = new AppSettingsPath("AiCommitMessage");
     private static readonly SettingsPath ConfirmationsSettingsPath = new AppSettingsPath("Confirmations");
     private static readonly SettingsPath DetailedSettingsPath = new AppSettingsPath("Detailed");
     private static readonly SettingsPath DialogSettingsPath = new AppSettingsPath("Dialogs");
@@ -461,6 +462,41 @@ public static partial class AppSettings
         get => GetInt("commitDialogNumberOfPreviousMessages", 6);
         set => SetInt("commitDialogNumberOfPreviousMessages", value);
     }
+
+    public static ISetting<bool> AiCommitMessageEnabled { get; } = Setting.Create(AiCommitMessageSettingsPath, nameof(AiCommitMessageEnabled), false);
+
+    public static ISetting<string> AiCommitMessageApiBaseUrl { get; } = Setting.Create(AiCommitMessageSettingsPath, nameof(AiCommitMessageApiBaseUrl), "https://api.openai.com/v1");
+
+    public static ISetting<string> AiCommitMessageModel { get; } = Setting.Create(AiCommitMessageSettingsPath, nameof(AiCommitMessageModel), "gpt-4o-mini");
+
+    // The API key is a secret, so it is stored in the Windows Credential Manager instead of the
+    // plaintext settings file. The credential target name is derived from the source's setting level,
+    // so a dedicated global-scoped source is used for both reading and writing - otherwise the
+    // ambient SettingsContainer level (which varies by context) would produce different target names
+    // and the saved key would not be found when generating.
+    private static readonly CredentialsSetting _aiCommitMessageApiKey
+        = new("aiCommitMessage.apiKey", "AI commit message API key", static () => null);
+
+    private static readonly Lazy<DistributedSettings> _aiCommitMessageApiKeySource
+        = new(static () => DistributedSettings.CreateGlobal());
+
+    public static string AiCommitMessageApiKey
+    {
+        get => _aiCommitMessageApiKey.GetValueOrDefault(_aiCommitMessageApiKeySource.Value).Password;
+        set
+        {
+            // The Windows Credential Manager rejects an empty secret, so an empty key clears the
+            // entry instead: a blank user name tells CredentialsSetting to drop the credential, while
+            // a real key is stored under a fixed (non-empty) user name.
+            string key = value ?? string.Empty;
+            _aiCommitMessageApiKey.SaveValue(_aiCommitMessageApiKeySource.Value, string.IsNullOrWhiteSpace(key) ? string.Empty : "token", key);
+            _aiCommitMessageApiKey.Save();
+        }
+    }
+
+    public static ISetting<string> AiCommitMessageSystemPrompt { get; } = Setting.Create(AiCommitMessageSettingsPath, nameof(AiCommitMessageSystemPrompt), AiCommitMessageGenerator.DefaultSystemPrompt);
+
+    public static ISetting<int> AiCommitMessageMaxDiffLength { get; } = Setting.Create(AiCommitMessageSettingsPath, nameof(AiCommitMessageMaxDiffLength), 12000);
 
     public static ISetting<bool> CommitDialogSelectStagedOnEnterMessage { get; } = Setting.Create(DialogSettingsPath, nameof(CommitDialogSelectStagedOnEnterMessage), true);
 

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -48,6 +48,12 @@ public sealed partial class FormCommit : GitModuleForm
 
     private readonly TranslationString _amendCommitCaption = new("Amend commit");
 
+    private readonly TranslationString _aiGenerateButton = new("✨ Generate AI commit message");
+    private readonly TranslationString _aiGenerating = new("Generating…");
+    private readonly TranslationString _aiCaption = new("AI commit message");
+    private readonly TranslationString _aiNoStagedChanges = new("No staged changes were found. Stage the files you want to commit, then try again.");
+    private readonly TranslationString _aiGenerationFailed = new("Failed to generate a commit message:");
+
     private readonly TranslationString _commitAndPush = new("Commit && &push");
 
     private readonly TranslationString _commitAndForcePush = new("Commit && force &push");
@@ -463,6 +469,120 @@ public sealed partial class FormCommit : GitModuleForm
         MinimizeBox = Owner is null;
 
         base.OnLoad(e);
+
+        AddAiCommitMessageButton();
+    }
+
+    /// <summary>
+    /// Adds the "Generate AI commit message" button to the commit toolbar when the feature is enabled
+    /// (Settings > Commit dialog). The staged diff is sent to the configured endpoint only on click.
+    /// </summary>
+    private void AddAiCommitMessageButton()
+    {
+        if (!AppSettings.AiCommitMessageEnabled.Value)
+        {
+            return;
+        }
+
+        ToolStripButton button = new(_aiGenerateButton.Text)
+        {
+            Name = "aiCommitMessageButton",
+            DisplayStyle = ToolStripItemDisplayStyle.Text,
+            ToolTipText = _aiGenerateButton.Text
+        };
+        button.Click += AiCommitMessageButton_Click;
+
+        int insertIndex = toolbarCommit.Items.IndexOf(commitTemplatesToolStripMenuItem) + 1;
+        if (insertIndex > 0 && insertIndex <= toolbarCommit.Items.Count)
+        {
+            toolbarCommit.Items.Insert(insertIndex, button);
+        }
+        else
+        {
+            toolbarCommit.Items.Add(button);
+        }
+    }
+
+    private void AiCommitMessageButton_Click(object? sender, EventArgs e)
+    {
+        if (sender is not ToolStripButton button)
+        {
+            return;
+        }
+
+        // Generate off the UI thread so the dialog stays responsive; show progress on the button.
+        button.Enabled = false;
+        button.Text = _aiGenerating.Text;
+        ThreadHelper.FileAndForget(() => RunAiCommitMessageGenerationAsync(button));
+    }
+
+    private async Task RunAiCommitMessageGenerationAsync(ToolStripButton button)
+    {
+        // Cancel the request if the user closes the commit dialog while it is running.
+        using CancellationTokenSource cts = new();
+        void CancelOnClose(object? sender, FormClosedEventArgs e) => cts.Cancel();
+        FormClosed += CancelOnClose;
+        try
+        {
+            string? message = await GetAiCommitMessageAsync(cts.Token);
+
+            await this.SwitchToMainThreadAsync();
+            if (!IsDisposed && !string.IsNullOrEmpty(message))
+            {
+                ReplaceMessage(message);
+                Message.Focus();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The commit dialog was closed while generating; nothing to do.
+        }
+        catch (Exception ex)
+        {
+            await this.SwitchToMainThreadAsync();
+            if (!IsDisposed)
+            {
+                MessageBoxes.Show(this, _aiGenerationFailed.Text + Environment.NewLine + Environment.NewLine + ex.Message, _aiCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        finally
+        {
+            FormClosed -= CancelOnClose;
+            await this.SwitchToMainThreadAsync();
+            if (!IsDisposed && !button.IsDisposed)
+            {
+                button.Text = _aiGenerateButton.Text;
+                button.Enabled = true;
+            }
+        }
+    }
+
+    private async Task<string?> GetAiCommitMessageAsync(CancellationToken cancellationToken)
+    {
+        IGitModule module = Module;
+
+        // Use a structured argument list with --no-ext-diff so a user-configured external diff
+        // driver is never invoked here; we only want the plain textual diff to send to the model.
+        GitArgumentBuilder args = new("diff")
+        {
+            "--no-ext-diff",
+            "--cached",
+            "--no-color"
+        };
+        string diff = await Task.Run(() => module.GitExecutable.GetOutput(args), cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(diff))
+        {
+            await this.SwitchToMainThreadAsync(cancellationToken);
+            if (!IsDisposed)
+            {
+                MessageBoxes.Show(this, _aiNoStagedChanges.Text, _aiCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+
+            return null;
+        }
+
+        return await AiCommitMessageGenerator.GenerateAsync(diff, cancellationToken);
     }
 
     private void RestoreSplitters()
@@ -1099,12 +1219,10 @@ public sealed partial class FormCommit : GitModuleForm
             {
                 // This is an amend commit.  Confirm the user understands the implications.  We don't want to prompt for an empty
                 // commit, because amend may be used just to change the commit message or timestamp.
-                if (!AppSettings.DontConfirmAmend)
+                if (!AppSettings.DontConfirmAmend
+                    && MessageBoxes.Show(this, _amendCommit.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
                 {
-                    if (MessageBoxes.Show(this, _amendCommit.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
 
                 return true;
@@ -1221,12 +1339,9 @@ public sealed partial class FormCommit : GitModuleForm
                         return;
                     }
                 }
-                else if (result == btnCreate)
+                else if (result == btnCreate && !UICommands.StartCreateBranchDialog(this, _editedCommit?.ObjectId ?? default))
                 {
-                    if (!UICommands.StartCreateBranchDialog(this, _editedCommit?.ObjectId ?? default))
-                    {
-                        return;
-                    }
+                    return;
                 }
             }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
@@ -43,12 +43,30 @@ partial class CommitDialogSettingsPage
         chkShowResetWorkTreeChanges = new CheckBox();
         chkShowResetAllChanges = new CheckBox();
         chkEnsureCommitMessageSecondLineEmpty = new CheckBox();
+        groupBoxAiCommitMessage = new GroupBox();
+        tableLayoutPanelAiCommitMessage = new TableLayoutPanel();
+        chkAiCommitMessageEnabled = new CheckBox();
+        lblAiCommitMessageProvider = new Label();
+        cboAiCommitMessageProvider = new ComboBox();
+        lblAiCommitMessageBaseUrl = new Label();
+        txtAiCommitMessageBaseUrl = new TextBox();
+        lblAiCommitMessageModel = new Label();
+        txtAiCommitMessageModel = new TextBox();
+        lblAiCommitMessageApiKey = new Label();
+        txtAiCommitMessageApiKey = new TextBox();
+        lblAiCommitMessageMaxDiff = new Label();
+        numAiCommitMessageMaxDiff = new NumericUpDown();
+        lblAiCommitMessageSystemPrompt = new Label();
+        txtAiCommitMessageSystemPrompt = new TextBox();
         groupBoxBehaviour.SuspendLayout();
         tableLayoutPanelBehaviour.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)(this
             ._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).BeginInit();
         grpAdditionalButtons.SuspendLayout();
         flowLayoutPanel1.SuspendLayout();
+        groupBoxAiCommitMessage.SuspendLayout();
+        tableLayoutPanelAiCommitMessage.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(numAiCommitMessageMaxDiff)).BeginInit();
         SuspendLayout();
         // 
         // groupBoxBehaviour
@@ -81,10 +99,12 @@ partial class CommitDialogSettingsPage
         tableLayoutPanelBehaviour.Controls.Add(grpAdditionalButtons, 0, 7);
         tableLayoutPanelBehaviour.Controls.Add(chkEnsureCommitMessageSecondLineEmpty,
             0, 2);
+        tableLayoutPanelBehaviour.Controls.Add(groupBoxAiCommitMessage, 0, 8);
         tableLayoutPanelBehaviour.Dock = DockStyle.Top;
         tableLayoutPanelBehaviour.Location = new Point(3, 19);
         tableLayoutPanelBehaviour.Name = "tableLayoutPanelBehaviour";
-        tableLayoutPanelBehaviour.RowCount = 8;
+        tableLayoutPanelBehaviour.RowCount = 9;
+        tableLayoutPanelBehaviour.RowStyles.Add(new RowStyle());
         tableLayoutPanelBehaviour.RowStyles.Add(new RowStyle());
         tableLayoutPanelBehaviour.RowStyles.Add(new RowStyle());
         tableLayoutPanelBehaviour.RowStyles.Add(new RowStyle());
@@ -239,9 +259,174 @@ partial class CommitDialogSettingsPage
         chkEnsureCommitMessageSecondLineEmpty.Text =
             "Ensure the second line of commit message is empty";
         chkEnsureCommitMessageSecondLineEmpty.UseVisualStyleBackColor = true;
-        // 
+        //
+        // groupBoxAiCommitMessage
+        //
+        groupBoxAiCommitMessage.AutoSize = true;
+        groupBoxAiCommitMessage.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        tableLayoutPanelBehaviour.SetColumnSpan(groupBoxAiCommitMessage, 2);
+        groupBoxAiCommitMessage.Controls.Add(tableLayoutPanelAiCommitMessage);
+        groupBoxAiCommitMessage.Dock = DockStyle.Fill;
+        groupBoxAiCommitMessage.Name = "groupBoxAiCommitMessage";
+        groupBoxAiCommitMessage.Padding = new Padding(3);
+        groupBoxAiCommitMessage.TabIndex = 7;
+        groupBoxAiCommitMessage.TabStop = false;
+        groupBoxAiCommitMessage.Text = "AI commit message";
+        //
+        // tableLayoutPanelAiCommitMessage
+        //
+        tableLayoutPanelAiCommitMessage.AutoSize = true;
+        tableLayoutPanelAiCommitMessage.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        tableLayoutPanelAiCommitMessage.ColumnCount = 2;
+        tableLayoutPanelAiCommitMessage.ColumnStyles.Add(new ColumnStyle());
+        tableLayoutPanelAiCommitMessage.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        tableLayoutPanelAiCommitMessage.Controls.Add(chkAiCommitMessageEnabled, 0, 0);
+        tableLayoutPanelAiCommitMessage.Controls.Add(lblAiCommitMessageProvider, 0, 1);
+        tableLayoutPanelAiCommitMessage.Controls.Add(cboAiCommitMessageProvider, 1, 1);
+        tableLayoutPanelAiCommitMessage.Controls.Add(lblAiCommitMessageBaseUrl, 0, 2);
+        tableLayoutPanelAiCommitMessage.Controls.Add(txtAiCommitMessageBaseUrl, 1, 2);
+        tableLayoutPanelAiCommitMessage.Controls.Add(lblAiCommitMessageModel, 0, 3);
+        tableLayoutPanelAiCommitMessage.Controls.Add(txtAiCommitMessageModel, 1, 3);
+        tableLayoutPanelAiCommitMessage.Controls.Add(lblAiCommitMessageApiKey, 0, 4);
+        tableLayoutPanelAiCommitMessage.Controls.Add(txtAiCommitMessageApiKey, 1, 4);
+        tableLayoutPanelAiCommitMessage.Controls.Add(lblAiCommitMessageMaxDiff, 0, 5);
+        tableLayoutPanelAiCommitMessage.Controls.Add(numAiCommitMessageMaxDiff, 1, 5);
+        tableLayoutPanelAiCommitMessage.Controls.Add(lblAiCommitMessageSystemPrompt, 0, 6);
+        tableLayoutPanelAiCommitMessage.Controls.Add(txtAiCommitMessageSystemPrompt, 1, 6);
+        tableLayoutPanelAiCommitMessage.Dock = DockStyle.Fill;
+        tableLayoutPanelAiCommitMessage.Name = "tableLayoutPanelAiCommitMessage";
+        tableLayoutPanelAiCommitMessage.RowCount = 7;
+        tableLayoutPanelAiCommitMessage.RowStyles.Add(new RowStyle());
+        tableLayoutPanelAiCommitMessage.RowStyles.Add(new RowStyle());
+        tableLayoutPanelAiCommitMessage.RowStyles.Add(new RowStyle());
+        tableLayoutPanelAiCommitMessage.RowStyles.Add(new RowStyle());
+        tableLayoutPanelAiCommitMessage.RowStyles.Add(new RowStyle());
+        tableLayoutPanelAiCommitMessage.RowStyles.Add(new RowStyle());
+        tableLayoutPanelAiCommitMessage.RowStyles.Add(new RowStyle());
+        tableLayoutPanelAiCommitMessage.SetColumnSpan(chkAiCommitMessageEnabled, 2);
+        tableLayoutPanelAiCommitMessage.TabIndex = 0;
+        //
+        // chkAiCommitMessageEnabled
+        //
+        chkAiCommitMessageEnabled.AutoSize = true;
+        chkAiCommitMessageEnabled.Margin = new Padding(3, 3, 3, 6);
+        chkAiCommitMessageEnabled.Name = "chkAiCommitMessageEnabled";
+        chkAiCommitMessageEnabled.TabIndex = 0;
+        chkAiCommitMessageEnabled.Text =
+            "Enable AI commit message generation (adds a button to the commit dialog; the staged diff is sent to the configured endpoint only when you click it)";
+        chkAiCommitMessageEnabled.UseVisualStyleBackColor = true;
+        //
+        // lblAiCommitMessageProvider
+        //
+        lblAiCommitMessageProvider.Anchor = AnchorStyles.Left;
+        lblAiCommitMessageProvider.AutoSize = true;
+        lblAiCommitMessageProvider.Margin = new Padding(3, 6, 3, 3);
+        lblAiCommitMessageProvider.Name = "lblAiCommitMessageProvider";
+        lblAiCommitMessageProvider.TabIndex = 1;
+        lblAiCommitMessageProvider.Text = "Provider:";
+        //
+        // cboAiCommitMessageProvider
+        //
+        cboAiCommitMessageProvider.Anchor = AnchorStyles.Left;
+        cboAiCommitMessageProvider.DropDownStyle = ComboBoxStyle.DropDownList;
+        cboAiCommitMessageProvider.FormattingEnabled = true;
+        cboAiCommitMessageProvider.Margin = new Padding(3);
+        cboAiCommitMessageProvider.Name = "cboAiCommitMessageProvider";
+        cboAiCommitMessageProvider.Size = new Size(220, 23);
+        cboAiCommitMessageProvider.TabIndex = 2;
+        cboAiCommitMessageProvider.SelectedIndexChanged += AiProvider_SelectedIndexChanged;
+        //
+        // lblAiCommitMessageBaseUrl
+        //
+        lblAiCommitMessageBaseUrl.Anchor = AnchorStyles.Left;
+        lblAiCommitMessageBaseUrl.AutoSize = true;
+        lblAiCommitMessageBaseUrl.Margin = new Padding(3, 6, 3, 3);
+        lblAiCommitMessageBaseUrl.Name = "lblAiCommitMessageBaseUrl";
+        lblAiCommitMessageBaseUrl.TabIndex = 3;
+        lblAiCommitMessageBaseUrl.Text = "API base URL (OpenAI-compatible):";
+        //
+        // txtAiCommitMessageBaseUrl
+        //
+        txtAiCommitMessageBaseUrl.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+        txtAiCommitMessageBaseUrl.Margin = new Padding(3);
+        txtAiCommitMessageBaseUrl.Name = "txtAiCommitMessageBaseUrl";
+        txtAiCommitMessageBaseUrl.TabIndex = 4;
+        //
+        // lblAiCommitMessageModel
+        //
+        lblAiCommitMessageModel.Anchor = AnchorStyles.Left;
+        lblAiCommitMessageModel.AutoSize = true;
+        lblAiCommitMessageModel.Margin = new Padding(3, 6, 3, 3);
+        lblAiCommitMessageModel.Name = "lblAiCommitMessageModel";
+        lblAiCommitMessageModel.TabIndex = 5;
+        lblAiCommitMessageModel.Text = "Model:";
+        //
+        // txtAiCommitMessageModel
+        //
+        txtAiCommitMessageModel.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+        txtAiCommitMessageModel.Margin = new Padding(3);
+        txtAiCommitMessageModel.Name = "txtAiCommitMessageModel";
+        txtAiCommitMessageModel.TabIndex = 6;
+        //
+        // lblAiCommitMessageApiKey
+        //
+        lblAiCommitMessageApiKey.Anchor = AnchorStyles.Left;
+        lblAiCommitMessageApiKey.AutoSize = true;
+        lblAiCommitMessageApiKey.Margin = new Padding(3, 6, 3, 3);
+        lblAiCommitMessageApiKey.Name = "lblAiCommitMessageApiKey";
+        lblAiCommitMessageApiKey.TabIndex = 7;
+        lblAiCommitMessageApiKey.Text = "API key (leave blank for local servers such as Ollama):";
+        //
+        // txtAiCommitMessageApiKey
+        //
+        txtAiCommitMessageApiKey.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+        txtAiCommitMessageApiKey.Margin = new Padding(3);
+        txtAiCommitMessageApiKey.Name = "txtAiCommitMessageApiKey";
+        txtAiCommitMessageApiKey.TabIndex = 8;
+        txtAiCommitMessageApiKey.UseSystemPasswordChar = true;
+        //
+        // lblAiCommitMessageMaxDiff
+        //
+        lblAiCommitMessageMaxDiff.Anchor = AnchorStyles.Left;
+        lblAiCommitMessageMaxDiff.AutoSize = true;
+        lblAiCommitMessageMaxDiff.Margin = new Padding(3, 6, 3, 3);
+        lblAiCommitMessageMaxDiff.Name = "lblAiCommitMessageMaxDiff";
+        lblAiCommitMessageMaxDiff.TabIndex = 9;
+        lblAiCommitMessageMaxDiff.Text = "Max diff characters sent to the model (0 = no limit):";
+        //
+        // numAiCommitMessageMaxDiff
+        //
+        numAiCommitMessageMaxDiff.Anchor = AnchorStyles.Left;
+        numAiCommitMessageMaxDiff.Increment = new decimal(new int[] { 1000, 0, 0, 0 });
+        numAiCommitMessageMaxDiff.Margin = new Padding(3);
+        numAiCommitMessageMaxDiff.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+        numAiCommitMessageMaxDiff.Name = "numAiCommitMessageMaxDiff";
+        numAiCommitMessageMaxDiff.Size = new Size(120, 23);
+        numAiCommitMessageMaxDiff.TabIndex = 10;
+        numAiCommitMessageMaxDiff.ThousandsSeparator = true;
+        //
+        // lblAiCommitMessageSystemPrompt
+        //
+        lblAiCommitMessageSystemPrompt.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+        lblAiCommitMessageSystemPrompt.AutoSize = true;
+        lblAiCommitMessageSystemPrompt.Margin = new Padding(3, 6, 3, 3);
+        lblAiCommitMessageSystemPrompt.Name = "lblAiCommitMessageSystemPrompt";
+        lblAiCommitMessageSystemPrompt.TabIndex = 11;
+        lblAiCommitMessageSystemPrompt.Text = "System prompt:";
+        //
+        // txtAiCommitMessageSystemPrompt
+        //
+        txtAiCommitMessageSystemPrompt.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+        txtAiCommitMessageSystemPrompt.Margin = new Padding(3);
+        txtAiCommitMessageSystemPrompt.Multiline = true;
+        txtAiCommitMessageSystemPrompt.Name = "txtAiCommitMessageSystemPrompt";
+        txtAiCommitMessageSystemPrompt.ScrollBars = ScrollBars.Vertical;
+        txtAiCommitMessageSystemPrompt.Size = new Size(400, 140);
+        txtAiCommitMessageSystemPrompt.TabIndex = 12;
+        txtAiCommitMessageSystemPrompt.WordWrap = true;
+        //
         // CommitDialogSettingsPage
-        // 
+        //
         AutoScaleDimensions = new SizeF(96F, 96F);
         AutoScaleMode = AutoScaleMode.Dpi;
         AutoScroll = true;
@@ -259,6 +444,11 @@ partial class CommitDialogSettingsPage
         grpAdditionalButtons.PerformLayout();
         flowLayoutPanel1.ResumeLayout(false);
         flowLayoutPanel1.PerformLayout();
+        groupBoxAiCommitMessage.ResumeLayout(false);
+        groupBoxAiCommitMessage.PerformLayout();
+        tableLayoutPanelAiCommitMessage.ResumeLayout(false);
+        tableLayoutPanelAiCommitMessage.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)(numAiCommitMessageMaxDiff)).EndInit();
         ResumeLayout(false);
         PerformLayout();
     }
@@ -279,4 +469,19 @@ partial class CommitDialogSettingsPage
     private CheckBox chkEnsureCommitMessageSecondLineEmpty;
     private CheckBox chkAutocomplete;
     private CheckBox cbRememberAmendCommitState;
+    private GroupBox groupBoxAiCommitMessage;
+    private TableLayoutPanel tableLayoutPanelAiCommitMessage;
+    private CheckBox chkAiCommitMessageEnabled;
+    private Label lblAiCommitMessageProvider;
+    private ComboBox cboAiCommitMessageProvider;
+    private Label lblAiCommitMessageBaseUrl;
+    private TextBox txtAiCommitMessageBaseUrl;
+    private Label lblAiCommitMessageModel;
+    private TextBox txtAiCommitMessageModel;
+    private Label lblAiCommitMessageApiKey;
+    private TextBox txtAiCommitMessageApiKey;
+    private Label lblAiCommitMessageMaxDiff;
+    private NumericUpDown numAiCommitMessageMaxDiff;
+    private Label lblAiCommitMessageSystemPrompt;
+    private TextBox txtAiCommitMessageSystemPrompt;
 }

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
@@ -1,13 +1,27 @@
-﻿using GitCommands;
+using GitCommands;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
 
 public partial class CommitDialogSettingsPage : SettingsPageWithHeader
 {
+    // Quick-fill presets for the most common OpenAI-compatible providers. "Custom" leaves the URL
+    // untouched; every preset only fills the fields below, which remain editable.
+    private static readonly (string Name, string BaseUrl, string Model)[] _aiProviderPresets =
+    [
+        ("Custom", "", ""),
+        ("OpenAI", "https://api.openai.com/v1", "gpt-4o-mini"),
+        ("GitHub Models", "https://models.github.ai/inference", "openai/gpt-4o-mini"),
+        ("Google Gemini", "https://generativelanguage.googleapis.com/v1beta/openai/", "gemini-3.5-flash"),
+        ("OpenRouter", "https://openrouter.ai/api/v1", "openai/gpt-4o-mini"),
+        ("Groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile"),
+        ("Ollama (local)", "http://localhost:11434/v1", "llama3.2"),
+    ];
+
     public CommitDialogSettingsPage(IServiceProvider serviceProvider)
         : base(serviceProvider)
     {
         InitializeComponent();
+        cboAiCommitMessageProvider.Items.AddRange([.. _aiProviderPresets.Select(p => (object)p.Name)]);
         InitializeComplete();
     }
 
@@ -22,6 +36,14 @@ public partial class CommitDialogSettingsPage : SettingsPageWithHeader
         chkShowResetAllChanges.Checked = AppSettings.ShowResetAllChanges;
         chkAutocomplete.Checked = AppSettings.ProvideAutocompletion;
         cbRememberAmendCommitState.Checked = AppSettings.RememberAmendCommitState;
+
+        chkAiCommitMessageEnabled.Checked = AppSettings.AiCommitMessageEnabled.Value;
+        txtAiCommitMessageBaseUrl.Text = AppSettings.AiCommitMessageApiBaseUrl.Value;
+        txtAiCommitMessageModel.Text = AppSettings.AiCommitMessageModel.Value;
+        txtAiCommitMessageApiKey.Text = AppSettings.AiCommitMessageApiKey;
+        txtAiCommitMessageSystemPrompt.Text = NormalizeNewLines(AppSettings.AiCommitMessageSystemPrompt.Value);
+        numAiCommitMessageMaxDiff.Value = Math.Clamp((decimal)AppSettings.AiCommitMessageMaxDiffLength.Value, numAiCommitMessageMaxDiff.Minimum, numAiCommitMessageMaxDiff.Maximum);
+        cboAiCommitMessageProvider.SelectedIndex = GetProviderPresetIndex(AppSettings.AiCommitMessageApiBaseUrl.Value);
 
         base.SettingsToPage();
     }
@@ -38,6 +60,48 @@ public partial class CommitDialogSettingsPage : SettingsPageWithHeader
         AppSettings.ProvideAutocompletion = chkAutocomplete.Checked;
         AppSettings.RememberAmendCommitState = cbRememberAmendCommitState.Checked;
 
+        AppSettings.AiCommitMessageEnabled.Value = chkAiCommitMessageEnabled.Checked;
+        AppSettings.AiCommitMessageApiBaseUrl.Value = txtAiCommitMessageBaseUrl.Text.Trim();
+        AppSettings.AiCommitMessageModel.Value = txtAiCommitMessageModel.Text.Trim();
+        AppSettings.AiCommitMessageApiKey = txtAiCommitMessageApiKey.Text.Trim();
+        AppSettings.AiCommitMessageSystemPrompt.Value = txtAiCommitMessageSystemPrompt.Text;
+        AppSettings.AiCommitMessageMaxDiffLength.Value = (int)numAiCommitMessageMaxDiff.Value;
+
         base.PageToSettings();
+    }
+
+    private static int GetProviderPresetIndex(string? baseUrl)
+    {
+        string normalized = (baseUrl ?? string.Empty).Trim().TrimEnd('/');
+        for (int i = 1; i < _aiProviderPresets.Length; i++)
+        {
+            if (string.Equals(_aiProviderPresets[i].BaseUrl, normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        return 0; // Custom
+    }
+
+    // A multiline TextBox only renders "\r\n" as a line break, but the stored or default prompt may
+    // use bare "\n", so normalise to the platform newline before displaying it.
+    private static string NormalizeNewLines(string value)
+        => value.Replace("\r\n", "\n").Replace('\r', '\n').Replace("\n", Environment.NewLine);
+
+    private void AiProvider_SelectedIndexChanged(object? sender, EventArgs e)
+    {
+        // Don't overwrite the user's saved values while the page is being loaded.
+        if (IsLoadingSettings || cboAiCommitMessageProvider.SelectedIndex <= 0)
+        {
+            return;
+        }
+
+        (_, string baseUrl, string model) = _aiProviderPresets[cboAiCommitMessageProvider.SelectedIndex];
+        txtAiCommitMessageBaseUrl.Text = baseUrl;
+        if (!string.IsNullOrWhiteSpace(model))
+        {
+            txtAiCommitMessageModel.Text = model;
+        }
     }
 }

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -872,6 +872,10 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkAiCommitMessageEnabled.Text">
+        <source>Enable AI commit message generation (adds a button to the commit dialog; the staged diff is sent to the configured endpoint only when you click it)</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkAutocomplete.Text">
         <source>Provide auto-completion in commit dialog</source>
         <target />
@@ -901,12 +905,40 @@ Please make sure that Git for Windows is installed or set the correct command ma
 (otherwise the message will be requested during commit)</source>
         <target />
       </trans-unit>
+      <trans-unit id="groupBoxAiCommitMessage.Text">
+        <source>AI commit message</source>
+        <target />
+      </trans-unit>
       <trans-unit id="groupBoxBehaviour.Text">
         <source>Behaviour</source>
         <target />
       </trans-unit>
       <trans-unit id="grpAdditionalButtons.Text">
         <source>Show additional buttons in commit button area</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblAiCommitMessageApiKey.Text">
+        <source>API key (leave blank for local servers such as Ollama):</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblAiCommitMessageBaseUrl.Text">
+        <source>API base URL (OpenAI-compatible):</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblAiCommitMessageMaxDiff.Text">
+        <source>Max diff characters sent to the model (0 = no limit):</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblAiCommitMessageModel.Text">
+        <source>Model:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblAiCommitMessageProvider.Text">
+        <source>Provider:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblAiCommitMessageSystemPrompt.Text">
+        <source>System prompt:</source>
         <target />
       </trans-unit>
       <trans-unit id="lblCommitDialogNumberOfPreviousMessages.Text">
@@ -4032,6 +4064,26 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
       </trans-unit>
       <trans-unit id="_addSelectionToCommitMessage.Text">
         <source>Add selection to commit message</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_aiCaption.Text">
+        <source>AI commit message</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_aiGenerateButton.Text">
+        <source>✨ Generate AI commit message</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_aiGenerating.Text">
+        <source>Generating…</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_aiGenerationFailed.Text">
+        <source>Failed to generate a commit message:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_aiNoStagedChanges.Text">
+        <source>No staged changes were found. Stage the files you want to commit, then try again.</source>
         <target />
       </trans-unit>
       <trans-unit id="_amendCommit.Text">

--- a/tests/app/UnitTests/GitCommands.Tests/AiCommitMessageGeneratorTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/AiCommitMessageGeneratorTests.cs
@@ -10,7 +10,7 @@ public class AiCommitMessageGeneratorTests
     {
         string json = """{"choices":[{"index":0,"message":{"role":"assistant","content":"feat: add the thing"}}]}""";
 
-        AiCommitMessageGenerator.ExtractContent(json).Should().Be("feat: add the thing");
+        AiCommitMessageGenerator.TestAccessor.ExtractContent(json).Should().Be("feat: add the thing");
     }
 
     [Test]
@@ -18,7 +18,7 @@ public class AiCommitMessageGeneratorTests
     {
         string json = """{"choices":[{"message":{"content":"  hello  "}}]}""";
 
-        AiCommitMessageGenerator.ExtractContent(json).Should().Be("hello");
+        AiCommitMessageGenerator.TestAccessor.ExtractContent(json).Should().Be("hello");
     }
 
     [TestCase("""{"choices":[]}""", TestName = "empty choices")]
@@ -28,7 +28,7 @@ public class AiCommitMessageGeneratorTests
     [TestCase("""{"choices":[{"message":{}}]}""", TestName = "message without content")]
     public void ExtractContent_throws_when_there_is_no_usable_message(string json)
     {
-        Action act = () => AiCommitMessageGenerator.ExtractContent(json);
+        Action act = () => AiCommitMessageGenerator.TestAccessor.ExtractContent(json);
 
         act.Should().Throw<UserExternalOperationException>();
     }

--- a/tests/app/UnitTests/GitCommands.Tests/AiCommitMessageGeneratorTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/AiCommitMessageGeneratorTests.cs
@@ -10,7 +10,7 @@ public class AiCommitMessageGeneratorTests
     {
         string json = """{"choices":[{"index":0,"message":{"role":"assistant","content":"feat: add the thing"}}]}""";
 
-        AiCommitMessageGenerator.GetTestAccessor().ExtractContent(json).Should().Be("feat: add the thing");
+        AiCommitMessageGenerator.ExtractContent(json).Should().Be("feat: add the thing");
     }
 
     [Test]
@@ -18,7 +18,7 @@ public class AiCommitMessageGeneratorTests
     {
         string json = """{"choices":[{"message":{"content":"  hello  "}}]}""";
 
-        AiCommitMessageGenerator.GetTestAccessor().ExtractContent(json).Should().Be("hello");
+        AiCommitMessageGenerator.ExtractContent(json).Should().Be("hello");
     }
 
     [TestCase("""{"choices":[]}""", TestName = "empty choices")]
@@ -28,7 +28,7 @@ public class AiCommitMessageGeneratorTests
     [TestCase("""{"choices":[{"message":{}}]}""", TestName = "message without content")]
     public void ExtractContent_throws_when_there_is_no_usable_message(string json)
     {
-        Action act = () => AiCommitMessageGenerator.GetTestAccessor().ExtractContent(json);
+        Action act = () => AiCommitMessageGenerator.ExtractContent(json);
 
         act.Should().Throw<UserExternalOperationException>();
     }

--- a/tests/app/UnitTests/GitCommands.Tests/AiCommitMessageGeneratorTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/AiCommitMessageGeneratorTests.cs
@@ -1,0 +1,35 @@
+using GitCommands;
+using GitExtensions.Extensibility;
+
+namespace GitCommandsTests;
+
+public class AiCommitMessageGeneratorTests
+{
+    [Test]
+    public void ExtractContent_returns_the_message_for_a_valid_response()
+    {
+        string json = """{"choices":[{"index":0,"message":{"role":"assistant","content":"feat: add the thing"}}]}""";
+
+        AiCommitMessageGenerator.GetTestAccessor().ExtractContent(json).Should().Be("feat: add the thing");
+    }
+
+    [Test]
+    public void ExtractContent_trims_surrounding_whitespace()
+    {
+        string json = """{"choices":[{"message":{"content":"  hello  "}}]}""";
+
+        AiCommitMessageGenerator.GetTestAccessor().ExtractContent(json).Should().Be("hello");
+    }
+
+    [TestCase("""{"choices":[]}""", TestName = "empty choices")]
+    [TestCase("""{"error":{"message":"invalid api key"}}""", TestName = "error response, no choices")]
+    [TestCase("""{"choices":[{"message":{"content":null}}]}""", TestName = "null content")]
+    [TestCase("""{"choices":[{"message":{"content":"   "}}]}""", TestName = "whitespace content")]
+    [TestCase("""{"choices":[{"message":{}}]}""", TestName = "message without content")]
+    public void ExtractContent_throws_when_there_is_no_usable_message(string json)
+    {
+        Action act = () => AiCommitMessageGenerator.GetTestAccessor().ExtractContent(json);
+
+        act.Should().Throw<UserExternalOperationException>();
+    }
+}

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.ISetting_properties_should_have_stable_storage_keys.verified.txt
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.ISetting_properties_should_have_stable_storage_keys.verified.txt
@@ -1,4 +1,9 @@
-﻿BranchFilterEnabled = BranchFilterEnabled
+﻿AiCommitMessageApiBaseUrl = AiCommitMessage.AiCommitMessageApiBaseUrl
+AiCommitMessageEnabled = AiCommitMessage.AiCommitMessageEnabled
+AiCommitMessageMaxDiffLength = AiCommitMessage.AiCommitMessageMaxDiffLength
+AiCommitMessageModel = AiCommitMessage.AiCommitMessageModel
+AiCommitMessageSystemPrompt = AiCommitMessage.AiCommitMessageSystemPrompt
+BranchFilterEnabled = BranchFilterEnabled
 CheckoutOtherBranchAfterReset = Dialogs.CheckoutOtherBranchAfterReset
 CommitDialogSelectStagedOnEnterMessage = Dialogs.CommitDialogSelectStagedOnEnterMessage
 ConEmuStyle = Detailed.ConEmuStyle


### PR DESCRIPTION
Fixes #12203

## Proposed changes

- Add an **opt-in, off-by-default** feature that drafts a commit message from the **staged diff** using any **OpenAI-compatible** endpoint — OpenAI, Azure OpenAI, OpenRouter, Groq, or a **local** model via Ollama.
- Add a "✨ Generate AI commit message" button to the commit dialog toolbar. It appears only when the feature is enabled, sends the staged diff **only when clicked**, and drops an editable suggestion into the message box.
- Add settings under **Settings › Commit dialog** (global, off by default): enable, API base URL, model, API key, system prompt, and a max-diff-size limit.
- Generation runs **off the UI thread**, so the dialog stays responsive (the button shows "Generating…"); failures (bad/missing key, network, quota) are reported in a dialog.
- **No new dependencies** (only `System.Text.Json` + `HttpClient`) and **no telemetry**. Only the staged diff is ever sent, only on an explicit click; pointing at a local model keeps everything on-machine.

> Context: this revisits #12203, which was discussed in early 2025 — before AI-assisted commit messages became a standard, expected editor feature and a recurring request here. The implementation is shaped around the privacy and dependency concerns raised in that thread.

## Screenshots

### Before

The commit dialog had no AI assistance.

### After

The new button in the commit dialog:

<img width="820" alt="Generate AI commit message button in the commit dialog" src="https://github.com/user-attachments/assets/16d7a860-c6ec-46af-964a-2bec811dc26f" />

Settings under Settings › Commit dialog:

<img width="820" alt="AI commit message settings" src="https://github.com/user-attachments/assets/f78f6df1-a96c-4c27-90d3-ffac81d702fc" />

## Test methodology

- Built the full solution (`GitExtensions.csproj`, Debug, net10) with StyleCop and warnings-as-errors — 0 errors/warnings.
- Ran the build and verified the button appears only when enabled, generates a message from the staged diff without freezing the dialog, and is editable before committing.
- Verified the "no staged changes" path and API failures (e.g. invalid key) surface as dialogs rather than hanging.
- Verified settings persist and the feature is off by default.
- Exercised both a cloud OpenAI-compatible endpoint and a local model.

## Test environment(s)

- GIT 2.48
- Windows 11

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
