### PR TITLE
feat(revision grid): hide Copilot App checkpoint refs

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -232,3 +232,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/07/15, SparshGarg999, Sparsh Garg, sparshgarg307@gmail.com
 2026/08/05, mantasaudickas, Mantas Audickas, mantas.audickas@gmail.com
 2026/08/04, AlexThunder1989, Alexander Karlsson, alexthunder(at)gmail.com
+2026/08/21, gusarov, Dmitry Gusarov, Dmitry.Gusarov@gmail.com

--- a/src/app/GitCommands/Git/GitRefName.cs
+++ b/src/app/GitCommands/Git/GitRefName.cs
@@ -40,6 +40,9 @@ public static partial class GitRefName
     /// <summary>"refs/sessions/".</summary>
     public static string RefsSessionsPrefix { get; } = "refs/sessions/";
 
+    /// <summary>"refs/copilot/checkpoints/".</summary>
+    public static string RefsCopilotCheckpointsPrefix { get; } = "refs/copilot/checkpoints/";
+
     /// <summary>"^{}".</summary>
     public static string TagDereferenceSuffix { get; } = "^{}";
 

--- a/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -481,6 +481,7 @@ public record FilterInfo
             if (!AppSettings.ShowSessionRefs)
             {
                 filter.Add($"--exclude={GitRefName.RefsSessionsPrefix}**");
+                filter.Add($"--exclude={GitRefName.RefsCopilotCheckpointsPrefix}**");
             }
 
             // All refs/

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -1145,13 +1145,22 @@ public class FilterInfoTests
                 args.ToString().Should().NotMatchRegex(@"(^|\s)--exclude=refs/stash($|\s)");
             }
 
-            if (showAll && !showSessionRefs)
+            string[] sessionRefExclusions =
             {
-                args.ToString().Should().MatchRegex(@"(^|\s)--exclude=refs/sessions/\*\*($|\s)");
-            }
-            else
+                @"(^|\s)--exclude=refs/sessions/\*\*($|\s)",
+                @"(^|\s)--exclude=refs/copilot/checkpoints/\*\*($|\s)"
+            };
+
+            foreach (string sessionRefExclusion in sessionRefExclusions)
             {
-                args.ToString().Should().NotMatchRegex(@"(^|\s)--exclude=refs/sessions/\*\*($|\s)");
+                if (showAll && !showSessionRefs)
+                {
+                    args.ToString().Should().MatchRegex(sessionRefExclusion);
+                }
+                else
+                {
+                    args.ToString().Should().NotMatchRegex(sessionRefExclusion);
+                }
             }
 
             if (showCurrentBranchOnly && !objectId.IsZero)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- CoPilot App produces uncontrollable amount of ref/copilot/checkpoints 
- GitExtensions already has "Show sessions" button in UI
- Existing regex takes care presumably about VS Extension, other generic agents or older version of CoPilot App that was done here:
https://github.com/gitextensions/gitextensions/pull/12953
- This PR adds current pattern for CoPilot app specifically, preserving previous pattern as well

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->
<img width="966" height="360" alt="image" src="https://github.com/user-attachments/assets/b9d378af-a3b6-459e-83e9-9126002f5c99" />

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
