### PR TITLE
fix(cancellation): Pass cancellation tokens to awaited tasks

### DIFF
--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -751,7 +751,7 @@ public partial class FileViewer : GitModuleControl
                     return CreateImage(file.Name, stream);
                 }
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
             }
 

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -745,7 +745,7 @@ public partial class FileViewer : GitModuleControl
         {
             try
             {
-                using MemoryStream? stream = await Module.GetFileStreamAsync(blobId.ToString(), cancellationToken: default);
+                using MemoryStream? stream = await Module.GetFileStreamAsync(blobId.ToString(), cancellationToken);
                 if (stream is not null)
                 {
                     return CreateImage(file.Name, stream);

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -164,8 +164,8 @@ public static partial class GitUIExtensions
             cancellationToken.ThrowIfCancellationRequested();
             string subText = status is null
                 ? $"Failed to get status for submodule \"{item.Item.Name}\""
-                : await Task.Run(() => SubmoduleResources.GetSubmoduleStatusText(fileViewer.Module, status))
-                    .ConfigureAwait(false);
+                : await Task.Run(() => SubmoduleResources.GetSubmoduleStatusText(fileViewer.Module, status), cancellationToken)
+                    .ConfigureAwait(continueOnCapturedContext: false);
 
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             await fileViewer.ViewPatchAsync(item, text: subText, line: line, openWithDifftool: openWithDiffTool, cancellationToken: cancellationToken);

--- a/src/app/GitUI/SpellChecker/EditNetSpell.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using GitCommands;
@@ -1023,7 +1023,7 @@ public partial class EditNetSpell : GitModuleControl
 
         if (!_autoCompleteListTask.IsValueFactoryCompleted)
         {
-            _autoCompleteListTask.GetValueAsync().Forget();
+            _autoCompleteListTask.GetValueAsync(_autoCompleteCancellationTokenSource.Token).Forget();
 
             if (calledByUser)
             {


### PR DESCRIPTION
Fixes https://sonarcloud.io/project/issues?impactSeverities=HIGH&sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&pullRequest=13208&id=gitextensions_gitextensions

## Proposed changes

SonarQube identified calls where existing cancellation tokens were not passed to awaited tasks. Follow the suggestions.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).