### PR TITLE
ci(app-release): revert to branch based build

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check:
+  tagcheck:
     name: Check HEAD has a version tag
     runs-on: ubuntu-latest
     # Releases are only produced from the upstream repository, never from forks.
@@ -33,9 +33,9 @@ jobs:
 
   build:
     name: ${{ matrix.os }}
-    needs: check
+    needs: tagcheck
     # Releases are only produced from the upstream repository, never from forks.
-    if: ${{ needs.check.outputs.proceed == 'true' }}
+    if: ${{ needs.tagcheck.outputs.proceed == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -2,9 +2,9 @@ name: App release (x64, arm64)
 
 on:
   push:
-    tags:
-      # Any tag starting with 'v' followed by a digit: v4, v4.2, v4.2.1, v3.5-RC1, v4-beta, v4.2-rc1, v4.2.1-win32-aarch64, ...
-      - 'v[0-9]*'
+    branches:
+      - 'release'
+      - 'release/*'
   workflow_dispatch:
 
 concurrency:
@@ -12,10 +12,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: ${{ matrix.os }}
+  check:
+    name: Check HEAD has a version tag
+    runs-on: ubuntu-latest
     # Releases are only produced from the upstream repository, never from forks.
     if: ${{ github.repository_owner == 'gitextensions' }}
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || git tag --points-at HEAD | grep -qE '^v'; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: ${{ matrix.os }}
+    needs: check
+    # Releases are only produced from the upstream repository, never from forks.
+    if: ${{ needs.check.outputs.proceed == 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes release build

## Proposed changes

`app-release.yml`: 
- Revert to branch based build
  because SignPath supports only builds triggered on branches.
- Check that the HEAD is tagged with "v*".
- Prepare for plain "release" branch.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

https://github.com/gitextensions/gitextensions/actions/workflows/app-release.yml

## Test methodology <!-- How did you ensure quality? -->

- released v7.2.1

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).