### PR TITLE
fix(worktree): normalise new branch name and offer to switch after create

### DIFF
--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.Designer.cs
@@ -19,7 +19,6 @@ partial class FormCreateWorktree
         txtNewBranchName = new TextBox();
         rbCreateNewBranch = new RadioButton();
         rbCheckoutExistingBranch = new RadioButton();
-        chkOpenWorktree = new CheckBox();
         txtWorktreeDirectory = new TextBox();
         lblNewWorktreeFolder = new Label();
         cbxBranches = new ComboBox();
@@ -69,6 +68,7 @@ partial class FormCreateWorktree
         txtNewBranchName.Size = new Size(419, 21);
         txtNewBranchName.TabIndex = 3;
         txtNewBranchName.TextChanged += UpdateWorktreePathAndValidateWorktreeOptions;
+        txtNewBranchName.Leave += txtNewBranchName_Leave;
         //
         // rbCreateNewBranch
         //
@@ -96,19 +96,6 @@ partial class FormCreateWorktree
         rbCheckoutExistingBranch.Text = "Checkout an &existing branch:";
         rbCheckoutExistingBranch.UseVisualStyleBackColor = true;
         rbCheckoutExistingBranch.Click += UpdateWorktreePathAndValidateWorktreeOptions;
-        //
-        // chkOpenWorktree
-        //
-        chkOpenWorktree.AutoSize = true;
-        chkOpenWorktree.Checked = true;
-        chkOpenWorktree.CheckState = CheckState.Checked;
-        tlpnlMain.SetColumnSpan(chkOpenWorktree, 3);
-        chkOpenWorktree.Location = new Point(3, 123);
-        chkOpenWorktree.Name = "chkOpenWorktree";
-        chkOpenWorktree.Size = new Size(228, 17);
-        chkOpenWorktree.TabIndex = 4;
-        chkOpenWorktree.Text = "&Open the new worktree after the creation";
-        chkOpenWorktree.UseVisualStyleBackColor = true;
         //
         // txtWorktreeDirectory
         //
@@ -204,13 +191,11 @@ partial class FormCreateWorktree
         tlpnlMain.Controls.Add(lblNewWorktreeFolder, 0, 1);
         tlpnlMain.Controls.Add(txtWorktreeDirectory, 1, 1);
         tlpnlMain.Controls.Add(btnBrowseWorktreeDir, 2, 1);
-        tlpnlMain.Controls.Add(chkOpenWorktree, 0, 2);
         tlpnlMain.Dock = DockStyle.Fill;
         tlpnlMain.Location = new Point(12, 12);
         tlpnlMain.Margin = new Padding(0);
         tlpnlMain.Name = "tlpnlMain";
-        tlpnlMain.RowCount = 3;
-        tlpnlMain.RowStyles.Add(new RowStyle());
+        tlpnlMain.RowCount = 2;
         tlpnlMain.RowStyles.Add(new RowStyle());
         tlpnlMain.RowStyles.Add(new RowStyle());
         tlpnlMain.Size = new Size(584, 143);
@@ -250,7 +235,6 @@ partial class FormCreateWorktree
     private UserControls.FolderBrowserButton btnBrowseWorktreeDir;
     private TextBox txtWorktreeDirectory;
     private Label lblNewWorktreeFolder;
-    private CheckBox chkOpenWorktree;
     private RadioButton rbCheckoutExistingBranch;
     private RadioButton rbCreateNewBranch;
     private TextBox txtNewBranchName;

--- a/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/src/app/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands;
+using GitCommands.Git;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
 using GitExtUtils;
@@ -9,11 +10,12 @@ public sealed partial class FormCreateWorktree : GitExtensionsDialog
 {
     private readonly AsyncLoader _branchesLoader = new();
     private readonly char[] _invalidCharsInPath = Path.GetInvalidFileNameChars();
+    private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
+    private readonly IGitBranchNameNormaliser _branchNameNormaliser;
 
     private readonly string? _initialDirectoryPath;
 
     public string WorktreeDirectory => txtWorktreeDirectory.Text;
-    public bool OpenWorktree => chkOpenWorktree.Checked;
 
     public IReadOnlyList<IGitRef>? ExistingBranches { get; set; }
 
@@ -21,6 +23,8 @@ public sealed partial class FormCreateWorktree : GitExtensionsDialog
         : base(commands, enablePositionRestore: false)
     {
         InitializeComponent();
+
+        _branchNameNormaliser = commands.GetRequiredService<IGitBranchNameNormaliser>();
 
         tlpnlMain.AdjustWidthToSize(0, rbCheckoutExistingBranch, rbCreateNewBranch, lblNewWorktreeFolder);
         tlpnlCheckout.AdjustWidthToSize(0, rbCheckoutExistingBranch, rbCreateNewBranch, lblNewWorktreeFolder);
@@ -91,6 +95,23 @@ public sealed partial class FormCreateWorktree : GitExtensionsDialog
         }
     }
 
