### PR TITLE
fix: clarify IGitRef MergeWith

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,6 +100,13 @@ For example:
 * Avoid null-forgiving (`!`) suppressions. Prefer making nullability explicit in the type system — for example, by declaring a parameter or property as nullable, adding a null guard, or restructuring code so that null states are unrepresentable. Use `!` only as a last resort when the type system cannot express a known invariant.
 * When modifying code that contains existing `!` suppressions, look for opportunities to remove them safely. Use `Validates.NotNull` for runtime null checks where a value is expected to be non-null but the type system cannot prove it.
 
+## constants
+
+* In GitExtensions, libraries may be used by plugins, also not in GitExtensions.Extensibility.
+  Prefix/suffix string members must remain public static string auto-properties
+  (not const), because const would inline values into dependent plugin assemblies
+  and break binary compatibility.
+
 ## WinForms UI
 
 * Follow the naming conventions in `.github/ui_design_guidelines.md` for all WinForms controls:

--- a/src/app/GitCommands/Config/SettingKeyString.cs
+++ b/src/app/GitCommands/Config/SettingKeyString.cs
@@ -7,6 +7,11 @@
 public static class SettingKeyString
 {
     /// <summary>
+    ///  "branch.{0}.merge"
+    /// </summary>
+    public static readonly string BranchMerge = "branch.{0}.merge";
+
+    /// <summary>
     /// "branch.{0}.remote"
     /// </summary>
     public static readonly string BranchRemote = "branch.{0}.remote";

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -2970,7 +2970,7 @@ public sealed partial class GitModule : IGitModule
     public string GetRemoteBranch(string branch)
     {
         string remote = GetSetting(string.Format(SettingKeyString.BranchRemote, branch));
-        string merge = GetSetting($"branch.{branch}.merge");
+        string merge = GetSetting(string.Format(SettingKeyString.BranchMerge, branch));
 
         if (string.IsNullOrEmpty(remote) || string.IsNullOrEmpty(merge))
         {
@@ -3912,7 +3912,7 @@ public sealed partial class GitModule : IGitModule
             (string section, string? subsection, string name) = IGitConfigSettingsGetter.SplitSetting(setting);
             if (section == "branch" && name == "remote" && value == remoteName)
             {
-                string? remoteBranch = localGitConfigSettings.GetValue($"{section}.{subsection}.merge")?.Replace("refs/heads/", string.Empty);
+                string? remoteBranch = localGitConfigSettings.GetValue(string.Format(SettingKeyString.BranchMerge, subsection))?.Replace("refs/heads/", string.Empty);
                 if (remoteBranch == branchName)
                 {
                     return subsection;

--- a/src/app/GitCommands/Git/GitRef.cs
+++ b/src/app/GitCommands/Git/GitRef.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using GitCommands.Config;
 using GitExtensions.Extensibility.Git;
 
 namespace GitCommands;
@@ -17,9 +18,10 @@ internal enum GitRefType
 
 public sealed class GitRef : IGitRef
 {
-    private readonly string _mergeSettingName;
-    private readonly string _remoteSettingName;
     private readonly GitRefType _type;
+    private string? _localName;
+    private string? _mergeWith;
+    private string? _trackingRemote;
 
     public IGitModule Module { get; }
 
@@ -27,145 +29,87 @@ public sealed class GitRef : IGitRef
     {
         Module = module;
         ObjectId = objectId;
-        Guid = objectId.IsZero ? null : objectId.ToString();
         CompleteName = completeName;
         Remote = remote;
-
         IsDereference = CompleteName.EndsWith(GitRefName.TagDereferenceSuffix);
-
-        _type = GetType();
-
-        string name = ParseName();
-
-        Name = string.IsNullOrWhiteSpace(name) ? CompleteName : name;
-
-        _remoteSettingName = $"branch.{Name}.remote";
-        _mergeSettingName = $"branch.{Name}.merge";
-
-        return;
-
-        GitRefType GetType()
-        {
-            if (CompleteName.StartsWith(GitRefName.RefsTagsPrefix))
-            {
-                return GitRefType.Tag;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsHeadsPrefix))
-            {
-                return GitRefType.Head;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsRemotesPrefix))
-            {
-                return GitRefType.Remote;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsBisectPrefix))
-            {
-                if (CompleteName.StartsWith(GitRefName.RefsBisectGoodPrefix))
-                {
-                    return GitRefType.BisectGood;
-                }
-
-                if (CompleteName.StartsWith(GitRefName.RefsBisectBadPrefix))
-                {
-                    return GitRefType.BisectBad;
-                }
-
-                return GitRefType.Bisect;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsStashPrefix))
-            {
-                return GitRefType.Stash;
-            }
-
-            return GitRefType.Other;
-        }
-
-        string ParseName()
-        {
-            if (IsRemote)
-            {
-                return CompleteName.SubstringAfter("remotes/");
-            }
-
-            if (IsTag)
-            {
-                // we need the one containing ^{}, because it contains the reference
-                return CompleteName.RemoveSuffix(GitRefName.TagDereferenceSuffix).SubstringAfter("tags/");
-            }
-
-            if (IsHead)
-            {
-                return CompleteName.SubstringAfter("heads/");
-            }
-
-            // if we don't know ref type then we don't know if '/' is a valid ref character
-            return CompleteName.SubstringAfter("refs/");
-        }
+        _type = DetermineType(completeName);
+        Name = ParseName(completeName, _type, IsDereference);
     }
 
     public string CompleteName { get; }
-    public bool IsSelected { get; set; }
-    public bool IsSelectedHeadMergeSource { get; set; }
 
-    public bool IsTag => _type == GitRefType.Tag;
-    public bool IsHead => _type == GitRefType.Head;
-    public bool IsRemote => _type == GitRefType.Remote;
-    public bool IsBisect => _type == GitRefType.Bisect;
-    public bool IsBisectGood => _type == GitRefType.BisectGood;
-    public bool IsBisectBad => _type == GitRefType.BisectBad;
-    public bool IsStash => _type == GitRefType.Stash;
+    public string Name { get; }
 
-    public bool IsDereference { get; }
+    public string LocalName => _localName ??= ComputeLocalName(IsRemote, Remote, Name);
 
-    public bool IsOther => !IsHead && !IsRemote && !IsTag;
+    [AllowNull]
+    public string MergeWith
+    {
+        get => _mergeWith ??= IsHead ? Module.GetEffectiveSetting(string.Format(SettingKeyString.BranchMerge, LocalName)).RemovePrefix(GitRefName.RefsHeadsPrefix) : "";
+        set
+        {
+            if (!IsHead)
+            {
+                throw new InvalidOperationException("MergeWith can only be set for local branches.");
+            }
 
-    public string LocalName => IsRemote && Name.StartsWith($"{Remote}/") ? Name[(Remote.Length + 1)..] : Name;
+            string settingName = string.Format(SettingKeyString.BranchMerge, LocalName);
+            if (string.IsNullOrEmpty(value))
+            {
+                Module.UnsetSetting(settingName);
+                _mergeWith = "";
+            }
+            else
+            {
+                Module.SetSetting(settingName, GitRefName.GetFullBranchName(value));
+                _mergeWith = value;
+            }
+        }
+    }
 
     public string Remote { get; }
 
     [AllowNull]
     public string TrackingRemote
     {
-        get => Module.GetEffectiveSetting(_remoteSettingName);
+        get => _trackingRemote ??= IsHead ? Module.GetEffectiveSetting(string.Format(SettingKeyString.BranchRemote, LocalName)) : "";
         set
         {
+            if (!IsHead)
+            {
+                throw new InvalidOperationException("Tracking remote can only be set for local branches.");
+            }
+
+            string settingName = string.Format(SettingKeyString.BranchRemote, LocalName);
             if (string.IsNullOrEmpty(value))
             {
-                Module.UnsetSetting(_remoteSettingName);
+                Module.UnsetSetting(settingName);
+                _trackingRemote = "";
             }
             else
             {
-                Module.SetSetting(_remoteSettingName, value);
+                Module.SetSetting(settingName, value);
+                _trackingRemote = value;
 
                 if (MergeWith == "")
                 {
-                    MergeWith = Name;
+                    MergeWith = LocalName;
                 }
             }
         }
     }
 
-    /// <inheritdoc />
-    [AllowNull]
-    public string MergeWith
-    {
-        get => Module.GetEffectiveSetting(_mergeSettingName).RemovePrefix(GitRefName.RefsHeadsPrefix);
-        set
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                Module.UnsetSetting(_mergeSettingName);
-            }
-            else
-            {
-                Module.SetSetting(_mergeSettingName, GitRefName.GetFullBranchName(value));
-            }
-        }
-    }
+    public bool IsHead => _type == GitRefType.Head;
+    public bool IsRemote => _type == GitRefType.Remote;
+    public bool IsTag => _type == GitRefType.Tag;
+    public bool IsStash => _type == GitRefType.Stash;
+    public bool IsDereference { get; }
+    public bool IsSelected { get; set; }
+    public bool IsSelectedHeadMergeSource { get; set; }
+
+    public bool IsBisect => _type == GitRefType.Bisect;
+    public bool IsBisectGood => _type == GitRefType.BisectGood;
+    public bool IsBisectBad => _type == GitRefType.BisectBad;
 
     public static GitRef NoHead(IGitModule module)
     {
@@ -175,8 +119,8 @@ public sealed class GitRef : IGitRef
     #region IGitItem Members
 
     public ObjectId ObjectId { get; }
-    public string? Guid { get; }
-    public string Name { get; }
+
+    public string? Guid => ObjectId.IsZero ? null : ObjectId.ToString();
 
     #endregion
 
@@ -184,20 +128,110 @@ public sealed class GitRef : IGitRef
 
     public static IReadOnlyCollection<string> GetAmbiguousRefNames(IEnumerable<IGitRef> refs)
     {
-        return refs
-            .GroupBy(r => r.Name)
-            .Where(group => group.Count() > 1)
-            .Select(e => e.Key)
-            .ToHashSet();
-    }
+        HashSet<string> seen = [];
+        HashSet<string> ambiguous = [];
 
-    public bool IsTrackingRemote(IGitRef? remote)
-    {
-        if (remote is null || IsRemote || !remote.IsRemote)
+        foreach (IGitRef r in refs)
         {
-            return false;
+            if (!seen.Add(r.Name))
+            {
+                ambiguous.Add(r.Name);
+            }
         }
 
-        return MergeWith == remote.LocalName && TrackingRemote == remote.Remote;
+        return ambiguous;
+    }
+
+    internal static GitRefType DetermineType(string completeName)
+    {
+        ReadOnlySpan<char> span = completeName.AsSpan();
+
+        if (span.StartsWith(GitRefName.RefsTagsPrefix))
+        {
+            return GitRefType.Tag;
+        }
+
+        if (span.StartsWith(GitRefName.RefsHeadsPrefix))
+        {
+            return GitRefType.Head;
+        }
+
+        if (span.StartsWith(GitRefName.RefsRemotesPrefix))
+        {
+            return GitRefType.Remote;
+        }
+
+        if (span.StartsWith(GitRefName.RefsBisectPrefix))
+        {
+            if (span.StartsWith(GitRefName.RefsBisectGoodPrefix))
+            {
+                return GitRefType.BisectGood;
+            }
+
+            if (span.StartsWith(GitRefName.RefsBisectBadPrefix))
+            {
+                return GitRefType.BisectBad;
+            }
+
+            return GitRefType.Bisect;
+        }
+
+        if (span.StartsWith(GitRefName.RefsStashPrefix))
+        {
+            return GitRefType.Stash;
+        }
+
+        return GitRefType.Other;
+    }
+
+    /// <summary>
+    ///  Computes <see cref="IGitRef.LocalName"/> of a ref, given <see cref="IGitRef.Remote"/> and <see cref="IGitRef.Name"/>.
+    /// </summary>
+    public static string ComputeLocalName(bool isRemote, string remote, string name)
+    {
+        if (!isRemote || remote.Length == 0 || name.Length <= remote.Length || name[remote.Length] != '/'
+            || !name.AsSpan().StartsWith(remote, StringComparison.Ordinal))
+        {
+            return name;
+        }
+
+        return name[(remote.Length + 1)..];
+    }
+
+    public static string ParseName(string completeName)
+    {
+        GitRefType type = DetermineType(completeName);
+        bool isDereference = completeName.EndsWith(GitRefName.TagDereferenceSuffix);
+        return ParseName(completeName, type, isDereference);
+    }
+
+    internal static string ParseName(string completeName, GitRefType type, bool isDereference)
+    {
+        // DetermineType already verified each prefix, so slice directly at the known
+        // offset rather than repeating an IndexOf search via SubstringAfter.
+        string name;
+
+        if (type == GitRefType.Remote)
+        {
+            name = completeName[GitRefName.RefsRemotesPrefix.Length..];
+        }
+        else if (type == GitRefType.Tag)
+        {
+            // Strip the dereference suffix (if present) without an intermediate string
+            // allocation by computing the end offset directly before slicing.
+            int end = completeName.Length - (isDereference ? GitRefName.TagDereferenceSuffix.Length : 0);
+            name = completeName[GitRefName.RefsTagsPrefix.Length..end];
+        }
+        else if (type == GitRefType.Head)
+        {
+            name = completeName[GitRefName.RefsHeadsPrefix.Length..];
+        }
+        else
+        {
+            // if we don't know ref type then we don't know if '/' is a valid ref character
+            name = completeName.SubstringAfter("refs/");
+        }
+
+        return name.Length == 0 ? completeName : name;
     }
 }

