### PR TITLE
fix(bug reporter): remove wrong configuration

### DIFF
--- a/src/app/GitUI/NBugReports/UIReporter.cs
+++ b/src/app/GitUI/NBugReports/UIReporter.cs
@@ -182,6 +182,10 @@ internal sealed class UIReporter : IBugReporter
             AddIgnoreButton();
         }
 
+        // AllowCancel requires a standard cancel button so that pressing Escape or the X button
+        // does not crash in TaskDialogPage.GetBoundButtonByID (IndexOutOfRangeException on IDCANCEL).
+        page.Buttons.Add(TaskDialogButton.Cancel);
+
         page.Text = text.ToString().Trim();
 
         return page;

--- a/src/app/GitUI/NBugReports/UIReporter.cs
+++ b/src/app/GitUI/NBugReports/UIReporter.cs
@@ -148,7 +148,6 @@ internal sealed class UIReporter : IBugReporter
             Icon = operationInfo.Icon,
             Caption = TranslatedStrings.Error,
             Heading = rootError,
-            AllowCancel = true,
             SizeToContent = true
         };
 
@@ -181,10 +180,6 @@ internal sealed class UIReporter : IBugReporter
         {
             AddIgnoreButton();
         }
-
-        // AllowCancel requires a standard cancel button so that pressing Escape or the X button
-        // does not crash in TaskDialogPage.GetBoundButtonByID (IndexOutOfRangeException on IDCANCEL).
-        page.Buttons.Add(TaskDialogButton.Cancel);
 
         page.Text = text.ToString().Trim();
 

--- a/tests/app/UnitTests/GitUI.Tests/NBugReports/UIReporterTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/NBugReports/UIReporterTests.cs
@@ -197,7 +197,7 @@ public sealed class UIReporterTests
 
         page.Icon.Should().Be(TaskDialogIcon.Error);
         page.Heading.Should().Be(RootError);
-        page.AllowCancel.Should().BeTrue();
+        page.AllowCancel.Should().BeFalse();
         page.Buttons.Should().HaveCount(2);
     }
 


### PR DESCRIPTION
Fixes #13224

## Proposed changes

`GitUI.NBugReports.UIReporter`: Remove `AllowCancel = true`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

?
Feel free to continue on this

## Test methodology <!-- How did you ensure quality? -->

?
Feel free to continue on this

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).