### PR TITLE
Resolve WSL worktree gitdir to \\wsl$ UNC path

### DIFF
--- a/src/app/GitCommands/Git/GitDirectoryResolver.cs
+++ b/src/app/GitCommands/Git/GitDirectoryResolver.cs
@@ -88,13 +88,33 @@ public sealed class GitDirectoryResolver : IGitDirectoryResolver
 
             if (line is not null)
             {
-                string path = line[gitdir.Length..].Trim().ToNativePath();
-                if (Path.IsPathRooted(path))
+                // The gitdir path is written by the git executable, so it is in the format that
+                // executable uses: a POSIX path for WSL git, a native Windows path otherwise.
+                // Do NOT convert to native separators before classifying, because
+                // GetWindowsPath() relies on the original POSIX form (e.g. "/mnt/c/..." or "/home/...").
+                string rawPath = line[gitdir.Length..].Trim();
+
+                // A fully qualified path (Windows drive path like "c:\..." or a UNC path like
+                // "\\wsl$\...") is already usable as-is once separators are normalized.
+                string nativePath = rawPath.ToNativePath();
+                if (Path.IsPathFullyQualified(nativePath))
                 {
-                    return path.EnsureTrailingPathSeparator();
+                    return nativePath.EnsureTrailingPathSeparator();
                 }
 
-                return Path.GetFullPath(Path.Join(repositoryPath, path)).EnsureTrailingPathSeparator();
+                // A rooted-but-not-fully-qualified path (e.g. "/home/user/...") is a POSIX
+                // absolute path produced by WSL git. Reconstruct the Windows \\wsl$ UNC path.
+                // For a non-WSL repository GetWslDistro() returns "", so GetWindowsPath() falls
+                // back to ToNativePath() and this remains correct for Windows too.
+                if (Path.IsPathRooted(nativePath))
+                {
+                    return PathUtil.GetWindowsPath(rawPath, PathUtil.GetWslDistro(repositoryPath))
+                        .EnsureTrailingPathSeparator();
+                }
+
+                // Otherwise it is a relative path (e.g. "../../.git/modules/...") — resolve it
+                // against the repository working folder.
+                return Path.GetFullPath(Path.Join(repositoryPath, nativePath)).EnsureTrailingPathSeparator();
             }
         }
 

--- a/tests/app/UnitTests/GitCommands.Tests/Git/GitDirectoryResolverTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/GitDirectoryResolverTests.cs
@@ -87,6 +87,55 @@ public class GitDirectoryResolverTests
         _directory.DidNotReceive().Exists(_gitWorkingDir);
     }
 
