### PR TITLE
perf(clone): choose Windows / WSL git according to destination directory

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -7,6 +7,7 @@ using GitExtensions.Extensibility.Git;
 using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
+using Microsoft;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs;
@@ -397,8 +398,9 @@ public partial class FormClone : GitExtensionsDialog
         }
         else
         {
+            Validates.NotNull(branchList.Result);
             string text = _NO_TRANSLATE_Branches.Text;
-            List<string> names = [.. _defaultBranchItems, .. branchList.Result!.Select(o => o.LocalName!)];
+            List<string> names = [.. _defaultBranchItems, .. branchList.Result.Select(branch => branch.LocalName)];
             _NO_TRANSLATE_Branches.DataSource = names;
             if (names.Any(a => a == text))
             {

--- a/src/app/GitUI/CommandsDialogs/FormClone.cs
+++ b/src/app/GitUI/CommandsDialogs/FormClone.cs
@@ -215,16 +215,21 @@ public partial class FormClone : GitExtensionsDialog
                 branch = null;
             }
 
+            // Use a commands instance rooted at the destination so that path conversion and
+            // git-executable selection (Windows vs WSL) match the destination directory, not the
+            // currently open module which may live on a different subsystem.
+            IGitUICommands destUICommands = UICommands.WithWorkingDirectory(dirTo);
+
             ArgumentString cloneCmd = Commands.Clone(_NO_TRANSLATE_From.Text,
                 dirTo,
-                UICommands.Module.GetPathForGitExecution,
+                destUICommands.Module.GetPathForGitExecution,
                 CentralRepository.Checked,
                 cbIntializeAllSubmodules.Checked,
                 branch, depth, isSingleBranch);
-            using (FormRemoteProcess fromProcess = new(UICommands, cloneCmd))
+            using (FormRemoteProcess fromProcess = new(destUICommands, cloneCmd))
             {
                 string sourceRepo = PathUtil.IsLocalFile(_NO_TRANSLATE_From.Text)
-                    ? UICommands.Module.GetPathForGitExecution(_NO_TRANSLATE_From.Text)
+                    ? destUICommands.Module.GetPathForGitExecution(_NO_TRANSLATE_From.Text)
                     : _NO_TRANSLATE_From.Text;
                 fromProcess.SetUrlTryingToConnect(sourceRepo);
                 fromProcess.ShowDialog(this);


### PR DESCRIPTION
Fixes #13097

## Proposed changes

`FormClone`: Use a `IGitUICommands` instance rooted at the destination directory instead of using `UICommands` of the currently opened repo

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).