--- a/src/app/GitCommands/Git/GitRef.cs
+++ b/src/app/GitCommands/Git/GitRef.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using GitCommands.Config;
 using GitExtensions.Extensibility.Git;
 
 namespace GitCommands;
@@ -17,9 +18,10 @@ internal enum GitRefType
 
 public sealed class GitRef : IGitRef
 {
-    private readonly string _mergeSettingName;
-    private readonly string _remoteSettingName;
     private readonly GitRefType _type;
+    private string? _localName;
+    private string? _mergeWith;
+    private string? _trackingRemote;
 
     public IGitModule Module { get; }
 
@@ -27,145 +29,87 @@ public sealed class GitRef : IGitRef
     {
         Module = module;
         ObjectId = objectId;
-        Guid = objectId.IsZero ? null : objectId.ToString();
         CompleteName = completeName;
         Remote = remote;
-
         IsDereference = CompleteName.EndsWith(GitRefName.TagDereferenceSuffix);
-
-        _type = GetType();
-
-        string name = ParseName();
-
-        Name = string.IsNullOrWhiteSpace(name) ? CompleteName : name;
-
-        _remoteSettingName = $"branch.{Name}.remote";
-        _mergeSettingName = $"branch.{Name}.merge";
-
-        return;
-
-        GitRefType GetType()
-        {
-            if (CompleteName.StartsWith(GitRefName.RefsTagsPrefix))
-            {
-                return GitRefType.Tag;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsHeadsPrefix))
-            {
-                return GitRefType.Head;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsRemotesPrefix))
-            {
-                return GitRefType.Remote;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsBisectPrefix))
-            {
-                if (CompleteName.StartsWith(GitRefName.RefsBisectGoodPrefix))
-                {
-                    return GitRefType.BisectGood;
-                }
-
-                if (CompleteName.StartsWith(GitRefName.RefsBisectBadPrefix))
-                {
-                    return GitRefType.BisectBad;
-                }
-
-                return GitRefType.Bisect;
-            }
-
-            if (CompleteName.StartsWith(GitRefName.RefsStashPrefix))
-            {
-                return GitRefType.Stash;
-            }
-
-            return GitRefType.Other;
-        }
-
-        string ParseName()
-        {
-            if (IsRemote)
-            {
-                return CompleteName.SubstringAfter("remotes/");
-            }
-
-            if (IsTag)
-            {
-                // we need the one containing ^{}, because it contains the reference
-                return CompleteName.RemoveSuffix(GitRefName.TagDereferenceSuffix).SubstringAfter("tags/");
-            }
-
-            if (IsHead)
-            {
-                return CompleteName.SubstringAfter("heads/");
-            }
-
-            // if we don't know ref type then we don't know if '/' is a valid ref character
-            return CompleteName.SubstringAfter("refs/");
-        }
+        _type = DetermineType(completeName);
+        Name = ParseName(completeName, _type, IsDereference);
     }
 
     public string CompleteName { get; }
-    public bool IsSelected { get; set; }
-    public bool IsSelectedHeadMergeSource { get; set; }
 
-    public bool IsTag => _type == GitRefType.Tag;
-    public bool IsHead => _type == GitRefType.Head;
-    public bool IsRemote => _type == GitRefType.Remote;
-    public bool IsBisect => _type == GitRefType.Bisect;
-    public bool IsBisectGood => _type == GitRefType.BisectGood;
-    public bool IsBisectBad => _type == GitRefType.BisectBad;
-    public bool IsStash => _type == GitRefType.Stash;
+    public string Name { get; }
 
-    public bool IsDereference { get; }
+    public string LocalName => _localName ??= ComputeLocalName(IsRemote, Remote, Name);
 
-    public bool IsOther => !IsHead && !IsRemote && !IsTag;
+    [AllowNull]
+    public string MergeWith
+    {
+        get => _mergeWith ??= IsHead ? Module.GetEffectiveSetting(string.Format(SettingKeyString.BranchMerge, LocalName)).RemovePrefix(GitRefName.RefsHeadsPrefix) : "";
+        set
+        {
+            if (!IsHead)
+            {
+                throw new InvalidOperationException("MergeWith can only be set for local branches.");
+            }
 
-    public string LocalName => IsRemote && Name.StartsWith($"{Remote}/") ? Name[(Remote.Length + 1)..] : Name;
+            string settingName = string.Format(SettingKeyString.BranchMerge, LocalName);
+            if (string.IsNullOrEmpty(value))
+            {
+                Module.UnsetSetting(settingName);
+                _mergeWith = "";
+            }
+            else
+            {
+                Module.SetSetting(settingName, GitRefName.GetFullBranchName(value));
+                _mergeWith = value;
+            }
+        }
+    }
 
     public string Remote { get; }
 
     [AllowNull]
     public string TrackingRemote
     {
-        get => Module.GetEffectiveSetting(_remoteSettingName);
+        get => _trackingRemote ??= IsHead ? Module.GetEffectiveSetting(string.Format(SettingKeyString.BranchRemote, LocalName)) : "";
         set
         {
+            if (!IsHead)
+            {
+                throw new InvalidOperationException("Tracking remote can only be set for local branches.");
+            }
+
+            string settingName = string.Format(SettingKeyString.BranchRemote, LocalName);
             if (string.IsNullOrEmpty(value))
             {
-                Module.UnsetSetting(_remoteSettingName);
+                Module.UnsetSetting(settingName);
+                _trackingRemote = "";
             }
             else
             {
-                Module.SetSetting(_remoteSettingName, value);
+                Module.SetSetting(settingName, value);
+                _trackingRemote = value;
 
                 if (MergeWith == "")
                 {
-                    MergeWith = Name;
+                    MergeWith = LocalName;
                 }
             }
         }
     }
 