+    [Platform(Include = "Win")]
+    [Test]
+    public void Resolve_should_reconstruct_wsl_unc_path_for_posix_gitdir_in_linked_worktree()
+    {
+        // Regression test for #13272: committing from a linked worktree in a WSL repo.
+        // The working tree is accessed via a \\wsl$ UNC path, but the .git file's "gitdir:"
+        // line points at a POSIX absolute path (as written by the Linux git binary) that
+        // lives under the main repo's .git, on a different top-level directory.
+        // The resolver must convert that POSIX path back into the \\wsl$ UNC path so that
+        // COMMITMESSAGE is written to the same location git reads it from.
+        string workingDir = @"\\wsl$\Ubuntu\home\user\source\MyRepo.wt\ACTIVE";
+        string gitFile = Path.Combine(workingDir, ".git");
+
+        _file.Exists(gitFile).Returns(true);
+        _file.ReadLines(gitFile).Returns(new[] { "gitdir: /home/user/source/MyRepo/.git/worktrees/ACTIVE" });
+
+        _resolver.Resolve(workingDir)
+            .Should().Be(@"\\wsl$\Ubuntu\home\user\source\MyRepo\.git\worktrees\ACTIVE\");
+
+        _directory.DidNotReceive().Exists(gitFile.EnsureTrailingPathSeparator());
+    }
+
+    [Platform(Include = "Win")]
+    [Test]
+    public void Resolve_should_map_wsl_mnt_path_to_windows_drive()
+    {
+        // A /mnt/<drive> path (WSL view of a Windows drive) must map back to the drive letter.
+        string workingDir = @"\\wsl$\Ubuntu\mnt\c\dev\repo";
+        string gitFile = Path.Combine(workingDir, ".git");
+
+        _file.Exists(gitFile).Returns(true);
+        _file.ReadLines(gitFile).Returns(new[] { "gitdir: /mnt/c/dev/repo/.git/worktrees/ACTIVE" });
+
+        _resolver.Resolve(workingDir)
+            .Should().Be(@"C:\dev\repo\.git\worktrees\ACTIVE\");
+    }
+
+    [Platform(Include = "Win")]
+    [Test]
+    public void Resolve_should_return_unc_gitdir_path_unchanged()
+    {
+        // A fully qualified UNC gitdir path is already usable and must be returned as-is.
+        _file.Exists(_gitFile).Returns(true);
+        _file.ReadLines(_gitFile).Returns(new[] { @"gitdir: \\wsl$\Ubuntu\home\user\source\MyRepo\.git\worktrees\ACTIVE" });
+
+        _resolver.Resolve(_workingDir)
+            .Should().Be(@"\\wsl$\Ubuntu\home\user\source\MyRepo\.git\worktrees\ACTIVE\");
+    }
+
     [Test]
     public void Resolve_non_bare_repository_real_filesystem()
     {


### PR DESCRIPTION
Fixes #13272

## Proposed changes

- Fix `GitDirectoryResolver.Resolve()` so that a `gitdir:` pointing at a POSIX absolute path (as written by WSL git in
a linked worktree, e.g. `/home/user/.../worktrees/ACTIVE`) is reconstructed into the corresponding
`\\wsl$\<distro>\...` UNC path instead of being mangled into an invalid Windows path (`\home\...`). This makes
GitExtensions write `COMMITMESSAGE` to the same location git reads it from, so committing from a WSL linked worktree
no longer fails with "could not read log file ... No such file or directory".
- Disambiguate path classification using `Path.IsPathFullyQualified()` before `Path.IsPathRooted()`: fully qualified
Windows/UNC paths are used as-is, rooted-but-not-fully-qualified POSIX paths are converted via
`PathUtil.GetWindowsPath()` / `PathUtil.GetWslDistro()`, and everything else is treated as relative. For non-WSL
repositories `GetWslDistro()` returns an empty string, so `GetWindowsPath()` falls back to `ToNativePath()` and
existing Windows behavior is unchanged.
- Add unit tests covering the WSL linked-worktree case, `/mnt/<drive>` mapping back to a Windows drive letter, and a
fully qualified UNC `gitdir:` passing through unchanged.

## Test methodology <!-- How did you ensure quality? -->

- Added and ran `GitDirectoryResolverTests` — 13/13 pass, including the three new cases and the existing
drive-letter/relative/submodule cases (no regressions).
- Manually traced `GetWindowsPath("/home/user/source/MyRepo/.git/worktrees/ACTIVE", "Ubuntu")` to confirm it produces
`\\wsl$\Ubuntu\home\user\source\MyRepo\.git\worktrees\ACTIVE\`.
- Built a `GitCommands.dll` with the fix and verified committing from a WSL linked worktree (GitExtensions driving git
inside WSL2 over a `\\wsl$` path) now succeeds.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.43.0
- Windows 11 24H2

<!-- WSL2 (Ubuntu); GitExtensions on Windows driving the Linux git binary; repository on the WSL ext4 filesystem
accessed via the \\wsl$ UNC path. .NET 10 desktop runtime. -->

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).

Adjust the Git/Windows versions under Test environment(s) if you verified on a different setup than the reporter's.