### PR TITLE
feat(FileHelper): Treat .webp files as images

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -229,3 +229,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/05/04, Henr1k80, Henrik Gedionsen, Henrik.Gedionsen[.@)gmail.com
 2026/05/06, LeeRedfield, Chiong Ngek Lee, chiongngeklee@gmail.com
 2026/06/01, becm, Marc Becker, becm@gmx.de
+2026/07/28, CookiePLMonster, Adrian Zdanowicz, zdanio95(at)gmail.com

--- a/src/app/GitCommands/FileHelper.cs
+++ b/src/app/GitCommands/FileHelper.cs
@@ -38,7 +38,8 @@ public static class FileHelper
         ".vsdx", // microsoft
         ".xls", // microsoft excel
         ".xlsx", // microsoft excel
-        ".odt" // Open office
+        ".odt", // Open office
+        ".webp", // image
     };
 
     private static readonly IEnumerable<string> ImageExtensions = new[]
@@ -51,6 +52,7 @@ public static class FileHelper
         ".png",
         ".tif",
         ".tiff",
+        ".webp",
     };
 
     public static bool IsBinaryFileName(IGitModule module, string? fileName)


### PR DESCRIPTION
## Proposed changes

WebP resources are currently not treated as image resources, so they show up as binary files when staging. This PR adds `.webp` as a supported image extension.

## Test methodology

**Full disclosure: This PR is untested as I don't have a local environment set up to build GitExtensions. I'm hoping to utilize this PR's CI artifacts to test it.**

* Set up a git repository with `.webp` images that are not commited.
* Open the Commit window.
* Observe that the `.webp` images visualize as images and not as binary files.

## Test environment(s)

See above.

## Merge strategy

No particular preference on the strategy, given the simplicity of the change.

I agree that the maintainer squash merge this PR (if the commit message is clear).

**Added:** This PR is small enough that I do not care about the authorship - if it's quicker to simply add this outside of this PR and "reject" mine, go ahead.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
