### PR TITLE
Fix/revision links stale remote

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -234,3 +234,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/08/04, AlexThunder1989, Alexander Karlsson, alexthunder(at)gmail.com
 2026/08/20, vovodroid, Arthur Pirozhkov, qa23d-vvdge(at)yahoo.com
 2026/08/21, gusarov, Dmitry Gusarov, Dmitry.Gusarov@gmail.com
+2026/08/31, inuik, Rishi Theivendran, vaendaam-29522253(at)yahoo.com

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1275,12 +1275,12 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
             return;
         }
 
-        _selectedRevisionUpdatedTargets |= UpdateTargets.CommitInfo;
-
         if (revision is null)
         {
             return;
         }
+
+        _selectedRevisionUpdatedTargets |= UpdateTargets.CommitInfo;
 
         IReadOnlyList<ObjectId> children = RevisionGrid.GetRevisionChildren(revision.ObjectId);
         RevisionInfo.SetRevisionWithChildren(revision, children);
@@ -1749,6 +1749,8 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
                 RevisionGrid.ResetAllFilters();
                 ToolStripFilters.ClearQuickFilters();
                 revisionDiff.RepositoryChanged();
+
+                _selectedRevisionUpdatedTargets = UpdateTargets.None;
             }
 
             RevisionInfo.SetRevisionWithChildren(revision: null, children: []);
@@ -3074,8 +3076,11 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         public SplitterManager SplitterManager => _form._splitterManager;
         public TabPage TreeTabPage => _form.TreeTabPage;
         public FilterToolBar ToolStripFilters => _form.ToolStripFilters;
+        public CommitInfo.CommitInfo RevisionInfo => _form.RevisionInfo;
+        public TabPage CommitInfoTabPage => _form.CommitInfoTabPage;
 
         public void RefreshRevisions() => _form.RefreshRevisions();
+        public void SetWorkingDir(string? path) => _form.SetWorkingDir(path);
     }
 
     private void FormBrowse_DragDrop(object? sender, DragEventArgs e)

--- a/src/app/GitUI/CommitInfo/CommitInfo.cs
+++ b/src/app/GitUI/CommitInfo/CommitInfo.cs
@@ -62,6 +62,7 @@ public partial class CommitInfo : GitModuleControl
     private readonly IConfigFileRemoteSettingsManager _remotesManager;
     private readonly GitDescribeProvider _gitDescribeProvider;
     private readonly CancellationTokenSequence _asyncLoadCancellation = new();
+    private IGitUICommandsSource? _uiCommandsSource;
 
     private readonly IDisposable _revisionInfoResizedSubscription;
     private readonly IDisposable _commitMessageResizedSubscription;
@@ -143,6 +144,11 @@ public partial class CommitInfo : GitModuleControl
         {
             _asyncLoadCancellation.Dispose();
 
+            if (_uiCommandsSource is not null)
+            {
+                _uiCommandsSource.UICommandsChanged -= OnUICommandsChanged;
+            }
+
             components?.Dispose();
         }
 
@@ -159,6 +165,13 @@ public partial class CommitInfo : GitModuleControl
     {
         base.OnUICommandsSourceSet(source);
 
+        if (_uiCommandsSource is not null)
+        {
+            _uiCommandsSource.UICommandsChanged -= OnUICommandsChanged;
+        }
+
+        _uiCommandsSource = source;
+
         if (source is null)
         {
             _linkFactory = null;
@@ -167,14 +180,38 @@ public partial class CommitInfo : GitModuleControl
         }
         else
         {
-            _linkFactory = source.UICommands.GetRequiredService<ILinkFactory>();
-            _commitDataBodyRenderer = new CommitDataBodyRenderer(() => Module, _linkFactory);
-            _refsFormatter = new RefsFormatter(_linkFactory);
+            InitializeRenderers(source.UICommands);
 
-            source.UICommandsChanged += delegate { RefreshSortedTags(); };
+            source.UICommandsChanged += OnUICommandsChanged;
 
             // call this event handler also now (necessary for "Contained in branches/tags")
             RefreshSortedTags();
+        }
+    }
+
+    private void InitializeRenderers(IGitUICommands uiCommands)
+    {
+        _linkFactory = uiCommands.GetRequiredService<ILinkFactory>();
+        _commitDataBodyRenderer = new CommitDataBodyRenderer(() => Module, _linkFactory);
+        _refsFormatter = new RefsFormatter(_linkFactory);
+    }
+
+    private void OnUICommandsChanged(object? sender, GitUICommandsChangedEventArgs e)
+    {
+        if (sender is not IGitUICommandsSource source)
+        {
+            return;
+        }
+
+        // Cancel unconditionally: any in-flight load belongs to the previous repository.
+        CancellationToken cancellationToken = _asyncLoadCancellation.Next();
+
+        InitializeRenderers(source.UICommands);
+        RefreshSortedTags();
+
+        if (_revision is not null && tableLayout.Visible)
+        {
+            ReloadCommitInfo(cancellationToken);
         }
     }
 
