### PR TITLE
fix(wsl): exec git directly instead of routing through the distro shell

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -235,3 +235,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/08/20, vovodroid, Arthur Pirozhkov, qa23d-vvdge(at)yahoo.com
 2026/08/21, gusarov, Dmitry Gusarov, Dmitry.Gusarov@gmail.com
 2026/09/08, norgera, Nathan Orgera, nathan.orgera@gmail.com
+2026/09/10, SAPHemlock, Sandip Patel, spatel(at)hemlock(dot)com

--- a/src/app/GitCommands/Git/GitExecutor.cs
+++ b/src/app/GitCommands/Git/GitExecutor.cs
@@ -28,7 +28,11 @@ internal sealed class GitExecutor : IGitExecutor
         {
             // In some WSL environments the current working directory is not passed along to the git command without using the `--cd` argument. Adding it to
             // the command line is required for these environments. For those that do not need it using the argument is just redundant.
-            GitExecutable = new Executable(() => AppSettings.WslCommand, WorkingDir, $"-d {WslDistro} --cd {WorkingDir.RemoveTrailingPathSeparator().Quote()} {AppSettings.WslGitCommand} ");
+            // `--exec` bypasses the distro's default login shell. Without it, wsl.exe re-parses the git command line through that shell
+            // (e.g. zsh), which glob-expands patterns like "--exclude=refs/sessions/**" before git ever sees them. zsh's default
+            // "nomatch" behaviour then aborts the whole command with a non-zero exit and no output when the pattern matches nothing,
+            // which silently empties revision/diff output for any repo whose distro defaults to zsh (or any shell) with that setting.
+            GitExecutable = new Executable(() => AppSettings.WslCommand, WorkingDir, $"-d {WslDistro} --cd {WorkingDir.RemoveTrailingPathSeparator().Quote()} --exec {AppSettings.WslGitCommand} ");
             GitCommandRunner = new GitCommandRunner(GitExecutable, () => SystemEncoding);
         }
         else

--- a/src/app/GitUI/HelperDialogs/FormProcess.cs
+++ b/src/app/GitUI/HelperDialogs/FormProcess.cs
@@ -38,7 +38,11 @@ public partial class FormProcess : FormStatus
 
                 // In some WSL environments the current working directory is not passed along to the git command without using the `--cd` argument. Adding it to
                 // the command line is required for these environments. For those that do not need it using the argument is just redundant.
-                arguments = $"-d {wslDistro} --cd {WorkingDirectory.RemoveTrailingPathSeparator().Quote()} {AppSettings.WslGitCommand} {arguments}";
+                // `--exec` bypasses the distro's default login shell. Without it, wsl.exe re-parses the git command line through that shell
+                // (e.g. zsh), which glob-expands patterns like "--exclude=refs/sessions/**" before git ever sees them. zsh's default
+                // "nomatch" behaviour then aborts the whole command with a non-zero exit and no output when the pattern matches nothing,
+                // which silently empties revision/diff output for any repo whose distro defaults to zsh (or any shell) with that setting.
+                arguments = $"-d {wslDistro} --cd {WorkingDirectory.RemoveTrailingPathSeparator().Quote()} --exec {AppSettings.WslGitCommand} {arguments}";
             }
         }
 

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitExecutorTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitExecutorTests.cs
@@ -1,0 +1,39 @@
+using GitCommands.Git;
+
+namespace GitCommandsTests.Git;
+
+[TestFixture]
+public class GitExecutorTests
+{
+    // Regression test for: WSL-routed git commands returned no revisions/diff output at all.
+    //
+    // wsl.exe, unless told to `--exec` (bypass the distro's default login shell), reconstructs
+    // the received argv into a single command line and runs it through that shell (e.g. zsh).
+    // The revision grid's own filter includes glob-like arguments such as
+    // "--exclude=refs/sessions/**", which are meant to be interpreted by git itself, not by a
+    // shell. Routed through a shell, they get glob-expanded against real files before git ever
+    // sees them; when nothing matches, zsh's default "nomatch" option aborts the whole command
+    // with a non-zero exit and zero output, which GitExtensions then rendered as "no commits".
+    // Passing `--exec` makes wsl.exe invoke git directly, without a shell in between, matching
+    // how the equivalent native Windows git invocation already behaves.
+    [TestCase(@"\\wsl$\Ubuntu\home\user\repo\", "Ubuntu")]
+    [TestCase(@"\\wsl.localhost\Ubuntu-20.04\home\user\repo\", "Ubuntu-20.04")]
+    public void GitExecutable_for_wsl_working_dir_uses_exec_to_bypass_the_distro_shell(string workingDir, string expectedDistro)
+    {
+        GitExecutor executor = new(new GitDirectoryResolver(), workingDir);
+
+        executor.WslDistro.Should().Be(expectedDistro);
+        executor.GitExecutable.PrefixArguments.Should().Contain("--exec")
+            .And.MatchRegex(@"--cd\s+\S+\s+--exec\s+git\s*$");
+    }
+
+    [Test]
+    public void GitExecutable_for_non_wsl_working_dir_has_no_wsl_prefix()
+    {
+        GitExecutor executor = new(new GitDirectoryResolver(), @"c:\repo\");
+
+        executor.WslDistro.Should().BeEmpty();
+        executor.GitExecutable.PrefixArguments.Should().BeEmpty();
+        executor.GitExecutable.Should().BeSameAs(executor.GitWindowsExecutable);
+    }
+}


### PR DESCRIPTION
Fixes #13156

## Root cause

`wsl.exe`, unless given `--exec`, reconstructs the received argv and runs it through the distro's default login shell instead of exec'ing the target program directly. The revision grid's filter (`FilterInfo.cs`) adds `--exclude=refs/sessions/**` and `--exclude=refs/copilot/checkpoints/**` — glob syntax meant for **git** to interpret internally via its own wildmatch, not the shell. Routed through a shell first, `**` gets glob-expanded against real files before git ever runs; when it matches nothing, zsh's default `nomatch` option aborts the whole command with a non-zero exit and zero output (exactly the `zsh: 1: no matches found: --exclude=refs/sessions/**` reported in #13156). Confirmed by replicating GitExtensions' exact `ProcessStartInfo.Arguments` invocation directly against a real WSL repo.

## Why `--exec` over `noglob` (#13249)

`noglob` is a zsh builtin — it isn't defined on bash, dash, or other POSIX shells some distros default to, so that approach only fixes zsh and can break (or no-op with a "command not found") elsewhere. `--exec` tells `wsl.exe` to invoke the target program directly, without any shell in between, on every distro regardless of its default shell — matching how the native Windows git invocation already behaves, and closing the whole class of shell-reinterpretation bugs (globbing, `$()`, backticks, etc.), not just this one glob pattern.

## Changes

- `GitExecutor.cs` and `FormProcess.cs`: add `--exec` to the `wsl.exe` invocation prefix.
- Added `GitExecutorTests.cs` regression test asserting the WSL prefix includes `--exec`.

## Test methodology

- Reproduced the exact failure against a real `\\wsl$\...` repo with a zsh-default distro.
- Verified the fix end-to-end: full revision history and diff pane populate correctly after the change.
- Full `GitCommands.Tests` suite passes (3464 passed, 0 failed, 1 unrelated skip).

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
