### PR TITLE
fix(ManagedExtensibility): use correct load func

### DIFF
--- a/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -1,5 +1,6 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.Loader;
 using GitUI;
 using Microsoft.VisualStudio.Composition;
 
@@ -96,7 +97,7 @@ public static class ManagedExtensibility
         {
             try
             {
-                Assembly assembly = Assembly.Load(file.FullName);
+                Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(file.FullName);
 
                 // Eagerly validate that all types in the assembly can be resolved.
                 // Outdated plugins targeting an incompatible interface version succeed
@@ -182,7 +183,7 @@ public static class ManagedExtensibility
 
                     return fileDescription is not null && args.Name.StartsWith(fileDescription);
                 });
-            return dll is null ? null : Assembly.Load(dll);
+            return dll is null ? null : AssemblyLoadContext.Default.LoadFromAssemblyPath(dll);
         }
         catch
         {


### PR DESCRIPTION
Fixes regression from #13241

## Proposed changes

`ManagedExtensibility`: use function `AssemblyLoadContext.Default.LoadFromAssemblyPath` instead of `Assembly.Load` as replacement for `Assembly.LoadFrom`

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

no plugins

### After

plugins loaded

## Test methodology <!-- How did you ensure quality? -->

- manually
- no exceptions any longer when run with debugger

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).