### PR TITLE
feat(commit message): add "Word wrap" to context menu

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -128,7 +128,7 @@ public sealed partial class FormCommit : GitModuleForm
     private readonly TranslationString _statusBarBranchWithoutRemote = new("(remote not configured)");
     private readonly TranslationString _untrackedRemote = new("(untracked)");
 
-    private readonly TranslationString _wrapCommitMessageBody = new("&Wrap body lines");
+    private readonly TranslationString _wordWrapCommitMessageBody = new("&Word wrap (except subject line)");
     #endregion
 
     private event Action? OnStageAreaLoaded;
@@ -2247,7 +2247,22 @@ public sealed partial class FormCommit : GitModuleForm
     private void Message_ContextMenuPopulating(object? sender, ContextMenuStrip menu)
     {
         int insertAt = menu.Items.OfType<ToolStripSeparator>().FirstOrDefault() is { } firstSeparator ? menu.Items.IndexOf(firstSeparator) : 0;
-        menu.Items.Insert(insertAt, new ToolStripMenuItem(_wrapCommitMessageBody.Text, null, (s, e) => WrapCommitMessageBodyLines()));
+        menu.Items.Insert(insertAt, new ToolStripMenuItem(_wordWrapCommitMessageBody.Text, null, (s, e) => WordWrapCommitMessageBody()));
+
+        return;
+
+        void WordWrapCommitMessageBody()
+        {
+            const int DefaultBodyLineLimit = 72;
+            int lineLimit = AppSettings.CommitValidationMaxCntCharsPerLine > 0
+                ? AppSettings.CommitValidationMaxCntCharsPerLine
+                : DefaultBodyLineLimit;
+
+            for (int line = 1; line < Message.LineCount(); line++)
+            {
+                WordWrapCommitMessageLineIfNecessary(line, lineLimit);
+            }
+        }
     }
 
     private void Message_KeyDown(object sender, KeyEventArgs e)
@@ -2347,7 +2362,7 @@ public sealed partial class FormCommit : GitModuleForm
 
             if (limitX > 0 && line >= (empty2 ? 2 : 1))
             {
-                if (commitValidationAutoWrap && WrapIfNecessary())
+                if (commitValidationAutoWrap && WordWrapCommitMessageLineIfNecessary(line, limitX))
                 {
                     changed = true;
                 }
@@ -2388,8 +2403,6 @@ public sealed partial class FormCommit : GitModuleForm
                     }
                 }
             }
-
-            bool WrapIfNecessary() => WrapMessageLineIfNecessary(line, limitX);
         }
 
         void SetFormattedLine(int lineNumber)
@@ -2819,20 +2832,7 @@ public sealed partial class FormCommit : GitModuleForm
         AppSettings.CommitDialogSelectStagedOnEnterMessage.Value = !AppSettings.CommitDialogSelectStagedOnEnterMessage.Value;
     }
 
-    private void WrapCommitMessageBodyLines()
-    {
-        const int DefaultBodyLineLimit = 72;
-        int lineLimit = AppSettings.CommitValidationMaxCntCharsPerLine > 0
-            ? AppSettings.CommitValidationMaxCntCharsPerLine
-            : DefaultBodyLineLimit;
-
-        for (int line = 1; line < Message.LineCount(); line++)
-        {
-            WrapMessageLineIfNecessary(line, lineLimit);
-        }
-    }
-
-    private bool WrapMessageLineIfNecessary(int line, int lineLimit)
+    private bool WordWrapCommitMessageLineIfNecessary(int line, int lineLimit)
     {
         if (Message.LineLength(line) <= lineLimit)
         {

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -127,6 +127,8 @@ public sealed partial class FormCommit : GitModuleForm
 
     private readonly TranslationString _statusBarBranchWithoutRemote = new("(remote not configured)");
     private readonly TranslationString _untrackedRemote = new("(untracked)");
+
+    private readonly TranslationString _wrapCommitMessageBody = new("&Wrap body lines");
     #endregion
 
     private event Action? OnStageAreaLoaded;
@@ -247,6 +249,7 @@ public sealed partial class FormCommit : GitModuleForm
         SelectedDiff.AddContextMenuSeparator();
         _addSelectionToCommitMessageToolStripMenuItem = SelectedDiff.AddContextMenuEntry(_addSelectionToCommitMessage.Text, (s, e) => AddSelectionToCommitMessage());
         _addSelectionToCommitMessageToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.AddSelectionToCommitMessage);
+        Message.ContextMenuPopulating += Message_ContextMenuPopulating;
         fileTooltip.SetToolTip(modifyCommitMessageButton, _modifyCommitMessageButtonToolTip.Text);
         commitAuthorStatus.ToolTipText = _commitCommitterToolTip.Text;
         toolStageAllItem.ToolTipText = _stageAll.Text;
@@ -2241,6 +2244,12 @@ public sealed partial class FormCommit : GitModuleForm
         CheckForStagedAndCommit(push: false);
     }
 
