### PR TITLE
fix(revision grid): persist branch view modes

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -1319,7 +1319,7 @@ public static partial class AppSettings
 
     public static ISetting<bool> ShowProcessDialogPasswordInput => Setting.Create(DetailedSettingsPath, nameof(ShowProcessDialogPasswordInput), false);
 
-    public static BoolRuntimeSetting ShowCurrentBranchOnly { get; } = new(RootSettingsPath, nameof(ShowCurrentBranchOnly), false);
+    public static ISetting<bool> ShowCurrentBranchOnly { get; } = Setting.Create(RootSettingsPath, nameof(ShowCurrentBranchOnly), false);
 
     public static bool ShowSimplifyByDecoration
     {

--- a/src/app/GitUI/CommandsDialogs/FormRebase.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRebase.cs
@@ -398,7 +398,7 @@ public partial class FormRebase : GitExtensionsDialog
     private void btnChooseFromRevision_Click(object sender, EventArgs e)
     {
         bool previousValueBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool previousValueShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool previousValueShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool previousValueShowReflogReferences = AppSettings.ShowReflogReferences;
         bool previousValueShowStashes = AppSettings.ShowStashes;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -126,7 +126,7 @@ public record FilterInfo
 
     public bool ShowCurrentBranchOnly
     {
-        get => AppSettings.ShowCurrentBranchOnly;
+        get => AppSettings.ShowCurrentBranchOnly.Value;
         set => AppSettings.ShowCurrentBranchOnly.Value = value;
     }
 
@@ -202,7 +202,7 @@ public record FilterInfo
 
     /// <summary>
     /// Disables all active filters.
-    /// CurrentBranch and Reflog are not disabled.
+    /// CurrentBranch, ShowOnlyFirstParent and Reflog are intentionally preserved.
     /// FullHistory and SimplifyMerges are considered settings and not reset.
     /// </summary>
     public void ResetAllFilters()
@@ -215,7 +215,6 @@ public record FilterInfo
         ByDiffContent = false;
         ByPathFilter = false;
         ByBranchFilter = false;
-        ShowOnlyFirstParent = false;
         HideMergeCommits = false;
         ShowSimplifyByDecoration = false;
     }

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -69,11 +69,13 @@ public class FormBrowseTests
 
         bool reflogEnabled = AppSettings.ShowReflogReferences;
         bool branchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool showCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool showCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
+        bool showOnlyFirstParent = AppSettings.ShowOnlyFirstParent;
         bool revisionGraphShowArtificialCommits = AppSettings.RevisionGraphShowArtificialCommits;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.BranchFilterEnabled.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
+        AppSettings.ShowOnlyFirstParent = false;
         AppSettings.RevisionGraphShowArtificialCommits = false;
 
         RunFormTest(
@@ -139,12 +141,26 @@ public class FormBrowseTests
                     AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
                     AppSettings.ShowCurrentBranchOnly.Value.Should().BeTrue();
                     form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tscboBranchFilter.Text.Should().BeEmpty();
+
+                    // 4. Switch repos with "Show only first parent" enabled
+                    // ------------------------------------------------------------------------------------------------
+
+                    Console.WriteLine("Scenario 4: enable 'Show only first parent' and switch repo");
+                    form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tsmiShowOnlyFirstParent.PerformClick();
+                    WaitForRevisionsToBeLoaded(form);
+
+                    using ReferenceRepository anotherRepository = new();
+                    form.SetWorkingDir(anotherRepository.Module.WorkingDir);
+                    WaitForRevisionsToBeLoaded(form);
+                    // Assert
+                    AppSettings.ShowOnlyFirstParent.Should().BeTrue();
                 }
                 finally
                 {
                     AppSettings.ShowReflogReferences.Value = reflogEnabled;
                     AppSettings.BranchFilterEnabled.Value = branchFilterEnabled;
                     AppSettings.ShowCurrentBranchOnly.Value = showCurrentBranchOnly;
+                    AppSettings.ShowOnlyFirstParent = showOnlyFirstParent;
                     AppSettings.RevisionGraphShowArtificialCommits = revisionGraphShowArtificialCommits;
                 }
             });