-    /// <inheritdoc />
-    [AllowNull]
-    public string MergeWith
-    {
-        get => Module.GetEffectiveSetting(_mergeSettingName).RemovePrefix(GitRefName.RefsHeadsPrefix);
-        set
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                Module.UnsetSetting(_mergeSettingName);
-            }
-            else
-            {
-                Module.SetSetting(_mergeSettingName, GitRefName.GetFullBranchName(value));
-            }
-        }
-    }
+    public bool IsHead => _type == GitRefType.Head;
+    public bool IsRemote => _type == GitRefType.Remote;
+    public bool IsTag => _type == GitRefType.Tag;
+    public bool IsStash => _type == GitRefType.Stash;
+    public bool IsDereference { get; }
+    public bool IsSelected { get; set; }
+    public bool IsSelectedHeadMergeSource { get; set; }
+
+    public bool IsBisect => _type == GitRefType.Bisect;
+    public bool IsBisectGood => _type == GitRefType.BisectGood;
+    public bool IsBisectBad => _type == GitRefType.BisectBad;
 
     public static GitRef NoHead(IGitModule module)
     {
@@ -175,8 +119,11 @@ public sealed class GitRef : IGitRef
     #region IGitItem Members
 
     public ObjectId ObjectId { get; }
-    public string? Guid { get; }
-    public string Name { get; }
+
+    public string? Guid => ObjectId.IsZero ? null : ObjectId.ToString();
+    public bool IsTrackingRemote(IGitRef? remote)
+    => remote is not null && IsHead && remote.IsRemote
+        && MergeWith == remote.LocalName && TrackingRemote == remote.Remote;
 
     #endregion
 
@@ -184,20 +131,67 @@ public sealed class GitRef : IGitRef
 
     public static IReadOnlyCollection<string> GetAmbiguousRefNames(IEnumerable<IGitRef> refs)
     {
-        return refs
-            .GroupBy(r => r.Name)
-            .Where(group => group.Count() > 1)
-            .Select(e => e.Key)
-            .ToHashSet();
-    }
+        HashSet<string> seen = [];
+        HashSet<string> ambiguous = [];
 
-    public bool IsTrackingRemote(IGitRef? remote)
-    {
-        if (remote is null || IsRemote || !remote.IsRemote)
+        foreach (IGitRef r in refs)
         {
-            return false;
+            if (!seen.Add(r.Name))
+            {
+                ambiguous.Add(r.Name);
+            }
         }
 
-        return MergeWith == remote.LocalName && TrackingRemote == remote.Remote;
+        return ambiguous;
+    }
+
+    internal static GitRefType DetermineType(string completeName)
+        => completeName switch
+        {
+            _ when completeName.StartsWith(GitRefName.RefsHeadsPrefix, StringComparison.Ordinal) => GitRefType.Head,
+            _ when completeName.StartsWith(GitRefName.RefsTagsPrefix, StringComparison.Ordinal) => GitRefType.Tag,
+            _ when completeName.StartsWith(GitRefName.RefsRemotesPrefix, StringComparison.Ordinal) => GitRefType.Remote,
+            _ when completeName.StartsWith(GitRefName.RefsStashPrefix, StringComparison.Ordinal) => GitRefType.Stash,
+            _ when completeName.StartsWith(GitRefName.RefsBisectGoodPrefix, StringComparison.Ordinal) => GitRefType.BisectGood,
+            _ when completeName.StartsWith(GitRefName.RefsBisectBadPrefix, StringComparison.Ordinal) => GitRefType.BisectBad,
+            _ when completeName.StartsWith(GitRefName.RefsBisectPrefix, StringComparison.Ordinal) => GitRefType.Bisect,
+            _ => GitRefType.Other
+        };
+
+    /// <summary>
+    ///  Computes <see cref="IGitRef.LocalName"/> for a ref,
+    ///  given <see cref="IGitRef.Remote"/> and <see cref="INamedGitItem.Name"/>.
+    /// </summary>
+    public static string ComputeLocalName(bool isRemote, string remote, string name)
+    {
+        if (!isRemote || remote.Length == 0 || name.Length <= remote.Length || name[remote.Length] != '/'
+            || !name.StartsWith(remote, StringComparison.Ordinal))
+        {
+            return name;
+        }
+
+        return name[(remote.Length + 1)..];
+    }
+
+    public static string ParseName(string completeName)
+    {
+        GitRefType type = DetermineType(completeName);
+        bool isDereference = type == GitRefType.Tag && completeName.EndsWith(GitRefName.TagDereferenceSuffix);
+        return ParseName(completeName, type, isDereference);
+    }
+
+    internal static string ParseName(string completeName, GitRefType type, bool isDereference)
+    {
+        // DetermineType already verified each prefix, so slice directly at the known
+        // offset rather than repeating an IndexOf search via SubstringAfter.
+        string name = type switch
+        {
+            GitRefType.Head => completeName[GitRefName.RefsHeadsPrefix.Length..],
+            GitRefType.Remote => completeName[GitRefName.RefsRemotesPrefix.Length..],
+            GitRefType.Tag => completeName[GitRefName.RefsTagsPrefix.Length..(completeName.Length - (isDereference ? GitRefName.TagDereferenceSuffix.Length : 0))],
+            _ => completeName.SubstringAfter("refs/")
+        };
+
+        return name.Length == 0 ? completeName : name;
     }
 }

--- a/src/app/GitCommands/Git/GitRefName.cs
+++ b/src/app/GitCommands/Git/GitRefName.cs
@@ -1,18 +1,12 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Text.RegularExpressions;
 using GitExtensions.Extensibility;
 using GitUIPluginInterfaces;
 
 namespace GitCommands;
 
-public static partial class GitRefName
+public static class GitRefName
 {
-    [GeneratedRegex(@"^refs/remotes/[^/]+/HEAD$", RegexOptions.ExplicitCapture)]
-    private static partial Regex RemoteHeadRegex { get; }
-    [GeneratedRegex(@"^refs/remotes/(?<remote>[^/]+)", RegexOptions.ExplicitCapture)]
-    private static partial Regex RemoteNameRegex { get; }
-
     /// <summary>"refs/tags/".</summary>
     public static string RefsTagsPrefix { get; } = "refs/tags/";
 
@@ -46,19 +40,18 @@ public static partial class GitRefName
     [Pure]
     public static string GetRemoteName(string refName)
     {
-        Match match = RemoteNameRegex.Match(refName);
-
-        if (match.Success)
+        if (!refName.StartsWith(RefsRemotesPrefix))
         {
-            return match.Groups["remote"].Value;
+            // This method requires the full form of the ref path, which begins with "refs/".
+            // The overload which accepts multiple remote names can be used when the format might
+            // be abbreviated to "remote/branch".
+            DebugHelpers.Assert(refName.StartsWith("refs/"), "Must begin with \"refs/\".");
+            return string.Empty;
         }
 
-        // This method requires the full form of the ref path, which begins with "refs/".
-        // The overload which accepts multiple remote names can be used when the format might
-        // be abbreviated to "remote/branch".
-        DebugHelpers.Assert(refName.StartsWith("refs/"), "Must begin with \"refs/\".");
-
-        return string.Empty;
+        ReadOnlySpan<char> afterPrefix = refName.AsSpan(RefsRemotesPrefix.Length);
+        int slash = afterPrefix.IndexOf('/');
+        return (slash < 0 ? afterPrefix : afterPrefix[..slash]).ToString();
     }
 
     [Pure]
@@ -120,12 +113,52 @@ public static partial class GitRefName
             return branch;
         }
 
-        return "refs/heads/" + branch;
+        return RefsHeadsPrefix + branch;
+    }
+
+    [Pure]
+    [return: NotNullIfNotNull(nameof(branch))]
+    public static string? GetFullRemoteName(string? branch, string remote)
+    {
+        if (branch is null)
+        {
+            return null;
+        }
+
+        branch = branch.Trim();
+
+        if (string.IsNullOrEmpty(branch) || branch.StartsWith("refs/"))
+        {
+            return branch;
+        }
+
+        // If the branch represents a commit hash, return it as-is without appending refs/heads/ (fix issue #2240)
+        // NOTE: We can use `String.IsNullOrEmpty(Module.RevParse(srcRev))` instead
+        if (GitRevision.Sha1HashRegex.IsMatch(branch))
+        {
+            return branch;
+        }
+
+        return RefsRemotesPrefix + remote + "/" + branch;
     }
 
     [Pure]
     public static bool IsRemoteHead(string refName)
     {
-        return RemoteHeadRegex.IsMatch(refName);
+        const string headSuffix = "/HEAD";
+        if (!refName.StartsWith(RefsRemotesPrefix) || !refName.EndsWith(headSuffix))
+        {
+            return false;
+        }
+
+        // The remote name segment between "refs/remotes/" and "/HEAD" must be non-empty and contain no '/'
+        int remoteStart = RefsRemotesPrefix.Length;
+        int remoteEnd = refName.Length - headSuffix.Length;
+        if (remoteEnd <= remoteStart)
+        {
+            return false;
+        }
+
+        return refName.AsSpan()[remoteStart..remoteEnd].IndexOf('/') < 0;
     }
 }

--- a/src/app/GitCommands/Git/GitRefName.cs
+++ b/src/app/GitCommands/Git/GitRefName.cs
@@ -1,17 +1,13 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Text.RegularExpressions;
 using GitExtensions.Extensibility;
 using GitUIPluginInterfaces;
 
 namespace GitCommands;
 
