### PR TITLE
fix(ISetting): read and store bool in lowercase

### DIFF
--- a/src/app/GitCommands/Settings/Setting.cs
+++ b/src/app/GitCommands/Settings/Setting.cs
@@ -42,8 +42,8 @@ public static class Setting
             settingsSource,
             name,
             defaultValue,
-            read: static s => s switch { "True" => (true, true), "False" => (true, false), _ => (false, default) },
-            store: static v => v ? "True" : "False");
+            read: static s => s switch { "true" or "True" => (true, true), "false" or "False" => (true, false), _ => (false, default) },
+            store: static v => v ? "true" : "false");
     }
 
     /// <summary>
@@ -55,8 +55,8 @@ public static class Setting
             settingsSource,
             name,
             defaultValue: null,
-            read: static s => s switch { "True" => (true, true), "False" => (true, false), _ => (false, default) },
-            store: static v => v switch { true => "True", false => "False", _ => null });
+            read: static s => s switch { "true" or "True" => (true, true), "false" or "False" => (true, false), _ => (false, default) },
+            store: static v => v switch { true => "true", false => "false", _ => null });
     }
 
     /// <summary>

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -315,6 +315,300 @@ internal sealed class SettingTests
         });
     }
 
+    [Test]
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Should_create_bool_setting(bool defaultValue)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        ISetting<bool> setting = Setting.Create(settingsPath, settingName, defaultValue);
+
+        setting.Should().NotBeNull();
+        setting.Name.Should().Be(settingName);
+        setting.Default.Should().Be(defaultValue);
+        setting.Value.Should().Be(defaultValue);
+        setting.FullPath.Should().Be($"{pathName}.{settingName}");
+    }
+
+    [Test]
+    [TestCase(false, false)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(true, true)]
+    public void Should_save_bool_setting(bool defaultValue, bool value)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<bool> setting = Setting.Create(settingsPath, settingName, defaultValue);
+
+            setting.Value = value;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<bool> setting = Setting.Create(settingsPath, settingName, defaultValue);
+
+            setting.Value.Should().Be(value);
+        });
+    }
+
+    [Test]
+    [TestCase("true", true)]
+    [TestCase("True", true)]
+    [TestCase("false", false)]
+    [TestCase("False", false)]
+    public void Should_read_bool_setting_case_insensitively(string storedValue, bool expected)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+            setting.Value = storedValue;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<bool> setting = Setting.Create(settingsPath, settingName, !expected);
+
+            setting.Value.Should().Be(expected);
+        });
+    }
+
+    [Test]
+    [TestCase("TRUE", false)]
+    [TestCase("FALSE", true)]
+    [TestCase("1", false)]
+    [TestCase("yes", true)]
+    public void Should_return_default_for_bool_setting_if_stored_value_is_unrecognized(string storedValue, bool defaultValue)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+            setting.Value = storedValue;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<bool> setting = Setting.Create(settingsPath, settingName, defaultValue);
+
+            setting.Value.Should().Be(defaultValue);
+        });
+    }
+
+    [Test]
+    [TestCase(false, "false")]
+    [TestCase(true, "true")]
+    public void Should_store_bool_setting_as_lowercase_string(bool value, string expectedStoredString)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<bool> setting = Setting.Create(settingsPath, settingName, !value);
+
+            setting.Value = value;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+            setting.Value.Should().Be(expectedStoredString);
+        });
+    }
+
+    [Test]
+    [TestCase("true", true)]
+    [TestCase("True", true)]
+    [TestCase("false", false)]
+    [TestCase("False", false)]
+    public void Should_read_nullable_bool_setting_case_insensitively(string storedValue, bool? expected)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+            setting.Value = storedValue;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<bool?> setting = Setting.CreateNullableBool(settingsPath, settingName);
+
+            setting.Value.Should().Be(expected);
+        });
+    }
+
+    [Test]
+    [TestCase("TRUE")]
+    [TestCase("FALSE")]
+    [TestCase("1")]
+    [TestCase("yes")]
+    public void Should_return_null_for_nullable_bool_setting_if_stored_value_is_unrecognized(string storedValue)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<string> setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+            setting.Value = storedValue;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<bool?> setting = Setting.CreateNullableBool(settingsPath, settingName);
+
+            setting.Value.Should().BeNull();
+        });
+    }
+
+    [Test]
+    [TestCase(null)]
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Should_save_nullable_bool_setting_as_string(bool? value)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<bool?> setting = Setting.CreateNullableBool(settingsPath, settingName);
+
+            setting.Value = value;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<bool?> setting = Setting.CreateNullableBool(settingsPath, settingName);
+
+            setting.Value.Should().Be(value);
+        });
+    }
+
+    [Test]
+    [TestCase(false, "false")]
+    [TestCase(true, "true")]
+    [TestCase(null, null)]
+    public void Should_store_nullable_bool_setting_as_lowercase_string(bool? value, string? expectedStoredString)
+    {
+        string pathName = Guid.NewGuid().ToString();
+        string settingName = Guid.NewGuid().ToString();
+        AppSettingsPath settingsPath = new(pathName);
+
+        AppSettings.UsingContainer(_settingContainer, () =>
+        {
+            ISetting<bool?> setting = Setting.CreateNullableBool(settingsPath, settingName);
+
+            setting.Value = value;
+
+            AppSettings.SaveSettings();
+        });
+
+        using TempFileCollection tempFiles = new();
+        string filePath = tempFiles.AddExtension(".settings");
+
+        File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+        DistributedSettings container = new(lowerPriority: null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+        AppSettings.UsingContainer(container, () =>
+        {
+            ISetting<string?> setting = Setting.CreateNullableString(settingsPath, settingName);
+
+            setting.Value.Should().Be(expectedStoredString);
+        });
+    }
+
     #endregion Bool Setting
 
     #region Char Setting


### PR DESCRIPTION
Fixes #13153

## Proposed changes

`ISetting<bool> Setting.Create(...)`, `ISetting<bool?> Setting.CreateNullableBool(...)`:
- restore lower-case bool values in settings file as used before v7.0.1
- keep support for "False" and "True" in order to not break settings files stored using v7.0.1 and v7.1.0.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- add unit tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).