### PR TITLE
fix(ManagedExtensibility): switch to recommended function

### DIFF
--- a/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -96,7 +96,7 @@ public static class ManagedExtensibility
         {
             try
             {
-                Assembly assembly = Assembly.LoadFile(file.FullName);
+                Assembly assembly = Assembly.Load(file.FullName);
 
                 // Eagerly validate that all types in the assembly can be resolved.
                 // Outdated plugins targeting an incompatible interface version succeed
@@ -182,7 +182,7 @@ public static class ManagedExtensibility
 
                     return fileDescription is not null && args.Name.StartsWith(fileDescription);
                 });
-            return dll is null ? null : Assembly.LoadFile(dll);
+            return dll is null ? null : Assembly.Load(dll);
         }
         catch
         {


### PR DESCRIPTION
Fixes SQ warning `csharpsquid:S3885`

## Proposed changes

`ManagedExtensibility`: use recommended function `Assembly.Load` instead of `Assembly.LoadFile`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).