-public static partial class GitRefName
+public static class GitRefName
 {
-    [GeneratedRegex(@"^refs/remotes/[^/]+/HEAD$", RegexOptions.ExplicitCapture)]
-    private static partial Regex RemoteHeadRegex { get; }
-    [GeneratedRegex(@"^refs/remotes/(?<remote>[^/]+)", RegexOptions.ExplicitCapture)]
-    private static partial Regex RemoteNameRegex { get; }
+    private const string RefsPrefix = "refs/";
 
     /// <summary>"refs/tags/".</summary>
     public static string RefsTagsPrefix { get; } = "refs/tags/";
@@ -49,25 +45,24 @@ public static partial class GitRefName
     [Pure]
     public static string GetRemoteName(string refName)
     {
-        Match match = RemoteNameRegex.Match(refName);
-
-        if (match.Success)
+        if (!refName.StartsWith(RefsRemotesPrefix))
         {
-            return match.Groups["remote"].Value;
+            // This method requires the full form of the ref path, which begins with "refs/".
+            // The overload which accepts multiple remote names can be used when the format might
+            // be abbreviated to "remote/branch".
+            DebugHelpers.Assert(refName.StartsWith(RefsPrefix), $"Must begin with \"{RefsPrefix}\".");
+            return string.Empty;
         }
 
-        // This method requires the full form of the ref path, which begins with "refs/".
-        // The overload which accepts multiple remote names can be used when the format might
-        // be abbreviated to "remote/branch".
-        DebugHelpers.Assert(refName.StartsWith("refs/"), "Must begin with \"refs/\".");
-
-        return string.Empty;
+        ReadOnlySpan<char> afterPrefix = refName.AsSpan(RefsRemotesPrefix.Length);
+        int slash = afterPrefix.IndexOf('/');
+        return (slash < 0 ? afterPrefix : afterPrefix[..slash]).ToString();
     }
 
     [Pure]
     public static string GetRemoteName(string refName, IEnumerable<string> remotes)
     {
-        if (refName.StartsWith("refs/"))
+        if (refName.StartsWith(RefsPrefix))
         {
             return GetRemoteName(refName);
         }
@@ -111,7 +106,7 @@ public static partial class GitRefName
 
         branch = branch.Trim();
 
-        if (string.IsNullOrEmpty(branch) || branch.StartsWith("refs/"))
+        if (string.IsNullOrEmpty(branch) || branch.StartsWith(RefsPrefix))
         {
             return branch;
         }
@@ -123,12 +118,52 @@ public static partial class GitRefName
             return branch;
         }
 
-        return "refs/heads/" + branch;
+        return RefsHeadsPrefix + branch;
+    }
+
+    [Pure]
+    [return: NotNullIfNotNull(nameof(branch))]
+    public static string? GetFullRemoteName(string? branch, string remote)
+    {
+        if (branch is null)
+        {
+            return null;
+        }
+
+        branch = branch.Trim();
+
+        if (string.IsNullOrEmpty(branch) || branch.StartsWith(RefsPrefix))
+        {
+            return branch;
+        }
+
+        // If the branch represents a commit hash, return it as-is without appending refs/heads/
+        // NOTE: We can use `String.IsNullOrEmpty(Module.RevParse(srcRev))` instead
+        if (GitRevision.Sha1HashRegex.IsMatch(branch))
+        {
+            return branch;
+        }
+
+        return $"{RefsRemotesPrefix}{remote}/{branch}";
     }
 
     [Pure]
     public static bool IsRemoteHead(string refName)
     {
-        return RemoteHeadRegex.IsMatch(refName);
+        const string headSuffix = "/HEAD";
+        if (!refName.StartsWith(RefsRemotesPrefix) || !refName.EndsWith(headSuffix))
+        {
+            return false;
+        }
+
+        // The remote name segment between "refs/remotes/" and "/HEAD" must be non-empty and contain no '/'
+        int remoteStart = RefsRemotesPrefix.Length;
+        int remoteEnd = refName.Length - headSuffix.Length;
+        if (remoteEnd <= remoteStart)
+        {
+            return false;
+        }
+
+        return refName.AsSpan()[remoteStart..remoteEnd].IndexOf('/') < 0;
     }
 }

--- a/src/app/GitExtensions.Extensibility/Git/IGitItem.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitItem.cs
@@ -3,7 +3,7 @@
 public interface IGitItem
 {
     /// <summary>
-    /// Gets the object ID, or the zero <see cref="ObjectId"/> if not known.
+    /// Gets the object ID, or default/zero <see cref="ObjectId"/> if not known.
     /// </summary>
     ObjectId ObjectId { get; }
 

--- a/src/app/GitExtensions.Extensibility/Git/IGitRef.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitRef.cs
@@ -2,50 +2,93 @@
 
 public interface IGitRef : INamedGitItem
 {
-    string CompleteName { get; }
-    bool IsBisect { get; }
-    bool IsBisectGood { get; }
-    bool IsBisectBad { get; }
-    bool IsStash { get; }
-
     /// <summary>
-    ///  Indicates whether it is a checksum of an object (e.g., commit) to which another object
-    ///  with <c>name</c> (e.g. annotated tag) is applied.
+    ///  Display name of the ref.
+    ///  Deviates from <see cref="INamedGitItem.Name"/>: the prefix <c>refs/*/</c>,
+    ///  is stripped.
+    ///  See <see cref="CompleteName"/> for the full ref path.
     /// </summary>
-    /// <value>
-    ///  <see langword="true"/> if it is a checksum of an object to which another object with <c>name</c> is applied;
-    ///  <see langword="false"/> when <c>name</c> and <c>guid</c> are denoting the same object.
-    /// </value>
-    bool IsDereference { get; }
+    new string Name { get; }
 
     /// <summary>
-    ///  Indicates whether the ref is a local, i.e., it is a <c>refs/heads/xyz</c>.
+    ///  The complete Git reference name, including prefix <c>refs/</c>.
+    /// </summary>
+    string CompleteName { get; }
+
+    /// <summary>
+    ///  The name of the reference in a local repo.
+    ///  The same as <see cref="Name"/>, except for <see cref="IsRemote"/>:
+    ///  <see cref="Remote"/> is dropped.
+    /// </summary>
+    string LocalName { get; }
+
+    /// <summary>
+    ///  The tracked local branch name as on the remote for <see cref="IsHead"/>,
+    ///  expanded use for <see cref="IsRemote"/> in <c>NestledRef</c>.
+    /// </summary>
+    string MergeWith { get; set; }
+
+    /// <summary>
+    ///  <see cref="IsRemote"/>: The name of the remote.
+    /// </summary>
+    string Remote { get; }
+
+    /// <summary>
+    ///  <see cref="IsHead"/>: The name of the remote this local branch tracks.
+    ///  If this is set, then <see cref="MergeWith"/> is set too.
+    /// </summary>
+    string TrackingRemote { get; set; }
+
+    /// <summary>
+    ///  Indicates whether the ref is a local branch, with ref prefix <c>refs/heads/</c>.
     /// </summary>
     bool IsHead { get; }
 
     /// <summary>
-    ///  Indicates whether the ref is a remote, i.e., it is a <c>refs/remotes/origin/xyz</c>.
+    ///  Indicates whether the ref is a remote branch, with ref prefix <c>refs/remotes/</c>.
     /// </summary>
     bool IsRemote { get; }
 
     /// <summary>
-    ///  Indicates whether the ref is a tag, i.e., it is a <c>refs/tags/xyz</c>.
+    ///  Indicates whether the ref is a tag, with ref prefix <c>refs/tags/</c>.
     /// </summary>
     bool IsTag { get; }
 
-    string LocalName { get; }
-    string MergeWith { get; set; }
-    IGitModule Module { get; }
-    string Remote { get; }
-    string TrackingRemote { get; set; }
-    bool IsSelected { get; set; }
-    bool IsSelectedHeadMergeSource { get; set; }
+    /// <summary>
+    ///  Indicates whether the ref refers to a <c>tag</c> object (with tagger info),
+    ///  that references a <c>commit</c> object where the tag is set.
+    ///  Used for annotated/signed tags.
+    ///  Note that lightweight tags directly refer to <c>commit</c> objects.
+    /// </summary>
+    bool IsDereference { get; }
+
+    bool IsStash { get; }
 
     /// <summary>
-    /// Return if the current `GitRef` is tracking another `GitRef` as a remote.
+    ///  For local branches: Indicates that this ref is the currently checked out local branch.
+    /// </summary>
+    bool IsSelected { get; set; }
+
+    /// <summary>
+    ///  <see cref="IsRemote"/>: Indicates that this ref is the tracked remote reference
+    ///  for the currently <see cref="IsSelected"/>.
+    /// </summary>
+    bool IsSelectedHeadMergeSource { get; set; }
+
+    bool IsBisect { get; }
+    bool IsBisectGood { get; }
+    bool IsBisectBad { get; }
+
+    IGitModule Module { get; }
+
+    /// <summary>
+    ///  Return if the current <c>GitRef</c> is tracking the remote <c>GitRef</c>.
     /// </summary>
     /// <param name="remote">the expected remote ref tracked</param>
-    /// <returns>true if the current ref is tracking the expected remote ref
-    /// false otherwise</returns>
-    bool IsTrackingRemote(IGitRef? remote);
+    /// <returns>
+    ///  true if the current ref is tracking the expected remote ref false otherwise.
+    /// </returns>
+    bool IsTrackingRemote(IGitRef? remote)
+        => remote is not null && IsHead && remote.IsRemote
+            && TrackingRemote == remote.Remote && MergeWith == remote.LocalName;
 }

--- a/src/app/GitExtensions.Extensibility/Git/IGitRef.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitRef.cs
@@ -2,50 +2,83 @@
 
 public interface IGitRef : INamedGitItem
 {
-    string CompleteName { get; }
-    bool IsBisect { get; }
-    bool IsBisectGood { get; }
-    bool IsBisectBad { get; }
-    bool IsStash { get; }
-
     /// <summary>
-    ///  Indicates whether it is a checksum of an object (e.g., commit) to which another object
-    ///  with <c>name</c> (e.g. annotated tag) is applied.
+    ///  The complete Git reference name, including prefix <c>refs/</c>.
     /// </summary>
-    /// <value>
-    ///  <see langword="true"/> if it is a checksum of an object to which another object with <c>name</c> is applied;
-    ///  <see langword="false"/> when <c>name</c> and <c>guid</c> are denoting the same object.
-    /// </value>
-    bool IsDereference { get; }
+    string CompleteName { get; }
 
     /// <summary>
-    ///  Indicates whether the ref is a local, i.e., it is a <c>refs/heads/xyz</c>.
+    ///  The name of the reference in a local repo.
+    ///  The same as the modified use of <see cref="INamedGitItem.Name"/>,
+    ///  except for <see cref="IsRemote"/>: <see cref="Remote"/> is dropped.
+    /// </summary>
+    string LocalName { get; }
+
+    /// <summary>
+    ///  The tracked local branch name as on the remote for <see cref="IsHead"/>,
+    ///  expanded use for <see cref="IsRemote"/> in <c>NestledRef</c>.
+    /// </summary>
+    string MergeWith { get; set; }
+
+    /// <summary>
+    ///  <see cref="IsRemote"/>: The name of the remote.
+    /// </summary>
+    string Remote { get; }
+
+    /// <summary>
+    ///  <see cref="IsHead"/>: The name of the remote this local branch tracks.
+    ///  If this is set, then <see cref="MergeWith"/> is set too.
+    /// </summary>
+    string TrackingRemote { get; set; }
+
+    /// <summary>
+    ///  Indicates whether the ref is a local branch, with ref prefix <c>refs/heads/</c>.
     /// </summary>
     bool IsHead { get; }
 
     /// <summary>
-    ///  Indicates whether the ref is a remote, i.e., it is a <c>refs/remotes/origin/xyz</c>.
+    ///  Indicates whether the ref is a remote branch, with ref prefix <c>refs/remotes/</c>.
     /// </summary>
     bool IsRemote { get; }
 
     /// <summary>
-    ///  Indicates whether the ref is a tag, i.e., it is a <c>refs/tags/xyz</c>.
+    ///  Indicates whether the ref is a tag, with ref prefix <c>refs/tags/</c>.
     /// </summary>
     bool IsTag { get; }
 
-    string LocalName { get; }
-    string MergeWith { get; set; }
-    IGitModule Module { get; }
-    string Remote { get; }
-    string TrackingRemote { get; set; }
-    bool IsSelected { get; set; }
-    bool IsSelectedHeadMergeSource { get; set; }
+    /// <summary>
+    ///  Indicates whether the ref refers to a <c>tag</c> object (with tagger info),
+    ///  that references a <c>commit</c> object where the tag is set.
+    ///  Used for annotated/signed tags.
+    ///  Note that lightweight tags directly refer to <c>commit</c> objects.
+    /// </summary>
+    bool IsDereference { get; }
+
+    bool IsStash { get; }
 
     /// <summary>
-    /// Return if the current `GitRef` is tracking another `GitRef` as a remote.
+    ///  For local branches: Indicates that this ref is the currently checked out local branch.
+    /// </summary>
+    bool IsSelected { get; set; }
+
+    /// <summary>
+    ///  <see cref="IsRemote"/>: Indicates that this ref is the tracked remote reference
+    ///  for the currently <see cref="IsSelected"/>.
+    /// </summary>
+    bool IsSelectedHeadMergeSource { get; set; }
+
+    bool IsBisect { get; }
+    bool IsBisectGood { get; }
+    bool IsBisectBad { get; }
+
+    IGitModule Module { get; }
+
+    /// <summary>
+    ///  Return if the current <c>GitRef</c> is tracking the remote <c>GitRef</c>.
     /// </summary>
     /// <param name="remote">the expected remote ref tracked</param>
-    /// <returns>true if the current ref is tracking the expected remote ref
-    /// false otherwise</returns>
+    /// <returns>
+    ///  true if the current ref is tracking the expected remote ref false otherwise.
+    /// </returns>
     bool IsTrackingRemote(IGitRef? remote);
 }

--- a/src/app/GitExtensions.Extensibility/Git/INamedGitItem.cs
+++ b/src/app/GitExtensions.Extensibility/Git/INamedGitItem.cs
@@ -2,5 +2,12 @@
 
 public interface INamedGitItem : IGitItem
 {
+    /// <summary>
+    ///  The name of the item.
+    ///
+    ///  For <see cref="IGitRef"/> this is a display name stripping the prefix
+    ///  <c>refs/*/</c> from the full unique name
+    ///  (<see cref="IGitRef.CompleteName"/> for the full name).
+    /// </summary>
     string Name { get; }
 }

--- a/src/app/GitExtensions.Extensibility/Git/INamedGitItem.cs
+++ b/src/app/GitExtensions.Extensibility/Git/INamedGitItem.cs
@@ -2,5 +2,11 @@
 
 public interface INamedGitItem : IGitItem
 {
+    /// <summary>
+    ///  The name of the item.
+    ///  This is generally not a unique name in global Git namespace.
+    ///  For instance, the derived interface <c>IGitRef</c> removes
+    ///  the initial <c>refs/*/</c> from the names.
+    /// </summary>
     string Name { get; }
 }

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -850,7 +850,7 @@ public sealed partial class FormCommit : GitModuleForm
         }
 
         string pushTo;