--- a/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -130,6 +130,12 @@ internal sealed class AppSettingsTests
         }
     }
 
+    [Test]
+    public void ShowCurrentBranchOnly_should_be_persistent()
+    {
+        AppSettings.ShowCurrentBranchOnly.Should().NotBeAssignableTo<IRuntimeSetting>();
+    }
+
     /// <summary>
     ///  Verifies that ISetting property names (storage keys) remain stable across changes.
     /// </summary>

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -26,7 +26,7 @@ public class FilterInfoTests
     public async Task FilterInfo_ctor_expected()
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -50,7 +50,7 @@ public class FilterInfoTests
     public async Task FilterInfo_ctor_with_Raw_expected()
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -431,7 +431,7 @@ public class FilterInfoTests
     public void FilterInfo_ByBranchFilter_expected()
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -473,7 +473,7 @@ public class FilterInfoTests
     public void FilterInfo_BranchFilter_with_Raw_expected(bool isRaw, bool byBranchFilter)
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -513,7 +513,7 @@ public class FilterInfoTests
     public void FilterInfo_IsShowAllBranchesChecked_expected(bool byBranchFilter, bool showCurrentBranchOnly, bool expected)
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -546,7 +546,7 @@ public class FilterInfoTests
     public void FilterInfo_IsShowCurrentBranchOnlyChecked_expected(bool byBranchFilter, bool showCurrentBranchOnly, bool expected)
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -579,7 +579,7 @@ public class FilterInfoTests
     public void FilterInfo_IsShowFilteredBranchesChecked_expected(bool byBranchFilter, bool showCurrentBranchOnly, bool expected)
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -609,7 +609,7 @@ public class FilterInfoTests
     public void FilterInfo_ShowCurrentBranchOnly_expected()
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -678,10 +678,21 @@ public class FilterInfoTests
     }
 
     [Test]
+    public void FilterInfo_ResetAllFilters_should_preserve_ShowOnlyFirstParent()
+    {
+        AppSettings.ShowOnlyFirstParent = true;
+        FilterInfo filterInfo = new();
+
+        filterInfo.ResetAllFilters();
+
+        filterInfo.ShowOnlyFirstParent.Should().BeTrue();
+    }
+
+    [Test]
     public void FilterInfo_ShowReflogReferences_expected()
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;
@@ -727,7 +738,7 @@ public class FilterInfoTests
     public void FilterInfo_ShowReflogReferences_dominates_other_filters(bool byBranchFilter, bool showCurrentBranchOnly, bool showReflog)
     {
         bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
-        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+        bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly.Value;
         bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
         AppSettings.ShowReflogReferences.Value = false;
         AppSettings.ShowCurrentBranchOnly.Value = false;


### PR DESCRIPTION
Fixes #13232

## Proposed changes

- Persist the **Show current branch only** selection across application restarts.
- Preserve **Show only first parent** when filters are reset while opening another repository.
- Keep custom/advanced branch filters session-specific so they are not applied to unrelated repositories.

## Why

Git Extensions previously remembered these history view modes, but they now reset whenever the application restarts. Repositories with many branches or merge commits therefore become noisy again, requiring users to restore both options several times a day.

This change respects the user's selected view modes without making repository-specific branch filters global.

## Test methodology

- `dotnet build /v:q`
- Full `GitCommands.Tests`: 3,458 passed, 1 skipped
- Full `GitUI.Tests`: 20,619 passed, 1 skipped
- Full `UI.IntegrationTests`: 287 passed, 1 skipped
- Manually tested the Release build across application restarts and repository changes

## Test environment

- Git 2.55.0.windows.3
- Microsoft Windows NT 10.0.26200.0

## Merge strategy

I agree that the maintainer squash merge this PR if the commit message is clear.

----

:black_nib: I contribute this code under the [Developer Certificate of Origin](https://github.com/gitextensions/gitextensions/blob/master/contributors.txt).

