### PR TITLE
Fix GetCommitCountString

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -869,7 +869,7 @@ public sealed partial class GitModule : IGitModule
     public string GetCommitCountString(ObjectId fromId, string to)
     {
         bool cache = !fromId.IsArtificial && ObjectId.TryParse(to, out ObjectId toId) && !toId.IsArtificial;
-        (int? added, int? removed) = GetRevListLeftRightCount(fromId, to, cache);
+        (int? removed, int? added) = GetRevListLeftRightCount(fromId, to, cache);
 
         if (removed is null || added is null)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to https://github.com/gitextensions/gitextensions/pull/12469

Not so sure what introduced the error, but the checkout commit and the checkout branch was showing incorrect commit counts. 

Used in FormCheckoutRevision, FormCreateBranch, FormCreateTag, FormCheckoutBranch, BranchSelector

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

### Before
Being in [master] and wanting to checkout [origin/master] (two commits below) it shows (+2-0) 
<img width="859" height="367" alt="image" src="https://github.com/user-attachments/assets/9d0e98cf-692b-4dcf-828b-910478ba537e" />

Same behavior when using checkout commit 
<img width="635" height="348" alt="image" src="https://github.com/user-attachments/assets/83b3a2b0-2000-44bc-ab7f-50c4ec0a26b3" />
 

### After
The commit counters correctly show the expected transition (+0-2) meaning you will go back -2 commits
<img width="886" height="364" alt="image" src="https://github.com/user-attachments/assets/10138752-7812-4d75-9f93-c0c4ae9f3d97" />

Same for commit revision 
<img width="608" height="307" alt="image" src="https://github.com/user-attachments/assets/46b62707-dddb-4244-b0d2-4bc760ac8f24" />


Note that he new behavior make it consistent with the commit counters for submodules. Before were not consistent. 

<img width="823" height="301" alt="image" src="https://github.com/user-attachments/assets/72e4b697-fb8a-4277-80cb-65e4caf3a950" />

And after checkout the commit, the super repository shows the changes in the submodule 
<img width="993" height="395" alt="image" src="https://github.com/user-attachments/assets/210ed21b-b2c5-493e-819f-8c7a16b75621" />



## Test methodology <!-- How did you ensure quality? -->

Visual screenshots, the affected method is only for the UI. 
## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
