### PR TITLE
Limit reset check to scope of documentation to "not loose commits"

### DIFF
--- a/src/app/GitCommands/Git/Commands.Arguments.cs
+++ b/src/app/GitCommands/Git/Commands.Arguments.cs
@@ -470,27 +470,6 @@ public static partial class Commands
         };
     }
 
-    /// <summary>
-    /// Push a local reference to a new commit
-    /// This is similar to "git branch --force "branch" "commit", except that you get a warning if commits are lost.
-    /// </summary>
-    /// <param name="gitRef">The branch to move.</param>
-    /// <param name="targetId">The commit to move to.</param>
-    /// <param name="repoDir">Directory to the current repo.</param>
-    /// <param name="force">Push the reference also if commits are lost.</param>
-    /// <param name="dryRun">Just test whether Git would perform the operation.</param>
-    /// <returns>The Git command to execute.</returns>
-    public static ArgumentString PushLocal(string gitRef, ObjectId targetId, string repoDir, Func<string?, string?> getPathForGitExecution, bool force = false, bool dryRun = false)
-    {
-        return new GitArgumentBuilder("push")
-        {
-            $@"""file://{getPathForGitExecution(repoDir)}""",
-            $"{targetId}:{gitRef}".QuoteNE(),
-            { force, "--force" },
-            { dryRun, "--dry-run" }
-        };
-    }
-
     /// <summary>Pushes multiple sets of local branches to remote branches.</summary>
     public static ArgumentString PushMultiple(string remote, IEnumerable<GitPushAction> pushActions)
     {

--- a/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/src/app/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -164,7 +164,12 @@ public partial class FormResetAnotherBranch : GitModuleForm
 
         ThreadHelper.FileAndForget(async () =>
         {
-            ArgumentString command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.WorkingDir, Module.GetPathForGitExecution, ForceReset.Checked, dryRun: true);
+            ArgumentString command = new GitExtUtils.GitArgumentBuilder("merge-base")
+            {
+                "--is-ancestor",
+                gitRefToReset.CompleteName.QuoteNE(),
+                _revision.ObjectId,
+            };
             ExecutionResult executionResult = await Module.GitExecutable.ExecuteAsync(command, throwOnErrorExit: false, cancellationToken: cancellationToken);
 
             await this.SwitchToMainThreadAsync(cancellationToken);

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -313,14 +313,6 @@ public partial class CommandsTests
         Commands.Push("remote", "from-branch", "to-branch", ForcePushOptions.DoNotForce, track: false, recursiveSubmodules: 2).Arguments.Should().Be("push --recurse-submodules=on-demand --progress \"remote\" from-branch:refs/heads/to-branch");
     }
 
-    [TestCase("mybranch", ".", false, false, ExpectedResult = @"push ""file://."" ""1111111111111111111111111111111111111111:mybranch""")]
-    [TestCase("branch2", "/my/path", true, false, ExpectedResult = @"push ""file:///my/path"" ""1111111111111111111111111111111111111111:branch2"" --force")]
-    [TestCase("branchx", @"c:/my/path", true, true, ExpectedResult = @"push ""file://c:/my/path"" ""1111111111111111111111111111111111111111:branchx"" --force --dry-run")]
-    public string PushLocalCmd(string gitRef, string repoDir, bool force, bool dryRun)
-    {
-        return Commands.PushLocal(gitRef, ObjectId.WorkTreeId, repoDir, PathUtil.ToPosixPath, force, dryRun).Arguments!;
-    }
-
     [Test]
     public void PushTagCmd()
     {


### PR DESCRIPTION
Current _push to local repository_ triggers `push` hooks, which is an operation bound to fail on e.g. fast-forward of a tracking branch with new LFS data in upstream.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13194

## Proposed changes

- remove the invocation of `push` with the current repository as a remote
- use pure ancestor check for target commit (as noted [as requirement](https://github.com/gitextensions/gitextensions/commit/43518add9f962064fa21a66f093dad008172fd4e) in documentation and UI hint)

## Test methodology <!-- How did you ensure quality? -->

- force-reset a branch to its parent commit
- remove arbitrary LFS object needed in target commit from `.git/lfs/objects`
  (simulate state of new data in upstream)
- reset branch to its original commit (did not work previously)
- verify LFS will (re-)fetch missing object on checkout

## Test environment(s) <!-- Remove any that don't apply -->

- GIT git version 2.55.0.windows.3
- Windows 10.0.26200.8875
- repository with LFS data and multiple tracking branches

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
