### PR TITLE
ci(pr-automation): set appropriate permissions for updating PRs

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.repository_owner == 'gitextensions' && (github.event.action == 'opened' || github.event.action == 'reopened') && github.event.pull_request.user.type != 'Bot' }}
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      issues: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.repository_owner == 'gitextensions' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch }}
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      issues: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:


### PR DESCRIPTION
## Proposed changes

`pr-automation.yml`: set appropriate permissions for assigning the author and merged PRs to milestone "vNext"
because (according to Cp):

GitHub Actions token permissions are granular — pull-requests: write covers PR-specific operations (merge, review requests, etc.), but setting a milestone calls the Issues REST API (PATCH /repos/.../issues/{number}), which requires the issues: write scope.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- to be checked with next PR to be merged

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).