-        if (string.IsNullOrEmpty(currentBranch.TrackingRemote) || string.IsNullOrEmpty(currentBranch.MergeWith))
+        if (string.IsNullOrEmpty(currentBranch.TrackingRemote))
         {
             string? defaultRemote = Module.GetRemoteNames().FirstOrDefault(r => r == "origin") ?? Module.GetRemoteNames().OrderBy(r => r).FirstOrDefault();
 

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -853,7 +853,7 @@ public sealed partial class FormCommit : GitModuleForm
         }
 
         string pushTo;
-        if (string.IsNullOrEmpty(currentBranch.TrackingRemote) || string.IsNullOrEmpty(currentBranch.MergeWith))
+        if (string.IsNullOrEmpty(currentBranch.TrackingRemote))
         {
             string? defaultRemote = Module.GetRemoteNames().FirstOrDefault(r => r == "origin") ?? Module.GetRemoteNames().OrderBy(r => r).FirstOrDefault();
 

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -1046,7 +1046,7 @@ public partial class FormPush : GitModuleForm
             foreach (IGitRef head in localHeads)
             {
                 string remoteName = head.Remote == remote
-                    ? head.MergeWith ?? head.Name
+                    ? head.MergeWith ?? head.LocalName
                     : string.Empty;
                 bool isKnownAtRemote = remoteBranches.TryGetValue(head.Name, out IGitRef? remoteBranch);
                 DataRow row = _branchTable.NewRow();

--- a/src/app/GitUI/CommandsDialogs/FormPush.cs
+++ b/src/app/GitUI/CommandsDialogs/FormPush.cs
@@ -1045,7 +1045,7 @@ public partial class FormPush : GitModuleForm
             foreach (IGitRef head in localHeads)
             {
                 string remoteName = head.Remote == remote
-                    ? head.MergeWith ?? head.Name
+                    ? head.MergeWith ?? head.LocalName
                     : string.Empty;
                 bool isKnownAtRemote = remoteBranches.TryGetValue(head.Name, out IGitRef? remoteBranch);
                 DataRow row = _branchTable.NewRow();

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -165,7 +165,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 // If this branch is at its tracked remote, draw them condensed.
                 if (gitRef.IsHead && trackedRemotes.TryGetValue(gitRef.Name, out IGitRef? remote))
                 {
-                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, remote, ref hitInfos);
+                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, remote, remote.Remote, ref hitInfos);
                     continue;
                 }
 
@@ -173,9 +173,8 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 (string aheadBehind, string trackedCompleteName) = GetAheadBehind(gitRef, withCounts: false);
                 if (aheadBehind.Length > 0)
                 {
-                    VirtualRef virtualRef = new(aheadBehind, trackedCompleteName, gitRef.TrackingRemote, mergeWith: gitRef.CompleteName, gitRef.Module)
-                    { IsHead = gitRef.IsRemote, IsRemote = !gitRef.IsRemote };
-                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, virtualRef, ref hitInfos);
+                    NestledRef nestledRef = new(gitRef, trackedCompleteName);
+                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, nestledRef, aheadBehind, ref hitInfos);
                     continue;
                 }
 
