### PR TITLE
fix: unblock UI thread while awaiting merge tool

### DIFF
--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -926,6 +926,14 @@ public sealed partial class GitModule : IGitModule
 
     public void RunMergeTool(string? fileName = "", string? customTool = null)
     {
+        ThreadHelper.JoinableTaskFactory.Run(() => RunMergeToolAsync(fileName, customTool));
+    }
+
+    // TODO: Replace RunMergeTool with RunMergeToolAsync in all usages.
+    private async Task RunMergeToolAsync(string? fileName, string? customTool)
+    {
+        await TaskScheduler.Default;
+
         // Use Windows Git if custom tool is selected as the list is native to the application.
         bool isWindowsGit = !string.IsNullOrWhiteSpace(customTool);
         string gui = (isWindowsGit ? Git.GitVersion.Current : GitVersion).SupportGuiMergeTool ? "--gui" : string.Empty;
@@ -937,7 +945,7 @@ public sealed partial class GitModule : IGitModule
         };
 
         using IProcess process = (isWindowsGit ? _executor.GitWindowsExecutable : GitExecutable).Start(args, createWindow: true, throwOnErrorExit: false);
-        process.WaitForExit();
+        await process.WaitForExitAsync();
     }
 
     public string Init(bool bare, bool shared)

--- a/src/app/GitUI/CommandsDialogs/FormPull.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPull.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Config;
@@ -290,15 +290,21 @@ public sealed partial class FormPull : GitExtensionsDialog
 
     private void MergetoolClick(object sender, EventArgs e)
     {
-        Module.RunMergeTool();
-
-        if (MessageBoxes.Show(this, _allMergeConflictSolvedQuestion.Text, _allMergeConflictSolvedQuestionCaption.Text,
-                            MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+        this.InvokeAndForget(async () =>
         {
-            return;
-        }
+            using (FormBusyScope.Enter(this))
+            {
+                await Task.Run(() => Module.RunMergeTool());
+            }
 
-        UICommands.StartCommitDialog(this);
+            if (MessageBoxes.Show(this, _allMergeConflictSolvedQuestion.Text, _allMergeConflictSolvedQuestionCaption.Text,
+                                MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+            {
+                return;
+            }
+
+            UICommands.StartCommitDialog(this);
+        });
     }
 
     private void BranchesDropDown(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
@@ -168,12 +168,15 @@ public partial class FormResolveConflicts : GitModuleForm
 
     private void Mergetool_Click(object sender, EventArgs e)
     {
-        using (WaitCursorScope.Enter())
+        this.InvokeAndForget(async () =>
         {
-            Directory.SetCurrentDirectory(Module.WorkingDir);
-            Module.RunMergeTool();
-            Initialize();
-        }
+            using (FormBusyScope.Enter(this))
+            {
+                Directory.SetCurrentDirectory(Module.WorkingDir);
+                await Task.Run(() => Module.RunMergeTool());
+                Initialize();
+            }
+        });
     }
 
     private readonly bool _offerCommit;
@@ -540,24 +543,24 @@ public partial class FormResolveConflicts : GitModuleForm
         progressBar.Visible = true;
     }
 
-    private void ResolveItemConflict(ConflictData item)
+    private async Task ResolveItemConflictAsync(ConflictData item)
     {
         ItemType itemType = GetItemType(item.Filename);
         if (itemType == ItemType.Submodule)
         {
             FormMergeSubmodule form = new(UICommands, item.Filename);
-            if (form.ShowDialog() == DialogResult.OK)
+            if (await form.ShowDialogAsync() == DialogResult.OK)
             {
                 StageFile(item.Filename);
             }
         }
         else if (itemType == ItemType.File)
         {
-            ResolveFilesConflict(item);
+            await ResolveFilesConflictAsync(item);
         }
     }
 
-    private void ResolveFilesConflict(ConflictData item)
+    private async Task ResolveFilesConflictAsync(ConflictData item)
     {
         (string? baseFile, string? localFile, string? remoteFile) = Module.CheckoutConflictedFiles(item);
 
@@ -585,8 +588,11 @@ public partial class FormResolveConflicts : GitModuleForm
 
                 if (string.IsNullOrWhiteSpace(_mergetoolCmd) || string.IsNullOrWhiteSpace(_mergetoolPath))
                 {
-                    // mergetool is set, but arguments cannot be manipulated
-                    Module.RunMergeTool(item.Filename);
+                    using (FormBusyScope.Enter(this))
+                    {
+                        // mergetool is set, but arguments cannot be manipulated
+                        await Task.Run(() => Module.RunMergeTool(item.Filename));
+                    }
 
                     // git-mergetool does not provide exit status, do not stage
                     return;
@@ -627,7 +633,10 @@ public partial class FormResolveConflicts : GitModuleForm
                 ExecutionResult res;
                 try
                 {
-                    res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments, throwOnErrorExit: false);
+                    using (FormBusyScope.Enter(this))
+                    {
+                        res = await new Executable(_mergetoolPath, Module.WorkingDir).ExecuteAsync(arguments, throwOnErrorExit: false);
+                    }
                 }
                 catch (Exception)
                 {
@@ -1227,45 +1236,48 @@ public partial class FormResolveConflicts : GitModuleForm
 
     private void OpenMergeTool()
     {
-        using (WaitCursorScope.Enter())
+        this.InvokeAndForget(async () =>
         {
-            try
+            using (WaitCursorScope.Enter())
             {
-                (IReadOnlyList<ConflictData> conflictItems,
-                    IReadOnlyList<ConflictData> filesDeletedLocallyAndModifiedRemotely,
-                    IReadOnlyList<ConflictData> filesModifiedLocallyAndDeletedRemotely,
-                    IReadOnlyList<ConflictData> filesRemaining)
-                    = GetConflicts();
-
-                _solveMergeConflictApplyToAll = false;
-                foreach (ConflictData conflictData in filesDeletedLocallyAndModifiedRemotely)
+                try
                 {
-                    IncrementProgressBarValue();
-                    ResolveItemConflict(conflictData);
+                    (IReadOnlyList<ConflictData> conflictItems,
+                        IReadOnlyList<ConflictData> filesDeletedLocallyAndModifiedRemotely,
+                        IReadOnlyList<ConflictData> filesModifiedLocallyAndDeletedRemotely,
+                        IReadOnlyList<ConflictData> filesRemaining)
+                        = GetConflicts();
+
+                    _solveMergeConflictApplyToAll = false;
+                    foreach (ConflictData conflictData in filesDeletedLocallyAndModifiedRemotely)
+                    {
+                        IncrementProgressBarValue();
+                        await ResolveItemConflictAsync(conflictData);
+                    }
+
+                    _solveMergeConflictApplyToAll = false;
+                    foreach (ConflictData conflictData in filesModifiedLocallyAndDeletedRemotely)
+                    {
+                        IncrementProgressBarValue();
+                        await ResolveItemConflictAsync(conflictData);
+                    }
+
+                    _solveMergeConflictDialogCheckboxText = string.Empty; // Hide checkbox "apply to all"
+                    _solveMergeConflictApplyToAll = false;
+                    foreach (ConflictData conflictData in filesRemaining)
+                    {
+                        IncrementProgressBarValue();
+                        await ResolveItemConflictAsync(conflictData);
+                    }
                 }
-
-                _solveMergeConflictApplyToAll = false;
-                foreach (ConflictData conflictData in filesModifiedLocallyAndDeletedRemotely)
+                finally
                 {
-                    IncrementProgressBarValue();
-                    ResolveItemConflict(conflictData);
-                }
-
-                _solveMergeConflictDialogCheckboxText = string.Empty; // Hide checkbox "apply to all"
-                _solveMergeConflictApplyToAll = false;
-                foreach (ConflictData conflictData in filesRemaining)
-                {
-                    IncrementProgressBarValue();
-                    ResolveItemConflict(conflictData);
+                    _solveMergeConflictApplyToAll = false;
+                    StopAndHideProgressBar();
+                    Initialize();
                 }
             }
-            finally
-            {
-                _solveMergeConflictApplyToAll = false;
-                StopAndHideProgressBar();
-                Initialize();
-            }
-        }
+        });
     }
 
     private void OpenMergetool_Click(object sender, EventArgs e)
@@ -1280,20 +1292,23 @@ public partial class FormResolveConflicts : GitModuleForm
         {
             // "main menu" clicked, cancel dropdown manually, invoke default mergetool
             item.HideDropDown();
-            item.Owner!.Hide();
+            item.Owner?.Hide();
         }
 
-        using (WaitCursorScope.Enter())
+        this.InvokeAndForget(async () =>
         {
-            string? customTool = item?.Tag as string;
-
-            foreach (ConflictData conflict in GetConflicts().conflicts)
+            using (FormBusyScope.Enter(this))
             {
-                Directory.SetCurrentDirectory(Module.WorkingDir);
-                Module.RunMergeTool(fileName: conflict.Filename, customTool: customTool);
-                Initialize();
+                string? customTool = item?.Tag as string;
+
+                foreach (ConflictData conflict in GetConflicts().conflicts)
+                {
+                    Directory.SetCurrentDirectory(Module.WorkingDir);
+                    await Task.Run(() => Module.RunMergeTool(fileName: conflict.Filename, customTool: customTool));
+                    Initialize();
+                }
             }
-        }
+        });
     }
 
     private void ContextOpenBaseWith_Click(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -548,7 +548,7 @@ public partial class FormResolveConflicts : GitModuleForm
         ItemType itemType = GetItemType(item.Filename);
         if (itemType == ItemType.Submodule)
         {
-            FormMergeSubmodule form = new(UICommands, item.Filename);
+            using FormMergeSubmodule form = new(UICommands, item.Filename);
             if (await form.ShowDialogAsync() == DialogResult.OK)
             {
                 StageFile(item.Filename);
@@ -1238,7 +1238,7 @@ public partial class FormResolveConflicts : GitModuleForm
     {
         this.InvokeAndForget(async () =>
         {
-            using (WaitCursorScope.Enter())
+            using (FormBusyScope.Enter(this))
             {
                 try
                 {

--- a/src/app/GitUI/FormBusyScope.cs
+++ b/src/app/GitUI/FormBusyScope.cs
@@ -1,0 +1,59 @@
+﻿namespace GitUI;
+
+/// <summary>
+///  Combines <see cref="WaitCursorScope"/> with disabling a <see cref="Form"/> for the duration of the scope.
+/// </summary>
+/// <remarks>
+///  Usage is:
+///  <code>
+///  using (FormBusyScope.Enter(form))
+///  {
+///      // perform UI activity
+///  }
+///  </code>
+///  This pattern ensures:
+///  <list type="bullet">
+///  <item>The form is always re-enabled when the block exits, whether by fall-through, return or exception,
+///  unless the form was already disposed.</item>
+///  <item>The wait cursor behavior of <see cref="WaitCursorScope"/> is preserved, including nested-scope handling.</item>
+///  </list>
+/// </remarks>
+public readonly struct FormBusyScope : IDisposable
+{
+    /// <summary>
+    ///  Starts a new scope, disabling <paramref name="form"/> and setting the mouse cursor to <see cref="Cursors.WaitCursor"/>.
+    /// </summary>
+    /// <param name="form">The form to disable for the duration of the scope.</param>
+    /// <param name="cursor">The cursor to display; defaults to <see cref="Cursors.WaitCursor"/>.</param>
+    public static FormBusyScope Enter(Form form, Cursor? cursor = null)
+    {
+        bool wasEnabled = form.Enabled;
+        form.Enabled = false;
+        WaitCursorScope waitCursor = WaitCursorScope.Enter(cursor);
+        return new FormBusyScope(form, wasEnabled, waitCursor);
+    }
+
+    private readonly Form _form;
+    private readonly bool _wasEnabled;
+    private readonly WaitCursorScope _waitCursor;
+
+    private FormBusyScope(Form form, bool wasEnabled, WaitCursorScope waitCursor)
+    {
+        _form = form;
+        _wasEnabled = wasEnabled;
+        _waitCursor = waitCursor;
+    }
+
+    /// <summary>
+    /// Restores the cursor and re-enables <see cref="_form"/> if it has not been disposed.
+    /// </summary>
+    public void Dispose()
+    {
+        _waitCursor.Dispose();
+
+        if (!_form.IsDisposed)
+        {
+            _form.Enabled = _wasEnabled;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13155

## Proposed changes

- Run the blocking `GitModule.RunMergeTool` asynchronously without blocking the UI thread
  but avoid changing `IGitModule`
- Add helper class `FormBusyScope`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).