### PR TITLE
docs: add DAG (Docs-Augmented Generation) agent documentation

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,28 @@
+# Custom Agents (planned)
+
+Custom agents are domain-scoped agent definitions (`*.agent.md`) that preload only the
+docs-indexes relevant to one area. They exist to **split context** when loading every
+docs-index at once becomes too expensive for a single agent.
+
+> **Status: SKELETON / OPTIONAL.** Git Extensions is a single cohesive repository, so the
+> default agent with the master [docs-index](../copilot-docs/docs-index.md) is sufficient
+> today. Add custom agents only when the indexes grow large enough to strain the token budget.
+
+## When to add a custom agent
+
+- The combined docs-indexes no longer fit comfortably in context alongside real work.
+- A subsystem has deep, self-contained docs that most sessions don't need.
+- You want to restrict which tools/MCP servers an agent can use to reduce preloaded context.
+
+Split along **logical ownership boundaries**, not arbitrarily.
+
+## Candidate agents (when needed)
+
+| Agent | Scope | Preloads |
+| --- | --- | --- |
+| `app.agent.md` | Core app (GitCommands + GitUI) | L1 + L2 + L3 indexes |
+| `plugins.agent.md` | `src/plugins/*` and plugin interfaces | L2 `plugin-system` + plugin docs |
+| `native.agent.md` | `src/native/*` (C++ shell ext, askpass) | L2 `shell-integration` |
+
+Each agent file MUST act as a blocking gate: *"Do not answer, search, or use any tool until
+all specified index files have been read."*

