### PR TITLE
fix(revision filter): suppress globbing in WSL

### DIFF
--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -392,7 +392,7 @@ public static partial class AppSettings
     // Currently not configurable in UI (Set manually in settings file)
     public static string WslGitCommand
     {
-        get => GetString(nameof(WslGitCommand), "git");
+        get => GetString(nameof(WslGitCommand), "noglob git");
     }
 
     public static bool StashKeepIndex


### PR DESCRIPTION
Fixes #13156

## Proposed changes

**not final**

`AppSettings.WslGitCommand`:
prepend `"noglob "` in front of the git command
in order to avoid globbing by f.i. zsh in WSL

Will not work with POSIX shells, which might need "set -f; git ..."

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

?

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).