### PR TITLE
refactor(translations): cache localizable property metadata

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -235,3 +235,4 @@ YYYY/MM/DD, github id, Full name, email
 2026/08/20, vovodroid, Arthur Pirozhkov, qa23d-vvdge(at)yahoo.com
 2026/08/21, gusarov, Dmitry Gusarov, Dmitry.Gusarov@gmail.com
 2026/09/08, norgera, Nathan Orgera, nathan.orgera@gmail.com
+2026/09/11, toneb, Miha Longino, tone.bone@protonmail.com

--- a/src/app/GitExtensions.Extensibility/Translations/Xliff/TranslationUtil.cs
+++ b/src/app/GitExtensions.Extensibility/Translations/Xliff/TranslationUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -15,6 +16,7 @@ public static class TranslationUtil
           BindingFlags.NonPublic | BindingFlags.SetField;
 
     private static readonly HashSet<string> _processedAssemblies = [];
+    private static readonly ConcurrentDictionary<Type, string[]?> _localizablePropertiesAttributeCache = new();
 
     private static readonly string[] _translatableItemInComponentNames =
     [
@@ -437,9 +439,8 @@ public static class TranslationUtil
 
     private static string[]? GetLocalizablePropertiesFromAttribute(object item)
     {
-        return item.GetType()
-            .GetCustomAttribute<LocalizablePropertiesAttribute>()
-            ?.TranslatableProperties;
+        return _localizablePropertiesAttributeCache.GetOrAdd(item.GetType(), static type => type
+            .GetCustomAttribute<LocalizablePropertiesAttribute>()?.TranslatableProperties);
     }
 
     private static readonly char PosixDirectorySeparatorChar = '/';


### PR DESCRIPTION
## Proposed changes
I'm investigating potential improvements to startup performance.  `TranslationUtil.GetLocalizablePropertiesFromAttribute` stands out when profiling.

It was calling GetCustomAttribute on a relatively hot path. This PR adds caching of `LocalizablePropertiesAttribute` lookup.

I considered changing attribute to interface but decided against since it would be breaking change in the extensibility project.

### Before
<img width="747" height="196" alt="image" src="https://github.com/user-attachments/assets/11bc6cc2-8219-4f3a-953c-ae4b3486ff2c" />

### After
<img width="745" height="197" alt="image" src="https://github.com/user-attachments/assets/a5f2ea0e-b81f-41f4-b4c6-dccadbf24152" />

## Test methodology <!-- How did you ensure quality? -->
Manual testing. Manually comparing performance snapshot.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
