### PR TITLE
ci: only clear no-recent-activity label on author response

### DIFF
--- a/.github/workflows/pr-check-stale.yml
+++ b/.github/workflows/pr-check-stale.yml
@@ -58,8 +58,13 @@ jobs:
           # even if they carry the "needs: author feedback" label.
           exempt-draft-pr: true
 
-          # The stale label is removed automatically when an item is updated.
-          remove-stale-when-updated: true
+          # Do not let the stale action clear the no-recent-activity label on any
+          # update: it treats a comment from *anyone* (e.g. a maintainer) as
+          # activity, which incorrectly resets the stale timer. The label must be
+          # removed only when the original author responds. That author-only
+          # removal is handled by the "Label Lifecycle" workflow
+          # (.github/workflows/label-lifecycle.yml).
+          remove-stale-when-updated: false
 
           # Process a generous number of items per run to avoid backlog.
           operations-per-run: 100


### PR DESCRIPTION
### Problem
On issue #13013 the `:zzz: status: no recent activity` label was removed when a non-author (a maintainer) commented, incorrectly resetting the stale timer. The label must only be cleared when the *original author* responds.

### Root cause
`actions/stale` was configured with `remove-stale-when-updated: true`, which treats *any* update — including comments from non-authors — as activity and strips the stale label.

### Fix
Set `remove-stale-when-updated: false` in `.github/workflows/pr-check-stale.yml`. Author-only removal is already handled correctly by the Label Lifecycle workflow (`.github/workflows/label-lifecycle.yml`), which for issues removes the label only when the actor is the author.