@@ -251,7 +250,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
                 foreach (IGitRef local in localBranches)
                 {
-                    if (local.MergeWith != remote.LocalName || local.TrackingRemote != remote.Remote)
+                    if (!local.IsTrackingRemote(remote))
                     {
                         continue;
                     }
@@ -275,6 +274,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
             ref int offset,
             bool isHighlighted,
             IGitRef nestledRef,
+            string nestledName,
             ref List<RefLabelHitInfo>? hitInfos)
         {
             int initialOffset = offset;
@@ -301,10 +301,6 @@ internal sealed class MessageColumnProvider : ColumnProvider
             // Position the NotchLeft rect so its notch tip (rect.X + pointWidth) aligns with the branch point tip (branchRect.Right), cancelling the inter-label margin.
             offset = Math.Max(initialOffset, branchRect.Right - messageBounds.X - pointWidth + 1);
 
-            // Show only the remote name when the tracked branch has the same local name,
-            // accounting for an optional prefix configured for the remote.
-            string nestledName = nestledRef.LocalName == GetRemotePrefix(nestledRef.Module, nestledRef.Remote) + gitRef.Name ? nestledRef.Remote : nestledRef.Name;
-
             // Draw the nestled directly via DrawRefEx with RefLabelIcon.None — the nestled remote never shows a head indicator.
             (Rectangle nestledRect, Action? drawNestledHighlight) = RevisionGridRefRenderer.DrawRefEx(
                 e.State.HasFlag(DataGridViewElementStates.Selected),
@@ -315,7 +311,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 RefLabelIcon.None,
                 messageBounds,
                 e.Graphics!,
-                dashedLine: nestledRef.Guid is null,
+                dashedLine: nestledRef.ObjectId.IsZero,
                 fill: _settings.FillRefLabels,
                 highlight: isRemoteHighlighted,
                 shape2);
@@ -377,12 +373,13 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
         if (highlightRef is not null)
         {
-            if (highlightRef is { Guid: null } aheadBehindRef)
+            if (highlightRef is { ObjectId: { IsZero: true } } aheadBehindRef)
             {
-                // VirtualRef(name: aheadBehind, completeName: trackedCompleteName, remote: gitRef.TrackingRemote, mergeWith: gitRef.CompleteName, ...) { IsRemote = !gitRef.IsRemote }
+                // NestledRef
                 bool realRefIsRemote = !aheadBehindRef.IsRemote;
-                string realRefCompleteName = aheadBehindRef.MergeWith;
-                string realRefName = realRefCompleteName[(realRefIsRemote ? GitRefName.RefsRemotesPrefix : GitRefName.RefsHeadsPrefix).Length..];
+                string realRefLocalName = aheadBehindRef.MergeWith;
+                string realRefCompleteName = realRefIsRemote ? GitRefName.GetFullRemoteName(realRefLocalName, aheadBehindRef.TrackingRemote) : GitRefName.GetFullBranchName(realRefLocalName);
+                string realRefName = realRefIsRemote ? realRefCompleteName[GitRefName.RefsRemotesPrefix.Length..] : realRefLocalName;
                 AheadBehindData? data = GetAheadBehindData(realRefIsRemote, realRefCompleteName);
                 _toolTipBuilder.Append('[').Append(realRefName).Append(']');
                 if (realRefIsRemote)
@@ -1050,41 +1047,52 @@ internal sealed class MessageColumnProvider : ColumnProvider
         _hitInfoListPool.Push(list);
     }
 
-    private sealed class VirtualRef(string name, string completeName, string remote, string mergeWith, IGitModule module) : IGitRef
+    private sealed class NestledRef(IGitRef gitRef, string completeName) : IGitRef
     {
-        public string Name => name;
-        public ObjectId ObjectId => throw new NotSupportedException();
+        public string Name { get; } = GitRef.ParseName(completeName);
+
+        /// <summary>
+        ///  <see cref="ObjectId"/> of a nestled ref is always default/zero.
+        /// </summary>
+        public ObjectId ObjectId => default;
         public string? Guid => null;
-        public IGitModule Module => module;
         public string CompleteName => completeName;
-        public string Remote => remote;
-        public string LocalName => Name;
-        public bool IsRemote { get; init; }
-        public bool IsHead { get; init; }
+        public string LocalName => GitRef.ComputeLocalName(IsRemote, Remote, Name);
+
+        /// <summary>
+        ///  The tracked local branch name as on the remote for <see cref="IsHead"/>,
+        ///  or the tracking local branch for <see cref="IsRemote"/>.
+        /// </summary>
+        public string MergeWith
+        {
+            get => gitRef.LocalName;
+            set => throw new NotSupportedException();
+        }
+
+        public string Remote => gitRef.TrackingRemote;
+        public string TrackingRemote
+        {
+            get => gitRef.Remote;
+            set => throw new NotSupportedException();
+        }
+
+        public bool IsHead => gitRef.IsRemote;
+        public bool IsRemote => gitRef.IsHead;
         public bool IsTag => false;
-        public bool IsBisect => false;
-        public bool IsBisectGood => false;
-        public bool IsBisectBad => false;
         public bool IsStash => false;
         public bool IsDereference => false;
         public bool IsSelected { get; set; }
         public bool IsSelectedHeadMergeSource { get; set; }
-        public string MergeWith
-        {
-            get => mergeWith;
-            set => throw new NotSupportedException();
-        }
+        public bool IsBisect => false;
+        public bool IsBisectGood => false;
+        public bool IsBisectBad => false;
 
-        public string TrackingRemote
-        {
-            get => "";
-            set => throw new NotSupportedException();
-        }
+        public IGitModule Module => gitRef.Module;
 
-        public bool IsTrackingRemote(IGitRef? remote) => false;
-
-        public override bool Equals(object? obj) => obj is VirtualRef other && CompleteName == other.CompleteName;
+        public override bool Equals(object? obj) => obj is NestledRef other && CompleteName == other.CompleteName;
 
         public override int GetHashCode() => completeName.GetHashCode();
+
+        public override string ToString() => $"NestledRef: {CompleteName}";
     }
 }

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -165,17 +165,16 @@ internal sealed class MessageColumnProvider : ColumnProvider
                 // If this branch is at its tracked remote, draw them condensed.
                 if (gitRef.IsHead && trackedRemotes.TryGetValue(gitRef.Name, out IGitRef? remote))
                 {
-                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, remote, ref hitInfos);
+                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, nestledRef: remote, nestledName: remote.Remote, ref hitInfos);
                     continue;
                 }
 
                 // If this branch has ahead/behind information, draw that info as virtual label of the tracked/tracking branch.
-                (string aheadBehind, string trackedCompleteName) = GetAheadBehind(gitRef, withCounts: false);
+                (string aheadBehind, string trackedCompleteName, bool isGone) = GetAheadBehind(gitRef, withCounts: false);
                 if (aheadBehind.Length > 0)
                 {
-                    VirtualRef virtualRef = new(aheadBehind, trackedCompleteName, gitRef.TrackingRemote, mergeWith: gitRef.CompleteName, gitRef.Module)
-                    { IsHead = gitRef.IsRemote, IsRemote = !gitRef.IsRemote };
-                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, virtualRef, ref hitInfos);
+                    NestledVirtualRef nestledRef = new(gitRef, trackedCompleteName, trackingBranchIsGone: isGone);
+                    DrawBranchWithNestledRemote(gitRef, superprojectRef, style, messageBounds, ref offset, isHighlighted, nestledRef, nestledName: aheadBehind, ref hitInfos);
                     continue;
                 }
 
@@ -251,7 +250,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
                 foreach (IGitRef local in localBranches)
                 {
-                    if (local.MergeWith != remote.LocalName || local.TrackingRemote != remote.Remote)
+                    if (!local.IsTrackingRemote(remote))
                     {
                         continue;
                     }
@@ -275,6 +274,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
             ref int offset,
             bool isHighlighted,
             IGitRef nestledRef,
+            string nestledName,
             ref List<RefLabelHitInfo>? hitInfos)
         {
             int initialOffset = offset;
@@ -301,21 +301,18 @@ internal sealed class MessageColumnProvider : ColumnProvider
             // Position the NotchLeft rect so its notch tip (rect.X + pointWidth) aligns with the branch point tip (branchRect.Right), cancelling the inter-label margin.
             offset = Math.Max(initialOffset, branchRect.Right - messageBounds.X - pointWidth + 1);
 
-            // Show only the remote name when the tracked branch has the same local name,
-            // accounting for an optional prefix configured for the remote.
-            string nestledName = nestledRef.LocalName == GetRemotePrefix(nestledRef.Module, nestledRef.Remote) + gitRef.Name ? nestledRef.Remote : nestledRef.Name;
-
             // Draw the nestled directly via DrawRefEx with RefLabelIcon.None — the nestled remote never shows a head indicator.
+            NestledVirtualRef? nestledVirtualRef = nestledRef as NestledVirtualRef;
             (Rectangle nestledRect, Action? drawNestledHighlight) = RevisionGridRefRenderer.DrawRefEx(
                 e.State.HasFlag(DataGridViewElementStates.Selected),
-                nestledName == AheadBehindData.GoneSymbol ? style.BoldFont : style.NormalFont,
+                nestledVirtualRef is { TrackingBranchIsGone: true } ? style.BoldFont : style.NormalFont,
                 ref offset,
                 nestledName,
                 remoteColor,
                 RefLabelIcon.None,
                 messageBounds,
                 e.Graphics!,
-                dashedLine: nestledRef.Guid is null,
+                dashedLine: nestledVirtualRef is not null,
                 fill: _settings.FillRefLabels,
                 highlight: isRemoteHighlighted,
                 shape2);
@@ -377,12 +374,12 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
         if (highlightRef is not null)
         {
-            if (highlightRef is { Guid: null } aheadBehindRef)
+            if (highlightRef is NestledVirtualRef aheadBehindRef)
             {
-                // VirtualRef(name: aheadBehind, completeName: trackedCompleteName, remote: gitRef.TrackingRemote, mergeWith: gitRef.CompleteName, ...) { IsRemote = !gitRef.IsRemote }
                 bool realRefIsRemote = !aheadBehindRef.IsRemote;
-                string realRefCompleteName = aheadBehindRef.MergeWith;
-                string realRefName = realRefCompleteName[(realRefIsRemote ? GitRefName.RefsRemotesPrefix : GitRefName.RefsHeadsPrefix).Length..];
+                string realRefLocalName = aheadBehindRef.MergeWith;
+                string realRefCompleteName = realRefIsRemote ? GitRefName.GetFullRemoteName(realRefLocalName, aheadBehindRef.TrackingRemote) : GitRefName.GetFullBranchName(realRefLocalName);
+                string realRefName = realRefIsRemote ? realRefCompleteName[GitRefName.RefsRemotesPrefix.Length..] : realRefLocalName;
                 AheadBehindData? data = GetAheadBehindData(realRefIsRemote, realRefCompleteName);
                 _toolTipBuilder.Append('[').Append(realRefName).Append(']');
                 if (realRefIsRemote)
@@ -994,7 +991,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
     ///  and <see cref="AheadBehindData.AheadCount"/> are swapped before formatting.
     ///  Returns an empty display string for untracked refs or when the provider is unavailable.
     /// </remarks>
-    private (string Display, string TrackedCompleteName) GetAheadBehind(IGitRef gitRef, bool withCounts = true)
+    private (string Display, string TrackedCompleteName, bool IsGone) GetAheadBehind(IGitRef gitRef, bool withCounts = true)
     {
         _aheadBehindDataByLocalBranch ??= _aheadBehindDataProvider?.GetData() ?? FrozenDictionary<string, AheadBehindData>.Empty;
 
@@ -1008,7 +1005,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
 
             if (_aheadBehindDataByRemoteBranch.TryGetValue(gitRef.CompleteName, out AheadBehindData aheadBehind))
             {
-               return (aheadBehind.ToDisplay(withCounts), GitRefName.RefsHeadsPrefix + aheadBehind.Branch);
+               return (aheadBehind.ToDisplay(withCounts), GitRefName.RefsHeadsPrefix + aheadBehind.Branch, aheadBehind.AheadCount == AheadBehindData.Gone);
             }
         }
         else
@@ -1017,11 +1014,11 @@ internal sealed class MessageColumnProvider : ColumnProvider
             {
                 // This info is displayed in a virtual remote ref label.
                 // From the remote ref's perspective, ahead/behind are swapped relative to the local branch.
-                return (aheadBehind.ToDisplay(withCounts, reverse: true), aheadBehind.RemoteRef);
+                return (aheadBehind.ToDisplay(withCounts, reverse: true), aheadBehind.RemoteRef, aheadBehind.AheadCount == AheadBehindData.Gone);
             }
         }
 
-        return (string.Empty, string.Empty);
+        return (string.Empty, string.Empty, false);
     }
 
     public AheadBehindData? GetAheadBehindData(bool isRemote, string completeName)
@@ -1049,42 +1046,4 @@ internal sealed class MessageColumnProvider : ColumnProvider
         list.Clear();
         _hitInfoListPool.Push(list);
     }
