### PR TITLE
feat(plugins): validate compatibility on load

### DIFF
--- a/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -65,7 +65,7 @@ public static class ManagedExtensibility
         else
         {
             Assembly[] assemblies = [.. pluginFiles.Union(userPluginFiles)
-                                               .Select(assemblyFile => TryLoadAssembly(assemblyFile))
+                                               .Select(TryLoadAssembly)
                                                .WhereNotNull()];
 
             PartDiscovery? discovery = PartDiscovery.Combine(
@@ -91,17 +91,26 @@ public static class ManagedExtensibility
         }
 
         return exportProviderFactory.CreateExportProvider();
-    }
 
-    private static Assembly? TryLoadAssembly(FileInfo file)
-    {
-        try
+        static Assembly? TryLoadAssembly(FileInfo file)
         {
-            return Assembly.LoadFile(file.FullName);
-        }
-        catch
-        {
-            return null;
+            try
+            {
+                Assembly assembly = Assembly.LoadFile(file.FullName);
+
+                // Eagerly validate that all types in the assembly can be resolved.
+                // Outdated plugins targeting an incompatible interface version succeed
+                // at load time but throw ReflectionTypeLoadException here when any
+                // referenced type cannot be found in the currently loaded dependencies.
+                _ = assembly.GetTypes();
+
+                return assembly;
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"Failed to load plugin {file.FullName}: {ex}");
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
Addresses https://github.com/gitextensions/gitextensions/pull/13230#issuecomment-5297334792

## Proposed changes

`ManagedExtensibility.TryLoadAssembly`: 
- Eagerly validate that all types in the assembly can be resolved.
  Outdated plugins targeting an incompatible interface version succeed at load time
  but now throw ReflectionTypeLoadException when any referenced type cannot be found in the currently loaded dependencies.
- Trace loading errors (in the Output History)

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- only existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).