### PR TITLE
build(SourceLink.GitHub): mark build-time-only

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,29 +8,33 @@
     <PackageVersion Include="ConEmu.Core" Version="23.07.24" />
     <PackageVersion Include="EnvDTE" Version="17.0.32112.339" />
     <PackageVersion Include="ExCSS" Version="4.1.3" />
-    <PackageVersion Include="GitInfo" Version="2.2.0" />    <!-- build-time only -->
     <PackageVersion Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />    <!-- build-time only -->
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />    <!-- build-time only -->
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />
     <PackageVersion Include="RestSharp" Version="106.12.0" />
     <PackageVersion Include="SmartFormat" Version="3.6.0" />
     <PackageVersion Include="StrongOf" Version="1.2.4" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />    <!-- build-time only -->
     <PackageVersion Include="System.ComponentModel.Composition" Version="6.0.0" />    <!-- Required by GitExtensions.PluginManager -->
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.12" />
     <PackageVersion Include="System.Reactive.Interfaces" Version="5.0.0" />
     <PackageVersion Include="System.Reactive.Linq" Version="5.0.0" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />
 
+    <!-- Code generators (build-time only) -->
+    <PackageVersion Include="GitInfo" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />
+    
     <!-- Analyzers (build-time only) -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+
+    <!-- IDE infra (build-time only) -->
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
 
     <!-- Setup infra (build-time only) -->
     <PackageVersion Include="vswhere" Version="3.1.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,37 +8,37 @@
     <PackageVersion Include="ConEmu.Core" Version="23.07.24" />
     <PackageVersion Include="EnvDTE" Version="17.0.32112.339" />
     <PackageVersion Include="ExCSS" Version="4.1.3" />
-    <PackageVersion Include="GitInfo" Version="2.2.0" />
+    <PackageVersion Include="GitInfo" Version="2.2.0" />    <!-- build-time only -->
     <PackageVersion Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />    <!-- build-time only -->
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />    <!-- build-time only -->
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />
     <PackageVersion Include="RestSharp" Version="106.12.0" />
     <PackageVersion Include="SmartFormat" Version="3.6.0" />
     <PackageVersion Include="StrongOf" Version="1.2.4" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />    <!-- build-time only -->
     <PackageVersion Include="System.ComponentModel.Composition" Version="6.0.0" />    <!-- Required by GitExtensions.PluginManager -->
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.12" />
     <PackageVersion Include="System.Reactive.Interfaces" Version="5.0.0" />
     <PackageVersion Include="System.Reactive.Linq" Version="5.0.0" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />
 
-    <!-- Analyzers -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
+    <!-- Analyzers (build-time only) -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
 
-    <!-- Setup infra -->
+    <!-- Setup infra (build-time only) -->
     <PackageVersion Include="vswhere" Version="3.1.7" />
     <PackageVersion Include="WiX" Version="3.14.1" />
 
-    <!-- Test infra -->
+    <!-- Test infra (build-time only)-->
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" PrivateAssets="all" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />    <!-- Required? -->
     <PackageVersion Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
Follow-up to #13268

## Proposed changes

`Directory.Packages.props`:
- Add a comment to all build-time-only packages:
  - GitInfo
  - SourceLink.GitHub
  - Windows.CsWin32
  - StyleCop.Analyzers
- Remove all `PrivateAssets="all"` from `PackageVersion` because it is the wrong place.
  At the right place `PackageReference`, the regarding packages already have that attribute.
  Exception: Microsoft.CodeAnalysis.CSharp is used for a Roslyn code generator only, which does not need explicit "PrivateAssets".

## Screenshots <!-- Include variants with higher scaling, e.g. 150% or 200%. Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- rebuild

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).