### PR TITLE
fix(installer): remove per user install

### DIFF
--- a/setup/installer/Product.wxs
+++ b/setup/installer/Product.wxs
@@ -25,7 +25,7 @@
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
     <WixVariable Id="WixUIDialogBmp" Value="dialog.bmp" />
     <WixVariable Id="WixUIBannerBmp" Value="banner.bmp" />
-    <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes" />
+    <WixVariable Id="WixUISupportPerUser" Value="0" Overridable="yes" />
     <WixVariable Id="WixUISupportPerMachine" Value="1" Overridable="yes" />
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.PlatformProgramFilesFolder)">

--- a/setup/installer/UI/WixUI.wxs
+++ b/setup/installer/UI/WixUI.wxs
@@ -38,10 +38,8 @@
 
       <?include ../Config.wxi ?>
       
-      <Publish Dialog="GitEx_WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallScopeDlg">1</Publish>
-      <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="GitEx_WelcomeDlg" Order="1">1</Publish>
-      <Publish Dialog="InstallScopeDlg" Control="Next" Event="NewDialog" Value="GitEx_InstallDirDlg" Order="1">1</Publish>
-      <Publish Dialog="GitEx_InstallDirDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg">1</Publish>
+      <Publish Dialog="GitEx_WelcomeDlg" Control="Next" Event="NewDialog" Value="GitEx_InstallDirDlg">1</Publish>
+      <Publish Dialog="GitEx_InstallDirDlg" Control="Back" Event="NewDialog" Value="GitEx_WelcomeDlg">1</Publish>
       
       <Publish Dialog="GitEx_InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
       <Publish Dialog="GitEx_InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>


### PR DESCRIPTION
Fixes #9074

## Proposed changes

The `InstallScopeDlg` is the dialog that presents the "install for user only" vs. "install for all users" choice.

- **`setup/installer/Product.wxs`**: Set `WixUISupportPerUser` to `0`, which disables the per-user installation path entirely.
- **`setup/installer/UI/WixUI.wxs`**: Removed the `InstallScopeDlg` from the dialog navigation flow — the installer now goes directly from the Welcome dialog to the Install Directory dialog, skipping the scope selection screen.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

not available

## Test methodology <!-- How did you ensure quality? -->

- on next release

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).