### PR TITLE
fix(VS integration): support prerelease versions

### DIFF
--- a/src/app/GitUI/VisualStudioIntegration.cs
+++ b/src/app/GitUI/VisualStudioIntegration.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using EnvDTE;
@@ -26,6 +26,7 @@ internal static class VisualStudioIntegration
             Executable executable = new(vswhere);
             ArgumentBuilder arguments =
             [
+                "-prerelease", // Include prerelease versions of Visual Studio in the search.
                 "-latest",
                 "-property productPath"
             ];

--- a/src/app/GitUI/VisualStudioIntegration.cs
+++ b/src/app/GitUI/VisualStudioIntegration.cs
@@ -28,6 +28,10 @@ internal static class VisualStudioIntegration
             [
                 "-prerelease", // Include prerelease versions of Visual Studio in the search.
                 "-latest",
+                "-requires Microsoft.VisualStudio.Product.Enterprise",
+                "-requires Microsoft.VisualStudio.Product.Professional",
+                "-requires Microsoft.VisualStudio.Product.Community",
+                "-requiresAny",
                 "-property productPath"
             ];
             _devEnvPath = await executable.GetOutputAsync(arguments);


### PR DESCRIPTION
Fixes #13253

## Proposed changes

`VisualStudioIntegration`: 
- include installed prereleases (Insiders) of Visual Studio 

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually

## Test environment(s) <!-- Remove any that don't apply -->

- tested with release version 18.8.3 only

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).