### PR TITLE
Fix minimum height of commit panel

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -234,3 +234,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/08/04, AlexThunder1989, Alexander Karlsson, alexthunder(at)gmail.com
 2026/08/20, vovodroid, Arthur Pirozhkov, qa23d-vvdge(at)yahoo.com
 2026/08/21, gusarov, Dmitry Gusarov, Dmitry.Gusarov@gmail.com
+2026/09/08, norgera, Nathan Orgera, nathan.orgera@gmail.com

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -290,7 +290,7 @@ public sealed partial class FormCommit : GitModuleForm
         btnResetAllChanges.Visible = AppSettings.ShowResetAllChanges;
         btnResetUnstagedChanges.Visible = AppSettings.ShowResetWorkTreeChanges;
         CommitAndPush.Visible = AppSettings.ShowCommitAndPush;
-        splitRight.Panel2MinSize = Math.Max(splitRight.Panel2MinSize, flowCommitButtons.PreferredSize.Height);
+        splitRight.Panel2MinSize = Math.Max(splitRight.Panel2MinSize, flowCommitButtons.PreferredSize.Height + flowCommitButtons.Margin.Vertical + splitRight.Panel2.Padding.Vertical);
         splitRight.SplitterDistance = Math.Min(splitRight.SplitterDistance, splitRight.Height - splitRight.Panel2MinSize);
 
         SelectedDiff.EscapePressed += () => DialogResult = DialogResult.Cancel;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13240

## Proposed changes

- Account for button panel spacing in the minimum height calculation.

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before

<img width="725" height="253" alt="Screenshot 2026-09-08 at 6 03 36 PM" src="https://github.com/user-attachments/assets/18528aeb-ecb4-438c-8073-30aba266227d" />


### After

<img width="656" height="246" alt="Screenshot 2026-09-08 at 5 55 05 PM" src="https://github.com/user-attachments/assets/541c644b-cf16-4987-bff4-312ce630e904" />

## Test methodology <!-- How did you ensure quality? -->

- Verified buttons are fully visible at minimum panel height on local build

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.54.0.windows.1
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
