### PR TITLE
fix: three cross-platform fixes for HOME, the avatar cache path and meld

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -230,3 +230,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/05/06, LeeRedfield, Chiong Ngek Lee, chiongngeklee@gmail.com
 2026/06/01, becm, Marc Becker, becm@gmx.de
 2026/07/15, SparshGarg999, Sparsh Garg, sparshgarg307@gmail.com
+2026/08/04, AlexThunder1989, Alexander Karlsson, alexthunder(at)gmail.com

--- a/src/app/GitCommands/DiffMergeTools/Meld.cs
+++ b/src/app/GitCommands/DiffMergeTools/Meld.cs
@@ -3,7 +3,7 @@ namespace GitCommands.DiffMergeTools;
 internal sealed class Meld : DiffMergeTool
 {
     /// <inheritdoc />
-    public override string ExeFileName => "meld.exe";
+    public override string ExeFileName => OperatingSystem.IsWindows() ? "meld.exe" : "meld";
 
     /// <inheritdoc />
     public override string MergeCommand => "\"$LOCAL\" \"$BASE\" \"$REMOTE\" --output \"$MERGED\"";

--- a/src/app/GitCommands/Git/EnvironmentConfiguration.cs
+++ b/src/app/GitCommands/Git/EnvironmentConfiguration.cs
@@ -119,6 +119,6 @@ public static class EnvironmentConfiguration
             return Env.GetEnvironmentVariable("USERPROFILE");
         }
 
-        return Env.GetFolderPath(Environment.SpecialFolder.Personal);
+        return Env.GetFolderPath(Environment.SpecialFolder.UserProfile);
     }
 }

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -599,7 +599,7 @@ public static partial class AppSettings
 
     #region Avatars
 
-    public static string AvatarImageCachePath => Path.Join(LocalApplicationDataPath.Value!, "Images\\");
+    public static string AvatarImageCachePath => Path.Join(LocalApplicationDataPath.Value!, "Images");
 
     public static AvatarFallbackType AvatarFallbackType
     {


### PR DESCRIPTION
Thanks for Git Extensions — it is the tool I reach for, and these are just three small
cross-platform fixes I ran into while using it on Linux.

Three one-line changes, each independent:

**`HOME` resolved to `~/Documents` on Unix.** `Environment.SpecialFolder.Personal` is
`~/Documents` there, so `SetEnvironmentVariables()` pointed `HOME` at it for the process
and every git child. `git config --global` could then not read `~/.gitconfig`, and since
`Commands.GetGitSettings()` treats a missing config file as empty output, the global
configuration silently looked empty — the settings checklist reported no user name/email,
no mergetool and no difftool although all three were configured. The changed line is only
reachable on non-Windows; the Windows branch returns above it.

**Avatar cache path hardcoded a Windows separator.** `Path.Join(..., "Images\\")` creates
a directory literally named `Images\` on Unix-like systems. All consumers use `Path.Join`
or the `Directory` APIs, so the trailing separator was never needed and dropping it is a
no-op on Windows.

**meld could never be located off Windows.** The registered tool declared `"meld.exe"`
unconditionally; on Linux/macOS the executable has no extension.

Verified by building `GitCommands` (`-p:EnableWindowsTargeting=true`) and by running the
`GitCommands` unit tests on Linux. Happy to split these into separate PRs if you prefer.
