### PR TITLE
feat(issue-triage): close legacy runtime loading reports

### DIFF
--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -30,9 +30,87 @@ env:
   EXCLUDED_AUTHORS: ""
 
 jobs:
+  triage-known-windows-update-error:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'gitextensions' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    outputs:
+      matched: ${{ steps.triage.outputs.matched }}
+    steps:
+      - name: "Triage known Windows update error"
+        id: triage
+        if: ${{ github.event_name == 'issues' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const title = issue.title || '';
+            const body = issue.body || '';
+            const vcruntimeTitle = /^\[NBug\]\s+Unable to load DLL\s+['"][^'"]*vcruntime[^'"]*['"]/i;
+            const vcruntimeException = /System\.DllNotFoundException:\s+Unable to load DLL\s+['"][^'"]*vcruntime/i;
+            const versionMatch = body.match(/^- Git Extensions (\d+)\./im);
+            const isLegacyVersion = versionMatch !== null && Number(versionMatch[1]) < 7;
+            const matched = vcruntimeTitle.test(title) && vcruntimeException.test(body) && isLegacyVersion;
+
+            core.setOutput('matched', matched.toString());
+            if (!matched) {
+              return;
+            }
+
+            const marker = '<!-- known-windows-update-vcruntime -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+
+            if (!comments.some(comment => comment.body?.includes(marker))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `${marker}
+            Thanks for reporting this. This VC runtime loading failure is a transient result of Windows, .NET, or Visual C++ servicing replacing a runtime DLL while Git Extensions is running.
+
+            Restart Git Extensions. If Windows is waiting for a restart, restart Windows too. Current Git Extensions releases suppress the misleading crash-report prompt for this condition, so please also [upgrade to the latest release](https://github.com/gitextensions/gitextensions/releases/latest).
+
+            If the error continues after restarting Windows and upgrading Git Extensions, please open a new bug report and mention that those steps did not resolve it. This issue has been automatically closed because it matches the known Windows update error.`,
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['status: workaround available'],
+            });
+
+            const needsReviewLabel = ':eyeglasses: status: needs review';
+            if (issue.labels.some(label => (typeof label === 'string' ? label : label.name) === needsReviewLabel)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: needsReviewLabel,
+              });
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });
+
+            core.info(`Closed issue #${issue.number} as a known Windows update VC runtime error.`);
+
   predict-issue-label:
     # Do not automatically run the workflow on forks outside the 'gitextensions' org
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'gitextensions' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || github.repository_owner == 'gitextensions') && needs.triage-known-windows-update-error.outputs.matched != 'true' }}
+    needs: triage-known-windows-update-error
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -49,16 +49,20 @@ jobs:
             const body = issue.body || '';
             const vcruntimeTitle = /^\[NBug\]\s+Unable to load DLL\s+['"][^'"]*vcruntime[^'"]*['"]/i;
             const vcruntimeException = /System\.DllNotFoundException:\s+Unable to load DLL\s+['"][^'"]*vcruntime/i;
+            const typeInitializerTitle = /^\[NBug\]\s+The type initializer for\s+/i;
+            const runtimeAssemblyException = /System\.IO\.FileNotFoundException:\s+Could not load file or assembly\s+['"](?:System\.|Microsoft\.|DirectWriteForwarder(?:,|['"]))/i;
             const versionMatch = body.match(/^- Git Extensions (\d+)\./im);
             const isLegacyVersion = versionMatch !== null && Number(versionMatch[1]) < 7;
-            const matched = vcruntimeTitle.test(title) && vcruntimeException.test(body) && isLegacyVersion;
+            const isVCRuntimeError = vcruntimeTitle.test(title) && vcruntimeException.test(body);
+            const isRuntimeAssemblyError = typeInitializerTitle.test(title) && runtimeAssemblyException.test(body);
+            const matched = isLegacyVersion && (isVCRuntimeError || isRuntimeAssemblyError);
 
             core.setOutput('matched', matched.toString());
             if (!matched) {
               return;
             }
 
-            const marker = '<!-- known-windows-update-vcruntime -->';
+            const marker = '<!-- known-windows-update-runtime -->';
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -72,9 +76,9 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: `${marker}
-            Thanks for reporting this. This VC runtime loading failure is a transient result of Windows, .NET, or Visual C++ servicing replacing a runtime DLL while Git Extensions is running.
+            Thanks for reporting this. This runtime loading failure is a transient result of Windows, .NET, or Visual C++ servicing replacing runtime files while Git Extensions is running.
 
-            Restart Git Extensions. If Windows is waiting for a restart, restart Windows too. Current Git Extensions releases suppress the misleading crash-report prompt for this condition, so please also [upgrade to the latest release](https://github.com/gitextensions/gitextensions/releases/latest).
+            Restart Git Extensions. If Windows is waiting for a restart, restart Windows too. Current Git Extensions releases suppress many of these misleading crash-report prompts, so please also [upgrade to the latest release](https://github.com/gitextensions/gitextensions/releases/latest).
 
             If the error continues after restarting Windows and upgrading Git Extensions, please open a new bug report and mention that those steps did not resolve it. This issue has been automatically closed because it matches the known Windows update error.`,
               });
@@ -105,7 +109,7 @@ jobs:
               state_reason: 'not_planned',
             });
 
-            core.info(`Closed issue #${issue.number} as a known Windows update VC runtime error.`);
+            core.info(`Closed issue #${issue.number} as a known Windows update runtime error.`);
 
   predict-issue-label:
     # Do not automatically run the workflow on forks outside the 'gitextensions' org

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -84,22 +84,12 @@ jobs:
               });
             }
 
-            await github.rest.issues.addLabels({
+            await github.rest.issues.setLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
               labels: ['status: workaround available'],
             });
-
-            const needsReviewLabel = ':eyeglasses: status: needs review';
-            if (issue.labels.some(label => (typeof label === 'string' ? label : label.name) === needsReviewLabel)) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                name: needsReviewLabel,
-              });
-            }
 
             await github.rest.issues.update({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Automatically triage recurring Patch Tuesday crash reports generated by older Git Extensions releases.

The issue-label workflow now detects reports from Git Extensions versions earlier than v7 with either of these signatures:

- `DllNotFoundException` loading a `vcruntime` DLL
- `TypeInitializationException` wrapping a missing `System.*`, `Microsoft.*`, or `DirectWriteForwarder` runtime assembly

For a match, the workflow:

- posts restart and upgrade guidance, with an idempotency marker to avoid duplicate comments
- replaces all existing labels with only `status: workaround available`
- closes the issue as not planned
- skips ML area-label prediction

## Safeguards

The matcher requires the generated NBug title, matching exception details in the body, and a parsed Git Extensions major version below 7. Reports from v7+, reports without version metadata, custom/plugin assembly failures, and unrelated initializer failures continue through normal triage.

This deliberately excludes cases such as #12363 (`TypeLoadException`) and #13223 (v7 plugin assembly failure).

## Historical results

Applying the exact predicate retrospectively to 83 title candidates matched 81 known servicing failures:

- 77 VC runtime DLL reports
- 4 runtime assembly initializer reports: #13227, #12482, #12284, and #11639

The remaining two candidates were the intentional exclusions above. Representative VC runtime reports include #13229 and #13228.

## Validation

- `actionlint .github/workflows/labeler-predict-issues.yml`
- `dotnet build /v:q`
- `git diff --check`
- seven positive and negative signature cases covering legacy runtime failures, v7 reports, custom assemblies, and unrelated initializer errors
- direct audit of the historical candidate set