+    private void Message_ContextMenuPopulating(object? sender, ContextMenuStrip menu)
+    {
+        int insertAt = menu.Items.OfType<ToolStripSeparator>().FirstOrDefault() is { } firstSeparator ? menu.Items.IndexOf(firstSeparator) : 0;
+        menu.Items.Insert(insertAt, new ToolStripMenuItem(_wrapCommitMessageBody.Text, null, (s, e) => WrapCommitMessageBodyLines()));
+    }
+
     private void Message_KeyDown(object sender, KeyEventArgs e)
     {
         if (e.Control && e.KeyCode == Keys.Enter)
@@ -2380,21 +2389,7 @@ public sealed partial class FormCommit : GitModuleForm
                 }
             }
 
-            bool WrapIfNecessary()
-            {
-                if (Message.LineLength(line) > limitX)
-                {
-                    string oldText = Message.Line(line);
-                    string newText = WordWrapper.WrapSingleLine(oldText, limitX);
-                    if (!string.Equals(oldText, newText))
-                    {
-                        Message.ReplaceLine(line, newText);
-                        return true;
-                    }
-                }
-
-                return false;
-            }
+            bool WrapIfNecessary() => WrapMessageLineIfNecessary(line, limitX);
         }
 
         void SetFormattedLine(int lineNumber)
@@ -2822,6 +2817,37 @@ public sealed partial class FormCommit : GitModuleForm
     private void tsmiSelectStagedOnEnterMessage_Click(object sender, EventArgs e)
     {
         AppSettings.CommitDialogSelectStagedOnEnterMessage.Value = !AppSettings.CommitDialogSelectStagedOnEnterMessage.Value;
+    }
+
+    private void WrapCommitMessageBodyLines()
+    {
+        const int DefaultBodyLineLimit = 72;
+        int lineLimit = AppSettings.CommitValidationMaxCntCharsPerLine > 0
+            ? AppSettings.CommitValidationMaxCntCharsPerLine
+            : DefaultBodyLineLimit;
+
+        for (int line = 1; line < Message.LineCount(); line++)
+        {
+            WrapMessageLineIfNecessary(line, lineLimit);
+        }
+    }
+
+    private bool WrapMessageLineIfNecessary(int line, int lineLimit)
+    {
+        if (Message.LineLength(line) <= lineLimit)
+        {
+            return false;
+        }
+
+        string oldText = Message.Line(line);
+        string newText = WordWrapper.WrapSingleLine(oldText, lineLimit);
+        if (string.Equals(oldText, newText))
+        {
+            return false;
+        }
+
+        Message.ReplaceLine(line, newText);
+        return true;
     }
 
     internal readonly struct TestAccessor

--- a/src/app/GitUI/SpellChecker/EditNetSpell.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.cs
@@ -19,6 +19,12 @@ public partial class EditNetSpell : GitModuleControl
 {
     public event EventHandler? TextAssigned;
 
+    /// <summary>
+    ///  Raised after all built-in items have been added to the spell-check context menu,
+    ///  allowing consumers to append additional items.
+    /// </summary>
+    public event EventHandler<ContextMenuStrip>? ContextMenuPopulating;
+
     private readonly TranslationString _cutMenuItemText = new("Cut");
     private readonly TranslationString _copyMenuItemText = new("Copy");
     private readonly TranslationString _pasteMenuItemText = new("Paste");
@@ -569,6 +575,8 @@ public partial class EditNetSpell : GitModuleControl
             ToggleAutoCompletion();
         };
         SpellCheckContextMenu.Items.Add(mi);
+
+        ContextMenuPopulating?.Invoke(this, SpellCheckContextMenu);
     }
 
     private void RemoveWordClick(object? sender, EventArgs e)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -4241,6 +4241,10 @@ You can unset the template:
         <source>(untracked)</source>
         <target />
       </trans-unit>
+      <trans-unit id="_wrapCommitMessageBody.Text">
+        <source>&amp;Wrap body lines</source>
+        <target />
+      </trans-unit>
       <trans-unit id="branchNameLabel.Text">
         <source>(Branch name)</source>
         <target />

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -4241,8 +4241,8 @@ You can unset the template:
         <source>(untracked)</source>
         <target />
       </trans-unit>
-      <trans-unit id="_wrapCommitMessageBody.Text">
-        <source>&amp;Wrap body lines</source>
+      <trans-unit id="_wordWrapCommitMessageBody.Text">
+        <source>&amp;Word wrap (except subject line)</source>
         <target />
       </trans-unit>
       <trans-unit id="branchNameLabel.Text">


### PR DESCRIPTION
Addresses https://github.com/gitextensions/gitextensions/pull/13149#issuecomment-5182613180

## Proposed changes

`FormCommit`: Add "Word wrap (except subject line)" to context menu of commit message editor

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="720" height="219" alt="image" src="https://github.com/user-attachments/assets/0780af22-5ede-4a3b-9b60-b97fa0c0f25d" />

### After

<img width="1232" height="259" alt="image" src="https://github.com/user-attachments/assets/fa095b15-d876-4b46-b621-4559384b2809" />

<img width="1232" height="259" alt="image" src="https://github.com/user-attachments/assets/304db592-a0a5-4da6-84c8-f60b31d1a227" />

### Not changed (for reference)

<img width="447" height="241" alt="image" src="https://github.com/user-attachments/assets/8e01a143-8c66-4d97-b4fb-8e21c74f1bc3" />

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).