-
-    private sealed class VirtualRef(string name, string completeName, string remote, string mergeWith, IGitModule module) : IGitRef
-    {
-        public string Name => name;
-        public ObjectId ObjectId => throw new NotSupportedException();
-        public string? Guid => null;
-        public IGitModule Module => module;
-        public string CompleteName => completeName;
-        public string Remote => remote;
-        public string LocalName => Name;
-        public bool IsRemote { get; init; }
-        public bool IsHead { get; init; }
-        public bool IsTag => false;
-        public bool IsBisect => false;
-        public bool IsBisectGood => false;
-        public bool IsBisectBad => false;
-        public bool IsStash => false;
-        public bool IsDereference => false;
-        public bool IsSelected { get; set; }
-        public bool IsSelectedHeadMergeSource { get; set; }
-        public string MergeWith
-        {
-            get => mergeWith;
-            set => throw new NotSupportedException();
-        }
-
-        public string TrackingRemote
-        {
-            get => "";
-            set => throw new NotSupportedException();
-        }
-
-        public bool IsTrackingRemote(IGitRef? remote) => false;
-
-        public override bool Equals(object? obj) => obj is VirtualRef other && CompleteName == other.CompleteName;
-
-        public override int GetHashCode() => completeName.GetHashCode();
     }
-}

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/NestledVirtualRef.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/NestledVirtualRef.cs
@@ -1,0 +1,58 @@
+﻿using GitCommands;
+using GitExtensions.Extensibility.Git;
+
+namespace GitUI.UserControls.RevisionGrid.Columns;
+
+public sealed class NestledVirtualRef(IGitRef gitRef, string completeName, bool trackingBranchIsGone) : IGitRef
+{
+    public string Name { get; } = GitRef.ParseName(completeName);
+
+    /// <summary>
+    ///  <see cref="ObjectId"/> of a nestled ref is always default/zero.
+    /// </summary>
+    public ObjectId ObjectId => default;
+    public string? Guid => null;
+    public string CompleteName => completeName;
+    public string LocalName => GitRef.ComputeLocalName(IsRemote, Remote, Name);
+
+    /// <summary>
+    ///  The tracked local branch name as on the remote for <see cref="IsHead"/>,
+    ///  or the tracking local branch for <see cref="IsRemote"/>.
+    /// </summary>
+    public string MergeWith
+    {
+        get => gitRef.LocalName;
+        set => throw new NotSupportedException();
+    }
+
+    public string Remote => gitRef.TrackingRemote;
+    public string TrackingRemote
+    {
+        get => gitRef.Remote;
+        set => throw new NotSupportedException();
+    }
+
+    public bool TrackingBranchIsGone => trackingBranchIsGone;
+
+    public bool IsHead => gitRef.IsRemote;
+    public bool IsRemote => gitRef.IsHead;
+    public bool IsTag => false;
+    public bool IsStash => false;
+    public bool IsDereference => false;
+    public bool IsSelected { get; set; }
+    public bool IsSelectedHeadMergeSource { get; set; }
+    public bool IsBisect => false;
+    public bool IsBisectGood => false;
+    public bool IsBisectBad => false;
+
+    public IGitModule Module => gitRef.Module;
+    public bool IsTrackingRemote(IGitRef? remote)
+    => remote is not null && IsHead && remote.IsRemote
+        && MergeWith == remote.LocalName && TrackingRemote == remote.Remote;
+
+    public override bool Equals(object? obj) => obj is NestledVirtualRef other && CompleteName == other.CompleteName;
+
+    public override int GetHashCode() => completeName.GetHashCode();
+
+    public override string ToString() => $"NestledVirtualRef: {CompleteName}";
+}

--- a/src/app/GitUI/UserControls/RevisionGrid/GitRefListsForRevision.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/GitRefListsForRevision.cs
@@ -22,7 +22,7 @@ internal sealed class GitRefListsForRevision
         _allBranches = [.. revision.Refs.Where(h => !h.IsTag && (h.IsHead || h.IsRemote))];
         _localBranches = Array.FindAll(_allBranches, b => !b.IsRemote);
         _branchesWithNoIdenticalRemotes = [.. _allBranches.Where(b => !b.IsRemote ||
-                                                                  !_localBranches.Any(lb => lb.TrackingRemote == b.Remote && lb.MergeWith == b.LocalName))];
+                                                                  !_localBranches.Any(lb => lb.IsTrackingRemote(b)))];
 
         _tags = [.. revision.Refs.Where(h => h.IsTag)];
     }

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1222,13 +1222,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             }
 
             selectedRef.IsSelected = true;
-
-            string selectedRemote = selectedRef.TrackingRemote;
-            string selectedMerge = selectedRef.MergeWith;
             IGitRef? selectedHeadMergeSource = gitRefs.FirstOrDefault(
-                gitRef => gitRef.IsRemote
-                     && selectedRemote == gitRef.Remote
-                     && selectedMerge == gitRef.LocalName);
+                gitRef => selectedRef.IsTrackingRemote(gitRef));
 
             selectedHeadMergeSource?.IsSelectedHeadMergeSource = true;
         }
@@ -2004,8 +1999,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
                 if (hitInfo?.GitRef is { } gitRef)
                 {
-                    bool isVirtualAheadBehingRef = gitRef.Guid is null;
-                    if (isVirtualAheadBehingRef)
+                    if (gitRef is NestledVirtualRef)
                     {
                         // Let the related ref be added to the selection afterwards in order to simulate standard Ctrl+click behavior.
                         // For this, let DataGridView's native Ctrl+click processing select this revision again first.
@@ -2239,10 +2233,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         }
 
         IGitRef? clickedRef = _rightClickedHitInfo?.GitRef;
-        string? relatedBranch = clickedRef is { Guid: null }
-            ? clickedRef.MergeWith.StartsWith(GitRefName.RefsRemotesPrefix)
-                ? clickedRef.MergeWith[GitRefName.RefsRemotesPrefix.Length..]
-                : clickedRef.MergeWith[GitRefName.RefsHeadsPrefix.Length..]
+        string? relatedBranch = clickedRef is NestledVirtualRef
+            ? (clickedRef.IsRemote ? clickedRef.Remote + "/" : "") + clickedRef.MergeWith
             : null;
         _rightClickedHitInfo = null;
         Func<IEnumerable<IGitRef>, IEnumerable<IGitRef>> filterRefs = clickedRef is null
@@ -3186,15 +3178,15 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
     private void GoToRelatedRef(IGitRef gitRef, Action<string>? handleGone = null, bool toggleSelection = false)
     {
-        if (gitRef.Guid is null)
+        if (gitRef is NestledVirtualRef nestledRef)
         {
-            if (gitRef.Name == AheadBehindData.GoneSymbol)
+            if (nestledRef.TrackingBranchIsGone)
             {
-                handleGone?.Invoke(gitRef.MergeWith[GitRefName.RefsHeadsPrefix.Length..]);
+                handleGone?.Invoke(nestledRef.MergeWith);
             }
             else
             {
-                GoToRef(gitRef.CompleteName, showNoRevisionMsg: true, toggleSelection);
+                GoToRef(nestledRef.CompleteName, showNoRevisionMsg: true, toggleSelection);
             }
         }
         else if (_messageColumnProvider.GetAheadBehindData(gitRef.IsRemote, gitRef.CompleteName) is { } aheadBehindData)

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1223,13 +1223,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             }
 
             selectedRef.IsSelected = true;
-
-            string selectedRemote = selectedRef.TrackingRemote;
-            string selectedMerge = selectedRef.MergeWith;
             IGitRef? selectedHeadMergeSource = gitRefs.FirstOrDefault(
-                gitRef => gitRef.IsRemote
-                     && selectedRemote == gitRef.Remote
-                     && selectedMerge == gitRef.LocalName);
+                gitRef => selectedRef.IsTrackingRemote(gitRef));
 
             selectedHeadMergeSource?.IsSelectedHeadMergeSource = true;
         }