--- a/.github/copilot-docs/L0-foundations/gitextensions-primer.md
+++ b/.github/copilot-docs/L0-foundations/gitextensions-primer.md
@@ -1,0 +1,63 @@
+<!-- L0 FOUNDATIONS PRIMER — ALWAYS LOADED. HARD CAP: 80 lines. No docs-index.
+     Only concepts that benefit 90%+ of contributors. Specialised knowledge → L1+. -->
+# Git Extensions Primer (L0 — always loaded)
+
+**What it is:** Git Extensions is a standalone **Windows GUI for Git** (WinForms, C# 14 / .NET 10)
+that also integrates with Windows Explorer and Visual Studio. It shells out to the real `git`
+executable and presents repositories, history, diffs, commits, and branch operations.
+
+## Architecture anchor (how the tiers connect)
+
+```
+GitExtensions.Extensibility  → interfaces + primitives (IGitCommand, IExecutable, ArgumentBuilder)
+        ▲
+GitCommands                  → git execution + models (GitModule, Executable, Commands, Settings)
+        ▲
+GitUI                        → WinForms UI (FormBrowse main window, dialogs, RevisionGrid)
+        ▲
+GitExtensions (exe)          → app entry point / bootstrap
+```
+
+Plus: **plugins** (`src/plugins/*`, via `GitUIPluginInterfaces`) and **native** code
+(`src/native/GitExtensionsShellEx` = Explorer shell extension).
+
+**Typical action flow:** user acts in a `Form` → `GitUICommands` orchestrates → `Commands`
+builds structured args (`IGitCommand`) → `GitModule` / `Executable` runs `git` → output is
+parsed into models → UI updates and `RepoChangedNotifier` fires.
+
+## Glossary (core terms)
+
+- **GitModule** — represents one git repository; the main entry for running git commands and reading state.
+- **Executable / IExecutable** — abstraction over launching a process (usually `git`); returns `ExecutionResult`.
+- **Commands** (`GitCommands.Git`) — factory of structured `IGitCommand` records that declare whether a command hits a remote and whether it changes repo state.
+- **GitUICommands / IGitUICommands** — runs commands *with UI feedback* (process dialogs) and raises repo-changed events.
+- **ArgumentBuilder** — safe builder for git command-line arguments (in `GitExtensions.Extensibility`).
+- **FormBrowse** — the main repository window (history, toolbars, panels).
+- **RevisionGrid** — the commit graph control that renders history.
+- **Revision** — a commit (plus Git Extensions metadata); **ref** = branch/tag/remote pointer.
+- **Module vs submodule** — the active repo vs nested git repos it contains.
+- **Plugin** — optional feature loaded via `GitUIPluginInterfaces` / `GitExtensions.Extensibility.Plugins`.
+
+## Ownership map (topic → where)
+
+| Topic | Location |
+| --- | --- |
+| Git execution / models | `src/app/GitCommands/` (esp. `Git/`) |
+| Plugin interfaces (versioned) | `src/app/GitExtensions.Extensibility/` |
+| UI forms & controls | `src/app/GitUI/` |
+| App bootstrap | `src/app/GitExtensions/` |
+| Plugins | `src/plugins/` |
+| Explorer shell / native | `src/native/` |
+| Translations | `src/app/ResourceManager/`, `GitUI/Translation/English.xlf` |
+| Build / installer / CI | `Setup/`, `eng/`, `.github/workflows/` |
+| Tests | `tests/` |
+
+## Hard rules (project-wide)
+
+- **ALWAYS** run git operations through `IGitModule`; build args via `Commands` (never raw strings).
+- Files **MUST** use CRLF endings and follow StyleCop + [.editorconfig](../../../.editorconfig).
+- Changing UI strings/controls **MUST** update `English.xlf` via `update-loc.cmd` (CI fails otherwise).
+- Changes under `GitExtensions.Extensibility/` affect the **plugin interface version** — note in commit message.
+- Tests: NUnit + `NSubstitute` + `AwesomeAssertions`; test names use snake_case suffix.
+
+**Next:** for anything beyond this anchor, load [docs-index.md](../docs-index.md) and follow a reading chain.

--- a/.github/copilot-docs/L1-conceptual/architecture-overview.md
+++ b/.github/copilot-docs/L1-conceptual/architecture-overview.md
@@ -1,0 +1,68 @@
+<!-- L1 CONCEPTUAL. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Architecture Overview (L1)
+
+**TL;DR:** Git Extensions is a WinForms desktop app that drives the real `git` executable.
+It is layered into four tiers with a strict one-way dependency direction:
+`Extensibility → GitCommands → GitUI → GitExtensions(exe)`. Plugins and native code hang off
+the sides. Read this to understand *how the pieces fit*; then jump to an
+[L2 subsystem](../L2-core-platform/docs-index.md) or [L3 flow](../L3-flows/docs-index.md).
+
+**Related:** [L0 primer](../L0-foundations/gitextensions-primer.md) · [project-map](project-map.md) · [git-command-execution](../L2-core-platform/docs-index.md) · [structured-commands](../L2-core-platform/docs-index.md)
+
+## Why (the shape of the app)
+
+Git Extensions does not reimplement git — it **builds git command lines, runs the git process,
+and parses the output** into models the UI can show. So the architecture separates three
+concerns: *how to talk to git* (execution), *what to ask git* (structured commands + models),
+and *how to show it* (WinForms UI). Keeping these in separate assemblies enforces the
+dependency direction and keeps the plugin surface (`Extensibility`) small and stable.
+
+## What (the four tiers)
+
+```mermaid
+graph TD
+    EXE[GitExtensions.exe<br/>bootstrap + DI] --> UI[GitUI<br/>WinForms dialogs, RevisionGrid]
+    UI --> CMD[GitCommands<br/>GitModule, Executable, Commands, Settings]
+    CMD --> EXT[GitExtensions.Extensibility<br/>interfaces: IGitModule, IExecutable, IGitCommand]
+    PLUG[src/plugins/*] -.via.-> PIF[GitUIPluginInterfaces]
+    PIF -.-> EXT
+    UI -.hosts.-> PLUG
+    NATIVE[src/native<br/>Explorer shell ext] -.separate process.-> EXE
+```
+
+- **`GitExtensions.Extensibility`** — the contract layer. Interfaces and primitives everyone
+  depends on: `IGitModule`, `IExecutable`/`IProcess`, `IGitCommand`, `ArgumentBuilder`,
+  `IGitUICommands`, settings abstractions. **Versioned** — changes here affect the public
+  plugin interface (call it out in commit messages).
+- **`GitCommands`** — the engine. `GitModule` (one instance per repository) runs git via
+  `Executable`, `Commands` builds structured argument sets, and output parsers produce models.
+  Also owns settings/config, remotes, and submodule logic. No WinForms dependency.
+- **`GitUI`** — the presentation tier. `FormBrowse` is the main window; dialogs under
+  `CommandsDialogs/` implement each user operation; `RevisionGrid` renders history.
+  `GitUICommands` is the bridge that runs commands *with* UI feedback and fires repo-changed events.
+- **`GitExtensions` (exe)** — thin bootstrap: sets up DI (`ServiceContainerRegistry`), global
+  exception handling, DPI/theming, then launches the UI.
+
+### Side dependencies
+
+- **Plugins** (`src/plugins/*`) implement `GitUIPluginInterfaces` and are hosted by `GitUI`.
+- **Native** (`src/native/GitExtensionsShellEx`) is a separate C++ Explorer shell extension.
+- **`ResourceManager`** provides translations; **`GitExtUtils`** provides shared utilities.
+
+## How (find it in code)
+
+- Entry point: `Program.Main` in [Program.cs](../../../src/app/GitExtensions/Program.cs).
+- DI registration: `ServiceContainerRegistry` (present in `GitExtensions`, `GitCommands`, and `GitUI`).
+- Repo engine: `GitModule` in [GitModule.cs](../../../src/app/GitCommands/Git/GitModule.cs).
+- UI bridge: `GitUICommands` in [GitUICommands.cs](../../../src/app/GitUI/GitUICommands.cs).
+- Contracts: browse [GitExtensions.Extensibility/](../../../src/app/GitExtensions.Extensibility/).
+
+## Hard rules
+
+- **NEVER** add a dependency that reverses the arrow direction (e.g. `GitCommands` must not
+  reference `GitUI`).
+- **ALWAYS** run git through `IGitModule` / `Executable`; never spawn `git` ad-hoc.
+- Treat `GitExtensions.Extensibility` as a **public API** — additive, deliberate changes only.
+
+**Next:** [project-map](project-map.md) for the per-project breakdown, or the
+[git-command-execution](../L2-core-platform/docs-index.md) doc for the execution pipeline.

--- a/.github/copilot-docs/L1-conceptual/architecture-overview.md
+++ b/.github/copilot-docs/L1-conceptual/architecture-overview.md
@@ -7,7 +7,7 @@ It is layered into four tiers with a strict one-way dependency direction:
 the sides. Read this to understand *how the pieces fit*; then jump to an
 [L2 subsystem](../L2-core-platform/docs-index.md) or [L3 flow](../L3-flows/docs-index.md).
 
-**Related:** [L0 primer](../L0-foundations/gitextensions-primer.md) · [project-map](project-map.md) · [git-command-execution](../L2-core-platform/docs-index.md) · [structured-commands](../L2-core-platform/docs-index.md)
+**Related:** [L0 primer](../L0-foundations/gitextensions-primer.md) · [project-map](project-map.md) · [git-command-execution](../L2-core-platform/git-command-execution.md) · [structured-commands](../L2-core-platform/structured-commands.md)
 
 ## Why (the shape of the app)
 
@@ -65,4 +65,4 @@ graph TD
 - Treat `GitExtensions.Extensibility` as a **public API** — additive, deliberate changes only.
 
 **Next:** [project-map](project-map.md) for the per-project breakdown, or the
-[git-command-execution](../L2-core-platform/docs-index.md) doc for the execution pipeline.
+[git-command-execution](../L2-core-platform/git-command-execution.md) doc for the execution pipeline.

--- a/.github/copilot-docs/L1-conceptual/docs-index.md
+++ b/.github/copilot-docs/L1-conceptual/docs-index.md
@@ -8,13 +8,13 @@ Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 
 | Doc | One-line description | Status |
 | --- | --- | --- |
-| `gitextensions-overview.md` | What Git Extensions is, who uses it, core capabilities, and non-goals. | planned |
+| [gitextensions-overview.md](gitextensions-overview.md) | What Git Extensions is, who uses it, core capabilities, and non-goals. | done |
 | [architecture-overview.md](architecture-overview.md) | The tiers (Extensibility → GitCommands → GitUI → exe), dependency direction, plugins & native. | done |
 | [project-map.md](project-map.md) | Every project under `src/` and `tests/` and what it owns. | done |
-| `domain-model.md` | Core model types: `GitModule`, `Revision`, `GitRef`, `ObjectId`, `GitItemStatus`. | planned |
-| `glossary.md` | Extended terminology beyond the L0 anchor. | planned |
-| `ui-composition.md` | How `FormBrowse` composes panels, toolbars, `RevisionGrid`, and dockable controls. | planned |
-| `threading-model.md` | UI thread rules, `AsyncLoader`, `JoinableTaskFactory`, background work conventions. | planned |
+| [domain-model.md](domain-model.md) | Core model types: `ObjectId`, `GitRevision`, `GitRef`, `GitItemStatus`, `GitItem`. | done |
+| [glossary.md](glossary.md) | Extended terminology beyond the L0 anchor. | done |
+| [ui-composition.md](ui-composition.md) | How `FormBrowse` composes panels, toolbars, `RevisionGrid`, and dockable controls. | done |
+| [threading-model.md](threading-model.md) | UI thread rules, `AsyncLoader`, `JoinableTaskFactory`, background work conventions. | done |
 
 ## Reading order for onboarding
 

--- a/.github/copilot-docs/L1-conceptual/docs-index.md
+++ b/.github/copilot-docs/L1-conceptual/docs-index.md
@@ -1,0 +1,23 @@
+# L1 — Conceptual · Docs-Index
+
+**TL;DR:** Foundational understanding of *what* Git Extensions is and how it is put together.
+Start here to orient before diving into a specific subsystem (L2) or flow (L3).
+Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
+
+> **Status: SKELETON** — docs below are the roadmap. `planned` = not written yet.
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| `gitextensions-overview.md` | What Git Extensions is, who uses it, core capabilities, and non-goals. | planned |
+| [architecture-overview.md](architecture-overview.md) | The tiers (Extensibility → GitCommands → GitUI → exe), dependency direction, plugins & native. | done |
+| [project-map.md](project-map.md) | Every project under `src/` and `tests/` and what it owns. | done |
+| `domain-model.md` | Core model types: `GitModule`, `Revision`, `GitRef`, `ObjectId`, `GitItemStatus`. | planned |
+| `glossary.md` | Extended terminology beyond the L0 anchor. | planned |
+| `ui-composition.md` | How `FormBrowse` composes panels, toolbars, `RevisionGrid`, and dockable controls. | planned |
+| `threading-model.md` | UI thread rules, `AsyncLoader`, `JoinableTaskFactory`, background work conventions. | planned |
+
+## Reading order for onboarding
+
+`gitextensions-overview` → `architecture-overview` → `project-map` → (then jump to the relevant [L2](../L2-core-platform/docs-index.md) subsystem).
+
+Back to [master docs-index](../docs-index.md).

--- a/.github/copilot-docs/L1-conceptual/docs-index.md
+++ b/.github/copilot-docs/L1-conceptual/docs-index.md
@@ -4,7 +4,7 @@
 Start here to orient before diving into a specific subsystem (L2) or flow (L3).
 Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 
-> **Status: SKELETON** — docs below are the roadmap. `planned` = not written yet.
+> All docs below are written. `Status` tracks any future additions.
 
 | Doc | One-line description | Status |
 | --- | --- | --- |

--- a/.github/copilot-docs/L1-conceptual/domain-model.md
+++ b/.github/copilot-docs/L1-conceptual/domain-model.md
@@ -1,0 +1,50 @@
+<!-- L1 CONCEPTUAL. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Domain Model (L1)
+
+**TL;DR:** The in-memory types that represent git objects. The most important are `ObjectId`
+(a SHA), `GitRevision` (a commit), `GitRef` (a branch/tag), and `GitItemStatus` (a changed file).
+Tree contents use `IGitItem`/`GitItem`; the rendered commit graph uses `RevisionGraphRow`. Core
+types live in the versioned `Extensibility` assembly; concrete helpers live in `GitCommands`.
+
+**Related:** [glossary](glossary.md) · [git-command-execution](../L2-core-platform/git-command-execution.md) · [git-output-parsing](../L2-core-platform/git-output-parsing.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Git speaks in text (SHAs, ref names, status lines). To reason about a repository safely, Git
+Extensions parses that text **once** into strongly-typed, mostly-immutable objects, so the UI and
+logic don't re-parse strings everywhere. Putting the core types in `Extensibility` lets plugins
+share the same model.
+
+## What (the core types)
+
+| Type | File | Role |
+| --- | --- | --- |
+| `ObjectId` | [Extensibility/Git/ObjectId.cs](../../../src/app/GitExtensions.Extensibility/Git/ObjectId.cs) | Immutable git SHA-1 (readonly struct, 20 bytes). Equality/parse helpers. |
+| `GitRevision` | [Extensibility/Git/GitRevision.cs](../../../src/app/GitExtensions.Extensibility/Git/GitRevision.cs) | A commit: `ObjectId`, parents, author/committer, subject/body, refs. |
+| `GitRef` | [GitCommands/Git/GitRef.cs](../../../src/app/GitCommands/Git/GitRef.cs) | A branch/tag/remote ref (`IGitRef`): name, target `ObjectId`, kind. |
+| `GitItemStatus` | [Extensibility/Git/GitItemStatus.cs](../../../src/app/GitExtensions.Extensibility/Git/GitItemStatus.cs) | A changed file's status flags (tracked/new/deleted/changed/renamed/…). |
+| `IGitItem` / `IObjectGitItem` | [Extensibility/Git/](../../../src/app/GitExtensions.Extensibility/Git/) | Tree-item contracts (object id + name + git object type). |
+| `GitItem` | [GitCommands/Git/GitItem.cs](../../../src/app/GitCommands/Git/GitItem.cs) | Concrete tree item (blob/tree/commit entry). |
+| `RevisionGraphRow` | [GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs](../../../src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs) | One graph row with lane segments to parents. |
+
+## How they're produced
+
+- Commits: `RevisionReader` parses `git log` output → `GitRevision`.
+- Files: `GetAllChangedFilesOutputParser` parses `git status --porcelain=2 -z` → `GitItemStatus`.
+- Trees: `GitTreeParser` parses `git ls-tree` → `GitItem`.
+- Refs: parsed by `GitModule` (see the `RefRegex` generated regex).
+- See [git-output-parsing](../L2-core-platform/git-output-parsing.md) for the parsing layer.
+
+## Notes
+
+- Prefer `ObjectId` over raw `string` SHAs; it's cheaper to compare and impossible to malform.
+- The grid shows two **artificial** revisions (WorkTree, Index) that are not real commits.
+- Model types are largely immutable — construct new instances rather than mutating.
+
+## Hard rules
+
+- **NEVER** pass SHAs around as `string` when an `ObjectId` is available.
+- New model types that plugins need MUST live in `Extensibility` (and bump the plugin interface version).
+- Keep parsing in the parser classes — model types should not parse git output themselves.
+
+**Next:** [threading-model](threading-model.md) for how these are loaded off the UI thread.

--- a/.github/copilot-docs/L1-conceptual/gitextensions-overview.md
+++ b/.github/copilot-docs/L1-conceptual/gitextensions-overview.md
@@ -1,0 +1,55 @@
+<!-- L1 CONCEPTUAL. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Git Extensions Overview (L1)
+
+**TL;DR:** Git Extensions is a standalone **Windows GUI for Git** plus a Windows Explorer shell
+extension and a Visual Studio integration. It doesn't reimplement git — it wraps the real `git`
+executable behind an approachable UI for history browsing, committing, branching, merging,
+diffing, and more. Written in C# (WinForms, .NET 10).
+
+**Related:** [architecture-overview](architecture-overview.md) · [project-map](project-map.md) · [glossary](glossary.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why it exists
+
+Git's command line is powerful but has a steep learning curve, especially on Windows. Git
+Extensions makes common and advanced git workflows **visual and discoverable** — you can see the
+commit graph, stage hunks, resolve conflicts, and manage submodules without memorising commands,
+while still generating (and showing) the exact git commands it runs.
+
+## What it does
+
+- **Repository browsing** — the commit graph (`RevisionGrid`), branch/tag/stash tree, commit
+  details, and file trees. Main window: `FormBrowse`.
+- **Working with changes** — stage/commit (`FormCommit`), stash, resolve conflicts, view diffs
+  and blame.
+- **Branches & remotes** — checkout, create/rename/delete branches, clone, push, pull, fetch,
+  rebase, merge, cherry-pick.
+- **Submodules & worktrees** — manage nested repositories and linked working trees.
+- **Extensibility** — a [plugin system](../L2-core-platform/plugin-system.md) (background fetch,
+  GitHub/Bitbucket hosting, build-server integration, statistics, etc.).
+- **OS integration** — a native [Explorer shell extension](../L2-core-platform/shell-integration.md)
+  (right-click → git actions) and a Visual Studio extension.
+- **Personalisation** — [themes](../L2-core-platform/theming-system.md),
+  [hotkeys](../L2-core-platform/hotkey-system.md), and
+  [user scripts](../L2-core-platform/scripts-engine.md).
+
+## Who it's for
+
+Windows developers who want a full-featured git GUI — from newcomers who prefer visual workflows
+to power users who want fast access to advanced operations (interactive rebase, sparse checkout,
+bisect) with the underlying commands always visible.
+
+## Non-goals (what it is not)
+
+- **Not a git reimplementation** — it always shells out to a real `git` binary.
+- **Not cross-platform first** — it targets Windows (WinForms, Explorer/VS integration).
+- **Not a text editor/IDE** — it focuses on git operations, not general code editing (though it
+  embeds a diff/blame viewer based on `ICSharpCode.TextEditor`).
+
+## How it's built (one paragraph)
+
+The app is layered: a small executable (`GitExtensions`) bootstraps DI and launches the WinForms
+UI (`GitUI`), which drives the git engine (`GitCommands`) through the versioned contract layer
+(`GitExtensions.Extensibility`). See [architecture-overview](architecture-overview.md) for the
+tiers and [project-map](project-map.md) for where each piece lives.
+
+**Next:** [glossary](glossary.md) for terminology, then [architecture-overview](architecture-overview.md).

--- a/.github/copilot-docs/L1-conceptual/glossary.md
+++ b/.github/copilot-docs/L1-conceptual/glossary.md
@@ -1,0 +1,44 @@
+<!-- L1 CONCEPTUAL. Agentic doc: TL;DR at top, code pointers not code, ~100 lines. -->
+# Glossary (L1)
+
+**TL;DR:** Terminology used across Git Extensions — both standard git concepts as they appear in
+this codebase and Git-Extensions-specific types/UI names. The [L0 primer](../L0-foundations/gitextensions-primer.md)
+has the short list; this is the extended one.
+
+**Related:** [domain-model](domain-model.md) (the types behind these terms) · [architecture-overview](architecture-overview.md)
+
+## Git concepts (as modelled here)
+
+| Term | Meaning in this codebase |
+| --- | --- |
+| **Revision / commit** | A commit, modelled by `GitRevision` (id, author, committer, subject, body). |
+| **ObjectId** | A git SHA-1 hash; the immutable `ObjectId` struct. |
+| **Ref** | A branch/tag/remote pointer; `GitRef` (implements `IGitRef`). |
+| **HEAD / detached HEAD** | Current checkout; "detached" = not on a branch (see `DetachedHeadParser`). |
+| **Index / staging area** | Staged changes; shown as the artificial **Index** row in the grid. |
+| **Working directory / worktree** | The checked-out files; the artificial **WorkTree** row represents uncommitted changes. |
+| **Item status** | A changed file's state; `GitItemStatus` (tracked/new/deleted/changed/…). |
+| **Remote / upstream / tracking** | A remote repo and the branch a local branch tracks. |
+| **Submodule** | A nested git repo inside the current one (see `SubmoduleHelpers`). |
+| **Stash / rebase / merge / cherry-pick / squash / fast-forward** | Standard git operations, each exposed by a dialog under `CommandsDialogs/`. |
+
+## Git Extensions specific
+
+| Term | Meaning |
+| --- | --- |
+| **GitModule** | The per-repository engine object (`IGitModule`); runs git and reads state. |
+| **GitUICommands** | Bridge that runs operations with UI feedback and raises repo-changed events. |
+| **IGitCommand** | A structured git command carrying `AccessesRemote` / `ChangesRepoState`. |
+| **Executable** | Abstraction over launching the `git` process (`IExecutable`/`IProcess`). |
+| **FormBrowse** | The main repository window. |
+| **RevisionGrid / RevisionGridControl** | The commit-graph control. |
+| **RevisionGraphRow** | One row/node in the rendered commit graph. |
+| **Artificial commits** | The synthetic **WorkTree** and **Index** rows shown atop real history. |
+| **RepoObjectsTree** | The left panel tree of branches/tags/stashes/submodules; nodes derive from `Node`. |
+| **Plugin (IGitPlugin)** | An optional feature discovered via MEF (see [plugin-system](../L2-core-platform/plugin-system.md)). |
+| **TranslationString** | A localizable UI string extracted into `English.xlf`. |
+| **AppSettings** | The app's own preferences facade (distinct from git config). |
+| **RepoChangedNotifier** | Fires after state-changing operations so views refresh. |
+| **AsyncLoader** | Helper that loads data on a background thread then calls back on the UI thread. |
+
+**Next:** [domain-model](domain-model.md) for the concrete types.

--- a/.github/copilot-docs/L1-conceptual/project-map.md
+++ b/.github/copilot-docs/L1-conceptual/project-map.md
@@ -1,0 +1,62 @@
+<!-- L1 CONCEPTUAL. Agentic doc: TL;DR at top, code pointers not code, ~100 lines. -->
+# Project Map (L1)
+
+**TL;DR:** Where everything lives. `src/app/` is the desktop app, `src/plugins/` are optional
+features, `src/native/` is C++ Windows integration, `tests/` mirrors `src/`. Use this to route
+a task to the right project before reading code.
+
+**Related:** [architecture-overview](architecture-overview.md) · [L0 primer](../L0-foundations/gitextensions-primer.md) · master [docs-index](../docs-index.md)
+
+## `src/app/` — the application
+
+| Project | Owns | Depends on |
+| --- | --- | --- |
+| [GitExtensions](../../../src/app/GitExtensions/) | Executable entry point, bootstrap, DI wiring, app manifest. | GitUI |
+| [GitUI](../../../src/app/GitUI/) | All WinForms UI: `FormBrowse`, dialogs (`CommandsDialogs/`), `RevisionGrid`, panels, theming, hotkeys, scripts engine, `GitUICommands`. | GitCommands |
+| [GitCommands](../../../src/app/GitCommands/) | Git execution engine (`GitModule`, `Executable`), `Commands`, settings/config, remotes, submodules, output parsing. | Extensibility |
+| [GitExtensions.Extensibility](../../../src/app/GitExtensions.Extensibility/) | **Public/versioned** interfaces & primitives: `IGitModule`, `IExecutable`, `IGitCommand`, `ArgumentBuilder`, settings/plugin contracts. | (base) |
+| [GitExtUtils](../../../src/app/GitExtUtils/) | Cross-cutting helpers (string/collection utils, `GitUI` helpers). | (base) |
+| [ResourceManager](../../../src/app/ResourceManager/) | Translation infrastructure & shared resources. | Extensibility |
+| [GitExtensions.Analyzers.CSharp](../../../src/app/GitExtensions.Analyzers.CSharp/) | Roslyn analyzers enforcing repo conventions. | (analyzer) |
+| [BugReporter](../../../src/app/BugReporter/) | Crash/bug reporting UI (NBug integration). | GitUI |
+
+## `src/plugins/` — optional features
+
+Each plugin implements [GitUIPluginInterfaces](../../../src/plugins/GitUIPluginInterfaces/) and is
+discovered/hosted by `GitUI`. Examples:
+`BackgroundFetch`, `AutoCompileSubmodules`, `Bitbucket`, `GitHub3`, `GitFlow`,
+`BuildServerIntegration`, `Statistics`, `Gource`, `FindLargeFiles`, `ProxySwitcher`,
+`CreateLocalBranches`, `DeleteUnusedBranches`, `ReleaseNotesGenerator`.
+See [plugin-system](../L2-core-platform/docs-index.md) for how they load.
+
+## `src/native/` — Windows integration (C++)
+
+| Project | Owns |
+| --- | --- |
+| [GitExtensionsShellEx](../../../src/native/GitExtensionsShellEx/) | Windows Explorer shell extension (context-menu / overlay integration). |
+| [GitExtSshAskPass](../../../src/native/GitExtSshAskPass/) | SSH `askpass` helper executable for credential prompts. |
+
+Built via [src/native/build.proj](../../../src/native/build.proj) (needs VC++/ATL).
+
+## `tests/`
+
+| Folder | Covers |
+| --- | --- |
+| [tests/app/](../../../tests/app/) | Unit/integration tests for `src/app/` projects. |
+| [tests/plugins/](../../../tests/plugins/) | Plugin tests. |
+| [tests/CommonTestUtils/](../../../tests/CommonTestUtils/) | Shared test helpers/fixtures. |
+
+Stack: NUnit + `NSubstitute` + `AwesomeAssertions`. See [testing-guide](../L2-core-platform/docs-index.md).
+
+## Top-level support folders
+
+- [Setup/](../../../Setup/) — installer (WiX), assets, `TranslationApp`, dictionaries.
+- [eng/](../../../eng/) — build/engineering scripts, rulesets, StyleCop config.
+- [Externals/](../../../Externals/) — git submodules (e.g. `ICSharpCode.TextEditor`, `NetSpell`).
+- [.github/](../../../.github/) — CI workflows, these DAG docs, contributor instructions.
+
+## Hard rules
+
+- Put new UI in `GitUI`, new git logic in `GitCommands`, new contracts in `Extensibility`.
+- Any change under `GitExtensions.Extensibility/` bumps the **plugin interface version** — note it in the commit message.
+- Solution file: [GitExtensions.slnx](../../../GitExtensions.slnx); build with `dotnet build`.

--- a/.github/copilot-docs/L1-conceptual/project-map.md
+++ b/.github/copilot-docs/L1-conceptual/project-map.md
@@ -27,7 +27,7 @@ discovered/hosted by `GitUI`. Examples:
 `BackgroundFetch`, `AutoCompileSubmodules`, `Bitbucket`, `GitHub3`, `GitFlow`,
 `BuildServerIntegration`, `Statistics`, `Gource`, `FindLargeFiles`, `ProxySwitcher`,
 `CreateLocalBranches`, `DeleteUnusedBranches`, `ReleaseNotesGenerator`.
-See [plugin-system](../L2-core-platform/docs-index.md) for how they load.
+See [plugin-system](../L2-core-platform/plugin-system.md) for how they load.
 
 ## `src/native/` — Windows integration (C++)
 
@@ -46,7 +46,7 @@ Built via [src/native/build.proj](../../../src/native/build.proj) (needs VC++/AT
 | [tests/plugins/](../../../tests/plugins/) | Plugin tests. |
 | [tests/CommonTestUtils/](../../../tests/CommonTestUtils/) | Shared test helpers/fixtures. |
 
-Stack: NUnit + `NSubstitute` + `AwesomeAssertions`. See [testing-guide](../L2-core-platform/docs-index.md).
+Stack: NUnit + `NSubstitute` + `AwesomeAssertions`. See [testing-guide](../L2-core-platform/testing-guide.md).
 
 ## Top-level support folders
 

--- a/.github/copilot-docs/L1-conceptual/threading-model.md
+++ b/.github/copilot-docs/L1-conceptual/threading-model.md
@@ -1,0 +1,54 @@
+<!-- L1 CONCEPTUAL. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Threading Model (L1)
+
+**TL;DR:** Git Extensions is a WinForms app, so all UI access **must** happen on the UI thread,
+while git commands run in the background. The project uses Microsoft's **vs-threading**
+(`JoinableTaskFactory` via `ThreadHelper`) to switch threads safely, and `AsyncLoader` to load
+data off-thread then marshal results back. Analyzer rule files under `eng/` enforce main-thread
+correctness at build time.
+
+**Related:** [architecture-overview](architecture-overview.md) · [ui-composition](ui-composition.md) · [git-command-execution](../L2-core-platform/git-command-execution.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+WinForms controls are not thread-safe: touching them off the UI thread causes crashes or subtle
+corruption. But git operations are slow (spawning processes, reading output), so they must not
+block the UI thread. The threading model reconciles these: **do work in the background, touch UI
+on the main thread**, using a deadlock-safe primitive (`JoinableTaskFactory`).
+
+## What
+
+- **`ThreadHelper`** — the app's static `JoinableTaskFactory` and assertions.
+  [ThreadHelper.cs](../../../src/app/GitExtUtils/GitUI/ThreadHelper.cs). Key members:
+  `ThreadHelper.JoinableTaskFactory`, `ThrowIfNotOnUIThread()`, `AssertOnUIThread()`.
+- **`SwitchToMainThreadAsync()`** — the awaitable that moves execution back onto the UI thread.
+- **`AsyncLoader`** — loads data on a background thread and invokes a callback on the UI thread;
+  cancellable, supports a debounce delay. [AsyncLoader.cs](../../../src/app/GitCommands/AsyncLoader.cs).
+- **`Control.CheckForIllegalCrossThreadCalls`** — enabled for non-official builds in
+  [Program.cs](../../../src/app/GitExtensions/Program.cs) to surface cross-thread bugs early.
+- **Analyzer rules** — `eng/vs-threading.*.txt` list main-thread-asserting/switching methods so
+  the vs-threading analyzers can flag violations:
+  [MainThreadAssertingMethods](../../../eng/vs-threading.MainThreadAssertingMethods.txt) ·
+  [MainThreadSwitchingMethods](../../../eng/vs-threading.MainThreadSwitchingMethods.txt) ·
+  [TypesRequiringMainThread](../../../eng/vs-threading.TypesRequiringMainThread.txt).
+
+## How (patterns)
+
+```
+await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();  // now safe to touch UI
+```
+
+- Background → UI: `await …SwitchToMainThreadAsync()` before touching controls.
+- Fire-and-forget UI work: run via `JoinableTaskFactory.Run(...)` / `RunAsync(...)`, not raw `Task.Run`.
+- Loading grids/panels: prefer `AsyncLoader` so cancellation + UI marshaling are handled for you.
+- Synchronously waiting on async: use `ThreadHelper.JoinableTaskFactory.Run(...)` (deadlock-safe),
+  never `.Result`/`.Wait()`.
+
+## Hard rules
+
+- **ALWAYS** switch to the main thread (`SwitchToMainThreadAsync`) before touching WinForms controls.
+- **NEVER** block on async with `.Result` or `.Wait()` — use `JoinableTaskFactory.Run`.
+- Respect the vs-threading analyzer; if it flags a method, fix the threading, don't suppress it.
+- Long-running git work belongs in the background (see [git-command-execution](../L2-core-platform/git-command-execution.md)).
+
+**Next:** [ui-composition](ui-composition.md) for how forms/controls are assembled.

--- a/.github/copilot-docs/L1-conceptual/ui-composition.md
+++ b/.github/copilot-docs/L1-conceptual/ui-composition.md
@@ -1,0 +1,64 @@
+<!-- L1 CONCEPTUAL. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# UI Composition (L1)
+
+**TL;DR:** WinForms UI is built from a small class hierarchy. Base classes add translation,
+theming, hotkeys, window-position memory, and access to `IGitUICommands`/`IGitModule`. The main
+window `FormBrowse` is a `sealed partial` split across several files, hosting the commit graph
+(`RevisionGridControl`), the left-panel object tree (`RepoObjectsTree`), commit details, menus,
+and toolbars.
+
+**Related:** [architecture-overview](architecture-overview.md) · [threading-model](threading-model.md) · [revision-grid-flow](../L3-flows/revision-grid-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Every dialog needs the same cross-cutting behavior: localised strings, theme colors, hotkeys,
+DPI/position handling, and a handle to the current repo. Rather than repeat that, Git Extensions
+puts it in base classes so each form/control focuses on its own job. Splitting the huge
+`FormBrowse` into partials keeps concerns (grid, menus, commit details) navigable.
+
+## What (form/control hierarchy)
+
+| Base type | File | Adds |
+| --- | --- | --- |
+| `GitExtensionsFormBase` | [ResourceManager/GitExtensionsFormBase.cs](../../../src/app/ResourceManager/GitExtensionsFormBase.cs) | Translation, theming, hotkey plumbing. |
+| `GitExtensionsForm` | [GitUI/GitExtensionsForm.cs](../../../src/app/GitUI/GitExtensionsForm.cs) | Window position restore, common form behavior. |
+| `GitModuleForm` | [GitUI/GitModuleForm.cs](../../../src/app/GitUI/GitModuleForm.cs) | `UICommands` / `Module` access for repo-aware dialogs. |
+| `GitModuleControl` | [GitUI/GitModuleControl.cs](../../../src/app/GitUI/GitModuleControl.cs) | UserControl base for repo-aware panels. |
+| `GitExtensionsDialog` | [GitUI/GitExtensionsDialog.cs](../../../src/app/GitUI/GitExtensionsDialog.cs) | Standard dialog chrome (see UI design guidelines). |
+
+Most dialogs derive from `GitModuleForm`; most panels from `GitModuleControl`.
+
+## What (the main window)
+
+`FormBrowse` ([FormBrowse.cs](../../../src/app/GitUI/CommandsDialogs/FormBrowse.cs)) is `sealed
+partial`, split into:
+
+- `FormBrowse.Designer.cs` — WinForms designer layout.
+- `FormBrowse.InitRevisionGrid.cs` — wires up the `RevisionGridControl`.
+- `FormBrowse.InitMenusAndToolbars.cs` — menus and toolbars.
+- `FormBrowse.InitCommitDetails.cs` — commit info / diff panels.
+- `FormBrowse.UpdateTargets.cs` — enable/disable UI based on state.
+
+### Hosted controls
+
+- **`RevisionGridControl`** — the commit graph.
+  [RevisionGridControl.cs](../../../src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs).
+- **`RepoObjectsTree`** — left panel of branches/tags/stashes/submodules/remotes.
+  [RepoObjectsTree.cs](../../../src/app/GitUI/LeftPanel/RepoObjectsTree.cs). Tree nodes derive
+  from `Node` / `BaseRevisionNode` ([Node.cs](../../../src/app/GitUI/LeftPanel/Node.cs)); concrete
+  types include `LocalBranchNode`, `RemoteBranchNode`, `TagNode`, `StashNode`.
+
+## How (add a new dialog)
+
+1. Derive from `GitModuleForm` (repo-aware) or `GitExtensionsDialog`.
+2. Follow control-naming in [ui_design_guidelines.md](../../ui_design_guidelines.md) (`btn`, `lbl`, `txt`, …).
+3. Use `UICommands`/`Module` for git; never new up a `GitModule` yourself.
+4. Add UI strings as `TranslationString` and run `update-loc.cmd` (see [translation-system](../L2-core-platform/translation-system.md)).
+
+## Hard rules
+
+- New dialogs **MUST** inherit from `GitExtensionsDialog` (or an existing base), not raw `Form`.
+- Follow the WinForms control-naming conventions in `ui_design_guidelines.md`.
+- Touch controls only on the UI thread ([threading-model](threading-model.md)).
+
+**Next:** jump to [L2 subsystems](../L2-core-platform/docs-index.md) or an [L3 flow](../L3-flows/docs-index.md).

--- a/.github/copilot-docs/L2-core-platform/build-and-installer.md
+++ b/.github/copilot-docs/L2-core-platform/build-and-installer.md
@@ -1,0 +1,61 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Build & Installer (L2)
+
+**TL;DR:** The managed app builds with `dotnet build` against `GitExtensions.slnx`; shared build
+settings live in `Directory.Build.props` (C# 14, nullable, WinForms, central package management).
+The native C++ pieces build via `src/native/build.proj`. The Windows installer is authored in
+**WiX** under `Setup/installer/`. Publishing (incl. plugin detection) is driven by `eng/Publish.targets`.
+
+**Related:** [project-map](../L1-conceptual/project-map.md) · [shell-integration](shell-integration.md) · [ci-workflows](ci-workflows.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Git Extensions ships a managed WinForms app **plus** native COM components and a Windows
+installer. Centralising build settings and separating the native build keeps the whole thing
+reproducible and lets CI gate every PR consistently.
+
+## What
+
+### Managed build
+
+- **`GitExtensions.slnx`** — the solution (modern `.slnx` format). Build: `dotnet build`.
+- **`Directory.Build.props`** — repo-wide MSBuild defaults: `LangVersion 14.0`, `Nullable enable`,
+  `UseWindowsForms`, code-analysis ruleset, StyleCop. [Directory.Build.props](../../../Directory.Build.props).
+- **`Directory.Packages.props`** — central package management (versions pinned in one place).
+  [Directory.Packages.props](../../../Directory.Packages.props).
+- **`global.json`** — pins the .NET SDK. [global.json](../../../global.json).
+
+### Native build
+
+- **`src/native/build.proj`** — uses VSwhere + MSBuild to build the C++ shell extension and
+  `GitExtSshAskPass` for Win32 and x64 (needs VC++/ATL). [build.proj](../../../src/native/build.proj).
+  In VS Code this is the `build-vc` task.
+
+### Installer (WiX, `Setup/installer/`)
+
+- **`Config.wxi`** — install paths/features/properties. [Config.wxi](../../../Setup/installer/Config.wxi).
+- **`RegisterShellExtension.wxi`** — registers the native shell-extension DLL.
+  [RegisterShellExtension.wxi](../../../Setup/installer/RegisterShellExtension.wxi).
+- **`UI/WixUI.wxs`** — installer dialogs/flow. [WixUI.wxs](../../../Setup/installer/UI/WixUI.wxs).
+
+### Publish
+
+- **`eng/Publish.targets`** — detects plugin assemblies (Roslyn code task) and publishes to
+  `artifacts/`. [Publish.targets](../../../eng/Publish.targets).
+
+## How (common commands)
+
+```
+dotnet build                              # managed build (default VS Code "build" task)
+dotnet build .\src\native\build.proj      # native build ("build-vc" task)
+dotnet test                               # run tests (see testing-guide)
+```
+
+## Hard rules
+
+- Files **MUST** use CRLF and satisfy StyleCop / [.editorconfig](../../../.editorconfig) — the build enforces analyzers.
+- Package versions go in `Directory.Packages.props` (central management), not per-project.
+- Changes under `GitExtensions.Extensibility/` bump the **plugin interface version** — note it in the commit message.
+- The native build requires the VC++ toolset (ATL) for x86/x64.
+
+**Next:** [ci-workflows](ci-workflows.md) for what gates a PR.

--- a/.github/copilot-docs/L2-core-platform/ci-workflows.md
+++ b/.github/copilot-docs/L2-core-platform/ci-workflows.md
@@ -1,0 +1,44 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# CI Workflows (L2)
+
+**TL;DR:** GitHub Actions gate every PR. The key one is `pr-build.yml` (build + unit/integration
+tests). Others enforce commit hygiene (`git.yml` blocks `fixup!`/`squash!`), the CLA, and PR
+housekeeping. A PR must build, pass tests, have a current `English.xlf`, contain no fixup commits,
+and pass the CLA check.
+
+**Related:** [build-and-installer](build-and-installer.md) · [testing-guide](testing-guide.md) · [translation-system](translation-system.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+A large WinForms app with native components and localisation needs automated gates so regressions,
+untranslated strings, and messy history never reach `master`. Encoding these as workflows makes
+the rules explicit and enforced for every contributor.
+
+## What (`.github/workflows/`)
+
+| Workflow | Gates |
+| --- | --- |
+| [pr-build.yml](../../../.github/workflows/pr-build.yml) | Builds and runs unit + integration tests on PR / push to master & release branches. The main quality gate. |
+| [git.yml](../../../.github/workflows/git.yml) | Blocks merging while `fixup!` / `squash!` commits are present. |
+| [cla-check.yml](../../../.github/workflows/cla-check.yml) | Verifies the Contributor License Agreement. |
+| [pr-automation.yml](../../../.github/workflows/pr-automation.yml) | PR triage: labels, milestones, cleanup. |
+| [pr-check-stale.yml](../../../.github/workflows/pr-check-stale.yml) | Flags/handles stale PRs and issues. |
+| [label-lifecycle.yml](../../../.github/workflows/label-lifecycle.yml) | Label lifecycle automation. |
+| `labeler-*.yml` | ML-based PR/issue labeling (train / predict / cache / promote). |
+
+## How (what fails a PR)
+
+- **Compilation errors** or analyzer/StyleCop violations → build fails.
+- **Failing tests** (NUnit unit or UI integration) → `pr-build` fails.
+- **Stale `English.xlf`** — if UI strings changed without running `update-loc.cmd`, the loc check
+  fails. See [translation-system](translation-system.md).
+- **`fixup!` / `squash!` commits** present → `git.yml` blocks merge (squash them first).
+- **Unsigned CLA** → `cla-check` blocks.
+
+## Hard rules
+
+- Before pushing: build clean, run `dotnet test`, and run `update-loc.cmd` if any UI string changed.
+- **NEVER** leave `fixup!`/`squash!` commits on a PR branch destined for merge — rebase/autosquash locally.
+- Don't disable or weaken these workflows to make a PR pass; fix the underlying issue.
+
+**Next:** [testing-guide](testing-guide.md).

--- a/.github/copilot-docs/L2-core-platform/docs-index.md
+++ b/.github/copilot-docs/L2-core-platform/docs-index.md
@@ -12,16 +12,16 @@ Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 | --- | --- | --- |
 | [git-command-execution.md](git-command-execution.md) | How `git` is launched: `Executable`, `GitCommandRunner`, `ExecutionResult`, encoding. | done |
 | [structured-commands.md](structured-commands.md) | `Commands`/`IGitCommand` records, `ArgumentBuilder`, remote vs state-changing flags. | done |
-| `git-module.md` | `GitModule` responsibilities: repo state, refs, submodules, command entry point. | planned |
+| [git-module.md](git-module.md) | `GitModule` responsibilities: repo state, refs, submodules, command entry point. | done |
 | `output-parsing.md` | Parsing git output into models (`RevisionReader`, status/tree/diff parsers). | planned |
 
 ## Application services
 
 | Doc | One-line description | Status |
 | --- | --- | --- |
-| `settings-system.md` | Layered settings/config: `GitExtensions.settings`, `SettingsSource`, git config. | planned |
-| `plugin-system.md` | Plugin loading & interfaces (`GitUIPluginInterfaces`, `Extensibility.Plugins`). | planned |
-| `translation-system.md` | Localization: `TranslatedStrings`, `English.xlf`, `update-loc.cmd`, `TranslationApp`. | planned |
+| [settings-system.md](settings-system.md) | Layered settings/config: `GitExtensions.settings`, `SettingsSource`, git config. | done |
+| [plugin-system.md](plugin-system.md) | Plugin loading & interfaces (`GitUIPluginInterfaces`, `Extensibility.Plugins`). | done |
+| [translation-system.md](translation-system.md) | Localization: `TranslatedStrings`, `English.xlf`, `update-loc.cmd`, `TranslationApp`. | done |
 | `theming-system.md` | Themes & colors: `Theming/`, `Themes/`, high-contrast handling. | planned |
 | `hotkey-system.md` | Hotkey registration and dispatch (`GitUI/Hotkey/`). | planned |
 | `scripts-engine.md` | User-defined scripts and command menus (`GitUI/ScriptsEngine/`). | planned |

--- a/.github/copilot-docs/L2-core-platform/docs-index.md
+++ b/.github/copilot-docs/L2-core-platform/docs-index.md
@@ -1,0 +1,39 @@
+# L2 — Core Platform · Docs-Index
+
+**TL;DR:** The infrastructure subsystems that flows (L3) build on. Load only the doc that
+matches your task. Each doc leads with *why*, then *what*, then code pointers.
+Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
+
+> **Status: SKELETON** — docs below are the roadmap. `planned` = not written yet.
+
+## Git execution
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| [git-command-execution.md](git-command-execution.md) | How `git` is launched: `Executable`, `GitCommandRunner`, `ExecutionResult`, encoding. | done |
+| [structured-commands.md](structured-commands.md) | `Commands`/`IGitCommand` records, `ArgumentBuilder`, remote vs state-changing flags. | done |
+| `git-module.md` | `GitModule` responsibilities: repo state, refs, submodules, command entry point. | planned |
+| `output-parsing.md` | Parsing git output into models (`RevisionReader`, status/tree/diff parsers). | planned |
+
+## Application services
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| `settings-system.md` | Layered settings/config: `GitExtensions.settings`, `SettingsSource`, git config. | planned |
+| `plugin-system.md` | Plugin loading & interfaces (`GitUIPluginInterfaces`, `Extensibility.Plugins`). | planned |
+| `translation-system.md` | Localization: `TranslatedStrings`, `English.xlf`, `update-loc.cmd`, `TranslationApp`. | planned |
+| `theming-system.md` | Themes & colors: `Theming/`, `Themes/`, high-contrast handling. | planned |
+| `hotkey-system.md` | Hotkey registration and dispatch (`GitUI/Hotkey/`). | planned |
+| `scripts-engine.md` | User-defined scripts and command menus (`GitUI/ScriptsEngine/`). | planned |
+| `service-container.md` | DI / `ServiceContainerRegistry`, how services are registered and resolved. | planned |
+
+## Platform & tooling
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| `shell-integration.md` | Native Windows Explorer shell extension (`src/native/GitExtensionsShellEx`). | planned |
+| `build-and-installer.md` | Build (`dotnet build`), native build, installer (`Setup/`), publish. | planned |
+| `ci-workflows.md` | GitHub Actions pipelines in `.github/workflows/` and what gates a PR. | planned |
+| `testing-guide.md` | Test layout, NUnit + NSubstitute + AwesomeAssertions conventions, `TestAccessor`. | planned |
+
+Back to [master docs-index](../docs-index.md).

--- a/.github/copilot-docs/L2-core-platform/docs-index.md
+++ b/.github/copilot-docs/L2-core-platform/docs-index.md
@@ -4,7 +4,7 @@
 matches your task. Each doc leads with *why*, then *what*, then code pointers.
 Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 
-> **Status: SKELETON** — docs below are the roadmap. `planned` = not written yet.
+> All docs below are written. `Status` tracks any future additions.
 
 ## Git execution
 

--- a/.github/copilot-docs/L2-core-platform/docs-index.md
+++ b/.github/copilot-docs/L2-core-platform/docs-index.md
@@ -13,7 +13,7 @@ Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 | [git-command-execution.md](git-command-execution.md) | How `git` is launched: `Executable`, `GitCommandRunner`, `ExecutionResult`, encoding. | done |
 | [structured-commands.md](structured-commands.md) | `Commands`/`IGitCommand` records, `ArgumentBuilder`, remote vs state-changing flags. | done |
 | [git-module.md](git-module.md) | `GitModule` responsibilities: repo state, refs, submodules, command entry point. | done |
-| `output-parsing.md` | Parsing git output into models (`RevisionReader`, status/tree/diff parsers). | planned |
+| [git-output-parsing.md](git-output-parsing.md) | Parsing git output into models (`RevisionReader`, status/tree/diff parsers). | done |
 
 ## Application services
 
@@ -22,18 +22,18 @@ Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 | [settings-system.md](settings-system.md) | Layered settings/config: `GitExtensions.settings`, `SettingsSource`, git config. | done |
 | [plugin-system.md](plugin-system.md) | Plugin loading & interfaces (`GitUIPluginInterfaces`, `Extensibility.Plugins`). | done |
 | [translation-system.md](translation-system.md) | Localization: `TranslatedStrings`, `English.xlf`, `update-loc.cmd`, `TranslationApp`. | done |
-| `theming-system.md` | Themes & colors: `Theming/`, `Themes/`, high-contrast handling. | planned |
-| `hotkey-system.md` | Hotkey registration and dispatch (`GitUI/Hotkey/`). | planned |
-| `scripts-engine.md` | User-defined scripts and command menus (`GitUI/ScriptsEngine/`). | planned |
-| `service-container.md` | DI / `ServiceContainerRegistry`, how services are registered and resolved. | planned |
+| [theming-system.md](theming-system.md) | Themes & colors: `Theming/`, `Themes/`, high-contrast handling. | done |
+| [hotkey-system.md](hotkey-system.md) | Hotkey registration and dispatch (`GitUI/Hotkey/`). | done |
+| [scripts-engine.md](scripts-engine.md) | User-defined scripts and command menus (`GitUI/ScriptsEngine/`). | done |
+| [service-container.md](service-container.md) | DI / `ServiceContainerRegistry`, how services are registered and resolved. | done |
 
 ## Platform & tooling
 
 | Doc | One-line description | Status |
 | --- | --- | --- |
-| `shell-integration.md` | Native Windows Explorer shell extension (`src/native/GitExtensionsShellEx`). | planned |
-| `build-and-installer.md` | Build (`dotnet build`), native build, installer (`Setup/`), publish. | planned |
-| `ci-workflows.md` | GitHub Actions pipelines in `.github/workflows/` and what gates a PR. | planned |
-| `testing-guide.md` | Test layout, NUnit + NSubstitute + AwesomeAssertions conventions, `TestAccessor`. | planned |
+| [shell-integration.md](shell-integration.md) | Native Windows Explorer shell extension (`src/native/GitExtensionsShellEx`). | done |
+| [build-and-installer.md](build-and-installer.md) | Build (`dotnet build`), native build, installer (`Setup/`), publish. | done |
+| [ci-workflows.md](ci-workflows.md) | GitHub Actions pipelines in `.github/workflows/` and what gates a PR. | done |
+| [testing-guide.md](testing-guide.md) | Test layout, NUnit + NSubstitute + AwesomeAssertions conventions, `TestAccessor`. | done |
 
 Back to [master docs-index](../docs-index.md).

--- a/.github/copilot-docs/L2-core-platform/git-command-execution.md
+++ b/.github/copilot-docs/L2-core-platform/git-command-execution.md
@@ -1,0 +1,70 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Git Command Execution (L2)
+
+**TL;DR:** This is the pipeline that actually runs `git`. `GitModule` is the per-repo entry
+point; it uses an `IExecutable` (`Executable`) to start a process (`IProcess`), and the
+`ExecutableExtensions` helpers (`GetOutput` / `RunCommand` / `ExecuteAsync`) handle
+input/output/encoding and return an `ExecutionResult`. Results can be cached via `CommandCache`.
+
+**Related:** [structured-commands](structured-commands.md) (what args to run) · [git-module](docs-index.md) · [L0 primer](../L0-foundations/gitextensions-primer.md) · [architecture-overview](../L1-conceptual/architecture-overview.md)
+
+## Why
+
+Git Extensions shells out to the real `git` binary rather than a library, so it needs a robust,
+testable process layer: consistent working directory, correct text encoding, cancellation,
+stdin/stdout redirection, logging, and optional result caching. The `IExecutable` abstraction
+also makes execution **mockable** in tests (substitute a fake `IExecutable`/`IProcess`).
+
+## What (the layers)
+
+1. **`IExecutable`** — a launchable command (usually `git`). Exposes `WorkingDir`, `Command`,
+   `PrefixArguments`, and a low-level `Start(...) : IProcess`.
+   Contract: [IExecutable.cs](../../../src/app/GitExtensions.Extensibility/IExecutable.cs).
+2. **`Executable`** — the concrete implementation. Resolves the git path (deferred via a
+   `Func<string>`), sets up `ProcessStartInfo`, logging, and environment.
+   [Executable.cs](../../../src/app/GitCommands/Git/Executable.cs).
+3. **`IProcess`** — a running process with redirected streams and an exit code.
+4. **`ExecutableExtensions`** — the high-level API most code uses instead of `Start`:
+   - `GetOutput(args, …)` — run and return concatenated stdout as a string (sync wrapper over async).
+   - `RunCommand(args, …)` — run when you only need success/failure (no output text).
+   - `ExecuteAsync(args, …)` — run and return a full `ExecutionResult` (stdout + stderr + exit code).
+   [ExecutableExtensions.cs](../../../src/app/GitCommands/Git/ExecutableExtensions.cs).
+5. **`ExecutionResult`** — value type holding `Command`, `Arguments`, `StandardOutput`,
+   `StandardError`, `ExitCode`, plus `ExitedSuccessfully` and `ThrowIfErrorExit()`.
+   [ExecutionResult.cs](../../../src/app/GitExtensions.Extensibility/ExecutionResult.cs).
+
+### Supporting pieces
+
+- **`GitModule`** — per-repository facade; most git operations are methods here that call the
+  extensions above. One instance per repo/submodule.
+  [GitModule.cs](../../../src/app/GitCommands/Git/GitModule.cs).
+- **`GitCommandRunner`** — coordinates running commands for a module.
+  [GitCommandRunner.cs](../../../src/app/GitCommands/Git/GitCommandRunner.cs).
+- **`GitExecutor` / `IGitExecutor` / `IGitExecutorProvider`** — provide the git `IExecutable`
+  (path, prefix args) to the rest of the app. Resolved through DI.
+- **`CommandCache`** (`GitModule.GitCommandCache`) — caches output of read-only commands to
+  avoid re-running identical queries. [CommandCache.cs](../../../src/app/GitCommands/Git/CommandCache.cs).
+- **Encoding** — git output is decoded with `GitModule.SystemEncoding` /
+  `_defaultEncoding` (UTF-8 without BOM); ANSI escape codes can be stripped.
+
+## How (typical call)
+
+```
+GitModule method  ──►  executable.GetOutput("status -z ...")  ──►  Executable.Start
+                                                              ──►  IProcess (stdout/stderr)
+                                                              ──►  ExecutionResult ──► parse
+```
+
+Read-only commands prefer `GetOutput`/`ExecuteAsync`; state-changing commands invoked from the
+UI go through the structured path (see [structured-commands](structured-commands.md) and
+`GitUICommands.StartCommandLineProcessDialog`).
+
+## Hard rules
+
+- **ALWAYS** run git through `IExecutable`/`GitModule`; never `Process.Start("git")` directly.
+- Prefer the **`-z`** (NUL-delimited) form of git commands when parsing paths (avoids newline/space bugs).
+- For UI-facing state changes, use the structured `IGitCommand` + `StartCommandLineProcessDialog`
+  path so `RepoChangedNotifier` fires correctly.
+- Honor `CancellationToken`; use `ExecutionResult.ThrowIfErrorExit()` rather than manual exit-code checks where possible.
+
+**Next:** [structured-commands](structured-commands.md) — how argument sets are built and classified.

--- a/.github/copilot-docs/L2-core-platform/git-command-execution.md
+++ b/.github/copilot-docs/L2-core-platform/git-command-execution.md
@@ -6,7 +6,7 @@ point; it uses an `IExecutable` (`Executable`) to start a process (`IProcess`), 
 `ExecutableExtensions` helpers (`GetOutput` / `RunCommand` / `ExecuteAsync`) handle
 input/output/encoding and return an `ExecutionResult`. Results can be cached via `CommandCache`.
 
-**Related:** [structured-commands](structured-commands.md) (what args to run) · [git-module](docs-index.md) · [L0 primer](../L0-foundations/gitextensions-primer.md) · [architecture-overview](../L1-conceptual/architecture-overview.md)
+**Related:** [structured-commands](structured-commands.md) (what args to run) · [git-module](git-module.md) · [L0 primer](../L0-foundations/gitextensions-primer.md) · [architecture-overview](../L1-conceptual/architecture-overview.md)
 
 ## Why
 

--- a/.github/copilot-docs/L2-core-platform/git-module.md
+++ b/.github/copilot-docs/L2-core-platform/git-module.md
@@ -1,0 +1,68 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# GitModule (L2)
+
+**TL;DR:** `GitModule` is the per-repository facade — the single object that represents one open
+git working directory and exposes methods to read state and run git. It implements the public
+`IGitModule` interface. There is **one instance per repository and per submodule**. Most code
+reaches git through a `GitModule` method rather than calling `Executable` directly.
+
+**Related:** [git-command-execution](git-command-execution.md) (the process layer it uses) · [structured-commands](structured-commands.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [GitModule.cs](../../../src/app/GitCommands/Git/GitModule.cs) ·
+[IGitModule.cs](../../../src/app/GitExtensions.Extensibility/Git/IGitModule.cs) (public contract) ·
+[GitModule.GitCommandCache](../../../src/app/GitCommands/Git/CommandCache.cs)
+
+## Why
+
+Git operations need a consistent context: the working directory, the git executable, encoding,
+caching, and submodule awareness. `GitModule` centralises all of that so callers don't repeat
+it. Because it implements `IGitModule` (in the versioned `Extensibility` assembly), plugins and
+UI code depend on the **interface**, keeping the concrete engine swappable and testable.
+
+## What (responsibilities)
+
+`GitModule` groups its (large) API into areas:
+
+- **Identity & validation** — `WorkingDir`, `WorkingDirGitDir`, `IsValidGitWorkingDir()`,
+  `IsBareRepository()`, `IsDetachedHead()`, `GetCurrentCheckout()`, `GetSelectedBranch()`.
+- **Revisions & refs** — `RevParse()`, `TryResolvePartialCommitId()`, ref parsing (see the
+  `RefRegex`/`ShaRegex` generated regexes at the top of the class), tags.
+- **Remotes** — `AddRemote()`, `RemoveRemote()`, `RenameRemote()`, `GetCurrentRemote()`.
+- **Settings passthrough** — `GetSetting()` / `GetEffectiveSetting()` bridge to the git-config
+  side of the [settings system](settings-system.md).
+- **State changes** — e.g. `ResetAllChanges()`; most mutating operations flow through
+  [structured commands](structured-commands.md) run by the UI.
+- **Submodules** — `GetSubmoduleFullPath()`, plus helpers in `Submodules/` and `SubmoduleHelpers`.
+- **Paths & encoding** — `GetPathForGitExecution()` (to git-style paths), `GetWindowsPath()`,
+  `CommitEncoding`; static `GitModule.SystemEncoding` / default UTF-8-no-BOM.
+
+### Execution & caching
+
+- `GitModule` holds an `IGitExecutor` (from `IGitExecutorProvider`, injected) and delegates to
+  the [ExecutableExtensions](git-command-execution.md) helpers.
+- `GitModule.GitCommandCache` (a static `CommandCache`) caches read-only command output.
+- The class is a `sealed partial class`; helpers are split across `Git/` (e.g. parsers,
+  `SubmoduleHelpers`, `RevisionReader`).
+
+## How (typical usage)
+
+```
+IGitModule module = uiCommands.Module;          // provided by GitUICommands
+ObjectId head = module.GetCurrentCheckout();    // read state
+string branch = module.GetSelectedBranch();
+bool ok = module.ResetAllChanges(clean: false); // mutate
+```
+
+- UI code gets the current `IGitModule` from `GitUICommands.Module`.
+- New repositories/submodules produce **new** `GitModule` instances (don't reuse across repos).
+- To add an operation: prefer a method on `GitModule`/`Commands` returning an `IGitCommand`, and
+  cover it with a unit test using a substituted `IExecutable`.
+
+## Hard rules
+
+- **ALWAYS** interact with git through `IGitModule` (interface), not a bare `Executable`.
+- One `GitModule` == one repo. **NEVER** share an instance across working directories/submodules.
+- Prefer NUL-delimited (`-z`) git output when parsing (see [git-command-execution](git-command-execution.md)).
+- Adding members to `IGitModule` changes the **plugin interface version** — note it in the commit message.
+
+**Next:** [settings-system](settings-system.md) for how `GetSetting`/config resolution works.

--- a/.github/copilot-docs/L2-core-platform/git-output-parsing.md
+++ b/.github/copilot-docs/L2-core-platform/git-output-parsing.md
@@ -1,0 +1,47 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Git Output Parsing (L2)
+
+**TL;DR:** Git commands emit text; parser classes turn that text into the typed
+[domain model](../L1-conceptual/domain-model.md) exactly once. The main parsers are
+`RevisionReader` (log → `GitRevision`), `GitTreeParser` (ls-tree → `GitItem`), and
+`GetAllChangedFilesOutputParser` (status → `GitItemStatus`). Parsers rely on NUL-delimited
+(`-z`, `--porcelain`) output for robustness.
+
+**Related:** [git-command-execution](git-command-execution.md) · [domain-model](../L1-conceptual/domain-model.md) · [git-module](git-module.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Parsing git output is error-prone: paths can contain spaces/newlines, encodings vary, and
+formats differ across git versions. Centralising parsing in dedicated classes (fed
+machine-readable `-z`/`--porcelain` output) keeps the fragile string handling in one place and
+produces immutable, reusable models for the rest of the app.
+
+## What
+
+| Parser | File | Reads → Produces |
+| --- | --- | --- |
+| `RevisionReader` | [RevisionReader.cs](../../../src/app/GitCommands/RevisionReader.cs) | `git log --format` → `GitRevision` list (range or explicit list). |
+| `GitTreeParser` | [GitTreeParser.cs](../../../src/app/GitCommands/Git/GitTreeParser.cs) | `git ls-tree` / `ls-files --stage` → `GitItem`. |
+| `GetAllChangedFilesOutputParser` | [GetAllChangedFilesOutputParser.cs](../../../src/app/GitCommands/Git/GetAllChangedFilesOutputParser.cs) | `git status --porcelain=2 -z` → `GitItemStatus`. |
+| `DetachedHeadParser` | [DetachedHeadParser.cs](../../../src/app/GitCommands/Git/DetachedHeadParser.cs) | Detects detached HEAD from status/branch text. |
+| `ExternalLinkRevisionParser` | [ExternalLinkRevisionParser.cs](../../../src/app/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs) | Extracts revision/remote patterns for external links. |
+
+`GitModule` also parses refs inline with generated regexes (`RefRegex`, `ShaRegex`,
+`RemoteVerboseLineRegex`) at the top of [GitModule.cs](../../../src/app/GitCommands/Git/GitModule.cs).
+
+## How
+
+- Producers ask git for machine-readable output: `--porcelain`, `-z` (NUL delimiters), fixed
+  `--format` strings — never human-formatted output.
+- `RevisionReader` streams and constructs `GitRevision`s incrementally for responsiveness (it
+  feeds the [revision-grid flow](../L3-flows/revision-grid-flow.md)).
+- Encoding: decode with `GitModule.SystemEncoding` / the module's `CommitEncoding` as appropriate.
+
+## Hard rules
+
+- **ALWAYS** parse `-z` / `--porcelain` output, not human-readable output (which changes across git versions/locales).
+- Keep parsing **inside** these parser classes; model types must not parse text themselves.
+- Split on the first delimiter only when values can contain spaces (paths, ref names).
+- Cover new parsing with unit tests using recorded git output (`Verify.NUnit` snapshots where useful).
+
+**Next:** [git-module](git-module.md) for who calls these parsers.

--- a/.github/copilot-docs/L2-core-platform/hotkey-system.md
+++ b/.github/copilot-docs/L2-core-platform/hotkey-system.md
@@ -1,0 +1,46 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Hotkey System (L2)
+
+**TL;DR:** Keyboard shortcuts are modelled as `HotkeyCommand`s grouped per form/control and
+managed by `HotkeySettingsManager`. Forms expose an `IHotkeySettingsLoader` (via `GitModuleForm`)
+to look up their bindings; users edit them in the Settings dialog's hotkey page. Defaults are
+generated in code.
+
+**Related:** [ui-composition](../L1-conceptual/ui-composition.md) · [settings-system](settings-system.md) · [scripts-engine](scripts-engine.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Power users expect customisable, discoverable keyboard shortcuts, and different windows need
+different bindings without collisions. Centralising hotkeys as serializable commands lets the app
+persist user overrides, detect duplicate keys, and show/edit everything in one settings page.
+
+## What
+
+- **`HotkeyCommand`** — an XML-serializable binding: a command code, a name, and the `Keys`.
+  [HotkeyCommand.cs](../../../src/app/ResourceManager/Hotkey/HotkeyCommand.cs).
+- **`HotkeySettings`** — a named set of `HotkeyCommand`s for one form/control group.
+  [HotkeySettings.cs](../../../src/app/GitUI/Hotkey/HotkeySettings.cs).
+- **`HotkeySettingsManager`** (`IHotkeySettingsManager`) — `LoadSettings()`,
+  `CreateDefaultSettings()`, `IsUniqueKey()`; persists user overrides.
+  [HotkeySettingsManager.cs](../../../src/app/GitUI/Hotkey/HotkeySettingsManager.cs).
+- **`IHotkeySettingsLoader`** — exposed on `GitModuleForm` so a form can read its own hotkeys.
+- **Settings UI** — `ControlHotkeys` page for editing bindings.
+  [ControlHotkeys.cs](../../../src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs).
+
+## How (add a hotkey to a form)
+
+1. Define a hotkey command code for the form and add it to that form's default `HotkeySettings`
+   (via `CreateDefaultSettings()` in `HotkeySettingsManager`).
+2. In the form, read the configured `Keys` through the `IHotkeySettingsLoader` and handle the key
+   (typically in `ProcessCmdKey`/hotkey dispatch).
+3. The Settings → Hotkeys page (`ControlHotkeys`) picks it up automatically for user editing.
+
+Note: user scripts can also be bound to hotkeys — see [scripts-engine](scripts-engine.md).
+
+## Hard rules
+
+- Register/lookup hotkeys through `HotkeySettingsManager` — don't hardcode `Keys` handling that bypasses user settings.
+- Keep command **names** stable; they are the serialization key for user overrides.
+- Check `IsUniqueKey()` semantics when adding defaults to avoid collisions within a form.
+
+**Next:** [scripts-engine](scripts-engine.md).

--- a/.github/copilot-docs/L2-core-platform/plugin-system.md
+++ b/.github/copilot-docs/L2-core-platform/plugin-system.md
@@ -1,0 +1,75 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Plugin System (L2)
+
+**TL;DR:** Plugins implement `IGitPlugin` (or a specialised sub-interface) and are exported via
+**MEF** (VS-MEF / `Microsoft.VisualStudio.Composition`). `PluginRegistry` discovers them through
+`ManagedExtensibility` and hosts them in the UI. A plugin `Register()`s hooks, exposes settings,
+and `Execute()`s on demand. Built-in plugins live in `src/plugins/`; users can drop extra ones in
+the `UserPlugins` folder.
+
+**Related:** [architecture-overview](../L1-conceptual/architecture-overview.md) · [settings-system](settings-system.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [IGitPlugin.cs](../../../src/app/GitExtensions.Extensibility/Plugins/IGitPlugin.cs) ·
+[GitPluginBase.cs](../../../src/app/GitExtensions.Extensibility/Plugins/GitPluginBase.cs) ·
+[PluginRegistry.cs](../../../src/app/GitUI/Plugin/PluginRegistry.cs) ·
+[ManagedExtensibility.cs](../../../src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs)
+
+## Why
+
+Optional features (background fetch, build-server integration, GitHub/Bitbucket hosting, stats)
+should be decoupled from the core so they can ship, fail, and evolve independently. MEF gives a
+discovery mechanism where a plugin just declares an `[Export]` and the host finds it — no central
+registration list to edit.
+
+## What (the pieces)
+
+### Contracts (`GitExtensions.Extensibility/Plugins/`)
+
+- **`IGitPlugin`** — the core contract: `Id`, `Name`, `Description`, `Icon`, `SettingsContainer`,
+  `HasSettings`, `GetSettings()`, `Register(IGitUICommands)`, `Unregister(...)`,
+  `Execute(GitUIEventArgs)` (returns whether to refresh `RevisionGrid`).
+- **`GitPluginBase`** — convenience base class most plugins derive from.
+- **`IRepositoryHostPlugin`** — repo hosts (GitHub, Bitbucket) with PR/remote features.
+- **`IGitPluginSettingsContainer`** — how a plugin reads/writes its own settings.
+
+### Legacy interfaces (`src/plugins/GitUIPluginInterfaces/`)
+
+`ManagedExtensibility` (MEF composition), `IGitPluginForCommit`, `PluginsPathScanner`,
+`RepositoryHosts/`. This project predates `Extensibility`; both are still referenced.
+
+### Host (`GitUI/Plugin/`)
+
+- **`PluginRegistry`** — static host. `Plugins` and `GitHosters` lists; `InitializeAll()`,
+  `InitializeForCommitForm()`, `InitializeGitHostersOnly()` call `LoadPlugins<T>()`, which pulls
+  exports via `ManagedExtensibility.GetExports<T>()`.
+- **`FailedPluginWrapper`** — wraps a plugin that threw during load so one bad plugin can't crash
+  the app.
+- **`GitPluginSettingsContainer`** — concrete settings bridge.
+
+### Built-in plugins (`src/plugins/*`)
+
+`BackgroundFetch`, `AutoCompileSubmodules`, `Bitbucket`, `GitHub3`, `GitFlow`,
+`BuildServerIntegration`, `Statistics`, `Gource`, `FindLargeFiles`, `ProxySwitcher`,
+`CreateLocalBranches`, `DeleteUnusedBranches`, `ReleaseNotesGenerator`.
+
+## How (add / load a plugin)
+
+```
+[Export(typeof(IGitPlugin))]           // MEF discovery — no registry edit needed
+public sealed class MyPlugin : GitPluginBase { ... }
+```
+
+1. Create a project under `src/plugins/`, derive from `GitPluginBase`, `[Export]` the interface.
+2. Implement `Register()` to subscribe to `IGitUICommands` events; `Execute()` for the action.
+3. Expose settings via `GetSettings()` + `IGitPluginSettingsContainer` (see [settings-system](settings-system.md)).
+4. Load timing: general plugins load on background init (`InitializeAll`); commit-form plugins
+   load via `InitializeForCommitForm`; repo hosts via `InitializeGitHostersOnly`.
+
+## Hard rules
+
+- Plugins depend **only** on the interface assemblies (`Extensibility` / `GitUIPluginInterfaces`) — never on `GitUI` internals.
+- Changes to `GitExtensions.Extensibility/Plugins/` alter the **public plugin interface version** — note it in the commit message.
+- **NEVER** let a plugin throw during load uncaught — the host wraps failures in `FailedPluginWrapper`; keep it that way.
+- `Execute()` MUST return whether the `RevisionGrid` should refresh.
+
+**Next:** [translation-system](translation-system.md) — plugin UI strings are localised too.

--- a/.github/copilot-docs/L2-core-platform/scripts-engine.md
+++ b/.github/copilot-docs/L2-core-platform/scripts-engine.md
@@ -1,0 +1,53 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Scripts Engine (L2)
+
+**TL;DR:** Users can define their own commands ("scripts") that run at lifecycle events
+(before/after commit, pull, push…) or from menus/hotkeys, without writing a plugin. `ScriptInfo`
+holds each script's metadata; `ScriptsManager` stores and runs them; `ScriptRunner` performs
+token substitution (e.g. `{sHashes}`, `{UserInput}`) and executes.
+
+**Related:** [hotkey-system](hotkey-system.md) · [plugin-system](plugin-system.md) · [commit-flow](../L3-flows/commit-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Teams have bespoke workflows (run a linter before commit, open a tool after pull). Rather than
+force everyone to build a plugin, Git Extensions lets users register parameterised shell/tool
+commands that hook into well-known events — a lightweight extension point configured entirely in
+settings.
+
+## What (`GitUI/ScriptsEngine/`)
+
+- **`ScriptEvent`** (enum) — the hook points: `BeforeCommit`, `AfterCommit`, `BeforePull`,
+  `AfterPull`, `ShowInUserMenuBar`, etc. [ScriptEvent.cs](../../../src/app/GitUI/ScriptsEngine/ScriptEvent.cs).
+- **`ScriptInfo`** — one script's definition: name, command, arguments, event filter, hotkey, icon.
+  [ScriptInfo.cs](../../../src/app/GitUI/ScriptsEngine/ScriptInfo.cs).
+- **`ScriptsManager`** (`IScriptsManager`, `IScriptsRunner`) — loads scripts from settings
+  (XML), registers their hotkeys, and runs event scripts.
+  [ScriptsManager.cs](../../../src/app/GitUI/ScriptsEngine/ScriptsManager.cs).
+- **`ScriptRunner`** — `RunScript(...)` executes a single script.
+  [ScriptsManager.ScriptRunner.cs](../../../src/app/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs).
+- **`ScriptOptionsParser`** — expands tokens like `{UserInput:label=default}`, `{plugin.name}`,
+  and revision/branch placeholders. [ScriptOptionsParser.cs](../../../src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs).
+
+## How (event scripts)
+
+Dialogs invoke scripts through the runner at defined points, e.g. in
+[FormCommit](../../../src/app/GitUI/CommandsDialogs/FormCommit.cs):
+
+```
+ScriptsRunner.RunEventScripts(ScriptEvent.BeforeCommit, this);   // may cancel the operation
+...
+ScriptsRunner.RunEventScripts(ScriptEvent.AfterCommit, this);
+```
+
+- `Before*` scripts can **cancel** the operation (return value gates the flow).
+- Tokens are resolved by `ScriptOptionsParser` against the current revision/selection before run.
+- Scripts marked `ShowInUserMenuBar` appear in the UI; others fire only on their event.
+
+## Hard rules
+
+- Run scripts through `IScriptsRunner`/`ScriptsManager`, not ad-hoc process launches.
+- Honor the cancel result of `Before*` event scripts — do not proceed if a script cancels.
+- Resolve tokens via `ScriptOptionsParser`; never string-concatenate user input into a command line.
+
+**Next:** [service-container](service-container.md) for how `IScriptsManager` is resolved.

--- a/.github/copilot-docs/L2-core-platform/service-container.md
+++ b/.github/copilot-docs/L2-core-platform/service-container.md
@@ -1,0 +1,51 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Service Container (DI) (L2)
+
+**TL;DR:** Git Extensions uses a lightweight DI container (`System.ComponentModel.Design.ServiceContainer`)
+wired up at startup in `Program.cs`. Each layer contributes a `ServiceContainerRegistry.RegisterServices`
+that registers its services; code resolves them with `GetRequiredService<T>()`. `GitUICommands` acts
+as the primary service hub passed to forms.
+
+**Related:** [architecture-overview](../L1-conceptual/architecture-overview.md) · [git-command-execution](git-command-execution.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+The app is layered and needs testable seams: forms shouldn't `new` up executors, parsers, or
+managers directly. A container lets each layer register its implementations once and lets
+consumers ask for interfaces, so tests can substitute fakes and layers stay decoupled.
+
+## What
+
+Startup composition in [Program.cs](../../../src/app/GitExtensions/Program.cs):
+
+```
+ServiceContainer container = new();
+ServiceContainerRegistry.RegisterServices(container);   // called per layer
+```
+
+Each layer owns a `ServiceContainerRegistry`:
+
+| Registry | File | Registers |
+| --- | --- | --- |
+| Utils | [GitExtUtils/ServiceContainerRegistry.cs](../../../src/app/GitExtUtils/ServiceContainerRegistry.cs) | Core services (e.g. `ISubscribableTraceListener`). |
+| Commands | [GitCommands/ServiceContainerRegistry.cs](../../../src/app/GitCommands/ServiceContainerRegistry.cs) | Git services: `IGitExecutorProvider`, submodule status, etc. |
+| UI | [GitUI/ServiceContainerRegistry.cs](../../../src/app/GitUI/ServiceContainerRegistry.cs) | UI services: `IScriptsManager`, `IHotkeySettingsManager`, repository-history UI, … |
+
+- **Resolution** — `serviceContainer.GetRequiredService<T>()` (throws if missing). Forms get the
+  container via `GitModuleForm`/`GitUICommands`.
+- **`GitUICommands`** implements the service-provider role for the UI and carries the current
+  `IGitModule`. [GitUICommands.cs](../../../src/app/GitUI/GitUICommands.cs).
+
+## How (add a service)
+
+1. Define the interface in the layer that owns the contract (often `Extensibility`).
+2. Register the implementation in that layer's `ServiceContainerRegistry.RegisterServices`.
+3. Resolve it via `GetRequiredService<T>()`; in tests, register a substitute instead.
+
+## Hard rules
+
+- Register services in the **owning layer's** `ServiceContainerRegistry`, not ad hoc.
+- Prefer container-resolved interfaces over `new`-ing concrete services in forms.
+- Use `GetRequiredService<T>()` for mandatory services so missing registrations fail fast.
+
+**Next:** [shell-integration](shell-integration.md) or back to the [L2 index](docs-index.md).

--- a/.github/copilot-docs/L2-core-platform/settings-system.md
+++ b/.github/copilot-docs/L2-core-platform/settings-system.md
@@ -1,0 +1,69 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Settings System (L2)
+
+**TL;DR:** Git Extensions has **two** settings worlds. (1) **App settings** — the app's own
+preferences, stored in the `GitExtensions.settings` XML file and accessed through the static
+`AppSettings` facade. (2) **Git config** — real `git config` values (system/global/local),
+accessed through the `*Settings` classes and `IGitModule.GetSetting/GetEffectiveSetting`. Know
+which world a value belongs to before reading or writing it.
+
+**Related:** [git-module](git-module.md) · [L0 primer](../L0-foundations/gitextensions-primer.md) · master [docs-index](../docs-index.md)
+
+**Key files:** [AppSettings.cs](../../../src/app/GitCommands/Settings/AppSettings.cs) ·
+[SettingsPath.cs](../../../src/app/GitCommands/Settings/SettingsPath.cs) ·
+[DistributedSettings.cs](../../../src/app/GitCommands/Settings/DistributedSettings.cs) ·
+[GitExtSettingsCache.cs](../../../src/app/GitCommands/Settings/GitExtSettingsCache.cs)
+
+## Why
+
+The app must persist user preferences independently of any repository, **and** read/write git's
+own configuration (which is layered: system → global → local). Separating these keeps app prefs
+portable across repos while still honoring git's precedence rules for config.
+
+## What
+
+### 1. App settings — `AppSettings`
+
+- Static facade with strongly-typed properties (e.g. sort orders, confirmations, appearance).
+  [AppSettings.cs](../../../src/app/GitCommands/Settings/AppSettings.cs) (partial across several files).
+- Stored in **`GitExtensions.settings`** (XML). Note the code split: `ApplicationName = "Git
+  Extensions"` but `ApplicationId = "GitExtensions"` (used for the file name and data folder).
+- Portable vs installed: `ApplicationDataPath` / `IsPortable()` decide where the file lives.
+- Keys are organised hierarchically via `SettingsPath` / `AppSettingsPath` (e.g. `Appearance`,
+  `Confirmations`, `Detailed`, `Dialogs`, `RecentRepositories`).
+- Backing store: `GitExtSettingsCache` / `FileSettingsCache` read & cache the XML; `SettingsContainer`
+  (a `DistributedSettings`) is the root source.
+
+### 2. Git config settings
+
+- `DistributedSettings` — settings that follow git's distributed layering (local/global).
+  `DetachedSettings` / `DetachedServerSettings` — non-repo-bound.
+- `EffectiveGitConfigSettings` / `GitConfigSettings` / `ConfigFileSettingsCache` — read the
+  actual `git config`. `IGitModule.GetSetting()` and `GetEffectiveSetting()` bridge to these.
+- Encoding-related config uses `GitEncodingSettingsGetter/Setter`.
+
+### Setting abstractions
+
+`ISetting` / `Setting` / `RuntimeSetting` model a single setting; `SettingsSource<T>` and
+`SettingsSourceExtension` provide typed get/set over a source.
+
+## How (typical usage)
+
+```
+bool confirm = AppSettings.DontConfirmCommitIfNoBranch;     // app setting
+AppSettings.LastCommitMessage = message;                    // app setting (persisted)
+string editor = module.GetEffectiveSetting("core.editor");  // git config (layered)
+```
+
+- The **Settings dialog** UI lives in `GitUI/CommandsDialogs/SettingsDialog/`; controls bind via
+  `GitUI/SettingControlBindings/`.
+- `AppSettings.Saved` fires when settings are persisted; `AppSettings.SaveSettings()` writes the file.
+
+## Hard rules
+
+- Decide the **world** first: app preference → `AppSettings`; git behavior → `GetEffectiveSetting`/config classes.
+- **NEVER** hand-edit the `GitExtensions.settings` path or key strings — go through `AppSettings` / `SettingsPath`.
+- Respect git config precedence; use `GetEffectiveSetting` (layered) rather than reading one file.
+- New user-facing settings SHOULD get a typed `AppSettings` member plus a Settings-dialog binding.
+
+**Next:** [plugin-system](plugin-system.md) — plugins get their own settings via `IGitPluginSettingsContainer`.

--- a/.github/copilot-docs/L2-core-platform/shell-integration.md
+++ b/.github/copilot-docs/L2-core-platform/shell-integration.md
@@ -1,0 +1,45 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Shell Integration (Native) (L2)
+
+**TL;DR:** A native C++ **Windows Explorer shell extension** adds right-click "git" actions in
+Explorer, launching `GitExtensions.exe` with a verb (browse, commit, push…). It's a separate
+COM DLL (`CGitExtensionsShellEx`) built by `src/native/build.proj` and registered by the
+installer. A companion native tool, `GitExtSshAskPass`, handles SSH passphrase prompts.
+
+**Related:** [project-map](../L1-conceptual/project-map.md) · [build-and-installer](build-and-installer.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Users expect to right-click a folder in Explorer and run git actions without first opening the
+app. Windows shell extensions must be **native COM** components (not .NET) for reliability inside
+`explorer.exe`, so this piece lives in C++ and simply shells out to the managed app.
+
+## What (`src/native/`)
+
+- **`CGitExtensionsShellEx`** — the shell extension COM class implementing `IShellExtInit` and
+  `IContextMenu3`; provides the Explorer context-menu entries and the DLL entry point (`DllMain`).
+  [ShellEx.cpp](../../../src/native/GitExtensionsShellEx/ShellEx.cpp).
+- **`GitExCommands`** (enum) — the menu commands (browse, clone, commit, push, …).
+  [GitExtensionsShellEx.h](../../../src/native/GitExtensionsShellEx/GitExtensionsShellEx.h).
+- **`GitExtSshAskPass`** — standalone native tool used as git's `SSH_ASKPASS` to prompt for
+  credentials/passphrases. [GitExtSshAskPass/](../../../src/native/GitExtSshAskPass/).
+- **Native build** — [build.proj](../../../src/native/build.proj) uses VSwhere + MSBuild to build
+  Win32 and x64 configurations (needs VC++/ATL).
+
+## How
+
+- The shell extension launches the managed app with a command-line verb (the same verbs the app's
+  command-line handler understands; see `FormCommandlineHelp`). It runs in a **separate process**
+  from the managed app.
+- Registration/unregistration of the COM DLL is done by the installer
+  ([RegisterShellExtension.wxi](../../../Setup/installer/RegisterShellExtension.wxi)); see
+  [build-and-installer](build-and-installer.md).
+
+## Hard rules
+
+- Shell-extension code is **native C++/COM** — keep it minimal; do real work in the managed app.
+- Don't block Explorer: the extension should launch the app and return quickly.
+- Building this requires the VC++ toolset (ATL) for x86/x64 — see the native build target.
+- Registration is installer-owned; don't hand-register the DLL in normal dev flows.
+
+**Next:** [build-and-installer](build-and-installer.md).

--- a/.github/copilot-docs/L2-core-platform/structured-commands.md
+++ b/.github/copilot-docs/L2-core-platform/structured-commands.md
@@ -1,0 +1,73 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Structured Commands (L2)
+
+**TL;DR:** Instead of hand-writing git command strings, Git Extensions builds them with
+`ArgumentBuilder`/`GitArgumentBuilder` and exposes them as `IGitCommand` records via the static
+`Commands` factory. Each `IGitCommand` declares two facts — `AccessesRemote` and
+`ChangesRepoState` — so the UI can pick the right process dialog and fire repo-changed events.
+Run them with `GitUICommands.StartCommandLineProcessDialog`.
+
+**Related:** [git-command-execution](git-command-execution.md) (how they run) · [commit-flow](../L3-flows/docs-index.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+Concatenating strings is error-prone (quoting, conditional flags) and loses metadata. The
+structured approach gives three wins: **safe argument building** (conditional/one-of options),
+**intent metadata** (does it hit a remote? does it change state?), and a **uniform run path**
+so that every state-changing command consistently notifies the UI to refresh.
+
+## What
+
+### ArgumentBuilder / GitArgumentBuilder
+
+`ArgumentBuilder` uses collection-initialiser syntax to compose arguments; `null`/whitespace is
+skipped, and conditional/either-or forms are supported:
+
+```
+new GitArgumentBuilder("checkout")
+{
+    { localChanges is LocalChangesAction.Merge, "--merge" },  // add only if condition
+    branchName.QuoteNE()                                       // unconditional (quoted)
+};
+```
+
+Contract & docs: [ArgumentBuilder.cs](../../../src/app/GitExtensions.Extensibility/ArgumentBuilder.cs).
+`ArgumentString` is the built value passed to the executable.
+
+### IGitCommand + the Commands factory
+
+- **`IGitCommand`** — exposes `Arguments`, `AccessesRemote`, `ChangesRepoState`.
+  Contract: [IGitCommand.cs](../../../src/app/GitExtensions.Extensibility/Git/IGitCommand.cs).
+- **`Commands`** — a `partial static` factory (`GitCommands.Git`) with one method per operation.
+  Each returns a private `GitCommand : IGitCommand` carrying the two flags.
+  - Main file: [Commands.cs](../../../src/app/GitCommands/Git/Commands.cs) (e.g. `CheckoutBranch`, `DeleteBranch`).
+  - Argument-only variants: [Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs) (e.g. `Commit`).
+  - Record definition: [Commands.GitCommand.cs](../../../src/app/GitCommands/Git/Commands.GitCommand.cs).
+
+### Two patterns (know the difference)
+
+| Pattern | Returns | Run via | Use when |
+| --- | --- | --- | --- |
+| Structured (preferred) | `IGitCommand` | `GitUICommands.StartCommandLineProcessDialog(owner, cmd)` | State-changing UI operations (checkout, delete branch, tag). |
+| Argument-only (legacy) | `ArgumentString` | `FormProcess.ShowDialog(...)` or `Executable` extensions | Read commands or older call sites (e.g. `Commands.Commit`). |
+
+`StartCommandLineProcessDialog` inspects `AccessesRemote` to choose a remote-capable process
+dialog and fires `RepoChangedNotifier` when `ChangesRepoState` is true.
+See [GitUICommands.cs](../../../src/app/GitUI/GitUICommands.cs) (`StartCommandLineProcessDialog`).
+
+## How (add a new structured command)
+
+1. Add a `public static IGitCommand MyThing(...)` to `Commands` (or a `Commands.*.cs` partial).
+2. Build args with `GitArgumentBuilder`; set `accessesRemote` / `changesRepoState` correctly.
+3. Call it from a dialog via `UICommands.StartCommandLineProcessDialog(this, Commands.MyThing(...))`.
+4. Add a unit test (structured commands are easy to assert on `.Arguments`).
+
+## Hard rules
+
+- **ALWAYS** build git arguments with `ArgumentBuilder`/`GitArgumentBuilder` — never string concat.
+- Set `AccessesRemote` and `ChangesRepoState` **accurately**; the UI relies on them for dialog
+  selection and repo-refresh notifications.
+- Quote user-provided values (`.Quote()` / `.QuoteNE()`).
+- New interactive git operations SHOULD go through `IGitModule`/`Commands` and have unit tests.
+
+**Next:** [commit-flow](../L3-flows/docs-index.md) to see the pattern end-to-end.

--- a/.github/copilot-docs/L2-core-platform/structured-commands.md
+++ b/.github/copilot-docs/L2-core-platform/structured-commands.md
@@ -7,7 +7,7 @@
 `ChangesRepoState` — so the UI can pick the right process dialog and fire repo-changed events.
 Run them with `GitUICommands.StartCommandLineProcessDialog`.
 
-**Related:** [git-command-execution](git-command-execution.md) (how they run) · [commit-flow](../L3-flows/docs-index.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+**Related:** [git-command-execution](git-command-execution.md) (how they run) · [commit-flow](../L3-flows/commit-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
 
 ## Why
 
@@ -70,4 +70,4 @@ See [GitUICommands.cs](../../../src/app/GitUI/GitUICommands.cs) (`StartCommandLi
 - Quote user-provided values (`.Quote()` / `.QuoteNE()`).
 - New interactive git operations SHOULD go through `IGitModule`/`Commands` and have unit tests.
 
-**Next:** [commit-flow](../L3-flows/docs-index.md) to see the pattern end-to-end.
+**Next:** [commit-flow](../L3-flows/commit-flow.md) to see the pattern end-to-end.

--- a/.github/copilot-docs/L2-core-platform/testing-guide.md
+++ b/.github/copilot-docs/L2-core-platform/testing-guide.md
@@ -1,0 +1,52 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Testing Guide (L2)
+
+**TL;DR:** Tests use **NUnit** with **NSubstitute** (mocking) and **AwesomeAssertions**
+(assertions). Unit tests live under `tests/app/UnitTests/` (mirroring the source projects); UI
+integration tests under `tests/app/IntegrationTests/`. Test names use a **snake_case suffix**
+while keeping the method-under-test name intact. Run with `dotnet test`.
+
+**Related:** [build-and-installer](build-and-installer.md) · [ci-workflows](ci-workflows.md) · [git-command-execution](git-command-execution.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+A git GUI has lots of parsing, argument-building, and stateful UI. Fast, isolated tests (with the
+`git` process and services substituted) catch regressions cheaply, and the shared conventions keep
+the large suite consistent and readable.
+
+## What
+
+- **Unit tests** — [tests/app/UnitTests/](../../../tests/app/UnitTests/): `GitCommands.Tests`,
+  `GitUI.Tests`, `ResourceManager.Tests`, `BugReporter.Tests`, etc.
+- **Integration tests** — [tests/app/IntegrationTests/](../../../tests/app/IntegrationTests/)
+  (`UI.IntegrationTests`): drive real forms/controls (`RevisionGridControl`, script engine, …).
+- **Shared helpers** — [tests/CommonTestUtils/](../../../tests/CommonTestUtils/).
+- **Test config** — [eng/Tests.targets](../../../eng/Tests.targets) / `eng/Tests.props` wire in
+  NUnit, AwesomeAssertions, NSubstitute, and `Verify.NUnit` (snapshot testing).
+
+## How (conventions)
+
+- **Framework:** NUnit. **Mocks:** `NSubstitute`. **Assertions:** `AwesomeAssertions` (never `ClassicAssert`).
+- **Naming:** keep the method name, add a snake_case suffix — e.g. a test for `MyMethod` →
+  `MyMethod_should_return_expected`. Don't repeat the name in a comment.
+- **No `Arrange`/`Act`/`Assert` comments.**
+- **Isolation:** substitute `IExecutable`/`IProcess` (see [git-command-execution](git-command-execution.md))
+  so tests don't spawn real `git`; substitute services registered in the
+  [service container](service-container.md).
+- **`TestAccessor`:** classes expose an internal `TestAccessor` to reach private members from
+  tests — do **not** add XML docs to `TestAccessor` types/members.
+- **Snapshots:** use `Verify.NUnit` (`.verified.*` files) for large/structured output.
+
+```
+dotnet test        # runs the suite (default VS Code "test" task)
+```
+
+## Hard rules
+
+- Use NUnit + `NSubstitute` + `AwesomeAssertions`. **NEVER** `ClassicAssert`, **never** Moq.
+- Test names: snake_case suffix, method-under-test name unchanged; no redundant name comment.
+- No `Arrange`/`Act`/`Assert` comments.
+- Fix flaky tests at the root cause — don't dismiss them as pre-existing.
+- New git operations SHOULD have unit tests asserting the built arguments.
+
+**Next:** back to the [L2 index](docs-index.md) or explore an [L3 flow](../L3-flows/docs-index.md).

--- a/.github/copilot-docs/L2-core-platform/theming-system.md
+++ b/.github/copilot-docs/L2-core-platform/theming-system.md
@@ -1,0 +1,57 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Theming System (L2)
+
+**TL;DR:** Colors are named by the `AppColor` enum and resolved through a `Theme` object rather
+than hardcoded. Themes are **CSS files** loaded by `ThemeLoader` and managed by `ThemeRepository`.
+This enables light/dark/high-contrast and user-authored themes. When you need a color in UI code,
+ask for the `AppColor`, don't write a literal `Color`.
+
+**Related:** [ui-composition](../L1-conceptual/ui-composition.md) · [settings-system](settings-system.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+## Why
+
+A git GUI shows lots of semantic color (graph branches, diff add/remove, ANSI terminal, panel
+chrome). Hardcoding colors breaks dark mode, accessibility (high contrast), and user
+customisation. A named-color + theme-file approach lets every surface stay consistent and
+re-skinnable without touching the drawing code.
+
+## What
+
+### Color model (`GitExtUtils/GitUI/Theming/`)
+
+- **`AppColor`** (enum) — every app-specific semantic color (panel background, editor background,
+  graph branch colors, ANSI terminal colors…). [AppColor.cs](../../../src/app/GitExtUtils/GitUI/Theming/AppColor.cs).
+- **`AppColorDefaults`** — default value for each `AppColor`.
+  [AppColorDefaults.cs](../../../src/app/GitExtUtils/GitUI/Theming/AppColorDefaults.cs).
+- **`Theme`** — container holding app colors + system colors + a `ThemeId`.
+  [Theme.cs](../../../src/app/GitExtUtils/GitUI/Theming/Theme.cs).
+- **`OtherColors`** — system-color mappings/helpers.
+  [OtherColors.cs](../../../src/app/GitExtUtils/GitUI/Theming/OtherColors.cs).
+
+### Theme lifecycle (`GitUI/Theming/`)
+
+- **`ThemeLoader`** — parses a CSS theme file into a `Theme`.
+  [ThemeLoader.cs](../../../src/app/GitUI/Theming/ThemeLoader.cs).
+- **`ThemeRepository`** — `GetTheme()` / `Save()` / `Delete()` theme management.
+  [ThemeRepository.cs](../../../src/app/GitUI/Theming/ThemeRepository.cs).
+- **`ThemePersistence`** — read/write a `Theme` to CSS.
+  [ThemePersistence.cs](../../../src/app/GitUI/Theming/ThemePersistence.cs).
+- **`ThemePathProvider`** / **`ThemeCssUrlResolver`** — resolve theme file paths / CSS URLs.
+
+Built-in theme assets live under `GitUI/Themes/`; the active theme is a
+[setting](settings-system.md).
+
+## How
+
+- In UI/drawing code, resolve a color via its `AppColor` (through the theming extensions) so it
+  honors the active theme and high-contrast mode.
+- To add a semantic color: add an `AppColor` value + a default in `AppColorDefaults`, then use it.
+- To ship a theme: add a CSS file that `ThemeLoader` can parse.
+
+## Hard rules
+
+- **NEVER** hardcode `Color.FromArgb(...)` for themable UI — add/use an `AppColor`.
+- Respect high-contrast / system themes; don't assume a light background.
+- Keep color *names* semantic (what it's for), not literal (its RGB).
+
+**Next:** [hotkey-system](hotkey-system.md) or [scripts-engine](scripts-engine.md).

--- a/.github/copilot-docs/L2-core-platform/translation-system.md
+++ b/.github/copilot-docs/L2-core-platform/translation-system.md
@@ -1,0 +1,60 @@
+<!-- L2 CORE PLATFORM. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines. -->
+# Translation System (L2)
+
+**TL;DR:** User-facing strings are `TranslationString` fields (often grouped on a `Translate`
+subclass such as `TranslatedStrings`). The English source of truth is the generated file
+**`English.xlf`**. When you add or change any UI string/control, you **MUST** regenerate it by
+running **`update-loc.cmd`** — CI fails if `English.xlf` is stale. Other languages come from
+Transifex; never hand-edit `.xlf`.
+
+**Related:** [L0 primer](../L0-foundations/gitextensions-primer.md) · [architecture-overview](../L1-conceptual/architecture-overview.md) · master [docs-index](../docs-index.md)
+
+**Key files:** [TranslationString.cs](../../../src/app/ResourceManager/TranslationString.cs) ·
+[Translate.cs](../../../src/app/ResourceManager/Translate.cs) ·
+[TranslatedStrings.cs](../../../src/app/ResourceManager/TranslatedStrings.cs) ·
+[English.xlf](../../../src/app/GitUI/Translation/English.xlf) · [update-loc.cmd](../../../update-loc.cmd)
+
+## Why
+
+Git Extensions is localised into many languages. To keep translators productive and the app
+consistent, the English strings are **extracted by reflection** into a single XLIFF catalog
+(`English.xlf`) rather than scattered resource files. Translators work from that catalog on
+Transifex; the app loads the matching language file at runtime.
+
+## What
+
+- **`TranslationString`** — wraps a single translatable string; supports `SmartFormat`
+  placeholders like `{0:second|seconds}` for pluralisation.
+  [TranslationString.cs](../../../src/app/ResourceManager/TranslationString.cs).
+- **`Translate`** — base class; a control/form/service derives from it and declares
+  `TranslationString` fields, which the tooling discovers.
+  [Translate.cs](../../../src/app/ResourceManager/Translate.cs).
+- **`TranslatedStrings`** — shared, app-wide common literals (dates, "Author", etc.).
+  [TranslatedStrings.cs](../../../src/app/ResourceManager/TranslatedStrings.cs).
+- **`TranslatedControl`** / **`LocalizationHelpers`** — apply translations to WinForms controls.
+- **`English.xlf`** — the generated English catalog and CI's reference; translated `.xlf` files
+  live alongside it in `GitUI/Translation/`.
+- **`TranslationApp`** (`Setup/TranslationApp`) — the generator run by `update-loc.cmd`. It
+  reflects over all translatable types, regenerates `English.xlf`, and stages the result.
+
+## How (add or change a UI string)
+
+1. Add a `TranslationString` field (or edit a control's designer text / a `TranslatedStrings` entry).
+2. Build succeeds first (`dotnet build /v:q`).
+3. Run **`update-loc.cmd`** from the repo root. This runs `TranslationApp`, regenerates
+   `English.xlf`, and stages the change.
+4. Commit the updated `English.xlf` **together** with your code change.
+
+```
+> .\update-loc.cmd      # regenerates & stages English.xlf
+```
+
+## Hard rules
+
+- Adding/modifying forms, controls, toolbar/menu items, or `TranslationString` fields **MUST**
+  update `English.xlf` via `update-loc.cmd`. **CI fails** otherwise.
+- **NEVER** hand-edit `.xlf` files — they are generated.
+- Do not translate non-user-facing/log/exception-internal strings; only wrap real UI text.
+- Commit the regenerated `English.xlf` in the **same** change as the code that introduced the string.
+
+**Next:** back to the [L2 index](docs-index.md) for other subsystems (theming, hotkeys, testing).

--- a/.github/copilot-docs/L3-flows/branch-management-flow.md
+++ b/.github/copilot-docs/L3-flows/branch-management-flow.md
@@ -1,0 +1,39 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Branch Management Flow (L3)
+
+**TL;DR:** Create, rename, and delete branches each have a dialog. Create and rename use the
+argument-only command pattern (`ArgumentString` + `FormProcess.ShowDialog`); delete uses the
+structured `IGitCommand` + `StartCommandLineProcessDialog` path (it needs worktree-safety checks).
+
+**Related:** [checkout-flow](checkout-flow.md) · [structured-commands](../L2-core-platform/structured-commands.md) · [commit-flow](commit-flow.md) (flow template) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormCreateBranch.cs](../../../src/app/GitUI/CommandsDialogs/FormCreateBranch.cs) ·
+[FormRenameBranch.cs](../../../src/app/GitUI/CommandsDialogs/FormRenameBranch.cs) ·
+[FormDeleteBranch.cs](../../../src/app/GitUI/CommandsDialogs/FormDeleteBranch.cs)
+
+## Why
+
+Branch operations have different risk profiles: creating/renaming is low-risk, while **deleting**
+can lose work or hit worktree constraints. The delete path therefore carries state-change metadata
+and extra guards, while create/rename stay simple.
+
+## What / How
+
+| Operation | Form | Builds | Runs via |
+| --- | --- | --- | --- |
+| Create | `FormCreateBranch` | `Commands.Branch(...)` / `Commands.CreateOrphan(...)` (`ArgumentString`) | `FormProcess.ShowDialog` |
+| Rename | `FormRenameBranch` | `Commands.RenameBranch(old, new)` (`ArgumentString`) | `FormProcess.ShowDialog` |
+| Delete | `FormDeleteBranch` | `Commands.DeleteBranch(branches, force)` (`IGitCommand`) | `UICommands.StartCommandLineProcessDialog` |
+
+- **Create** supports orphan branches and optional checkout-after-create; reverts on failure.
+- **Rename** can auto-normalise the branch name (if `AutoNormaliseBranchName` is enabled).
+- **Delete** checks worktrees, prevents deleting the current branch, and distinguishes
+  merged vs unmerged (force). It may run `worktree prune` afterward.
+
+## Hard rules
+
+- Deleting a branch is destructive — keep the current-branch and worktree guards intact.
+- Quote/normalise branch names (`.Quote()`/normaliser); never concatenate raw user text into args.
+- After any of these, refresh via `RepoChangedNotifier`.
+
+**Next:** [clone-flow](clone-flow.md).

--- a/.github/copilot-docs/L3-flows/browse-flow.md
+++ b/.github/copilot-docs/L3-flows/browse-flow.md
@@ -1,0 +1,47 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines.
+     Follows the pattern documented in commit-flow.md (the template). -->
+# Browse / Open Repository Flow (L3)
+
+**TL;DR:** `FormBrowse` is the main window. Opening (or switching) a repository sets the active
+`GitModule` and triggers a revision refresh, which loads history on a background thread via
+`RevisionReader` and renders it in `RevisionGridControl`. The left `RepoObjectsTree` and commit
+details refresh alongside.
+
+**Related:** [revision-grid-flow](revision-grid-flow.md) · [ui-composition](../L1-conceptual/ui-composition.md) · [commit-flow](commit-flow.md) (flow template) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormBrowse.cs](../../../src/app/GitUI/CommandsDialogs/FormBrowse.cs) (+ partials) ·
+[RevisionGridControl.cs](../../../src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs) ·
+[RepoObjectsTree.cs](../../../src/app/GitUI/LeftPanel/RepoObjectsTree.cs)
+
+## Why
+
+The browse window is the hub every other flow launches from. It must open a repo, show its
+history and refs quickly, and stay responsive while git reads potentially huge logs — so loading
+is asynchronous and refresh is coordinated centrally.
+
+## What / How
+
+1. **Open a module** — `FormBrowse` is constructed with `UICommands`/`Module`; switching repos
+   updates the active `GitModule` and persists recent-repo history.
+2. **Refresh revisions** — `FormBrowse` calls into the grid to refresh; `RevisionGridControl`
+   runs `RevisionReader` on a background thread (see [revision-grid-flow](revision-grid-flow.md)).
+3. **Populate panels** — the left `RepoObjectsTree` loads branches/tags/stashes/submodules; the
+   commit-details/diff panels update via the `FormBrowse.InitCommitDetails` partial.
+4. **Enable/disable UI** — `FormBrowse.UpdateTargets` adjusts toolbar/menu state for the current repo.
+
+The window is split across partials (`Designer`, `InitRevisionGrid`, `InitMenusAndToolbars`,
+`InitCommitDetails`, `UpdateTargets`) — see [ui-composition](../L1-conceptual/ui-composition.md).
+
+## Quirks
+
+- History loads **asynchronously**; the grid may still be populating right after a repo opens.
+- Refresh is suspended/resumed around bulk layout changes to avoid flicker and wasted work.
+- The grid shows the artificial **WorkTree** and **Index** rows above real commits.
+
+## Hard rules
+
+- Get the repo via `UICommands.Module`; never `new` a `GitModule` in the form.
+- Do history/ref loading on the background thread ([threading-model](../L1-conceptual/threading-model.md)); touch controls only after switching to the UI thread.
+- After a state change elsewhere, rely on `RepoChangedNotifier` to refresh — don't force ad-hoc reloads.
+
+**Next:** [revision-grid-flow](revision-grid-flow.md).

--- a/.github/copilot-docs/L3-flows/checkout-flow.md
+++ b/.github/copilot-docs/L3-flows/checkout-flow.md
@@ -1,0 +1,44 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Checkout Flow (L3)
+
+**TL;DR:** `FormCheckoutBranch` switches branches. It builds an `IGitCommand` via
+`Commands.CheckoutBranch(...)` and runs it with `UICommands.StartCommandLineProcessDialog`, which
+fires the repo-changed refresh. It can auto-stash local changes, create/reset a new branch, and
+handle tracking-branch setup. `FormCheckoutRevision` does a detached checkout of a specific commit.
+
+**Related:** [structured-commands](../L2-core-platform/structured-commands.md) · [branch-management-flow](branch-management-flow.md) · [commit-flow](commit-flow.md) (flow template) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormCheckoutBranch.cs](../../../src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs) ·
+[FormCheckoutRevision.cs](../../../src/app/GitUI/CommandsDialogs/FormCheckoutRevision.cs) ·
+`Commands.CheckoutBranch` in [Commands.cs](../../../src/app/GitCommands/Git/Commands.cs)
+
+## Why
+
+Checkout must safely reconcile the working tree: it may need to stash/restore local changes, warn
+about conflicts, or create a new local branch tracking a remote. Encoding those choices in a
+structured command (with `ChangesRepoState = true`) ensures the UI refreshes and the right process
+dialog is used.
+
+## What / How
+
+1. User picks a branch (and options: how to handle local changes, create/reset a new branch).
+2. `FormCheckoutBranch` calls `Commands.CheckoutBranch(branchName, isRemote, localChanges,
+   newBranchMode, newBranchName)` → an `IGitCommand`.
+3. It runs via `UICommands.StartCommandLineProcessDialog(this, cmd)` — this is the **preferred**
+   structured path (see [structured-commands](../L2-core-platform/structured-commands.md)).
+4. On success, `RepoChangedNotifier` refreshes the grid and panels.
+
+## Quirks
+
+- **Local changes**: `LocalChangesAction` decides merge/reset/stash behavior; the form can
+  auto-stash then pop.
+- **New branch**: `CheckoutNewBranchMode` (Create/Reset) + `--track` for remote branches.
+- `FormCheckoutRevision` checks out a commit (detached HEAD) rather than a branch.
+
+## Hard rules
+
+- Use the structured `Commands.CheckoutBranch` + `StartCommandLineProcessDialog` path — don't build a raw checkout string.
+- Preserve the local-changes handling; silently discarding user changes is a data-loss bug.
+- Rely on `RepoChangedNotifier` for refresh after checkout.
+
+**Next:** [branch-management-flow](branch-management-flow.md).

--- a/.github/copilot-docs/L3-flows/clone-flow.md
+++ b/.github/copilot-docs/L3-flows/clone-flow.md
@@ -1,0 +1,42 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Clone Flow (L3)
+
+**TL;DR:** `FormClone` clones a remote repository. It builds a `git clone` `ArgumentString` via
+`Commands.Clone(...)` and runs it through `FormRemoteProcess` (a remote-aware process dialog).
+It validates paths, supports shallow/single-branch clones and submodule init, and can open the
+cloned repo afterward.
+
+**Related:** [push-flow](push-flow.md) · [pull-flow](pull-flow.md) · [structured-commands](../L2-core-platform/structured-commands.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormClone.cs](../../../src/app/GitUI/CommandsDialogs/FormClone.cs) ·
+`Commands.Clone` in [Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs)
+
+## Why
+
+Cloning is the entry point to a repository and touches a remote, so it needs a remote-capable
+process dialog (auth prompts, progress), path validation, and options for large repos (shallow /
+single-branch) and submodules.
+
+## What / How
+
+1. User enters source URL, destination path, and options (branch, depth, single-branch,
+   init submodules, central/bare).
+2. `FormClone` builds the command with `Commands.Clone(url, destPath, getPathForGitExecution,
+   centralRepo, initSubmodules, branch, depth, isSingleBranch)` → an `ArgumentString`.
+3. It runs via `FormRemoteProcess.ShowDialog(...)` (remote-aware: shows progress, handles
+   credentials/SSH).
+4. On success it can store the SSH key and optionally open the cloned repo in a new `FormBrowse`.
+
+## Quirks
+
+- **Shallow** (`depth`) and **single-branch** options speed up large clones.
+- Validates source/destination paths before running.
+- Because it accesses a remote, the command's `AccessesRemote` is true → remote process dialog.
+
+## Hard rules
+
+- Clone accesses a remote — run it through the remote process dialog, not a plain one.
+- Validate/quote user-provided URLs and paths.
+- Don't assume submodules are initialised unless the user opted in.
+
+**Next:** [push-flow](push-flow.md).

--- a/.github/copilot-docs/L3-flows/commit-flow.md
+++ b/.github/copilot-docs/L3-flows/commit-flow.md
@@ -1,0 +1,80 @@
+<!-- L3 FLOW. Agentic doc: TL;DR at top, Why→What→How, code pointers not code, ~100 lines.
+     This is the template for other flow docs: trace UI → command → git → refresh. -->
+# Commit Flow (L3)
+
+**TL;DR:** The commit UI is `FormCommit`. It shows working-tree changes, lets the user stage
+files and write a message, then builds a `git commit` argument set with `Commands.Commit(...)`
+and runs it through `FormProcess.ShowDialog`. Before/after commit it runs user scripts and, on
+success, notifies the app to refresh via `RepoChangedNotifier`.
+
+**Related:** [structured-commands](../L2-core-platform/structured-commands.md) · [git-command-execution](../L2-core-platform/git-command-execution.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormCommit.cs](../../../src/app/GitUI/CommandsDialogs/FormCommit.cs) ·
+[Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs) (`Commit`) ·
+[CommitMessageManager.cs](../../../src/app/GitCommands/CommitMessageManager.cs) ·
+[FormProcess.cs](../../../src/app/GitUI/HelperDialogs/FormProcess.cs)
+
+## Why
+
+Committing is more than `git commit`: Git Extensions must validate state (merge conflicts,
+detached HEAD, empty message), persist and template the commit message, honor amend/sign-off/
+GPG options, run pre/post commit **user scripts**, and refresh every open view afterward. All of
+that orchestration lives in `FormCommit`, keeping the raw git call thin.
+
+## What (the actors)
+
+- **`FormCommit`** — the dialog. Hosts the *Unstaged* and *Staged* file lists, the message box,
+  and commit options (amend, sign-off, GPG, `--no-verify`, reset author).
+- **`CommitMessageManager`** — loads/saves the in-progress commit message and template
+  (`Module.WorkingDirGitDir`, `CommitEncoding`).
+- **`Commands.Commit(...)`** — builds the `git commit` `ArgumentString` from the chosen options.
+- **`FormProcess`** — the process dialog that runs the git command and shows its output.
+- **`ScriptsRunner` + `ScriptEvent.BeforeCommit`/`AfterCommit`** — user-defined hooks.
+
+## How (the sequence)
+
+Entry: user clicks *Commit* → `CheckForStagedAndCommit(bool push)`
+([FormCommit.cs](../../../src/app/GitUI/CommandsDialogs/FormCommit.cs) ~L1070) → inner `DoCommit()` (~L1172):
+
+1. **Guard checks:** abort if `Module.InTheMiddleOfConflictedMerge()`; require a non-empty,
+   valid message (`IsCommitMessageValid()`); if `Module.IsDetachedHead()` and not rebasing,
+   prompt to checkout/create a branch or continue.
+2. **Persist message:** save `AppSettings.LastCommitMessage` and write the message to file via
+   `_commitMessageManager.WriteCommitMessageToFileAsync(...)`.
+3. **Pre-commit scripts:** `ScriptsRunner.RunEventScripts(ScriptEvent.BeforeCommit, this)`;
+   abort if it returns false.
+4. **Build the command:** `Commands.Commit(amend, signOff, author, useExplicitCommitMessage,
+   commitMessageFile, Module.GetPathForGitExecution, noVerify, gpgSign, gpgKeyId, allowEmpty,
+   resetAuthor)` → an `ArgumentString`.
+5. **Run git:** `FormProcess.ShowDialog(this, UICommands, arguments: commitCmd, Module.WorkingDir,
+   input: null, useDialogSettings: true)` → runs `git commit` and returns success.
+6. **Notify + post scripts:** `UICommands.RepoChangedNotifier.Notify()` refreshes open views;
+   on success run `ScriptEvent.AfterCommit`. If *Commit & Push* was chosen, the push flow follows.
+
+```mermaid
+sequenceDiagram
+    User->>FormCommit: Click Commit
+    FormCommit->>FormCommit: DoCommit() guards + validate
+    FormCommit->>CommitMessageManager: persist message
+    FormCommit->>ScriptsRunner: BeforeCommit scripts
+    FormCommit->>Commands: Commit(...) build args
+    FormCommit->>FormProcess: ShowDialog(git commit)
+    FormProcess-->>FormCommit: success
+    FormCommit->>RepoChangedNotifier: Notify() (refresh)
+    FormCommit->>ScriptsRunner: AfterCommit scripts
+```
+
+## Notes & gotchas
+
+- Staging/unstaging happens in the file lists before `DoCommit`; `Staged.IsEmpty` maps to the
+  `allowEmpty` argument.
+- Commit uses the **argument-only** command pattern (`ArgumentString` + `FormProcess`), not the
+  `IGitCommand` + `StartCommandLineProcessDialog` path — see [structured-commands](../L2-core-platform/structured-commands.md).
+- Amend, GPG sign, sign-off, and `--no-verify` are all driven by toolbar/menu toggles in `FormCommit`.
+
+## Hard rules
+
+- **NEVER** bypass the guard checks — merge-conflict and detached-HEAD handling prevent data loss.
+- Any new commit option MUST be threaded through `Commands.Commit(...)`, not appended as a raw string.
+- After a state change, **ALWAYS** call `RepoChangedNotifier.Notify()` so views refresh.
+- If you add UI strings here, update `English.xlf` via `update-loc.cmd`.

--- a/.github/copilot-docs/L3-flows/conflict-resolution-flow.md
+++ b/.github/copilot-docs/L3-flows/conflict-resolution-flow.md
@@ -1,0 +1,41 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Conflict Resolution Flow (L3)
+
+**TL;DR:** `FormResolveConflicts` (with `MergeConflictHandler`) walks the user through conflicted
+files. It launches the configured mergetool via `Module.RunMergeTool(...)` for text conflicts and
+uses `git add` / `git rm` to record resolutions. It handles 2-way/3-way merges, binary files, and
+prompts to commit once everything is resolved.
+
+**Related:** [merge-flow](merge-flow.md) · [rebase-flow](rebase-flow.md) · [pull-flow](pull-flow.md) · [commit-flow](commit-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormResolveConflicts.cs](../../../src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs) ·
+[MergeConflictHandler.cs](../../../src/app/GitUI/CommandsDialogs/MergeConflictHandler.cs)
+
+## Why
+
+Conflicts are the highest-stakes moment in git workflows — the point where work is most easily
+lost. A guided flow (with base/local/remote context and the user's mergetool) makes resolution
+safe and repeatable across merge, rebase, pull, and stash-apply.
+
+## What / How
+
+1. After a conflicting merge/rebase/pull, `MergeConflictHandler` detects the conflict and offers to
+   open `FormResolveConflicts`.
+2. The form lists conflicted files. For each:
+   - **Text** — launch the configured mergetool via `Module.RunMergeTool(...)` (base/local/remote).
+   - **Binary / choose-side** — pick ours/theirs; recorded with `git add` / `git rm`.
+3. Once all files are resolved, it prompts to **commit** the merge (see [commit-flow](commit-flow.md)).
+
+## Quirks
+
+- Supports **2-way and 3-way** merges; shows base/local/remote where available.
+- **Binary** files can't be text-merged — the flow offers side selection.
+- The repo stays "in the middle of a merge" until resolved+committed; that state gates other actions.
+
+## Hard rules
+
+- Never mark a file resolved without recording it (`git add`/`git rm`); half-resolved state is dangerous.
+- Respect the user's configured mergetool; don't hardcode a diff/merge tool.
+- Only offer to commit once **all** conflicts are resolved.
+
+**Next:** [submodule-flow](submodule-flow.md).

--- a/.github/copilot-docs/L3-flows/diff-blame-flow.md
+++ b/.github/copilot-docs/L3-flows/diff-blame-flow.md
@@ -1,0 +1,45 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Diff & Blame Flow (L3)
+
+**TL;DR:** Diffs are shown either in the embedded file viewer or an external difftool
+(`FormDiff` compares two revisions, using merge-base for branch comparisons). Blame is shown by
+`FormBlame`, whose blame control loads annotations asynchronously. Both are read-only views over
+git output.
+
+**Related:** [file-history-flow](file-history-flow.md) · [revision-grid-flow](revision-grid-flow.md) · [git-command-execution](../L2-core-platform/git-command-execution.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormDiff.cs](../../../src/app/GitUI/CommandsDialogs/FormDiff.cs) ·
+[FormBlame.cs](../../../src/app/GitUI/CommandsDialogs/FormBlame.cs) · diff/editor controls under
+[GitUI/Editor/](../../../src/app/GitUI/Editor/)
+
+## Why
+
+Understanding changes is core to a git GUI. Diffs and blame must handle large files, binary files,
+different encodings, and both internal (embedded editor) and external (configured difftool)
+viewing — so these flows delegate to the file viewer or an external tool rather than reimplementing
+diffing.
+
+## What / How
+
+- **Diff (`FormDiff`)** — compares two selected revisions. For branch comparison it diffs from the
+  **merge-base**. It can render inside the embedded viewer or launch the configured difftool via
+  `Module.OpenWithDifftoolDirDiff(...)` (a separate process).
+- **Blame (`FormBlame`)** — annotates each line with its last-changing commit. The blame control
+  loads asynchronously (cancellable) and lets you navigate to the responsible revision.
+- **Embedded viewer** — the diff/file viewer lives under `GitUI/Editor/` (based on
+  `ICSharpCode.TextEditor`) with syntax highlighting.
+
+## Quirks
+
+- Branch-vs-branch diff uses the **merge-base**, not a raw two-dot diff, so it shows "what changed
+  on this branch".
+- Blame loads **async** with cancellation; switching selection cancels the prior load.
+- External difftool runs out-of-process; the app doesn't block on it as an internal view.
+
+## Hard rules
+
+- Prefer the existing viewer/difftool integration; don't shell out to `git diff` ad hoc.
+- Load blame/diff off the UI thread and marshal back ([threading-model](../L1-conceptual/threading-model.md)).
+- Respect the user's configured difftool/mergetool settings.
+
+**Next:** [file-history-flow](file-history-flow.md).

--- a/.github/copilot-docs/L3-flows/docs-index.md
+++ b/.github/copilot-docs/L3-flows/docs-index.md
@@ -1,0 +1,44 @@
+# L3 — Flows · Docs-Index
+
+**TL;DR:** End-to-end user flows that compose the [L2](../L2-core-platform/docs-index.md) subsystems.
+Each flow doc traces a user action from the UI down to `git` and back, with code pointers at every hop.
+Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
+
+> **Status: SKELETON** — docs below are the roadmap. `planned` = not written yet.
+
+## Repository & history
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| `browse-flow.md` | App → `FormBrowse` startup, loading a repo, populating panels. | planned |
+| `revision-grid-flow.md` | How history is read (`RevisionReader`) and rendered in `RevisionGrid`. | planned |
+| `diff-blame-flow.md` | Viewing diffs and blame for files/commits. | planned |
+| `file-history-flow.md` | `FormFileHistory` — following a single file's history. | planned |
+
+## Working with changes
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| [commit-flow.md](commit-flow.md) | `FormCommit` — staging, commit message, amend, hooks. | done |
+| `stash-flow.md` | `FormStash` — save/apply/pop/drop stashes. | planned |
+| `conflict-resolution-flow.md` | `FormResolveConflicts` + `MergeConflictHandler`. | planned |
+
+## Branches & remotes
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| `checkout-flow.md` | `FormCheckoutBranch` / `FormCheckoutRevision`. | planned |
+| `branch-management-flow.md` | Create / rename / delete branches. | planned |
+| `clone-flow.md` | `FormClone` — clone a remote repository. | planned |
+| `push-flow.md` | `FormPush` — push, force options, tracking. | planned |
+| `pull-flow.md` | `FormPull` — fetch + merge/rebase. | planned |
+| `rebase-flow.md` | `FormRebase` — interactive and non-interactive rebase. | planned |
+| `merge-flow.md` | `FormMergeBranch` — merge branches. | planned |
+
+## Submodules
+
+| Doc | One-line description | Status |
+| --- | --- | --- |
+| `submodule-flow.md` | `FormSubmodules` + `SubmoduleHelpers` — init/update/sync. | planned |
+
+Back to [master docs-index](../docs-index.md).

--- a/.github/copilot-docs/L3-flows/docs-index.md
+++ b/.github/copilot-docs/L3-flows/docs-index.md
@@ -4,7 +4,7 @@
 Each flow doc traces a user action from the UI down to `git` and back, with code pointers at every hop.
 Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 
-> **Status: SKELETON** — docs below are the roadmap. `planned` = not written yet.
+> All docs below are written. `Status` tracks any future additions.
 
 ## Repository & history
 

--- a/.github/copilot-docs/L3-flows/docs-index.md
+++ b/.github/copilot-docs/L3-flows/docs-index.md
@@ -10,35 +10,35 @@ Read the [L0 primer](../L0-foundations/gitextensions-primer.md) first.
 
 | Doc | One-line description | Status |
 | --- | --- | --- |
-| `browse-flow.md` | App → `FormBrowse` startup, loading a repo, populating panels. | planned |
-| `revision-grid-flow.md` | How history is read (`RevisionReader`) and rendered in `RevisionGrid`. | planned |
-| `diff-blame-flow.md` | Viewing diffs and blame for files/commits. | planned |
-| `file-history-flow.md` | `FormFileHistory` — following a single file's history. | planned |
+| [browse-flow.md](browse-flow.md) | App → `FormBrowse` startup, loading a repo, populating panels. | done |
+| [revision-grid-flow.md](revision-grid-flow.md) | How history is read (`RevisionReader`) and rendered in `RevisionGrid`. | done |
+| [diff-blame-flow.md](diff-blame-flow.md) | Viewing diffs and blame for files/commits. | done |
+| [file-history-flow.md](file-history-flow.md) | `FormFileHistory` — following a single file's history. | done |
 
 ## Working with changes
 
 | Doc | One-line description | Status |
 | --- | --- | --- |
 | [commit-flow.md](commit-flow.md) | `FormCommit` — staging, commit message, amend, hooks. | done |
-| `stash-flow.md` | `FormStash` — save/apply/pop/drop stashes. | planned |
-| `conflict-resolution-flow.md` | `FormResolveConflicts` + `MergeConflictHandler`. | planned |
+| [stash-flow.md](stash-flow.md) | `FormStash` — save/apply/pop/drop stashes. | done |
+| [conflict-resolution-flow.md](conflict-resolution-flow.md) | `FormResolveConflicts` + `MergeConflictHandler`. | done |
 
 ## Branches & remotes
 
 | Doc | One-line description | Status |
 | --- | --- | --- |
-| `checkout-flow.md` | `FormCheckoutBranch` / `FormCheckoutRevision`. | planned |
-| `branch-management-flow.md` | Create / rename / delete branches. | planned |
-| `clone-flow.md` | `FormClone` — clone a remote repository. | planned |
-| `push-flow.md` | `FormPush` — push, force options, tracking. | planned |
-| `pull-flow.md` | `FormPull` — fetch + merge/rebase. | planned |
-| `rebase-flow.md` | `FormRebase` — interactive and non-interactive rebase. | planned |
-| `merge-flow.md` | `FormMergeBranch` — merge branches. | planned |
+| [checkout-flow.md](checkout-flow.md) | `FormCheckoutBranch` / `FormCheckoutRevision`. | done |
+| [branch-management-flow.md](branch-management-flow.md) | Create / rename / delete branches. | done |
+| [clone-flow.md](clone-flow.md) | `FormClone` — clone a remote repository. | done |
+| [push-flow.md](push-flow.md) | `FormPush` — push, force options, tracking. | done |
+| [pull-flow.md](pull-flow.md) | `FormPull` — fetch + merge/rebase. | done |
+| [rebase-flow.md](rebase-flow.md) | `FormRebase` — interactive and non-interactive rebase. | done |
+| [merge-flow.md](merge-flow.md) | `FormMergeBranch` — merge branches. | done |
 
 ## Submodules
 
 | Doc | One-line description | Status |
 | --- | --- | --- |
-| `submodule-flow.md` | `FormSubmodules` + `SubmoduleHelpers` — init/update/sync. | planned |
+| [submodule-flow.md](submodule-flow.md) | `FormSubmodules` + `SubmoduleHelpers` — init/update/sync. | done |
 
 Back to [master docs-index](../docs-index.md).

--- a/.github/copilot-docs/L3-flows/file-history-flow.md
+++ b/.github/copilot-docs/L3-flows/file-history-flow.md
@@ -1,0 +1,38 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# File History Flow (L3)
+
+**TL;DR:** `FormFileHistory` shows the commit history of a single file (or submodule) by reusing
+the revision-grid engine filtered to that path. `FormFileHistoryController` builds it; the view
+follows renames and can diff/blame any revision of the file.
+
+**Related:** [revision-grid-flow](revision-grid-flow.md) · [diff-blame-flow](diff-blame-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormFileHistory.cs](../../../src/app/GitUI/CommandsDialogs/FormFileHistory.cs) ·
+[FormFileHistoryController.cs](../../../src/app/GitUI/CommandsDialogs/FormFileHistoryController.cs)
+
+## Why
+
+Developers often ask "how did this file evolve?" Rather than build a separate history engine, file
+history reuses the same `RevisionGrid`/`RevisionReader` machinery with a path filter, so graph,
+diff, and blame behave identically to the main window.
+
+## What / How
+
+1. **Open** — `FormFileHistoryController` constructs `FormFileHistory` for a selected path.
+2. **Load** — the embedded revision grid runs the [revision-grid flow](revision-grid-flow.md)
+   scoped to the file's path (git log for that path), following renames.
+3. **Inspect** — selecting a revision shows that version's diff/blame (see
+   [diff-blame-flow](diff-blame-flow.md)); comparisons can launch the difftool via `UICommands`.
+
+## Quirks
+
+- **Follows renames** so history isn't truncated when a file was moved.
+- A **submodule** can be shown as a "file" whose history is its recorded commits.
+- Uses the same async load + cancellation as the main grid.
+
+## Hard rules
+
+- Reuse the revision-grid engine with a path filter; don't fork a parallel history reader.
+- Off-thread load, UI-thread render ([threading-model](../L1-conceptual/threading-model.md)).
+
+**Next:** back to the [L3 index](docs-index.md).

--- a/.github/copilot-docs/L3-flows/merge-flow.md
+++ b/.github/copilot-docs/L3-flows/merge-flow.md
@@ -1,0 +1,39 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Merge Flow (L3)
+
+**TL;DR:** `FormMergeBranch` merges another branch into the current one. It builds
+`Commands.MergeBranch(...)` and runs it via `FormProcess`. Options include no-fast-forward,
+squash, no-commit, and adding log messages. Conflicts route to the conflict-resolution flow.
+
+**Related:** [rebase-flow](rebase-flow.md) · [pull-flow](pull-flow.md) · [conflict-resolution-flow](conflict-resolution-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormMergeBranch.cs](../../../src/app/GitUI/CommandsDialogs/FormMergeBranch.cs) ·
+`Commands.MergeBranch` in [Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs)
+
+## Why
+
+Merging integrates branches while preserving history. Different situations want different merge
+shapes (fast-forward vs an explicit merge commit vs squash), so the dialog surfaces those options
+and handles the conflict case cleanly.
+
+## What / How
+
+1. User selects the branch to merge and options (no-ff, squash, no-commit, log messages).
+2. `FormMergeBranch` builds `Commands.MergeBranch(branchToMerge, noFastForward, squash, noCommit,
+   addLogMessages, getPathForGitExecution, logMessagesCount)`.
+3. It runs via `FormProcess.ShowDialog(...)`; on conflict, route to
+   [conflict resolution](conflict-resolution-flow.md), then commit.
+
+## Quirks
+
+- **--no-ff** forces a merge commit even when a fast-forward is possible (keeps topic-branch shape).
+- **squash** stages the result without recording a merge commit (you commit separately).
+- Optional shortlog of merged commits can be added to the merge message.
+
+## Hard rules
+
+- Keep the merge-option semantics accurate (no-ff/squash/no-commit) — they change history shape.
+- On conflicts, use the conflict-resolution flow; don't force-complete a conflicted merge.
+- Refresh via `RepoChangedNotifier` after merge/commit.
+
+**Next:** [conflict-resolution-flow](conflict-resolution-flow.md).

--- a/.github/copilot-docs/L3-flows/pull-flow.md
+++ b/.github/copilot-docs/L3-flows/pull-flow.md
@@ -1,0 +1,41 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Pull Flow (L3)
+
+**TL;DR:** `FormPull` fetches from a remote and then merges or rebases (user's choice). It composes
+`Commands.Fetch` with `Commands.Merge` or `Commands.Rebase` and runs via `FormProcess`. It can
+auto-stash local changes, run before/after pull scripts, detect conflicts, and pop the stash after.
+
+**Related:** [push-flow](push-flow.md) · [rebase-flow](rebase-flow.md) · [merge-flow](merge-flow.md) · [conflict-resolution-flow](conflict-resolution-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormPull.cs](../../../src/app/GitUI/CommandsDialogs/FormPull.cs) ·
+`Commands.Fetch` / `Merge` / `Rebase` in [Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs)
+
+## Why
+
+"Pull" is really fetch + integrate, and the safe way to integrate depends on the user's workflow
+(merge vs rebase). Wrapping both in one dialog — with auto-stash and conflict handling — makes a
+multi-step, error-prone operation reliable.
+
+## What / How
+
+1. User picks remote/branch and integration mode (merge, rebase, or fetch-only).
+2. `FormPull` (`CreateFormProcess()`) builds `Commands.Fetch(...)` and, per the choice,
+   `Commands.Merge(...)` or `Commands.Rebase(...)`.
+3. It runs via `FormProcess.ShowDialog(...)`.
+4. If local changes exist it may **auto-stash** first and **pop** afterward; conflicts route to
+   [conflict resolution](conflict-resolution-flow.md).
+5. `ScriptEvent.BeforePull` / `AfterPull` scripts run around the operation (see [scripts-engine](../L2-core-platform/scripts-engine.md)).
+
+## Quirks
+
+- Merge vs rebase changes history shape — the dialog makes the choice explicit.
+- Auto-stash/pop protects uncommitted work; a conflict during pop is surfaced.
+- Fetch accesses the remote (remote-aware progress/auth).
+
+## Hard rules
+
+- Honor the user's merge/rebase choice; don't silently pick one.
+- Preserve auto-stash/pop and conflict detection — dropping them risks losing local work.
+- Run before/after pull scripts and refresh via `RepoChangedNotifier`.
+
+**Next:** [rebase-flow](rebase-flow.md).

--- a/.github/copilot-docs/L3-flows/push-flow.md
+++ b/.github/copilot-docs/L3-flows/push-flow.md
@@ -1,0 +1,40 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Push Flow (L3)
+
+**TL;DR:** `FormPush` pushes branches/tags to a remote. It builds a push command via
+`Commands.Push` / `PushAll` / `PushTag` / `PushMultiple` and runs it through `FormRemoteProcess`
+(remote-aware). It manages tracking branches, multiple-branch pushes, and suggests
+force-with-lease instead of a plain force.
+
+**Related:** [pull-flow](pull-flow.md) · [clone-flow](clone-flow.md) · [structured-commands](../L2-core-platform/structured-commands.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormPush.cs](../../../src/app/GitUI/CommandsDialogs/FormPush.cs) ·
+`Commands.Push*` in [Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs)
+
+## Why
+
+Push writes to a shared remote, so it needs credential/progress handling and safety around forced
+updates. Supporting single, all, tag, and multi-branch pushes from one dialog keeps common
+workflows fast while steering users away from destructive plain `--force`.
+
+## What / How
+
+1. User selects remote, branch(es)/tags, and options (force, track, recurse submodules).
+2. `FormPush` builds the appropriate command: `Commands.Push` (one), `PushAll`, `PushTag`, or
+   `PushMultiple` (a branch matrix from the grid).
+3. It runs via `FormRemoteProcess.ShowDialog(...)` (progress, auth, SSH).
+4. Post-push, tracking may be set and the repo refreshed.
+
+## Quirks
+
+- Prefers **force-with-lease** over `--force` to avoid clobbering others' work.
+- The multi-branch grid pushes several refs in one operation (`PushMultiple`).
+- Remote-listing (to populate the UI) may run a lighter process dialog first.
+
+## Hard rules
+
+- Push accesses a remote — always use the remote process dialog.
+- Prefer **force-with-lease**; never silently do a bare `--force`.
+- Quote ref/remote names; rely on `RepoChangedNotifier` afterward.
+
+**Next:** [pull-flow](pull-flow.md).

--- a/.github/copilot-docs/L3-flows/rebase-flow.md
+++ b/.github/copilot-docs/L3-flows/rebase-flow.md
@@ -1,0 +1,40 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Rebase Flow (L3)
+
+**TL;DR:** `FormRebase` rebases the current branch onto another (or interactively). It builds
+`Commands.Rebase(...)` and, during a conflicted rebase, `Commands.ContinueRebase` /
+`SkipRebase` / `AbortRebase`, running each via `FormProcess`. It supports interactive rebase and
+manages the continue/skip/abort/edit-todo lifecycle.
+
+**Related:** [merge-flow](merge-flow.md) · [pull-flow](pull-flow.md) · [conflict-resolution-flow](conflict-resolution-flow.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormRebase.cs](../../../src/app/GitUI/CommandsDialogs/FormRebase.cs) ·
+`Commands.Rebase` / `ContinueRebase` / `SkipRebase` / `AbortRebase` in [Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs)
+
+## Why
+
+Rebase rewrites history and is stateful: it can pause on conflicts and must be continued, skipped,
+or aborted. The dialog exposes that lifecycle safely so users don't leave the repo mid-rebase in a
+confusing state.
+
+## What / How
+
+1. User chooses the upstream/onto target and options (interactive, autosquash, etc.).
+2. `FormRebase` runs `Commands.Rebase(rebaseOptions)` via `FormProcess.ShowDialog(...)`.
+3. If it stops on a conflict, the dialog offers **Continue** (`ContinueRebase`), **Skip**
+   (`SkipRebase`), **Abort** (`AbortRebase`), or edit-todo — each a separate git command.
+4. Conflicts route to [conflict resolution](conflict-resolution-flow.md); state is re-read after each step.
+
+## Quirks
+
+- **Interactive** rebase opens the todo list for reordering/squashing.
+- The middle-of-rebase state (`Module.InTheMiddleOfRebase()`) gates other operations (e.g. commit).
+- Abort restores the pre-rebase state; encourage it over leaving a half-done rebase.
+
+## Hard rules
+
+- Always provide continue/skip/**abort** paths — never leave the user stuck mid-rebase.
+- Re-check repo state after each rebase step before enabling other actions.
+- Refresh via `RepoChangedNotifier` after completion/abort.
+
+**Next:** [merge-flow](merge-flow.md).

--- a/.github/copilot-docs/L3-flows/revision-grid-flow.md
+++ b/.github/copilot-docs/L3-flows/revision-grid-flow.md
@@ -1,0 +1,45 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Revision Grid Loading Flow (L3)
+
+**TL;DR:** `RevisionGridControl` loads history by running `RevisionReader` against the current
+`GitModule` (plus `GetStashes()`), on a background thread guarded by a `CancellationTokenSequence`.
+It raises `RevisionsLoading`/`RevisionsLoaded` events, builds the commit-graph model
+(`RevisionGraphRow`s), and renders lanes/labels. This is the engine behind the browse window.
+
+**Related:** [browse-flow](browse-flow.md) · [git-output-parsing](../L2-core-platform/git-output-parsing.md) · [domain-model](../L1-conceptual/domain-model.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [RevisionGridControl.cs](../../../src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs) ·
+[RevisionReader.cs](../../../src/app/GitCommands/RevisionReader.cs) ·
+[RevisionGraphRow.cs](../../../src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs)
+
+## Why
+
+Commit history can be enormous. The grid must stream revisions in without freezing the UI, cancel
+cleanly when the user filters or switches repos, and lay out the branch graph efficiently. Hence a
+background reader + cancellation + incremental graph building.
+
+## What / How
+
+1. **Kick off** — a refresh creates a new `RevisionReader(module)` and starts reading on a
+   background thread; a `CancellationTokenSequence` cancels any in-flight load first.
+2. **Read** — `RevisionReader` parses `git log --format …` into `GitRevision`s (see
+   [git-output-parsing](../L2-core-platform/git-output-parsing.md)); stashes are added via
+   `GetStashes()`.
+3. **Signal** — `RevisionsLoading` fires at start, `RevisionsLoaded` at completion; consumers
+   (commit details, toolbars) react.
+4. **Build graph** — revisions become `RevisionGraphRow`s with lane segments to parents; the
+   control draws rows, refs, and the graph.
+
+## Quirks
+
+- Loading respects **suspend/resume** guards from the browse window to batch updates.
+- Filtering (by path, branch, text) restarts the read with a fresh cancellation token.
+- Two **artificial** rows (WorkTree, Index) are inserted above real commits.
+
+## Hard rules
+
+- Cancel the previous load before starting a new one (use the `CancellationTokenSequence`); don't leak background reads.
+- Marshal to the UI thread before touching the grid ([threading-model](../L1-conceptual/threading-model.md)).
+- Keep git-output parsing in `RevisionReader`, not in the control.
+
+**Next:** [diff-blame-flow](diff-blame-flow.md) or [file-history-flow](file-history-flow.md).

--- a/.github/copilot-docs/L3-flows/stash-flow.md
+++ b/.github/copilot-docs/L3-flows/stash-flow.md
@@ -1,0 +1,40 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Stash Flow (L3)
+
+**TL;DR:** `FormStash` saves, applies, pops, and drops stashes. It goes through
+`UICommands.StashSave` / `StashApply` / `StashDrop` (which wrap the underlying git commands). It
+supports partial (per-file) stashing and a keep-index option, and shows the current worktree as
+the first item.
+
+**Related:** [commit-flow](commit-flow.md) · [pull-flow](pull-flow.md) · [git-module](../L2-core-platform/git-module.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormStash.cs](../../../src/app/GitUI/CommandsDialogs/FormStash.cs)
+
+## Why
+
+Stashing lets users park uncommitted work safely (e.g. before checkout/pull). Because stashes are
+easy to lose track of, the dialog surfaces existing stashes, their contents, and safe apply/pop/drop
+actions in one place.
+
+## What / How
+
+1. The dialog lists existing stashes plus the **current worktree** (first item) with its changes.
+2. **Save** — `UICommands.StashSave(...)` (optionally keep index, include untracked, or stash only
+   selected files).
+3. **Apply / Pop** — `UICommands.StashApply(...)` restores a stash (pop = apply + drop).
+4. **Drop** — `UICommands.StashDrop(...)` removes a stash.
+5. `RepoChangedNotifier` refreshes views after any change.
+
+## Quirks
+
+- **Partial stash**: only selected files can be stashed.
+- **Keep index** stashes working-tree changes while leaving staged changes intact.
+- Applying a stash can conflict → route to [conflict resolution](conflict-resolution-flow.md).
+
+## Hard rules
+
+- Use the `UICommands.Stash*` methods; don't hand-roll stash command strings.
+- Dropping a stash is destructive — confirm before dropping.
+- Refresh via `RepoChangedNotifier` after save/apply/pop/drop.
+
+**Next:** [conflict-resolution-flow](conflict-resolution-flow.md).

--- a/.github/copilot-docs/L3-flows/submodule-flow.md
+++ b/.github/copilot-docs/L3-flows/submodule-flow.md
@@ -1,0 +1,41 @@
+<!-- L3 FLOW. Agentic doc: TL;DR + key files at top, code pointers not code, ~80 lines. -->
+# Submodule Flow (L3)
+
+**TL;DR:** `FormSubmodules` manages nested repositories: init, update, and sync. It builds
+`Commands.SubmoduleSync(...)` / `SubmoduleUpdate(...)` (`ArgumentString`) and runs them via
+`FormProcess`. Selecting a submodule can open it as its own repository in a new `FormBrowse`.
+`SubmoduleHelpers` provides the supporting logic.
+
+**Related:** [browse-flow](browse-flow.md) · [git-module](../L2-core-platform/git-module.md) · [structured-commands](../L2-core-platform/structured-commands.md) · [L0 primer](../L0-foundations/gitextensions-primer.md)
+
+**Key files:** [FormSubmodules.cs](../../../src/app/GitUI/CommandsDialogs/FormSubmodules.cs) ·
+[SubmoduleHelpers.cs](../../../src/app/GitCommands/Git/SubmoduleHelpers.cs) ·
+[GitCommands/Submodules/](../../../src/app/GitCommands/Submodules/)
+
+## Why
+
+A repository can contain other git repositories (submodules), each with its own state. Managing
+them (init/update/sync) and being able to open one as a first-class repo is essential for
+multi-repo projects.
+
+## What / How
+
+1. `FormSubmodules` lists the current repo's submodules and their status.
+2. **Init/Update** — `Commands.SubmoduleUpdate(path)` brings a submodule to its recorded commit.
+3. **Sync** — `Commands.SubmoduleSync(path)` updates submodule remote URLs from `.gitmodules`.
+4. Commands run via `FormProcess.ShowDialog(...)`; opening a submodule launches a new `FormBrowse`
+   bound to a new `GitModule` for that nested repo.
+
+## Quirks
+
+- Each submodule is a **separate** `GitModule` (one module per repo — see [git-module](../L2-core-platform/git-module.md)).
+- Submodule **status** (ahead/behind/dirty) is computed by a background status provider.
+- `GetSubmoduleFullPath()` resolves a submodule's absolute path from the parent.
+
+## Hard rules
+
+- Treat each submodule as its own repo/`GitModule`; never reuse the parent's module for it.
+- Use `Commands.Submodule*` for init/update/sync rather than raw command strings.
+- Refresh parent and submodule views via `RepoChangedNotifier` after changes.
+
+**Next:** back to the [L3 index](docs-index.md) or the [master docs-index](../docs-index.md).

--- a/.github/copilot-docs/README.md
+++ b/.github/copilot-docs/README.md
@@ -10,9 +10,8 @@ This folder contains **Docs-Augmented Generation (DAG)** documentation: reposito
 agent-optimised docs that let an AI coding agent build accurate context about Git Extensions
 *incrementally* — without vector databases, embeddings, or external infrastructure.
 
-> **Status: SKELETON.** The layer indexes list the *planned* documents. Most are not written
-> yet. We are filling them in iteratively ("meat on the bones"). Entries are marked
-> `planned` / `draft` / `done`.
+> The layer indexes list every doc with a `planned` / `draft` / `done` status. The L1–L3 docs
+> and skills are written; use the status column when adding new docs.
 
 ## How it works (30-second version)
 
@@ -51,7 +50,7 @@ These are **hard rules**. Agents behave inconsistently when docs are long or bur
 ## Related folders
 
 - [.github/agents/](../agents/) — custom domain-scoped agents (planned).
-- [.github/skills/](../skills/) — cross-cutting workflow skills (planned).
+- [.github/skills/](../skills/) — cross-cutting workflow skills.
 
 ## How to add a doc
 

--- a/.github/copilot-docs/README.md
+++ b/.github/copilot-docs/README.md
@@ -1,0 +1,61 @@
+<!--
+  Meta-doc for MAINTAINERS (humans). This is the only file in copilot-docs/
+  written primarily for people rather than agents. It explains how the DAG
+  documentation set is organised and how to grow it. Agents should start from
+  docs-index.md, not here.
+-->
+# Git Extensions Agent Documentation (DAG)
+
+This folder contains **Docs-Augmented Generation (DAG)** documentation: repository-native,
+agent-optimised docs that let an AI coding agent build accurate context about Git Extensions
+*incrementally* — without vector databases, embeddings, or external infrastructure.
+
+> **Status: SKELETON.** The layer indexes list the *planned* documents. Most are not written
+> yet. We are filling them in iteratively ("meat on the bones"). Entries are marked
+> `planned` / `draft` / `done`.
+
+## How it works (30-second version)
+
+1. VS Code auto-loads [.github/copilot-instructions.md](../copilot-instructions.md) into every chat.
+2. That file links to the always-loaded [L0 primer](L0-foundations/gitextensions-primer.md) and to the master [docs-index.md](docs-index.md).
+3. `docs-index.md` links to the per-layer indexes, which link to individual docs.
+4. The agent reads the cheap **indexes** first, then loads **only** the specific docs a task needs — preserving the token budget for reading real code.
+
+```
+copilot-instructions.md  ──►  L0 primer (always loaded, < 80 lines)
+                          └─►  docs-index.md (master)
+                                    ├─► L1-conceptual/docs-index.md   ──► concept docs
+                                    ├─► L2-core-platform/docs-index.md ──► platform docs
+                                    └─► L3-flows/docs-index.md         ──► end-to-end flow docs
+```
+
+## The four layers
+
+| Layer | Folder | Contains | Loading |
+| --- | --- | --- | --- |
+| **L0 – Foundations** | `L0-foundations/` | The irreducible minimum every agent needs: architecture anchor, glossary, ownership map. | **Always loaded.** No index. Hard cap **80 lines**. |
+| **L1 – Conceptual** | `L1-conceptual/` | What Git Extensions is: architecture, terminology, project map. | On-demand via `docs-index.md`. |
+| **L2 – Core Platform** | `L2-core-platform/` | Infrastructure: git execution, settings, plugins, translation, theming, build/test. | On-demand via `docs-index.md`. |
+| **L3 – Flows** | `L3-flows/` | End-to-end user flows that compose L2 (commit, checkout, clone, push/pull, rebase, diff). | On-demand via `docs-index.md`. |
+
+## Rules for writing DAG docs (agentic docs, not user docs)
+
+These are **hard rules**. Agents behave inconsistently when docs are long or bury the point.
+
+- **TL;DR + links at the TOP.** Put the summary and cross-links in the first ~50 lines. Agents often read only the first 80–100 lines of a file.
+- **Why → What → How.** Lead with *why* the component exists, then *what* it does, then *how* to find it. Code answers "how"; docs must supply the "why".
+- **Code pointers, not code.** Reference `ClassName` / `MethodName` / file paths the agent can open — never paste code snippets that go stale.
+- **~100 lines per doc.** If a topic needs more, split it and link from the index.
+- **Hard rules beat suggestions.** Write `MUST` / `ALWAYS` / `STOP`, not "you might consider".
+
+## Related folders
+
+- [.github/agents/](../agents/) — custom domain-scoped agents (planned).
+- [.github/skills/](../skills/) — cross-cutting workflow skills (planned).
+
+## How to add a doc
+
+1. Write the doc in the correct layer folder following the rules above.
+2. Add a one-line entry to that layer's `docs-index.md`.
+3. If it participates in a common query, add/extend a **reading chain** in the master [docs-index.md](docs-index.md).
+4. (Later) Add a benchmark test so growth doesn't regress other areas.

--- a/.github/copilot-docs/docs-index.md
+++ b/.github/copilot-docs/docs-index.md
@@ -53,13 +53,13 @@ verifying against the actual source files referenced in the docs.
 - **"How does the commit flow work?"**
   L0 primer → [architecture-overview](L1-conceptual/architecture-overview.md) → [commit-flow](L3-flows/commit-flow.md) → verify in `FormCommit`.
 - **"How does checkout / branch switching work?"**
-  L0 primer → [checkout-flow](L3-flows/docs-index.md) → verify in `FormCheckoutBranch`.
+  L0 primer → [checkout-flow](L3-flows/checkout-flow.md) → verify in `FormCheckoutBranch`.
 - **"How do plugins work / how do I write one?"**
   L0 primer → [plugin-system](L2-core-platform/plugin-system.md) → verify in `GitExtensions.Extensibility/Plugins/` + a sample under `src/plugins/`.
 - **"How does translation / adding UI strings work?"**
   L0 primer → [translation-system](L2-core-platform/translation-system.md) → verify with `update-loc.cmd` + `English.xlf`.
 - **"How is the commit graph rendered?"**
-  L0 primer → [architecture-overview](L1-conceptual/architecture-overview.md) → [revision-grid-flow](L3-flows/docs-index.md) → verify in `RevisionGrid`.
+  L0 primer → [architecture-overview](L1-conceptual/architecture-overview.md) → [revision-grid-flow](L3-flows/revision-grid-flow.md) → verify in `RevisionGrid`.
 
 ## Cross-cutting
 

--- a/.github/copilot-docs/docs-index.md
+++ b/.github/copilot-docs/docs-index.md
@@ -6,8 +6,8 @@ Use the **Ownership Table** to find which area owns a topic, then follow the mat
 **Reading Chain** to load docs in the right order. Read the cheap indexes first; open
 individual docs only when the task requires them.
 
-> **Status: SKELETON.** Most linked docs are `planned` (not written yet). This index is the
-> roadmap. See [README.md](README.md) for how DAG works and how to add docs.
+> This index is the ownership + navigation map for the DAG docs. All L1–L3 docs and skills are
+> written; the `Status` columns track any future additions. See [README.md](README.md) for how DAG works.
 
 ## Always loaded
 
@@ -46,8 +46,6 @@ Use this to route a question to the right layer/doc and the right part of the co
 Ordered doc sequences for the most common questions. `→` means "read next". End every chain by
 verifying against the actual source files referenced in the docs.
 
-> Chains reference `planned` docs. As docs are written, these become live.
-
 - **"How does Git Extensions run a git command?"**
   L0 primer → [git-command-execution](L2-core-platform/git-command-execution.md) → [structured-commands](L2-core-platform/structured-commands.md) → verify in `GitModule` / `Executable`.
 - **"How does the commit flow work?"**
@@ -64,4 +62,4 @@ verifying against the actual source files referenced in the docs.
 ## Cross-cutting
 
 - [Custom agents](../agents/README.md) — domain-scoped agents (planned).
-- [Skills](../skills/README.md) — reusable workflows: code search, deep explanation, PR creation, doc management (planned).
+- [Skills](../skills/README.md) — reusable workflows: code search, deep explanation, PR creation, doc management.

--- a/.github/copilot-docs/docs-index.md
+++ b/.github/copilot-docs/docs-index.md
@@ -1,0 +1,67 @@
+# Git Extensions Docs-Index (Master)
+
+**TL;DR — read this first, then load only what your task needs.**
+This is the master navigation map for Git Extensions agent documentation.
+Use the **Ownership Table** to find which area owns a topic, then follow the matching
+**Reading Chain** to load docs in the right order. Read the cheap indexes first; open
+individual docs only when the task requires them.
+
+> **Status: SKELETON.** Most linked docs are `planned` (not written yet). This index is the
+> roadmap. See [README.md](README.md) for how DAG works and how to add docs.
+
+## Always loaded
+
+- [L0 Foundations Primer](L0-foundations/gitextensions-primer.md) — architecture anchor, glossary, ownership map. **Read this every session.** (< 80 lines)
+
+## Layer indexes (load on demand)
+
+- [L1 — Conceptual](L1-conceptual/docs-index.md) — what Git Extensions is: architecture, terminology, project map.
+- [L2 — Core Platform](L2-core-platform/docs-index.md) — git execution, settings, plugins, translation, theming, build/test.
+- [L3 — Flows](L3-flows/docs-index.md) — end-to-end user flows (commit, checkout, clone, push/pull, rebase, diff).
+
+## Ownership Table (topic → area → where to look)
+
+Use this to route a question to the right layer/doc and the right part of the codebase.
+
+| Topic | Layer | Where in code |
+| --- | --- | --- |
+| App startup / entry point | L1 | `src/app/GitExtensions/` (`Program`, `GitExtensionsForm`) |
+| Running git commands / process execution | L2 | `src/app/GitCommands/Git/` (`GitModule`, `Executable`, `Commands`) |
+| Command arguments (structured) | L2 | `src/app/GitExtensions.Extensibility/` (`ArgumentBuilder`), `GitCommands.Git.Commands` |
+| UI dialogs & forms | L1/L3 | `src/app/GitUI/CommandsDialogs/` (`FormBrowse`, `FormCommit`, …) |
+| Commit graph / revision grid | L3 | `src/app/GitUI/UserControls/RevisionGrid/` |
+| Settings & configuration | L2 | `src/app/GitCommands/Settings/`, `GitCommands/Config/` |
+| Plugins & extensibility | L2 | `src/app/GitExtensions.Extensibility/Plugins/`, `src/plugins/`, `GitUIPluginInterfaces/` |
+| Translation / localization | L2 | `src/app/ResourceManager/`, `GitUI/Translation/English.xlf` |
+| Theming / colors | L2 | `src/app/GitUI/Theming/`, `GitUI/Themes/` |
+| Hotkeys | L2 | `src/app/GitUI/Hotkey/` |
+| User scripts engine | L2 | `src/app/GitUI/ScriptsEngine/` |
+| Windows Explorer shell integration | L2 | `src/native/GitExtensionsShellEx/` |
+| Build / installer / CI | L2 | `Setup/`, `.github/workflows/`, `eng/` |
+| Tests | L2 | `tests/` (NUnit, NSubstitute, AwesomeAssertions) |
+| Submodules | L2/L3 | `src/app/GitCommands/Submodules/`, `GitCommands/Git/SubmoduleHelpers.cs` |
+
+## Reading Chains (ordered — read top to bottom, then verify against code)
+
+Ordered doc sequences for the most common questions. `→` means "read next". End every chain by
+verifying against the actual source files referenced in the docs.
+
+> Chains reference `planned` docs. As docs are written, these become live.
+
+- **"How does Git Extensions run a git command?"**
+  L0 primer → [git-command-execution](L2-core-platform/git-command-execution.md) → [structured-commands](L2-core-platform/structured-commands.md) → verify in `GitModule` / `Executable`.
+- **"How does the commit flow work?"**
+  L0 primer → [architecture-overview](L1-conceptual/architecture-overview.md) → [commit-flow](L3-flows/commit-flow.md) → verify in `FormCommit`.
+- **"How does checkout / branch switching work?"**
+  L0 primer → [checkout-flow](L3-flows/docs-index.md) → verify in `FormCheckoutBranch`.
+- **"How do plugins work / how do I write one?"**
+  L0 primer → [plugin-system](L2-core-platform/docs-index.md) → verify in `GitExtensions.Extensibility/Plugins/` + a sample under `src/plugins/`.
+- **"How does translation / adding UI strings work?"**
+  L0 primer → [translation-system](L2-core-platform/docs-index.md) → verify with `update-loc.cmd` + `English.xlf`.
+- **"How is the commit graph rendered?"**
+  L0 primer → [architecture-overview](L1-conceptual/architecture-overview.md) → [revision-grid-flow](L3-flows/docs-index.md) → verify in `RevisionGrid`.
+
+## Cross-cutting
+
+- [Custom agents](../agents/README.md) — domain-scoped agents (planned).
+- [Skills](../skills/README.md) — reusable workflows: code search, deep explanation, PR creation, doc management (planned).

--- a/.github/copilot-docs/docs-index.md
+++ b/.github/copilot-docs/docs-index.md
@@ -55,9 +55,9 @@ verifying against the actual source files referenced in the docs.
 - **"How does checkout / branch switching work?"**
   L0 primer → [checkout-flow](L3-flows/docs-index.md) → verify in `FormCheckoutBranch`.
 - **"How do plugins work / how do I write one?"**
-  L0 primer → [plugin-system](L2-core-platform/docs-index.md) → verify in `GitExtensions.Extensibility/Plugins/` + a sample under `src/plugins/`.
+  L0 primer → [plugin-system](L2-core-platform/plugin-system.md) → verify in `GitExtensions.Extensibility/Plugins/` + a sample under `src/plugins/`.
 - **"How does translation / adding UI strings work?"**
-  L0 primer → [translation-system](L2-core-platform/docs-index.md) → verify with `update-loc.cmd` + `English.xlf`.
+  L0 primer → [translation-system](L2-core-platform/translation-system.md) → verify with `update-loc.cmd` + `English.xlf`.
 - **"How is the commit graph rendered?"**
   L0 primer → [architecture-overview](L1-conceptual/architecture-overview.md) → [revision-grid-flow](L3-flows/docs-index.md) → verify in `RevisionGrid`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,20 @@
 
 <https://github.blog/changelog/2025-01-21-custom-repository-instructions-are-now-available-for-copilot-on-github-com-public-preview/>
 
+## Agent documentation (DAG) — read this first
+
+This repository uses **Docs-Augmented Generation (DAG)**: hierarchical, agent-optimised docs
+under [.github/copilot-docs/](copilot-docs/README.md) that let you build accurate context
+incrementally without loading the whole codebase.
+
+- **ALWAYS load the foundation:** [L0 Foundations Primer](copilot-docs/L0-foundations/gitextensions-primer.md) — architecture anchor, glossary, and ownership map. Read it every session.
+- **Navigate via the index:** the master [docs-index.md](copilot-docs/docs-index.md) has the ownership table and reading chains. Read the relevant index and follow a reading chain **before** grep-ing the code.
+- **Layers:** [L1 Conceptual](copilot-docs/L1-conceptual/docs-index.md) · [L2 Core Platform](copilot-docs/L2-core-platform/docs-index.md) · [L3 Flows](copilot-docs/L3-flows/docs-index.md).
+- **Cross-cutting:** [skills](skills/README.md) and [custom agents](agents/README.md).
+
+> **HARD RULE:** for any non-trivial task, first read the L0 primer, then the matching
+> docs-index reading chain, *then* verify against the source. Load only the docs a task needs.
+
 ## Repository setup
 
 This repository uses git submodules (under `externals/`). After cloning or creating a new worktree, always run:

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,4 +1,4 @@
-# Skills (planned)
+# Skills
 
 Skills are cross-cutting workflows that apply across all documentation areas. Each skill lives
 in its own folder as `.github/skills/<name>/SKILL.md` and is auto-matched by the agent from its
@@ -12,7 +12,7 @@ description/keyword triggers.
   first (read the relevant docs-index reading chain + anchor docs) before acting.
 - **Execution (runbook):** deterministic "do X" procedures with prechecks, steps, and STOP conditions.
 
-## Planned skills
+## Available skills
 
 | Skill | Class | Purpose | Status |
 | --- | --- | --- | --- |

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,0 +1,31 @@
+# Skills (planned)
+
+Skills are cross-cutting workflows that apply across all documentation areas. Each skill lives
+in its own folder as `.github/skills/<name>/SKILL.md` and is auto-matched by the agent from its
+description/keyword triggers.
+
+> **Status: SKELETON.** Skills below are the roadmap. None are written yet.
+
+## Two classes of skills
+
+- **SDLC (SME-first):** judgment-heavy work. MUST force the agent to become a domain expert
+  first (read the relevant docs-index reading chain + anchor docs) before acting.
+- **Execution (runbook):** deterministic "do X" procedures with prechecks, steps, and STOP conditions.
+
+## Planned skills
+
+| Skill | Class | Purpose | Status |
+| --- | --- | --- | --- |
+| `code-search` | SDLC | How to search this codebase effectively (symbols, forms, command flows) before editing. | planned |
+| `deep-explanation` | SDLC | Explain a subsystem/flow with Why→What→How, Mermaid diagram, and code pointers. | planned |
+| `doc-management` | SDLC | Create/maintain DAG docs: enforce agentic-doc rules, update the right docs-index, keep chains valid. | planned |
+| `pr-creation` | Execution | Branch naming, conventional-commit messages, and the pre-PR checklist. | planned |
+| `add-translation-strings` | Execution | Runbook for adding/changing UI strings and regenerating `English.xlf` via `update-loc.cmd`. | planned |
+| `add-winforms-dialog` | Execution | Runbook for adding a new Form/control following naming + designer conventions. | planned |
+| `run-tests` | Execution | Build and run the NUnit suite; interpret failures. | planned |
+
+## Authoring rules
+
+Every SDLC skill MUST begin with a blocking **"Build SME context"** phase: read the relevant
+[docs-index](../copilot-docs/docs-index.md) reading chain and 1–N anchor docs, extract the rules/
+invariants and code pointers, then explore surrounding code — *before* making changes.

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -4,7 +4,7 @@ Skills are cross-cutting workflows that apply across all documentation areas. Ea
 in its own folder as `.github/skills/<name>/SKILL.md` and is auto-matched by the agent from its
 description/keyword triggers.
 
-> **Status: SKELETON.** Skills below are the roadmap. None are written yet.
+> **Status:** core skills written. Add more as recurring workflows emerge.
 
 ## Two classes of skills
 
@@ -16,13 +16,13 @@ description/keyword triggers.
 
 | Skill | Class | Purpose | Status |
 | --- | --- | --- | --- |
-| `code-search` | SDLC | How to search this codebase effectively (symbols, forms, command flows) before editing. | planned |
-| `deep-explanation` | SDLC | Explain a subsystem/flow with Why→What→How, Mermaid diagram, and code pointers. | planned |
-| `doc-management` | SDLC | Create/maintain DAG docs: enforce agentic-doc rules, update the right docs-index, keep chains valid. | planned |
-| `pr-creation` | Execution | Branch naming, conventional-commit messages, and the pre-PR checklist. | planned |
-| `add-translation-strings` | Execution | Runbook for adding/changing UI strings and regenerating `English.xlf` via `update-loc.cmd`. | planned |
-| `add-winforms-dialog` | Execution | Runbook for adding a new Form/control following naming + designer conventions. | planned |
-| `run-tests` | Execution | Build and run the NUnit suite; interpret failures. | planned |
+| [code-search](code-search/SKILL.md) | SDLC | How to search this codebase effectively (symbols, forms, command flows) before editing. | done |
+| [deep-explanation](deep-explanation/SKILL.md) | SDLC | Explain a subsystem/flow with Why→What→How, Mermaid diagram, and code pointers. | done |
+| [doc-management](doc-management/SKILL.md) | SDLC | Create/maintain DAG docs: enforce agentic-doc rules, update the right docs-index, keep chains valid. | done |
+| [pr-creation](pr-creation/SKILL.md) | Execution | Branch naming, conventional-commit messages, and the pre-PR checklist. | done |
+| [add-translation-strings](add-translation-strings/SKILL.md) | Execution | Runbook for adding/changing UI strings and regenerating `English.xlf` via `update-loc.cmd`. | done |
+| [add-winforms-dialog](add-winforms-dialog/SKILL.md) | Execution | Runbook for adding a new Form/control following naming + designer conventions. | done |
+| [run-tests](run-tests/SKILL.md) | Execution | Build and run the NUnit suite; interpret failures. | done |
 
 ## Authoring rules
 

--- a/.github/skills/add-translation-strings/SKILL.md
+++ b/.github/skills/add-translation-strings/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: add-translation-strings
+description: '**EXECUTION (runbook) SKILL** — Add or change a user-facing UI string in Git Extensions and regenerate the translation catalog. USE FOR: adding a TranslationString, changing a control/menu/toolbar caption, any UI text change that must update English.xlf. DO NOT USE FOR: non-UI/log/exception-internal strings, or general feature work. Triggers: "add a UI string", "change this label", "regenerate English.xlf", "update-loc".'
+---
+
+# Add Translation Strings (runbook)
+
+Any user-facing string must be a `TranslationString` and reflected in `English.xlf`. Follow in order.
+
+## Steps
+
+1. **Add/edit the string** in the right place:
+   - A form/control literal → declare a `private readonly TranslationString _x = new("...");` on the
+     `Translate`-derived class, or edit the control's designer text.
+   - A shared/common literal → add to
+     [TranslatedStrings.cs](../../../src/app/ResourceManager/TranslatedStrings.cs).
+   - Use `SmartFormat` placeholders for plurals (e.g. `"{0:item|items}"`).
+2. **Build first:** `dotnet build /v:q` must succeed (the generator reflects over the built assemblies).
+3. **Regenerate the catalog:** run from the repo root:
+   ```
+   .\update-loc.cmd
+   ```
+   This runs `TranslationApp`, regenerates [English.xlf](../../../src/app/GitUI/Translation/English.xlf),
+   and stages it.
+4. **Commit together:** include the regenerated `English.xlf` in the **same** commit as the code change.
+
+## Verify
+
+- `git status` shows `English.xlf` staged/updated.
+- The new string appears in `English.xlf`.
+
+## STOP conditions / hard rules
+
+- **NEVER** hand-edit any `.xlf` file — they are generated.
+- Do **not** wrap non-UI strings (logs, internal exceptions) as `TranslationString`.
+- If you skip `update-loc.cmd`, **CI will fail** on a stale `English.xlf`.
+
+Background: [translation-system](../../copilot-docs/L2-core-platform/translation-system.md).

--- a/.github/skills/add-winforms-dialog/SKILL.md
+++ b/.github/skills/add-winforms-dialog/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: add-winforms-dialog
+description: '**EXECUTION (runbook) SKILL** — Add a new WinForms dialog/control to Git Extensions following the project''s base classes and naming conventions. USE FOR: creating a new Form or UserControl, wiring it to git via UICommands. DO NOT USE FOR: editing existing dialogs'' logic only, or non-UI code. Triggers: "add a new dialog", "create a form", "new WinForms control", "new settings page".'
+---
+
+# Add a WinForms Dialog (runbook)
+
+Create a new dialog that matches the codebase's conventions. Follow in order.
+
+## Steps
+
+1. **Pick the base class** (see [ui-composition](../../copilot-docs/L1-conceptual/ui-composition.md)):
+   - Repo-aware dialog → derive from `GitModuleForm` (gives `UICommands` / `Module`).
+   - Standard dialog chrome → derive from / use `GitExtensionsDialog`.
+   - A panel/control → derive from `GitModuleControl`.
+   - **NEVER** derive directly from raw `Form`.
+2. **Place the files** under `src/app/GitUI/CommandsDialogs/` (or a suitable subfolder): `Form<Name>.cs`,
+   `Form<Name>.Designer.cs`, `Form<Name>.resx`.
+3. **Name controls** per [ui_design_guidelines.md](../../ui_design_guidelines.md):
+   `btn`, `lbl`, `txt`, `cbx`, `chk`, `rb`, `gbx`, `tlpnl`, `flpnl`, `lnk`, …
+4. **Talk to git** only through `UICommands` / `Module`; build commands with `Commands.*` (structured
+   `IGitCommand` preferred). **NEVER** `new` a `GitModule` or spawn `git` directly.
+5. **Localize:** make every user-facing string a `TranslationString`, then run the
+   [add-translation-strings](../add-translation-strings/SKILL.md) runbook (`update-loc.cmd`).
+6. **Hotkeys (if any):** register via `HotkeySettingsManager`, not hardcoded key handling
+   (see [hotkey-system](../../copilot-docs/L2-core-platform/hotkey-system.md)).
+7. **Refresh:** after a state-changing action, call `UICommands.RepoChangedNotifier.Notify()`.
+
+## Verify
+
+- `dotnet build /v:q` succeeds; control names follow the prefixes.
+- `English.xlf` updated (localization gate).
+- UI touched only on the UI thread ([threading-model](../../copilot-docs/L1-conceptual/threading-model.md)).
+
+## STOP conditions
+
+- Deriving from raw `Form`, hardcoded `Color`s (use `AppColor`), or raw git command strings → fix before proceeding.
+- Add a unit test if the dialog builds git arguments via `Commands.*`.

--- a/.github/skills/code-search/SKILL.md
+++ b/.github/skills/code-search/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: code-search
+description: '**SDLC (SME-first) SKILL** — Efficiently locate code in the Git Extensions repository before editing or explaining. USE FOR: finding the form/command/parser behind a feature, tracing a UI action to its git call, locating a symbol''s definition and usages. DO NOT USE FOR: making edits (do the edit after finding), or questions already answered by a DAG doc. Triggers: "where is", "find the code that", "which form handles", "locate the command for".'
+---
+
+# Code Search (Git Extensions)
+
+Find the right code fast by using the DAG map first, then targeted symbol search.
+
+## Phase 1 — Orient via the docs (do this first)
+
+1. Check the [master docs-index](../../copilot-docs/docs-index.md) **ownership table** to map the
+   topic to a code area, and follow the matching **reading chain**.
+2. The [project-map](../../copilot-docs/L1-conceptual/project-map.md) tells you which project owns it.
+
+## Phase 2 — Search with the repo's conventions
+
+Knowing these conventions makes search precise:
+- **Dialogs / UI actions** → `src/app/GitUI/CommandsDialogs/Form<Name>.cs` (+ `.Designer.cs`,
+  and split partials like `FormBrowse.Init*.cs`).
+- **Git commands (structured)** → `Commands.<Verb>(...)` in
+  [Commands.cs](../../../src/app/GitCommands/Git/Commands.cs) /
+  [Commands.Arguments.cs](../../../src/app/GitCommands/Git/Commands.Arguments.cs).
+- **Repo operations / state** → methods on `GitModule` /
+  [IGitModule.cs](../../../src/app/GitExtensions.Extensibility/Git/IGitModule.cs).
+- **Output parsing** → `*Parser` / `RevisionReader` in `src/app/GitCommands/`.
+- **Left-panel tree nodes** → `src/app/GitUI/LeftPanel/`.
+- **Contracts/interfaces** → `src/app/GitExtensions.Extensibility/`.
+
+Techniques: search the **symbol** (exact `ClassName`/`MethodName`), then find its usages/definition.
+For a UI action, grep the button/menu handler, then follow to `Commands.*` / `Module.*` /
+`StartCommandLineProcessDialog` / `FormProcess.ShowDialog`.
+
+## Phase 3 — Confirm before acting
+
+- Open the file and confirm it's the real owner (not a similarly named helper/test).
+- Note the tier boundary you're crossing so an edit stays in the right project.
+
+## Hard rules
+
+- Use the docs-index **before** brute-force searching the whole tree.
+- Verify the match by opening the file; don't act on a filename guess.
+- Respect the dependency direction (see [architecture-overview](../../copilot-docs/L1-conceptual/architecture-overview.md)).

--- a/.github/skills/deep-explanation/SKILL.md
+++ b/.github/skills/deep-explanation/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: deep-explanation
+description: '**SDLC (SME-first) SKILL** — Explain a Git Extensions subsystem or end-to-end flow accurately, grounded in the DAG docs and verified against source. USE FOR: "how does X work", "explain the commit/checkout/push flow", "trace this from UI to git", onboarding walkthroughs, architecture questions. DO NOT USE FOR: making code changes, writing new docs (use doc-management), or trivial single-file lookups. Triggers: "explain how", "walk me through", "how does X work end to end", "trace the flow".'
+---
+
+# Deep Explanation
+
+Produce an accurate, grounded explanation — never hand-wave.
+
+## Phase 1 — Become a mini-SME first (BLOCKING)
+
+STOP — before explaining, ground yourself:
+1. Read the [L0 primer](../../copilot-docs/L0-foundations/gitextensions-primer.md).
+2. Open the [master docs-index](../../copilot-docs/docs-index.md), pick the matching **reading chain**,
+   and read those docs in order (L1 concept → L2 subsystem → L3 flow).
+3. **Verify against source** — open the actual `src/` files the docs point to. Docs give the
+   "why"; the code confirms the "how".
+
+## Phase 2 — Explain with structure
+
+Use **Why → What → How**:
+- **Why** — the motivation/design rationale (from the docs).
+- **What** — the components/actors and how they connect.
+- **How** — the concrete path, with **code pointers** (`ClassName` / `Method` / file links) the
+  reader can open. Prefer pointers over pasted code.
+
+Include a compact **Mermaid** diagram for multi-step flows (sequence or graph). Label the
+execution context (UI thread vs background) where it matters — see
+[threading-model](../../copilot-docs/L1-conceptual/threading-model.md).
+
+## Phase 3 — Close the loop
+
+- Note cross-tier hops explicitly (UI → `GitUICommands` → `Commands`/`GitModule` → `git`).
+- Call out quirks/gotchas the code reveals (e.g. legacy `ArgumentString` vs `IGitCommand`).
+- End with pointers to the exact files to read next.
+
+## Hard rules
+
+- **NEVER** state a class/method/flow you haven't verified in source or a DAG doc.
+- Ground every claim in a code pointer or a doc reference.
+- Keep it scannable: lead with a 2–3 line summary, then the structured explanation.

--- a/.github/skills/doc-management/SKILL.md
+++ b/.github/skills/doc-management/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: doc-management
+description: '**SDLC (SME-first) SKILL** — Create, update, or review Git Extensions DAG agent-docs under .github/copilot-docs. USE FOR: writing a new L1/L2/L3 doc; updating a docs-index; adding/fixing a reading chain; keeping the L0 primer within its size cap; reviewing a doc for the agentic-doc rules. DO NOT USE FOR: writing product/user documentation, README changes for end users, or code changes. Triggers: "add a DAG doc", "document this subsystem", "update the docs-index", "add a reading chain", "is this doc agentic".'
+---
+
+# Doc Management (DAG)
+
+Keep the [DAG documentation](../../copilot-docs/README.md) consistent, small, and navigable.
+
+## Phase 1 — Build SME context (BLOCKING; do this first)
+
+STOP — do not write a doc until you have:
+1. Read the [L0 primer](../../copilot-docs/L0-foundations/gitextensions-primer.md) and the
+   [master docs-index](../../copilot-docs/docs-index.md).
+2. Read the target layer's `docs-index.md` and 1–2 sibling docs to match tone/shape.
+3. Verified the real code you'll point to (open the actual `src/` files — pointers MUST be correct).
+
+## Phase 2 — Write / update the doc
+
+Follow the **agentic-doc rules** (hard rules):
+- **TL;DR + related links in the first ~15 lines.** Agents often read only the first 80–100 lines.
+- **Why → What → How.** Lead with motivation, then concepts, then code pointers.
+- **Code pointers, not code.** Link `ClassName` / file paths; do NOT paste code that will rot.
+- **~100 lines max** (L0 primer: **80 lines max**, no index). Split if larger.
+- **Hard rules use MUST/ALWAYS/NEVER/STOP**, not "consider".
+- Use workspace-relative markdown links; verify every link resolves.
+
+## Phase 3 — Wire it in (MUST)
+
+1. Add a one-line row to the correct `docs-index.md` with a status (`planned`/`done`) and a link.
+2. If it answers a common question, add/extend a **reading chain** in the [master docs-index](../../copilot-docs/docs-index.md).
+3. Keep the ownership table current if the doc introduces a new area.
+
+## Phase 4 — Validate (MUST)
+
+- Confirm line count is within the cap (L0 ≤ 80; others ≤ ~100).
+- Confirm every relative link resolves (docs and `src/` files).
+- Re-ask the driving question mentally: does the reading chain now reach the right code faster?
+
+## STOP conditions
+
+- A code pointer you can't verify → open the file first; never guess class/file names.
+- The doc exceeds the size cap → split it and link from the index.
+- L0 primer needs an index → it's too big; move detail to L1.

--- a/.github/skills/pr-creation/SKILL.md
+++ b/.github/skills/pr-creation/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: pr-creation
+description: '**EXECUTION (runbook) SKILL** — Prepare a Git Extensions change for a pull request so it passes CI. USE FOR: "create a PR", "get this ready to push", pre-commit/pre-push checklist, writing a conventional-commit message. DO NOT USE FOR: designing the change itself or explaining code. Triggers: "prepare a PR", "ready to commit", "pre-PR checklist", "write the commit message".'
+---
+
+# PR Creation (runbook)
+
+A deterministic checklist to make a change merge-ready. Do the steps in order; STOP on any failure.
+
+## Prechecks
+
+1. Confirm you're on a feature branch (not `master`) with a descriptive name.
+2. Confirm the working tree contains only intended changes (`git status`).
+
+## Build & test (gates)
+
+3. **Build clean:** `dotnet build /v:q` — no errors, no new analyzer/StyleCop warnings.
+4. **Run tests:** `dotnet test` (or the affected test project). All green. See
+   [testing-guide](../../copilot-docs/L2-core-platform/testing-guide.md).
+
+## Localization gate (MUST if UI changed)
+
+5. If you added/changed any form, control, menu/toolbar item, or `TranslationString`:
+   run `.\update-loc.cmd` from the repo root and stage the regenerated
+   [English.xlf](../../../src/app/GitUI/Translation/English.xlf). **CI fails if it's stale.**
+   See [translation-system](../../copilot-docs/L2-core-platform/translation-system.md).
+
+## Commit
+
+6. Use **Conventional Commits** (e.g. `feat:`, `fix:`, `docs:`, `perf:`, `refactor:`).
+7. If any file under `src/app/GitExtensions.Extensibility/` changed, **note the plugin interface
+   version impact** in the commit message.
+8. Create a **new** commit (do not amend published commits).
+
+## Postchecks (STOP conditions)
+
+- **NEVER** leave `fixup!` / `squash!` commits on the branch — the `git` workflow blocks merge. Autosquash locally.
+- Ensure the CLA is signed (the `cla-check` workflow gates it).
+- Files MUST be CRLF and satisfy `.editorconfig`/StyleCop.
+- Do **not** use `--no-verify` or disable CI checks to force a pass — fix the cause.
+
+## Do NOT push unless explicitly asked
+
+Prepare the commit(s); only run `git push` when the user explicitly requests it.

--- a/.github/skills/run-tests/SKILL.md
+++ b/.github/skills/run-tests/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: run-tests
+description: '**EXECUTION (runbook) SKILL** — Build and run the Git Extensions test suite and interpret results. USE FOR: running tests, running a single test/project, diagnosing a failing or flaky test. DO NOT USE FOR: writing new features (write tests as part of that), or CI config changes. Triggers: "run the tests", "run this test", "why is this test failing", "dotnet test".'
+---
+
+# Run Tests (runbook)
+
+## Steps
+
+1. **Build first:** `dotnet build /v:q` (tests won't be meaningful over a broken build).
+2. **Run the suite:** `dotnet test` (the default VS Code "test" task). Or scope it:
+   ```
+   dotnet test .\tests\app\UnitTests\<Project>\<Project>.csproj
+   ```
+3. **Read failures:** note the test name (its snake_case suffix describes the expected behavior) and
+   the AwesomeAssertions message.
+
+## Conventions (see [testing-guide](../../copilot-docs/L2-core-platform/testing-guide.md))
+
+- **NUnit** + **NSubstitute** (mocks) + **AwesomeAssertions** (never `ClassicAssert`, never Moq).
+- Test names keep the method name and add a snake_case suffix (`MyMethod_should_do_x`).
+- Substitute `IExecutable`/`IProcess` so tests don't spawn real `git`.
+- `Verify.NUnit` snapshots use `.verified.*` files — review diffs when they change.
+- Reach private members via a class's `TestAccessor`.
+
+## Diagnosing a failure
+
+- Reproduce the single test in isolation before changing code.
+- Check whether a `Verify` snapshot legitimately changed (update it) vs a real regression.
+
+## STOP conditions / hard rules
+
+- A **flaky** test → find and fix the **root cause**; do not dismiss it as pre-existing or retry blindly.
+- Do not weaken assertions or add `[Ignore]` to make a suite green — fix the underlying issue.
+- Never use `[DataTestMethod]` (that's MSTest); this repo uses NUnit `[TestCase]`/`[TestCaseSource]`.


### PR DESCRIPTION
## Why

Large codebases are hard for AI coding agents to navigate — the model has the intelligence but lacks the domain context (which project owns a concept, where a flow lives, and the *why* behind the code). This PR adds **Docs-Augmented Generation (DAG)**: repository-native, agent-optimised documentation that lets Copilot/agents build accurate context incrementally — no vector DBs, embeddings, or external infrastructure, just markdown in the repo.

## What

A four-layer documentation hierarchy under `.github/copilot-docs/`, wired into `.github/copilot-instructions.md` so it auto-loads:

- **L0 — Foundations**: an always-loaded primer (architecture anchor, glossary, ownership map; ≤ 80 lines).
- **L1 — Conceptual (7)**: overview, architecture, project-map, domain-model, glossary, threading-model, ui-composition.
- **L2 — Core Platform (15)**: git execution, structured commands, `GitModule`, settings, plugins, translation, output parsing, theming, hotkeys, scripts engine, DI, shell integration, build/installer, CI, testing.
- **L3 — Flows (14)**: commit, browse, revision-grid, diff/blame, file-history, checkout, branch-management, clone, push, pull, rebase, merge, stash, conflict-resolution, submodule.
- **7 skills** under `.github/skills/` — SME-first + runbook workflows: doc-management, deep-explanation, code-search, pr-creation, add-translation-strings, add-winforms-dialog, run-tests.

Each doc follows agentic-doc rules: TL;DR + links at the top, Why → What → How, **code pointers not code**, ~100-line cap, hard rules. A master `docs-index.md` provides an ownership table and reading chains that map common questions to an ordered set of docs.

## How it works

`copilot-instructions.md` → always-loaded L0 primer + master `docs-index.md` → per-layer indexes → individual docs. Agents read the cheap indexes first, then load only the specific docs a task needs, preserving the token budget for reading real code.

## Notes

- **Docs only** — no product/code changes; nothing ships to end users.
- All internal links validated; every code pointer was verified against the current source.
- `.github/agents/` is intentionally left optional (single repo, small indexes) with documented guidance on when custom agents become worthwhile.
- Product name is written as "Git Extensions" in prose; code identifiers (`GitExtensions.Extensibility`, project/assembly names) are unchanged.

Opening as a **draft** for discussion / feedback on structure and content before filling in benchmark tests.
