### PR TITLE
ci(cla-check): Reject "noreply" email

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -81,12 +81,15 @@ jobs:
 
             // Extract the lowercased GitHub ids that have signed from the contributors.txt content. Entries look like:
             //   YYYY/MM/DD, github id, Full name, email
-            // The GitHub id is the second comma-separated column.
+            // The GitHub id is the second comma-separated column; the email is the fourth column.
+            // Entries whose email contains "noreply" are rejected.
             const parseSignedIds = (content) => {
               const ids = new Set();
               for (const line of content.split(/\r?\n/)) {
-                const match = line.match(/^\s*\d{4}\/\d{2}\/\d{2}\s*,\s*([^,]+?)\s*,/);
+                const match = line.match(/^\s*\d{4}\/\d{2}\/\d{2}\s*,\s*([^,]+?)\s*,\s*[^,]+?\s*,\s*(\S+)/);
                 if (match) {
+                  const email = match[2].trim().toLowerCase();
+                  if (email.includes('noreply')) continue;
                   ids.add(match[1].trim().toLowerCase());
                 }
               }


### PR DESCRIPTION
## Proposed changes

GHA `cla-check.yml`: Reject email addresses containing "noreply"

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- none

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).