### PR TITLE
fix(scripts): avoid crash by outdated plugins

### DIFF
--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsProviderBase.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsProviderBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace GitUI.ScriptsEngine;
 
@@ -7,9 +8,12 @@ namespace GitUI.ScriptsEngine;
 ///  Basic implementation of <see cref="IScriptOptionsProvider"/>.
 ///  It replaces all script options of all implementations of <see cref="IScriptOptionsProvider"/> with an empty string.
 /// </summary>
-internal class ScriptOptionsProviderBase : IScriptOptionsProvider
+internal partial class ScriptOptionsProviderBase : IScriptOptionsProvider
 {
     private static readonly string[] _options;
+
+    [GeneratedRegex(@"^(System|Microsoft|netstandard|Accessibility|Ben\.Demystifier|BenjaminAbt\.StrongOf|ExCSS|Git\.Hub|ICSharpCode\.TextEditor|ResourceManager|SmartFormat|TestableIO|Testably|PresentationCore|UIAutomationTypes|WindowsBase|ZString)[.,]", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex _excludedAssemblies { get; }
 
     static ScriptOptionsProviderBase()
     {
@@ -27,6 +31,11 @@ internal class ScriptOptionsProviderBase : IScriptOptionsProvider
         {
             try
             {
+                if (assembly.FullName is not string name || _excludedAssemblies.IsMatch(name))
+                {
+                    return [];
+                }
+
                 return assembly.GetTypes();
             }
             catch (Exception ex)

--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsProviderBase.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsProviderBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 
 namespace GitUI.ScriptsEngine;
 
@@ -14,13 +15,27 @@ internal class ScriptOptionsProviderBase : IScriptOptionsProvider
     {
         Type interfaceType = typeof(IScriptOptionsProvider);
         _options = [.. AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(assembly => assembly.GetTypes())
+            .SelectMany(GetTypes)
             .Where(type => type != interfaceType && interfaceType.IsAssignableFrom(type))
             .SelectMany(implementingType =>
                 {
                     PropertyInfo? property = implementingType.GetProperty(nameof(ImplementedOptions), BindingFlags.Static | BindingFlags.NonPublic);
                     return (string[])property!.GetValue(obj: null)!;
                 })];
+
+        static Type[] GetTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (Exception ex)
+            {
+                // Ignore outdated plugins, which may reference assemblies that are no longer available.
+                Trace.WriteLine(ex);
+                return [];
+            }
+        }
     }
 
     /// <summary>

--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsProviderBase.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsProviderBase.cs
@@ -12,6 +12,15 @@ internal partial class ScriptOptionsProviderBase : IScriptOptionsProvider
 {
     private static readonly string[] _options;
 
+    /// <summary>
+    ///  Matches assembly names that can be skipped when scanning for <see cref="IScriptOptionsProvider"/> implementations.
+    ///  Excluded prefixes fall into three categories:
+    ///  - .NET runtime assemblies
+    ///  - third-party libraries bundled with the application
+    ///  - test infrastructure assemblies
+    ///  Update this list whenever a new third-party or runtime assembly is added to the application
+    ///  that would otherwise be unnecessarily scanned, or when an excluded assembly is removed from the project.
+    /// </summary>
     [GeneratedRegex(@"^(System|Microsoft|netstandard|Accessibility|Ben\.Demystifier|BenjaminAbt\.StrongOf|ExCSS|Git\.Hub|ICSharpCode\.TextEditor|ResourceManager|SmartFormat|TestableIO|Testably|PresentationCore|UIAutomationTypes|WindowsBase|ZString)[.,]", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex _excludedAssemblies { get; }
 


### PR DESCRIPTION
Fixes #13223

## Proposed changes

`ScriptOptionsProviderBase`:
- Trace exceptions from `Assembly.GetTypes` and ignore affected assemblies,
  which are most likely outdated plugins
- skip getting types of .NET framework and 3rd party assemblies (350ms -> 30ms)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

This error message is way too uninformative:

<img width="424" height="166" alt="Image" src="https://github.com/user-attachments/assets/86a55805-b674-44fc-8f42-0ce765c26d48" />

### After

no popup

## Test methodology <!-- How did you ensure quality? -->

- just existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).