### PR TITLE
fix(push button): restore color if not behind

### DIFF
--- a/src/app/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/src/app/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -1,7 +1,6 @@
 ﻿using GitCommands;
 using GitCommands.Git;
 using GitExtUtils;
-using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
 using ResourceManager;
 
@@ -24,7 +23,7 @@ public class ToolStripPushButton : ToolStripButton
             || aheadBehindData?.TryGetValue(branchName, out AheadBehindData data) is not true)
         {
             ResetToDefaultState();
-            ToolTipText = ToolTipText!.UpdateSuffix(shortcut);
+            ToolTipText = ToolTipText?.UpdateSuffix(shortcut);
             return;
         }
 
@@ -32,12 +31,9 @@ public class ToolStripPushButton : ToolStripButton
         AutoSize = true;
         Text = data.ToDisplay();
         DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
-        ToolTipText = GetToolTipText(data)!.UpdateSuffix(shortcut);
+        ToolTipText = GetToolTipText(data)?.UpdateSuffix(shortcut);
 
-        if (!string.IsNullOrEmpty(data.BehindCount))
-        {
-            Image = Images.Unstage;
-        }
+        Image = string.IsNullOrEmpty(data.BehindCount) ? Images.Push : Images.Unstage;
     }
 
     /// <summary>

--- a/src/app/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/src/app/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -87,7 +87,7 @@ public class ToolStripPushButton : ToolStripButton
             _button = button;
         }
 
-        public string GetButtonText() => _button.Text!;
+        public string? GetButtonText() => _button.Text;
         public int GetButtonWidth() => _button.Width;
     }
 }


### PR DESCRIPTION
Fixes #13204
as suggested by @valeskas

## Proposed changes

`ToolStripPushButton`:
- restore (blue) color if not behind any longer
- cleanup: replace null-forgiving operator and remove unnecessary `using`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

not worth it

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).