@@ -225,6 +262,8 @@ public partial class CommitInfo : GitModuleControl
         if (revision is null)
         {
             tableLayout.Visible = false;
+            ClearRevisionDetailsFields();
+            RevisionInfo.Clear();
             return;
         }
 
@@ -319,11 +358,8 @@ public partial class CommitInfo : GitModuleControl
         _tags = null;
         _annotatedTagsMessages = null;
 
-        _annotatedTagsInfo = "";
-        _linksInfo = "";
-        _branchInfo = "";
-        _tagInfo = "";
-        _gitDescribeInfo = "";
+        ClearRevisionDetailsFields();
+        RevisionInfo.Clear();
 
         if (_revision is not null && !_revision.IsArtificial && !_revision.IsAutostash)
         {
@@ -595,6 +631,15 @@ public partial class CommitInfo : GitModuleControl
                 }
             }
         }
+    }
+
+    private void ClearRevisionDetailsFields()
+    {
+        _annotatedTagsInfo = "";
+        _linksInfo = "";
+        _branchInfo = "";
+        _tagInfo = "";
+        _gitDescribeInfo = "";
     }
 
     private void UpdateRevisionInfo()

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -341,6 +341,46 @@ public class FormBrowseTests
             commands);
     }
 
+    [Test]
+    public void SetWorkingDir_should_reload_commit_info_for_auto_selected_revision_after_repository_switch()
+    {
+        using (CommitInfoPanelTestSettingsScope.ForBrowseRepositorySwitch())
+        {
+            using GitModuleTestHelper repoA = new("formBrowseRepoSwitchA");
+            using GitModuleTestHelper repoB = new("formBrowseRepoSwitchB");
+            CreateCommitWithSubject(repoA, "REPO_A_HEAD subject");
+            CreateCommitWithSubject(repoB, "REPO_B_HEAD subject");
+
+            GitUICommands commandsA = new(GlobalServiceContainer.CreateDefaultMockServiceContainer(), repoA.Module);
+
+            RunFormTest(
+                async form =>
+                {
+                    FormBrowse.TestAccessor ta = form.GetTestAccessor();
+                    ta.CommitInfoTabControl.SelectedTab = ta.CommitInfoTabPage;
+
+                    WaitForRevisionsToBeLoaded(form);
+                    await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                    ta.RevisionInfo.GetTestAccessor().CommitMessage.Text.Should().Contain("REPO_A_HEAD");
+
+                    ta.SetWorkingDir(repoB.Module.WorkingDir);
+                    WaitForRevisionsToBeLoaded(form);
+                    await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                    GitUI.CommitInfo.CommitInfo.TestAccessor commitInfoAccessor = ta.RevisionInfo.GetTestAccessor();
+                    commitInfoAccessor.CommitMessage.Text.Should().Contain("REPO_B_HEAD");
+                    commitInfoAccessor.CommitMessage.Text.Should().NotContain("REPO_A_HEAD");
+                },
+                commandsA);
+        }
+    }
+
+    private static void CreateCommitWithSubject(GitModuleTestHelper helper, string subject)
+    {
+        helper.Module.GitExecutable.GetOutput($@"commit --allow-empty -m ""{subject}""");
+    }
+
     private static void RunFormTest(Action<FormBrowse> testDriver, GitUICommands commands)
     {
         UITest.RunForm(

--- a/tests/app/IntegrationTests/UI.IntegrationTests/CommitInfoPanelTestSettingsScope.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/CommitInfoPanelTestSettingsScope.cs
@@ -1,0 +1,75 @@
+using GitCommands;
+using GitCommands.Settings;
+
+namespace GitExtensions.UITests;
+
+/// <summary>
+/// Restores <see cref="AppSettings"/> changed for CommitInfo / FormBrowse integration tests.
+/// </summary>
+internal sealed class CommitInfoPanelTestSettingsScope : IDisposable
+{
+    private readonly bool _commitInfoShowContainedInBranchesLocal;
+    private readonly bool _commitInfoShowContainedInBranchesRemote;
+    private readonly bool _commitInfoShowContainedInBranchesRemoteIfNoLocal;
+    private readonly bool _commitInfoShowContainedInTags;
+    private readonly bool _commitInfoShowTagThisCommitDerivesFrom;
+    private readonly bool _showAnnotatedTagsMessages;
+    private readonly CommitInfoPosition _commitInfoPosition;
+    private readonly bool _revisionGraphShowArtificialCommits;
+
+    private CommitInfoPanelTestSettingsScope(
+        bool disableAsyncCommitInfoData,
+        CommitInfoPosition? commitInfoPosition,
+        bool? revisionGraphShowArtificialCommits)
+    {
+        _commitInfoShowContainedInBranchesLocal = AppSettings.CommitInfoShowContainedInBranchesLocal;
+        _commitInfoShowContainedInBranchesRemote = AppSettings.CommitInfoShowContainedInBranchesRemote;
+        _commitInfoShowContainedInBranchesRemoteIfNoLocal = AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal;
+        _commitInfoShowContainedInTags = AppSettings.CommitInfoShowContainedInTags;
+        _commitInfoShowTagThisCommitDerivesFrom = AppSettings.CommitInfoShowTagThisCommitDerivesFrom;
+        _showAnnotatedTagsMessages = AppSettings.ShowAnnotatedTagsMessages;
+        _commitInfoPosition = AppSettings.CommitInfoPosition;
+        _revisionGraphShowArtificialCommits = AppSettings.RevisionGraphShowArtificialCommits;
+
+        if (disableAsyncCommitInfoData)
+        {
+            AppSettings.CommitInfoShowContainedInBranchesLocal = false;
+            AppSettings.CommitInfoShowContainedInBranchesRemote = false;
+            AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal = false;
+            AppSettings.CommitInfoShowContainedInTags = false;
+            AppSettings.CommitInfoShowTagThisCommitDerivesFrom = false;
+            AppSettings.ShowAnnotatedTagsMessages = false;
+        }
+
+        if (commitInfoPosition is not null)
+        {
+            AppSettings.CommitInfoPosition = commitInfoPosition.Value;
+        }
+
+        if (revisionGraphShowArtificialCommits is not null)
+        {
+            AppSettings.RevisionGraphShowArtificialCommits = revisionGraphShowArtificialCommits.Value;
+        }
+    }
+
+    public static CommitInfoPanelTestSettingsScope ForMinimalCommitInfoDataLoad()
+        => new(disableAsyncCommitInfoData: true, commitInfoPosition: null, revisionGraphShowArtificialCommits: null);
+
+    public static CommitInfoPanelTestSettingsScope ForBrowseRepositorySwitch()
+        => new(
+            disableAsyncCommitInfoData: true,
+            commitInfoPosition: CommitInfoPosition.BelowList,
+            revisionGraphShowArtificialCommits: false);
+
+    public void Dispose()
+    {
+        AppSettings.CommitInfoShowContainedInBranchesLocal = _commitInfoShowContainedInBranchesLocal;
+        AppSettings.CommitInfoShowContainedInBranchesRemote = _commitInfoShowContainedInBranchesRemote;
+        AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal = _commitInfoShowContainedInBranchesRemoteIfNoLocal;
+        AppSettings.CommitInfoShowContainedInTags = _commitInfoShowContainedInTags;
+        AppSettings.CommitInfoShowTagThisCommitDerivesFrom = _commitInfoShowTagThisCommitDerivesFrom;
+        AppSettings.ShowAnnotatedTagsMessages = _showAnnotatedTagsMessages;
+        AppSettings.CommitInfoPosition = _commitInfoPosition;
+        AppSettings.RevisionGraphShowArtificialCommits = _revisionGraphShowArtificialCommits;
+    }
+}

--- a/tests/app/IntegrationTests/UI.IntegrationTests/ExternalLinksIntegrationTestHelper.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/ExternalLinksIntegrationTestHelper.cs
@@ -1,0 +1,174 @@
+using System.ComponentModel.Design;
+using CommonTestUtils;
+using GitCommands;
+using GitCommands.Config;
+using GitCommands.ExternalLinks;
+using GitCommands.Git;
+using GitCommands.Settings;
+using GitExtensions.Extensibility.Git;
+using GitExtensions.Extensibility.Settings;
+using GitExtUtils;
+using GitUI;
+using GitUI.Editor.RichTextBoxExtension;
+using GitUIPluginInterfaces;
+using ResourceManager;
+
+namespace GitExtensions.UITests;
+
+internal static class ExternalLinksIntegrationTestHelper
+{
+    internal const string MergePullRequestSubject = "Merge pull request #3657";
+    internal const string MergePullRequestBody = "Merge pull request #3657 from RussKie/tweak_FormRemotes_tooltips";
+
+    internal const string RepoAUserRepoSlug = "userA/repoA";
+    internal const string RepoBUserRepoSlug = "userB/repoB";
+
+    private const string GitHubSchemeAndHost = "https://github.com/";
+
+    internal static readonly DateTime SampleAuthorTime = new(2010, 3, 24, 13, 37, 12, DateTimeKind.Unspecified);
+
+    internal static string OriginUrlForUserRepo(string userRepoSlug) => GitHubSchemeAndHost + userRepoSlug + ".git";
+
+    public static ExternalLinkDefinition CreateGitHubIssuesLinkDefinition()
+    {
+        ExternalLinkDefinition definition = new()
+        {
+            Name = "GitHub - issues",
+            Enabled = true,
+            SearchPattern = @"(\s*(,|and)?\s*#\d+)+",
+            NestedSearchPattern = @"(\d+)+",
+            RemoteSearchPattern = @"github.com[:/](.+)\.git",
+            UseRemotesPattern = "origin",
+            UseOnlyFirstRemote = true,
+        };
+        definition.SearchInParts.Add(ExternalLinkDefinition.RevisionPart.Message);
+        definition.RemoteSearchInParts.Add(ExternalLinkDefinition.RemotePart.URL);
+        definition.LinkFormats.Add(new ExternalLinkFormat
+        {
+            Caption = "Issue {1}",
+            Format = "https://github.com/{0}/issues/{1}",
+        });
+        return definition;
+    }
+
+    public static void ConfigureRepositoryForExternalLinks(GitModuleTestHelper helper, string originUrl, ExternalLinkDefinition linkDefinition)
+    {
+        GitModule module = helper.Module;
+        module.SetSetting(string.Format(SettingKeyString.RemoteUrl, "origin"), originUrl);
+
+        string settingsPath = helper.CreateRepoFile(".git", "GitExtensions.settings", "<dictionary />");
+        using GitExtSettingsCache settingsCache = new(settingsPath);
+        DistributedSettings settings = new(lowerPriority: null, settingsCache, SettingLevel.Unknown);
+        new ExternalLinksStorage().Save(settings, [linkDefinition]);
+        settings.Save();
+    }
+
+    public static GitRevision CreateMergePullRequestRevision(string authorFullIdentity, string authorEmail, DateTime authorTime)
+    {
+        return new GitRevision(ObjectId.Random())
+        {
+            Author = authorFullIdentity,
+            AuthorUnixTime = DateTimeUtils.ToUnixTime(authorTime),
+            AuthorEmail = authorEmail,
+            Subject = MergePullRequestSubject,
+            Body = MergePullRequestBody,
+        };
+    }
+
+    public static string? FindFirstGitHubIssueLink(RichTextBox box)
+    {
+        for (int i = 0; i < box.TextLength; i++)
+        {
+            string? link = box.GetLink(i);
+            if (link?.Contains("github.com", StringComparison.OrdinalIgnoreCase) is true
+                && link.Contains("issues", StringComparison.OrdinalIgnoreCase))
+            {
+                return link;
+            }
+        }
+
+        return null;
+    }
+
+    public static int FindLinkCharIndex(RichTextBox box, string uriPart)
+    {
+        for (int i = 0; i < box.TextLength; i++)
+        {
+            string? link = box.GetLink(i);
+            if (link?.Contains(uriPart, StringComparison.Ordinal) is true)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}
+
+internal sealed class ExternalLinksTwoRepositoryFixture : IDisposable
+{
+    private readonly GitModuleTestHelper _repoA;
+    private readonly GitModuleTestHelper _repoB;
+
+    public GitUICommands CommandsA { get; }
+    public GitUICommands CommandsB { get; }
+    public TestGitUICommandsSource UiCommandsSource { get; }
+    public GitRevision Revision { get; }
+
+    public ExternalLinksTwoRepositoryFixture(
+        ILinkFactory linkFactory,
+        string repositoryNamePrefix,
+        string authorFullIdentity,
+        string authorEmail,
+        DateTime authorTime)
+    {
+        ExternalLinkDefinition linkDefinition = ExternalLinksIntegrationTestHelper.CreateGitHubIssuesLinkDefinition();
+
+        _repoA = new GitModuleTestHelper($"{repositoryNamePrefix}A");
+        _repoB = new GitModuleTestHelper($"{repositoryNamePrefix}B");
+        ExternalLinksIntegrationTestHelper.ConfigureRepositoryForExternalLinks(
+            _repoA,
+            ExternalLinksIntegrationTestHelper.OriginUrlForUserRepo(ExternalLinksIntegrationTestHelper.RepoAUserRepoSlug),
+            linkDefinition);
+        ExternalLinksIntegrationTestHelper.ConfigureRepositoryForExternalLinks(
+            _repoB,
+            ExternalLinksIntegrationTestHelper.OriginUrlForUserRepo(ExternalLinksIntegrationTestHelper.RepoBUserRepoSlug),
+            linkDefinition);
+
+        ServiceContainer serviceContainer = GlobalServiceContainer.CreateDefaultMockServiceContainer();
+        serviceContainer.RemoveService<ILinkFactory>();
+        serviceContainer.AddService<ILinkFactory>(linkFactory);
+
+        CommandsA = new GitUICommands(serviceContainer, _repoA.Module);
+        CommandsB = new GitUICommands(serviceContainer, _repoB.Module);
+        UiCommandsSource = new TestGitUICommandsSource(CommandsA);
+        Revision = ExternalLinksIntegrationTestHelper.CreateMergePullRequestRevision(authorFullIdentity, authorEmail, authorTime);
+    }
+
+    public void Dispose()
+    {
+        _repoB.Dispose();
+        _repoA.Dispose();
+    }
+}
+
+internal sealed class TestGitUICommandsSource : IGitUICommandsSource
+{
+    private IGitUICommands _commands;
+
+    public TestGitUICommandsSource(IGitUICommands commands)
+    {
+        _commands = commands;
+    }
+
+    public event EventHandler<GitUICommandsChangedEventArgs>? UICommandsChanged;
+
+    public IGitUICommands UICommands => _commands;
+
+    public void SetCommands(IGitUICommands commands)
+    {
+        IGitUICommands oldCommands = _commands;
+        _commands = commands;
+        UICommandsChanged?.Invoke(this, new GitUICommandsChangedEventArgs(oldCommands));
+    }
+}

--- a/tests/app/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
+++ b/tests/app/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
@@ -1,11 +1,16 @@
 ﻿using System.ComponentModel.Design;
 using CommonTestUtils;
 using GitCommands;
+using GitCommands.Config;
+using GitCommands.ExternalLinks;
 using GitCommands.Git;
+using GitCommands.Settings;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Git;
+using GitExtensions.Extensibility.Settings;
 using GitExtUtils;
 using GitUI;
+using GitUI.Editor.RichTextBoxExtension;
 using GitUIPluginInterfaces;
 using NSubstitute;
 using ResourceManager;
@@ -336,16 +341,19 @@ public class CommitInfoTests
     }
 
     private void RunCommitInfoTest(Func<GitUI.CommitInfo.CommitInfo, Task> runTestAsync)
+        => RunCommitInfoTest(CreateDefaultUiCommandsSource(), runTestAsync, stageEmptyTagListOutput: true);
+
+    private void RunCommitInfoTest(IGitUICommandsSource uiCommandsSource, Func<GitUI.CommitInfo.CommitInfo, Task> runTestAsync, bool stageEmptyTagListOutput = false)
     {
+        if (stageEmptyTagListOutput)
+        {
+            // CommitInfo.UICommandsSource assignment triggers RefreshSortedTags
+            _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/", "");
+        }
+
         UITest.RunControl(
             createControl: form =>
             {
-                IGitUICommandsSource uiCommandsSource = Substitute.For<IGitUICommandsSource>();
-                uiCommandsSource.UICommands.Returns(x => _commands);
-
-                // the following assignment of CommitInfo.UICommandsSource will already call this command
-                _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/", "");
-
                 form.Size = new(600, 480);
 
                 return new GitUI.CommitInfo.CommitInfo
@@ -363,6 +371,56 @@ public class CommitInfoTests
 
                 await runTestAsync(commitInfo);
             });
+    }
+
+    private IGitUICommandsSource CreateDefaultUiCommandsSource()
+    {
+        IGitUICommandsSource uiCommandsSource = Substitute.For<IGitUICommandsSource>();
+        uiCommandsSource.UICommands.Returns(_ => _commands);
+        return uiCommandsSource;
+    }
+
+    [Test]
+    public void ReloadCommitInfo_should_use_current_repository_for_related_links_after_module_switch()
+    {
+        using (CommitInfoPanelTestSettingsScope.ForMinimalCommitInfoDataLoad())
+        {
+            using ExternalLinksTwoRepositoryFixture fixture = new(
+                _mockLinkFactory,
+                repositoryNamePrefix: "externalLinksRepo",
+                ReferenceRepository.AuthorFullIdentity,
+                ReferenceRepository.AuthorEmail,
+                ExternalLinksIntegrationTestHelper.SampleAuthorTime);
+
+            RunCommitInfoTest(
+                fixture.UiCommandsSource,
+                async commitInfo =>
+                {
+                    commitInfo.SetRevisionWithChildren(fixture.Revision, children: null);
+                    await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                    GitUI.CommitInfo.CommitInfo.TestAccessor ta = commitInfo.GetTestAccessor();
+                    string? linkUriA = ExternalLinksIntegrationTestHelper.FindFirstGitHubIssueLink(ta.RevisionInfo);
+                    linkUriA.Should().NotBeNull();
+                    linkUriA.Should().Contain(ExternalLinksIntegrationTestHelper.RepoAUserRepoSlug);
+
+                    fixture.UiCommandsSource.SetCommands(fixture.CommandsB);
+                    await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                    ta.RevisionInfo.Text.Should().NotContain(ExternalLinksIntegrationTestHelper.RepoAUserRepoSlug);
+
+                    string? linkUriB = ExternalLinksIntegrationTestHelper.FindFirstGitHubIssueLink(ta.RevisionInfo);
+                    linkUriB.Should().NotBeNull();
+                    linkUriB.Should().Contain(ExternalLinksIntegrationTestHelper.RepoBUserRepoSlug);
+
+                    int linkStart = ExternalLinksIntegrationTestHelper.FindLinkCharIndex(
+                        ta.RevisionInfo,
+                        ExternalLinksIntegrationTestHelper.RepoBUserRepoSlug);
+                    linkStart.Should().BeGreaterThan(-1);
+                    ta.LinkClicked(ta.RevisionInfo, new("Issue 3657", linkStart, linkLength: 10));
+                    _mockLinkFactory.LastExecutedLinkUri.Should().Contain(ExternalLinksIntegrationTestHelper.RepoBUserRepoSlug);
+                });
+        }
     }
 
     private class MockLinkFactory : ILinkFactory


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13246

## Proposed changes

- Fix **Related links** in commit info using the wrong repository’s remote URL after switching from repo A to repo B (first auto-selected commit still opened repo A’s URL until selection changed).
- **FormBrowse:** reset selection update flags when the working directory changes; do not mark commit info as updated when `FillCommitInfo` is called with a null revision (avoids skipping reload after grid refresh).
- **CommitInfo:** clear revision-details UI when reloading; snapshot module for async link parsing; ignore stale async results when revision or working dir changed; reload related links on `UICommandsChanged`.
- **Test:** integration test `ReloadCommitInfo_should_use_current_repository_for_related_links_after_module_switch` (reproduces the GUI path, not parser-only coverage).


### Before

1. Open repo A (e.g. recent repo on startup).
2. Switch to repo B.
3. On the auto-selected commit, click a **Related links** entry (e.g. GitHub issue from merge message).
4. Browser opens URL for **repo A** `origin`.

### After
Same steps; link uses **repo B** `origin` without changing selection.


## Test methodology <!-- How did you ensure quality? -->

- `dotnet test tests/app/IntegrationTests/UI.IntegrationTests/UI.IntegrationTests.csproj --filter FullyQualifiedName~ReloadCommitInfo_should_use_current_repository_for_related_links_after_module_switch`
- Manual: startup repo A → switch to repo B → click Related link on HEAD once; confirm URL matches B. Repeat after changing commit and back (regression check).
- Commit order: test (fails without fix) → fix → CI workflow.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.55.windows.3
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

- Squash merge

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