+    private void txtNewBranchName_Leave(object sender, EventArgs e)
+    {
+        NormaliseNewBranchName();
+    }
+
+    private void NormaliseNewBranchName()
+    {
+        if (!AppSettings.AutoNormaliseBranchName || !txtNewBranchName.Text.Any(PathUtil.IsValidPathChar))
+        {
+            return;
+        }
+
+        int caretPosition = txtNewBranchName.SelectionStart;
+        txtNewBranchName.Text = _branchNameNormaliser.Normalise(txtNewBranchName.Text, _gitBranchNameOptions);
+        txtNewBranchName.SelectionStart = caretPosition;
+    }
+
     private void btnCreateWorktree_Click(object sender, EventArgs e)
     {
         CreateWorktree();
@@ -98,6 +119,13 @@ public sealed partial class FormCreateWorktree : GitExtensionsDialog
 
     private void CreateWorktree()
     {
+        // The branch name may not have lost focus yet (e.g. when triggered via the accept button),
+        // so normalise it here to avoid passing an invalid name (e.g. containing spaces) to git.
+        if (rbCreateNewBranch.Checked)
+        {
+            NormaliseNewBranchName();
+        }
+
         string relativePath = Path.GetRelativePath(Module.WorkingDir, WorktreeDirectory).ToPosixPath().Quote();
         string? newBranchOption =
             rbCreateNewBranch.Checked

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -336,14 +336,8 @@ public sealed class GitUICommands : IGitUICommands
                 return false;
             }
 
-            if (form.OpenWorktree)
-            {
-                GitModule newModule = new(this.GetRequiredService<IGitExecutorProvider>(), form.WorktreeDirectory);
-                if (newModule.IsValidGitWorkingDir() && FindFormBrowse(owner) is FormBrowse browse)
-                {
-                    browse.SetWorkingDir(Path.GetFullPath(form.WorktreeDirectory));
-                }
-            }
+            // Offer to switch to the freshly created worktree, mirroring the clone flow.
+            WorktreeSwitch(owner, form.WorktreeDirectory);
 
             return true;
         });
@@ -356,8 +350,19 @@ public sealed class GitUICommands : IGitUICommands
             return browse;
         }
 
+        // The owner may be a child control (e.g. the repository objects tree), so resolve its containing form first.
+        if (window is Control control and not Form)
+        {
+            window = control.FindForm();
+        }
+
         if (window is Form form)
         {
+            if (form is FormBrowse formBrowse)
+            {
+                return formBrowse;
+            }
+
             while (form.Owner is not null)
             {
                 if (form.Owner is FormBrowse ownerBrowse)

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -345,32 +345,17 @@ public sealed class GitUICommands : IGitUICommands
 
     private static FormBrowse? FindFormBrowse(IWin32Window? window)
     {
-        if (window is FormBrowse browse)
-        {
-            return browse;
-        }
-
         // The owner may be a child control (e.g. the repository objects tree), so resolve its containing form first.
         if (window is Control control and not Form)
         {
             window = control.FindForm();
         }
 
-        if (window is Form form)
+        for (Form? form = window as Form; form is not null; form = form.Owner)
         {
             if (form is FormBrowse formBrowse)
             {
                 return formBrowse;
-            }
-
-            while (form.Owner is not null)
-            {
-                if (form.Owner is FormBrowse ownerBrowse)
-                {
-                    return ownerBrowse;
-                }
-
-                form = form.Owner;
             }
         }
 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -4575,10 +4575,6 @@ Examples on branch name: "feature/ABC-4587-commitMessageRegex"
         <source>&amp;Create the new worktree</source>
         <target />
       </trans-unit>
-      <trans-unit id="chkOpenWorktree.Text">
-        <source>&amp;Open the new worktree after the creation</source>
-        <target />
-      </trans-unit>
       <trans-unit id="gbxWhatToCheckout.Text">
         <source>What to checkout:</source>
         <target />


### PR DESCRIPTION
﻿### What
- Apply the existing branch-name normalisation routine when creating a worktree with a new branch, so names containing spaces (or other invalid characters) no longer cause the create to fail.
- After a worktree is created, prompt the user to switch to it (mirroring the clone flow). The non-functional `"Open the new worktree after the creation" checkbox has been removed in favour of this prompt.
- Fix `FindFormBrowse` so it resolves the owning `FormBrowse` when invoked from a child control (e.g. the repository objects tree), which previously prevented switching from the left panel.

### Testing
- `dotnet build` clean (0 warnings/errors)
- `update-loc.cmd` reports English translations up to date
- `GitUI.Tests` all green (20603 passed)

### Notes
- No changes under `src/app/GitExtensions.Extensibility/` (no plugin interface version impact).