@@ -2005,8 +2000,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
                 if (hitInfo?.GitRef is { } gitRef)
                 {
-                    bool isVirtualAheadBehingRef = gitRef.Guid is null;
-                    if (isVirtualAheadBehingRef)
+                    // Nestled ref
+                    if (gitRef.ObjectId.IsZero)
                     {
                         // Let the related ref be added to the selection afterwards in order to simulate standard Ctrl+click behavior.
                         // For this, let DataGridView's native Ctrl+click processing select this revision again first.
@@ -2240,10 +2235,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         }
 
         IGitRef? clickedRef = _rightClickedHitInfo?.GitRef;
-        string? relatedBranch = clickedRef is { Guid: null }
-            ? clickedRef.MergeWith.StartsWith(GitRefName.RefsRemotesPrefix)
-                ? clickedRef.MergeWith[GitRefName.RefsRemotesPrefix.Length..]
-                : clickedRef.MergeWith[GitRefName.RefsHeadsPrefix.Length..]
+        string? relatedBranch = clickedRef is { ObjectId: { IsZero: true } }
+            ? (clickedRef.IsRemote ? clickedRef.Remote + "/" : "") + clickedRef.MergeWith
             : null;
         _rightClickedHitInfo = null;
         Func<IEnumerable<IGitRef>, IEnumerable<IGitRef>> filterRefs = clickedRef is null
@@ -3241,11 +3234,11 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
     private void GoToRelatedRef(IGitRef gitRef, Action<string>? handleGone = null, bool toggleSelection = false)
     {
-        if (gitRef.Guid is null)
+        if (gitRef.ObjectId.IsZero)
         {
             if (gitRef.Name == AheadBehindData.GoneSymbol)
             {
-                handleGone?.Invoke(gitRef.MergeWith[GitRefName.RefsHeadsPrefix.Length..]);
+                handleGone?.Invoke(gitRef.MergeWith);
             }
             else
             {

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitRefTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitRefTests.cs
@@ -11,9 +11,9 @@ public sealed class GitRefTests
     {
         string remoteBranchShortName = "remote_branch";
         string remoteName = "origin";
-        GitRef localBranchRef = SetupLocalBranchWithATrackingReference(remoteBranchShortName, remoteName);
+        IGitRef localBranchRef = SetupLocalBranchWithATrackingReference(remoteBranchShortName, remoteName);
 
-        GitRef remoteBranchRef = SetupRemoteRef(remoteBranchShortName, remoteName);
+        IGitRef remoteBranchRef = SetupRemoteRef(remoteBranchShortName, remoteName);
 
         localBranchRef.IsTrackingRemote(remoteBranchRef).Should().BeTrue();
     }
@@ -21,7 +21,7 @@ public sealed class GitRefTests
     [Test]
     public void IsTrackingRemote_should_return_false_when_remote_is_null()
     {
-        GitRef localBranchRef = SetupLocalBranchWithATrackingReference("remote_branch", "origin");
+        IGitRef localBranchRef = SetupLocalBranchWithATrackingReference("remote_branch", "origin");
 
         localBranchRef.IsTrackingRemote(null).Should().BeFalse();
     }
@@ -30,9 +30,9 @@ public sealed class GitRefTests
     public void IsTrackingRemote_should_return_false_when_tracking_another_remote()
     {
         string remoteBranchShortName = "remote_branch";
-        GitRef localBranchRef = SetupLocalBranchWithATrackingReference(remoteBranchShortName, "origin");
+        IGitRef localBranchRef = SetupLocalBranchWithATrackingReference(remoteBranchShortName, "origin");
 
-        GitRef remoteBranchRef = SetupRemoteRef(remoteBranchShortName, "upstream");
+        IGitRef remoteBranchRef = SetupRemoteRef(remoteBranchShortName, "upstream");
 
         localBranchRef.IsTrackingRemote(remoteBranchRef).Should().BeFalse();
     }
@@ -40,9 +40,9 @@ public sealed class GitRefTests
     [Test]
     public void IsTrackingRemote_should_return_false_when_tracking_another_remote_branch()
     {
-        GitRef localBranchRef = SetupLocalBranchWithATrackingReference("one_remote_branch", "origin");
+        IGitRef localBranchRef = SetupLocalBranchWithATrackingReference("one_remote_branch", "origin");
 
-        GitRef remoteBranchRef = SetupRemoteRef("another_remote_branch", "origin");
+        IGitRef remoteBranchRef = SetupRemoteRef("another_remote_branch", "origin");
 
         localBranchRef.IsTrackingRemote(remoteBranchRef).Should().BeFalse();
     }
@@ -50,9 +50,9 @@ public sealed class GitRefTests
     [Test]
     public void IsTrackingRemote_should_return_false_when_supposedly_local_branch_is_a_remote_ref()
     {
-        GitRef localBranchRef = SetupRemoteRef("a_remote_branch", "origin");
+        IGitRef localBranchRef = SetupRemoteRef("a_remote_branch", "origin");
 
-        GitRef remoteBranchRef = SetupRemoteRef("a_remote_branch", "origin");
+        IGitRef remoteBranchRef = SetupRemoteRef("a_remote_branch", "origin");
 
         localBranchRef.IsTrackingRemote(remoteBranchRef).Should().BeFalse();
     }
@@ -60,9 +60,9 @@ public sealed class GitRefTests
     [Test]
     public void IsTrackingRemote_should_return_false_when_supposedly_remote_branch_is_a_local_ref()
     {
-        GitRef localBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
+        IGitRef localBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
 
-        GitRef remoteBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
+        IGitRef remoteBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
 
         localBranchRef.IsTrackingRemote(remoteBranchRef).Should().BeFalse();
     }
@@ -73,9 +73,9 @@ public sealed class GitRefTests
         IGitModule localGitModule = Substitute.For<IGitModule>();
         localGitModule.GetEffectiveSetting($"branch.local_branch.merge").Returns(string.Empty);
         localGitModule.GetEffectiveSetting($"branch.local_branch.remote").Returns(string.Empty);
-        GitRef localBranchRef = new(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
+        IGitRef localBranchRef = new GitRef(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
 
-        GitRef remoteBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
+        IGitRef remoteBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
 
         localBranchRef.IsTrackingRemote(remoteBranchRef).Should().BeFalse();
     }
@@ -87,7 +87,7 @@ public sealed class GitRefTests
         string name = "local_branch";
         string completeName = $"refs/remotes/{remoteName}/{name}";
 
-        GitRef remoteBranchRef = SetupRawRemoteRef(remoteName, completeName);
+        IGitRef remoteBranchRef = SetupRawRemoteRef(remoteName, completeName);
         name.Should().Be(remoteBranchRef.LocalName);
     }
 
@@ -99,32 +99,29 @@ public sealed class GitRefTests
         string name = "a_short_name";
         string completeName = $"refs/remotes/{name}";
 
-        GitRef remoteBranchRef = SetupRawRemoteRef(remoteName, completeName);
+        IGitRef remoteBranchRef = SetupRawRemoteRef(remoteName, completeName);
         name.Should().Be(remoteBranchRef.LocalName);
     }
 
-    private static GitRef SetupRawRemoteRef(string remoteName, string completeName)
+    private static IGitRef SetupRawRemoteRef(string remoteName, string completeName)
     {
         IGitModule localGitModule = Substitute.For<IGitModule>();
         localGitModule.GetEffectiveSetting($"branch.local_branch.merge").Returns(completeName);
         localGitModule.GetEffectiveSetting($"branch.local_branch.remote").Returns(remoteName);
-        GitRef remoteBranchRef = new(localGitModule, ObjectId.Random(), completeName, remoteName);
-        return remoteBranchRef;
+        return new GitRef(localGitModule, ObjectId.Random(), completeName, remoteName);
     }
 
-    private static GitRef SetupRemoteRef(string remoteBranchShortName, string remoteName)
+    private static IGitRef SetupRemoteRef(string remoteBranchShortName, string remoteName)
     {
         IGitModule remoteGitModule = Substitute.For<IGitModule>();
-        GitRef remoteBranchRef = new(remoteGitModule, ObjectId.Random(), $"refs/remotes/{remoteName}/{remoteBranchShortName}", remoteName);
-        return remoteBranchRef;
+        return new GitRef(remoteGitModule, ObjectId.Random(), $"refs/remotes/{remoteName}/{remoteBranchShortName}", remoteName);
     }
 
-    private static GitRef SetupLocalBranchWithATrackingReference(string remoteShortName, string remoteName)
+    private static IGitRef SetupLocalBranchWithATrackingReference(string remoteShortName, string remoteName)
     {
         IGitModule localGitModule = Substitute.For<IGitModule>();
         localGitModule.GetEffectiveSetting($"branch.local_branch.merge").Returns($"refs/heads/{remoteShortName}");
         localGitModule.GetEffectiveSetting($"branch.local_branch.remote").Returns(remoteName);
-        GitRef localBranchRef = new(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
-        return localBranchRef;
+        return new GitRef(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
     }
 }


### PR DESCRIPTION
## Proposed changes

Some combined changes seen when working with #13063 These changes were not strictly needed, but I got tired of investigating the pecularities of GitRef. The use of VirtualRef (now NestledRef) broke the contract even more. So the documentation turned into a minor cleanup.

--

- Document IGitRef members, describe specific special cases in the derived classes.
Especially, Name and LocalName was not used consistently. Some unifications on usage.

The methods are in logical order, to simplify reading of the functionality.
IGitRef.Name is set to new to documented properly.

- Minor optimization of GitRef and GitRefName. Some ,spans, avoid some allocations.
Allocate LocalName lazily.

> With 1600 refs, this decreases ref load time from about 34 ms -> 18 ms, then some reduced allocations.

- NestledRef shares code with GitRef and avoids special usage of LocalName and MergeWith.
Set ObjectId to default to avoid allocations with Guid.

> partly in #13063 

## Test methodology <!-- How did you ensure quality? -->

Existing tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
